### PR TITLE
refactor(compiler-core): reuse hoisted

### DIFF
--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -287,9 +287,8 @@ export function createTransformContext(
           d.loc.source === (exp as SimpleExpressionNode).loc.source
       )
       if (index === -1) context.hoists.push(exp)
-
       const identifier = createSimpleExpression(
-        `_hoisted_${context.hoists.length}`,
+        `_hoisted_${index !== -1 ? index + 1 : context.hoists.length}`,
         false,
         exp.loc,
         ConstantTypes.CAN_HOIST

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -280,7 +280,11 @@ export function createTransformContext(
     },
     hoist(exp) {
       if (isString(exp)) exp = createSimpleExpression(exp)
-      context.hoists.push(exp)
+      const index = context.hoists.findIndex(
+        d => d && d.loc.source === exp.loc.source
+      )
+      if (index === -1) context.hoists.push(exp)
+
       const identifier = createSimpleExpression(
         `_hoisted_${context.hoists.length}`,
         false,

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -279,9 +279,12 @@ export function createTransformContext(
       }
     },
     hoist(exp) {
-      if (isString(exp)) exp = createSimpleExpression(exp) 
+      if (isString(exp)) exp = createSimpleExpression(exp)
       const index = context.hoists.findIndex(
-        d => d && d.loc.source === (exp as SimpleExpressionNode).loc.source
+        d =>
+          d &&
+          d.loc.source &&
+          d.loc.source === (exp as SimpleExpressionNode).loc.source
       )
       if (index === -1) context.hoists.push(exp)
 

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -279,9 +279,9 @@ export function createTransformContext(
       }
     },
     hoist(exp) {
-      if (isString(exp)) exp = createSimpleExpression(exp)
+      if (isString(exp)) exp = createSimpleExpression(exp) 
       const index = context.hoists.findIndex(
-        d => d && d.loc.source === exp.loc.source
+        d => d && d.loc.source === (exp as SimpleExpressionNode).loc.source
       )
       if (index === -1) context.hoists.push(exp)
 

--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -314,9 +314,7 @@ describe('stringify static html', () => {
         StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
       )}</foo>`
     )
-    expect(ast.hoists.length).toBe(
-      StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
-    )
+    expect(ast.hoists.length).toBe(1)
     ast.hoists.forEach(node => {
       expect(node).toMatchObject({
         type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
@@ -329,9 +327,7 @@ describe('stringify static html', () => {
         StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
       )}</template></foo>`
     )
-    expect(ast2.hoists.length).toBe(
-      StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
-    )
+    expect(ast2.hoists.length).toBe(1)
     ast2.hoists.forEach(node => {
       expect(node).toMatchObject({
         type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION

--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -98,7 +98,7 @@ describe('stringify static html', () => {
         StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
       )}</div>`
     )
-    // should have 1 hoisted nodes, because they are reused
+    // should have 1 hoisted nodes, because it's reused
     expect(ast.hoists).toMatchObject([
       {
         type: NodeTypes.JS_CALL_EXPRESSION,

--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -98,8 +98,7 @@ describe('stringify static html', () => {
         StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
       )}</div>`
     )
-    // should have 6 hoisted nodes (including the entire array),
-    // but 2~5 should be null because they are merged into 1
+    // should have 1 hoisted nodes, because they are reused
     expect(ast.hoists).toMatchObject([
       {
         type: NodeTypes.JS_CALL_EXPRESSION,
@@ -114,10 +113,6 @@ describe('stringify static html', () => {
           '5'
         ]
       },
-      null,
-      null,
-      null,
-      null,
       {
         type: NodeTypes.JS_ARRAY_EXPRESSION
       }

--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -148,7 +148,8 @@ const replaceHoist = (
   context: TransformContext
 ) => {
   const hoistToReplace = (node.codegenNode as SimpleExpressionNode).hoisted!
-  context.hoists[context.hoists.indexOf(hoistToReplace)] = replacement
+  const index = context.hoists.indexOf(hoistToReplace)
+  if (index !== -1) context.hoists[index] = replacement
 }
 
 const isNonStringifiable = /*#__PURE__*/ makeMap(

--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
@@ -7,12 +7,11 @@ import _imports_0 from './logo.png'
 
 const _hoisted_1 = _imports_0
 const _hoisted_2 = _imports_0 + ' 2x'
-const _hoisted_3 = _imports_0 + ' 2x'
-const _hoisted_4 = _imports_0 + ', ' + _imports_0 + ' 2x'
-const _hoisted_5 = _imports_0 + ' 2x, ' + _imports_0
-const _hoisted_6 = _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
-const _hoisted_7 = _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
-const _hoisted_8 = \\"/logo.png\\" + ', ' + _imports_0 + ' 2x'
+const _hoisted_3 = _imports_0 + ', ' + _imports_0 + ' 2x'
+const _hoisted_4 = _imports_0 + ' 2x, ' + _imports_0
+const _hoisted_5 = _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_6 = _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_7 = \\"/logo.png\\" + ', ' + _imports_0 + ' 2x'
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock(_Fragment, null, [
@@ -23,6 +22,10 @@ export function render(_ctx, _cache) {
     _createElementVNode(\\"img\\", {
       src: \\"./logo.png\\",
       srcset: _hoisted_1
+    }),
+    _createElementVNode(\\"img\\", {
+      src: \\"./logo.png\\",
+      srcset: _hoisted_2
     }),
     _createElementVNode(\\"img\\", {
       src: \\"./logo.png\\",
@@ -45,10 +48,6 @@ export function render(_ctx, _cache) {
       srcset: _hoisted_6
     }),
     _createElementVNode(\\"img\\", {
-      src: \\"./logo.png\\",
-      srcset: _hoisted_7
-    }),
-    _createElementVNode(\\"img\\", {
       src: \\"/logo.png\\",
       srcset: \\"/logo.png, /logo.png 2x\\"
     }),
@@ -58,7 +57,7 @@ export function render(_ctx, _cache) {
     }),
     _createElementVNode(\\"img\\", {
       src: \\"/logo.png\\",
-      srcset: _hoisted_8
+      srcset: _hoisted_7
     }),
     _createElementVNode(\\"img\\", {
       src: \\"data:image/png;base64,i\\",
@@ -133,13 +132,12 @@ import _imports_1 from '/logo.png'
 
 const _hoisted_1 = _imports_0
 const _hoisted_2 = _imports_0 + ' 2x'
-const _hoisted_3 = _imports_0 + ' 2x'
-const _hoisted_4 = _imports_0 + ', ' + _imports_0 + ' 2x'
-const _hoisted_5 = _imports_0 + ' 2x, ' + _imports_0
-const _hoisted_6 = _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
-const _hoisted_7 = _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
-const _hoisted_8 = _imports_1 + ', ' + _imports_1 + ' 2x'
-const _hoisted_9 = _imports_1 + ', ' + _imports_0 + ' 2x'
+const _hoisted_3 = _imports_0 + ', ' + _imports_0 + ' 2x'
+const _hoisted_4 = _imports_0 + ' 2x, ' + _imports_0
+const _hoisted_5 = _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_6 = _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_7 = _imports_1 + ', ' + _imports_1 + ' 2x'
+const _hoisted_8 = _imports_1 + ', ' + _imports_0 + ' 2x'
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock(_Fragment, null, [
@@ -150,6 +148,10 @@ export function render(_ctx, _cache) {
     _createElementVNode(\\"img\\", {
       src: \\"./logo.png\\",
       srcset: _hoisted_1
+    }),
+    _createElementVNode(\\"img\\", {
+      src: \\"./logo.png\\",
+      srcset: _hoisted_2
     }),
     _createElementVNode(\\"img\\", {
       src: \\"./logo.png\\",
@@ -172,12 +174,8 @@ export function render(_ctx, _cache) {
       srcset: _hoisted_6
     }),
     _createElementVNode(\\"img\\", {
-      src: \\"./logo.png\\",
-      srcset: _hoisted_7
-    }),
-    _createElementVNode(\\"img\\", {
       src: \\"/logo.png\\",
-      srcset: _hoisted_8
+      srcset: _hoisted_7
     }),
     _createElementVNode(\\"img\\", {
       src: \\"https://example.com/logo.png\\",
@@ -185,7 +183,7 @@ export function render(_ctx, _cache) {
     }),
     _createElementVNode(\\"img\\", {
       src: \\"/logo.png\\",
-      srcset: _hoisted_9
+      srcset: _hoisted_8
     }),
     _createElementVNode(\\"img\\", {
       src: \\"data:image/png;base64,i\\",


### PR DESCRIPTION
before
```javascript
import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from "vue"

const _hoisted_1 = /*#__PURE__*/_createVNode("img", { src: "./logo.png" }, null, -1 /* HOISTED */)
const _hoisted_2 = /*#__PURE__*/_createVNode("img", { src: "./logo.png" }, null, -1 /* HOISTED */)
const _hoisted_3 = /*#__PURE__*/_createVNode("img", { src: "./logo.png" }, null, -1 /* HOISTED */)

export function render(_ctx, _cache, $props, $setup, $data, $options) {
  return (_openBlock(), _createBlock("div", null, [
    _hoisted_1,
    _hoisted_2,
    _hoisted_3
  ]))
}
```
after
```javascript
import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from "vue"

const _hoisted_1 = /*#__PURE__*/_createVNode("img", { src: "./logo.png" }, null, -1 /* HOISTED */)

export function render(_ctx, _cache, $props, $setup, $data, $options) {
  return (_openBlock(), _createBlock("div", null, [
    _hoisted_1,
    _hoisted_1,
    _hoisted_1
  ]))
}
```

