### PR TITLE
types(reactivity): make Ref _shallow type public

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -14,9 +14,6 @@ export interface Ref<T = any> {
    * autocomplete, so we use a private Symbol instead.
    */
   [RefSymbol]: true
-  /**
-   * @internal
-   */
   _shallow?: boolean
 }
 


### PR DESCRIPTION
This will help to use @vue/reactivity standalone. Current I have to use `// @ts-expect-error` in my custom watch.

https://github.com/vue-mini/vue-mini/blob/master/packages/wechat/src/watch.ts#L152