### PR TITLE
fix(runtime-core): h.ts generic type

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -119,7 +119,7 @@ export function h(type: Component, children?: RawChildren): VNode
 
 // concrete component
 export function h<P>(
-  type: ConcreteComponent | string,
+  type: ConcreteComponent<P> | string,
   children?: RawChildren
 ): VNode
 export function h<P>(


### PR DESCRIPTION
One of the override for function `h`, with `ConcreteComponent` as type.

**Now**
```ts
// concrete component
export function h<P>(
  type: ConcreteComponent | string,
  children?: RawChildren
): VNode
export function h<P>(
  type: ConcreteComponent<P> | string,
  props?: (RawProps & P) | ({} extends P ? null : never),
  children?: RawChildren
): VNode
```

**Change to**
```ts
// concrete component
export function h<P>(
  type: ConcreteComponent<P> | string,
  children?: RawChildren
): VNode
export function h<P>(
  type: ConcreteComponent<P> | string,
  props?: (RawProps & P) | ({} extends P ? null : never),
  children?: RawChildren
): VNode
```