### PR TITLE
feat(compiler): recover parser from incomplete open tag

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2759,7 +2759,7 @@ foo
     }
   })
 
-  describe.only('Error Recovery', () => {
+  describe('Error Recovery', () => {
     test('incomplete tag followed by closing parent tag', () => {
       const ast = baseParse('<div><d</div>', { onError() {} })
 

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2758,4 +2758,47 @@ foo
       })
     }
   })
+
+  describe.only('Error Recovery', () => {
+    test('incomplete tag followed by closing parent tag', () => {
+      const ast = baseParse('<div><d</div>', { onError() {} })
+
+      expect(ast.children).toHaveLength(1)
+      const div = ast.children[0] as ElementNode
+      expect(div).toEqual(
+        expect.objectContaining({
+          type: NodeTypes.ELEMENT,
+          isSelfClosing: false,
+          tag: 'div'
+        })
+      )
+      expect(div.children).toHaveLength(1)
+      expect(div.children[0]).toEqual(
+        expect.objectContaining({
+          type: NodeTypes.ELEMENT,
+          tag: 'd',
+          isSelfClosing: true
+        })
+      )
+    })
+    test('incomplete tag followed by opening sibling tag', () => {
+      const ast = baseParse('<d<div></div>', { onError() {} })
+
+      expect(ast.children).toHaveLength(2)
+      expect(ast.children).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: NodeTypes.ELEMENT,
+            tag: 'd',
+            isSelfClosing: true
+          }),
+          expect.objectContaining({
+            type: NodeTypes.ELEMENT,
+            isSelfClosing: false,
+            tag: 'div'
+          })
+        ])
+      )
+    })
+  })
 })

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -56,6 +56,7 @@ export const enum ErrorCodes {
   UNEXPECTED_SOLIDUS_IN_TAG,
 
   // Vue-specific parse errors
+  X_UNEXPECTED_CHARACTER_IN_START_TAG,
   X_INVALID_END_TAG,
   X_MISSING_END_TAG,
   X_MISSING_INTERPOLATION_END,

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -440,7 +440,7 @@ function parseTag(
 
   // Tag open.
   const start = getCursor(context)
-  const match = /^<\/?([a-z][^\t\r\n\f />]*)/i.exec(context.source)!
+  const match = /^<\/?([a-z][^\t\r\n\f /<>]*)/i.exec(context.source)!
   const tag = match[1]
   const ns = context.options.getNamespace(tag, parent)
 
@@ -476,6 +476,9 @@ function parseTag(
   let isSelfClosing = false
   if (context.source.length === 0) {
     emitError(context, ErrorCodes.EOF_IN_TAG)
+  } else if (startsWith(context.source, '<')) {
+    isSelfClosing = true
+    emitError(context, ErrorCodes.X_UNEXPECTED_CHARACTER_IN_START_TAG)
   } else {
     isSelfClosing = startsWith(context.source, '/>')
     if (type === TagType.End && isSelfClosing) {
@@ -537,6 +540,7 @@ function parseAttributes(
   const attributeNames = new Set<string>()
   while (
     context.source.length > 0 &&
+    !startsWith(context.source, '<') &&
     !startsWith(context.source, '>') &&
     !startsWith(context.source, '/>')
   ) {


### PR DESCRIPTION
```html
<div>
  <div |
</div>
```

and

```html
<div |
<div></div>
```

are the most common error state when editing `<template>`. This PR processes these partial/incomplete tags as self-closing elements. Parsing these tags as elements is important as node type is used in VueDX to provide completion.