### PR TITLE
feat(keepAlive): trim name when matching in component names

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -300,10 +300,11 @@ export const KeepAlive = (KeepAliveImpl as any) as {
 }
 
 function matches(pattern: MatchPattern, name: string): boolean {
+  name = name.trim()
   if (isArray(pattern)) {
     return pattern.some((p: string | RegExp) => matches(p, name))
   } else if (isString(pattern)) {
-    return pattern.split(',').indexOf(name) > -1
+    return pattern.split(',').map(i => i.trim()).indexOf(name) > -1
   } else if (pattern.test) {
     return pattern.test(name)
   }

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -304,7 +304,7 @@ function matches(pattern: MatchPattern, name: string): boolean {
   if (isArray(pattern)) {
     return pattern.some((p: string | RegExp) => matches(p, name))
   } else if (isString(pattern)) {
-    return pattern.split(',').map(i => i.trim()).indexOf(name) > -1
+    return pattern.split(',').map((i: string) => i.trim()).indexOf(name) > -1
   } else if (pattern.test) {
     return pattern.test(name)
   }


### PR DESCRIPTION
It should trim the name of component and string pattern split by `,` and then do the matching, same as [vue2#11882](https://github.com/vuejs/vue/pull/11882)