### PR TITLE
types(h): Support passing `props` to `Component` when using `h`

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -129,9 +129,9 @@ export function h<P>(
 ): VNode
 
 // component without props
-export function h(
-  type: Component,
-  props: null,
+export function h<P>(
+  type: Component<P>,
+  props?: (RawProps & P) | null,
   children?: RawChildren | RawSlots
 ): VNode
 

--- a/test-dts/h.test-d.ts
+++ b/test-dts/h.test-d.ts
@@ -144,12 +144,11 @@ describe('h inference w/ defineComponent', () => {
 //   expectError(h(Foo, { bar: 1, foo: 1 }))
 // })
 
-// #922
+// #922 and #3218
 describe('h support for generic component type', () => {
   function foo(bar: Component) {
     h(bar)
     h(bar, 'hello')
-    // @ts-expect-error
     h(bar, { id: 'ok' }, 'hello')
   }
   foo({})


### PR DESCRIPTION
fix #3218 
