### PR TITLE
fix(compiler-sfc): set `vue` peerDep as optional for compiler-sfc

### DIFF
--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -33,6 +33,11 @@
   "peerDependencies": {
     "vue": "3.0.5"
   },
+  "peerDependenciesMeta": {
+    "vue": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@babel/parser": "^7.12.0",
     "@babel/types": "^7.12.0",


### PR DESCRIPTION
fix https://github.com/formatjs/formatjs/issues/2581