### PR TITLE
perf(reactivity): minimize memory usage and improve runtime performance

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -44,17 +44,24 @@ const arrayInstrumentations: Record<string, Function> = {}
   const method = Array.prototype[key] as any
   arrayInstrumentations[key] = function(this: unknown[], ...args: unknown[]) {
     const arr = toRaw(this)
-    for (let i = 0, l = this.length; i < l; i++) {
-      track(arr, TrackOpTypes.GET, i + '')
+    const doTrack = (len: number) => {
+      // for length
+      this.length
+      // for integer key
+      for (let i = 0, l = len; i <= l; i++) {
+        track(arr, TrackOpTypes.GET, i + '')
+      }
     }
     // we run the method using the original args first (which may be reactive)
-    const res = method.apply(arr, args)
+    let res = method.apply(arr, args)
     if (res === -1 || res === false) {
       // if that didn't work, run it again using raw values.
-      return method.apply(arr, args.map(toRaw))
-    } else {
-      return res
+      res = method.apply(arr, args.map(toRaw))
     }
+
+    doTrack(typeof res === 'number' && res > -1 ? res : this.length - 1)
+
+    return res
   }
 })
 // instrument length-altering mutation methods to avoid length being tracked

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -45,15 +45,14 @@ const arrayInstrumentations: Record<string, Function> = {}
   arrayInstrumentations[key] = function(this: unknown[], ...args: unknown[]) {
     const arr = toRaw(this)
     const doTrack = (index: number) => {
+      // tracking array length
+      const len = this.length
+      // tracking integer key
       if (key === 'lastIndexOf') {
-        // tracking integer key and array length
-        for (let i = index; i < this.length; i++) {
+        for (let i = index; i < len; i++) {
           track(arr, TrackOpTypes.GET, i + '')
         }
       } else {
-        // tracking array length
-        this.length
-        // tracking integer key
         for (let i = 0; i <= index; i++) {
           track(arr, TrackOpTypes.GET, i + '')
         }

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -44,12 +44,19 @@ const arrayInstrumentations: Record<string, Function> = {}
   const method = Array.prototype[key] as any
   arrayInstrumentations[key] = function(this: unknown[], ...args: unknown[]) {
     const arr = toRaw(this)
-    const doTrack = (len: number) => {
-      // for length
-      this.length
-      // for integer key
-      for (let i = 0, l = len; i <= l; i++) {
-        track(arr, TrackOpTypes.GET, i + '')
+    const doTrack = (index: number) => {
+      if (key === 'lastIndexOf') {
+        // tracking integer key and array length
+        for (let i = index; i < this.length; i++) {
+          track(arr, TrackOpTypes.GET, i + '')
+        }
+      } else {
+        // tracking array length
+        this.length
+        // tracking integer key
+        for (let i = 0; i <= index; i++) {
+          track(arr, TrackOpTypes.GET, i + '')
+        }
       }
     }
     // we run the method using the original args first (which may be reactive)


### PR DESCRIPTION
According to these specs:
- https://tc39.es/ecma262/#sec-array.prototype.indexof
- https://tc39.es/ecma262/#sec-array.prototype.lastindexof

~~Once a suitable value is found, the function(`indexOf/lastIndexOf`) will return immediately and will not access the remaining elements. That means that only the integer keys that are accessed need to be tracked, which can minimize memory usage and improve runtime performance~~

**Edit: Finally, I realized a more efficient and concise way** 😆