### PR TITLE
chore(runtime-core): adjust createApp warning

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -125,8 +125,13 @@ export function createAppAPI<HostElement>(
   hydrate?: RootHydrateFunction
 ): CreateAppFunction<HostElement> {
   return function createApp(rootComponent, rootProps = null) {
+    if (!isObject(rootComponent)) {
+      __DEV__ && warn(`root component passed to createApp() must be an object.`)
+      rootComponent = {}
+    }
+
     if (rootProps != null && !isObject(rootProps)) {
-      __DEV__ && warn(`root props passed to app.mount() must be an object.`)
+      __DEV__ && warn(`root props passed to createApp() must be an object.`)
       rootProps = null
     }
 


### PR DESCRIPTION
When just call `createApp()` without params, i got error: `Uncaught TypeError: Cannot read property 'render' of undefined`.

This will provide warning message for user: `root component passed to createApp() must be an object`.

And also fixed rootProps's warning: `root props passed to app.mount() must be an object.`, it should be `createApp()`.
