### PR TITLE
chore(runtime-code): delete job.cb related test code

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -495,18 +495,6 @@ describe('scheduler', () => {
     expect(count).toBe(5)
   })
 
-  test('should prevent duplicate queue', async () => {
-    let count = 0
-    const job = () => {
-      count++
-    }
-    job.cb = true
-    queueJob(job)
-    queueJob(job)
-    await nextTick()
-    expect(count).toBe(1)
-  })
-
   // #1947 flushPostFlushCbs should handle nested calls
   // e.g. app.mount inside app.mount
   test('flushPostFlushCbs', async () => {


### PR DESCRIPTION
Delete test code(`.cb` in runtime-core) that is no longer used.