### PR TITLE
feat(computed): deref cache value on invalidation

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -44,7 +44,6 @@ class ComputedRefImpl<T> {
         }
       },
       onStop: () => {
-        this._dirty = true
         this._value = undefined!
       }
     })

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -39,8 +39,13 @@ class ComputedRefImpl<T> {
       scheduler: () => {
         if (!this._dirty) {
           this._dirty = true
+          this._value = undefined!
           trigger(toRaw(this), TriggerOpTypes.SET, 'value')
         }
+      },
+      onStop: () => {
+        this._dirty = true
+        this._value = undefined!
       }
     })
 


### PR DESCRIPTION
With a similar motivation as #2389. While #2389 is trying to provide an explicit way to clean up, this PR makes it auto clean up the computed cache value on invalidation. Should improve memory usage on large and dynamic data sets. 