### PR TITLE
fix(teleport): when updating the target, should also ensure that the …

### DIFF
--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -70,14 +70,17 @@ describe('renderer: teleport', () => {
     const targetB = nodeOps.createElement('div')
     const target = ref(targetA)
     const root = nodeOps.createElement('div')
+    const Comp = defineComponent({
+      props: ['children'],
+      setup(props) {
+        return () => [
+          h(Teleport, { to: target.value }, props.children),
+          h('div', 'root')
+        ]
+      }
+    })
 
-    render(
-      h(() => [
-        h(Teleport, { to: target.value }, h('div', 'teleported')),
-        h('div', 'root')
-      ]),
-      root
-    )
+    render(h(Comp, { children: [h('div', 'teleported')] }), root)
 
     expect(serializeInner(root)).toMatchInlineSnapshot(
       `"<!--teleport start--><!--teleport end--><div>root</div>"`
@@ -96,6 +99,13 @@ describe('renderer: teleport', () => {
     expect(serializeInner(targetA)).toMatchInlineSnapshot(`""`)
     expect(serializeInner(targetB)).toMatchInlineSnapshot(
       `"<div>teleported</div>"`
+    )
+
+    render(h(Comp, { children: [h('div', 'teleported'), h('span')] }), root)
+
+    // the right order should still be maintained
+    expect(serializeInner(targetB)).toMatchInlineSnapshot(
+      `"<div>teleported</div><span></span>"`
     )
   })
 

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -185,7 +185,7 @@ export const TeleportImpl = {
             moveTeleport(
               n2,
               nextTarget,
-              null,
+              n2.targetAnchor,
               internals,
               TeleportMoveTypes.TARGET_CHANGE
             )
@@ -243,9 +243,9 @@ function moveTeleport(
 ) {
   // move target anchor if this is a target change.
   if (moveType === TeleportMoveTypes.TARGET_CHANGE) {
-    insert(vnode.targetAnchor!, container, parentAnchor)
+    insert(vnode.targetAnchor!, container)
   }
-  const { el, anchor, shapeFlag, children, props, targetAnchor } = vnode
+  const { el, anchor, shapeFlag, children, props } = vnode
   const isReorder = moveType === TeleportMoveTypes.REORDER
   // move main view anchor if this is a re-order.
   if (isReorder) {
@@ -261,7 +261,7 @@ function moveTeleport(
         move(
           (children as VNode[])[i],
           container,
-          parentAnchor || targetAnchor,
+          parentAnchor,
           MoveType.REORDER
         )
       }

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -245,7 +245,7 @@ function moveTeleport(
   if (moveType === TeleportMoveTypes.TARGET_CHANGE) {
     insert(vnode.targetAnchor!, container, parentAnchor)
   }
-  const { el, anchor, shapeFlag, children, props } = vnode
+  const { el, anchor, shapeFlag, children, props, targetAnchor } = vnode
   const isReorder = moveType === TeleportMoveTypes.REORDER
   // move main view anchor if this is a re-order.
   if (isReorder) {
@@ -261,7 +261,7 @@ function moveTeleport(
         move(
           (children as VNode[])[i],
           container,
-          parentAnchor,
+          parentAnchor || targetAnchor,
           MoveType.REORDER
         )
       }


### PR DESCRIPTION
when updating the target, should also ensure that the targetAnchor is in the correct position.
see the test case of Teleport.spec.ts -> 'should update target'
![微信截图_20201223231120](https://user-images.githubusercontent.com/31395977/103011239-8f70f680-4574-11eb-817e-70c5dbebe7ee.png)
This test case has also been modified to test this situation.