### PR TITLE
[WIP] types(defineComponent): support passing Prop interface to defineComponent

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -16,7 +16,8 @@ import {
 import {
   ExtractPropTypes,
   ComponentPropsOptions,
-  ExtractDefaultPropTypes
+  ExtractDefaultPropTypes,
+  Prop
 } from './componentProps'
 import { EmitsOptions } from './componentEmits'
 import { isFunction } from '@vue/shared'
@@ -25,6 +26,12 @@ import {
   CreateComponentPublicInstance,
   ComponentPublicInstanceConstructor
 } from './componentPublicInstance'
+
+export type PropObjectTyped<T extends Record<string, any>> = {
+  [K in keyof T]: undefined extends T[K]
+    ? Prop<T[K], T[K]>
+    : Prop<T[K]> & { required: true }
+}
 
 export type PublicProps = VNodeProps &
   AllowedComponentProps &
@@ -178,6 +185,31 @@ export function defineComponent<
     EE
   >
 ): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE>
+
+export function defineComponent<
+  Props extends Record<string, any>,
+  RawBindings = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = Record<string, any>,
+  EE extends string = string,
+  PropOptions extends PropObjectTyped<Props> = PropObjectTyped<Props>
+>(
+  options: ComponentOptionsWithObjectProps<
+    PropOptions,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE
+  >
+): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
 
 // implementation, close to no-op
 export function defineComponent(options: unknown) {

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -186,6 +186,8 @@ export function defineComponent<
   >
 ): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE>
 
+// overload 5: Props interface passed as argument
+// see `ExtractPropTypes` in ./componentProps.ts
 export function defineComponent<
   Props extends Record<string, any>,
   RawBindings = {},

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -960,6 +960,34 @@ describe('async setup', () => {
   vm.a = 2
 })
 
+// type is correct
+defineComponent<{ a?: string }>({
+  props: {
+    a: String
+  },
+
+  setup(props) {
+    props.a
+  }
+})
+
+// error type is incorrect
+
+//@ts-expect-error invalid type on the prop definition
+defineComponent<{ a: number }>({
+  props: {
+    a: {
+      type: String,
+      required: true
+    }
+  },
+
+  // @ts-expect-error cannot resolve props type because of the mismatch
+  setup(props) {
+    props.a
+  }
+})
+
 // check if defineComponent can be exported
 export default {
   // function components

--- a/test-dts/tsx.test-d.tsx
+++ b/test-dts/tsx.test-d.tsx
@@ -5,8 +5,7 @@ import {
   Fragment,
   Teleport,
   expectError,
-  expectType,
-  defineComponent
+  expectType
 } from './index'
 
 expectType<JSX.Element>(<div />)

--- a/test-dts/tsx.test-d.tsx
+++ b/test-dts/tsx.test-d.tsx
@@ -55,18 +55,3 @@ expectType<JSX.Element>(
 )
 // @ts-expect-error
 expectError(<Suspense onResolve={123} />)
-
-const Comp = defineComponent({
-  props: {
-    msg: String
-  },
-  setup(props) {
-    return () => <div>{props.msg}</div>
-  }
-})
-
-const Other = defineComponent({
-  setup() {
-    return () => <Comp msg={1} />
-  }
-})

--- a/test-dts/tsx.test-d.tsx
+++ b/test-dts/tsx.test-d.tsx
@@ -5,7 +5,8 @@ import {
   Fragment,
   Teleport,
   expectError,
-  expectType
+  expectType,
+  defineComponent
 } from './index'
 
 expectType<JSX.Element>(<div />)
@@ -54,3 +55,18 @@ expectType<JSX.Element>(
 )
 // @ts-expect-error
 expectError(<Suspense onResolve={123} />)
+
+const Comp = defineComponent({
+  props: {
+    msg: String
+  },
+  setup(props) {
+    return () => <div>{props.msg}</div>
+  }
+})
+
+const Other = defineComponent({
+  setup() {
+    return () => <Comp msg={1} />
+  }
+})


### PR DESCRIPTION
```ts
// type is correct
defineComponent<{ a?: string }>({
  props: {
    a: String
  },

  setup(props) {
    props.a
  }
})

// error type is incorrect

//@ts-expect-error invalid type on the prop definition
defineComponent<{ a: number }>({
  props: {
    a: {
      type: String,
      required: true
    }
  },

  // @ts-expect-error cannot resolve props type because of the mismatch
  setup(props) {
    props.a
  }
})
```

- Type tests are missing
- There's an issue where optional and required don't show error 
- defining `prop` with a `type: Object` will accept `arrays`