### PR TITLE
feat(scheduler): dedupe rendering jobs that are enqueued in a pre-flush job

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -558,4 +558,25 @@ describe('scheduler', () => {
     await nextTick()
     expect(count).toBe(1)
   })
+
+  // #3385
+  test('dedupe rendering jobs that are enqueued in a pre-flush job', async () => {
+    // prev cb, e.g. the watch callback
+    const job = () => {
+      // enqueue a render job
+      queueJob(renderJob)
+    }
+    job.allowRecurse = true
+
+    let count = 0
+    const renderJob = () => {
+      count++
+    }
+    renderJob.allowRecurse = true
+
+    queuePreFlushCb(job)
+    queueJob(renderJob)
+    await nextTick()
+    expect(count).toBe(1)
+  })
 })

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -91,7 +91,7 @@ export function queueJob(job: SchedulerJob) {
    * these jobs have the `job.allowRecurse` with the `true` value,
    * consider the job flush order is pre --> job --> post,
    * some pre-jobs may enqueue a job that allows recursive execution, for example,
-   * chaning the reactivity data in the watch callback:
+   * changing the reactivity data in the watch callback:
    *
    * ```
    * watch(refA, () => refB.value = xxx)


### PR DESCRIPTION
Close: #3385 

Explained in the code