### PR TITLE
refactor(scheduler): make findInsertionIndex return -1

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -92,11 +92,8 @@ export function queueJob(job: SchedulerJob) {
     job !== currentPreFlushParentJob
   ) {
     const pos = findInsertionIndex(job)
-    if (pos > -1) {
-      queue.splice(pos, 0, job)
-    } else {
-      queue.push(job)
-    }
+    queue.splice(pos, 0, job)
+
     queueFlush()
   }
 }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -91,6 +91,7 @@ export function queueJob(job: SchedulerJob) {
       )) &&
     job !== currentPreFlushParentJob
   ) {
+    // #3435 pos is always > -1
     const pos = findInsertionIndex(job)
     queue.splice(pos, 0, job)
 

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -63,8 +63,9 @@ export function nextTick(
 // which can prevent the job from being skipped and also can avoid repeated patching.
 function findInsertionIndex(job: SchedulerJob) {
   // the start index should be `flushIndex + 1`
+  let len = queue.length
   let start = flushIndex + 1
-  let end = queue.length
+  let end = len
   const jobId = getId(job)
 
   while (start < end) {
@@ -73,7 +74,7 @@ function findInsertionIndex(job: SchedulerJob) {
     middleJobId < jobId ? (start = middle + 1) : (end = middle)
   }
 
-  return start
+  return start !== len ? start : -1
 }
 
 export function queueJob(job: SchedulerJob) {
@@ -91,10 +92,12 @@ export function queueJob(job: SchedulerJob) {
       )) &&
     job !== currentPreFlushParentJob
   ) {
-    // #3435 pos is always > -1
     const pos = findInsertionIndex(job)
-    queue.splice(pos, 0, job)
-
+    if (pos > -1) {
+      queue.splice(pos, 0, job)
+    } else {
+      queue.push(job)
+    }
     queueFlush()
   }
 }


### PR DESCRIPTION
# Background
`findInsertionIndex` method will never return `-1`, so the `else` branch in `queueJob` will never be executed

# Original code
```ts
// This method will never return -1, so the else branch in `queueJob` will never be executed
function findInsertionIndex(job: SchedulerJob) {
  let start = flushIndex + 1
  let end = queue.length
  const jobId = getId(job)

  while (start < end) {
    const middle = (start + end) >>> 1
    const middleJobId = getId(queue[middle])
    middleJobId < jobId ? (start = middle + 1) : (end = middle)
  }

  return start
}

export function queueJob(job: SchedulerJob) {
  if (
    (!queue.length ||
      !queue.includes(
        job,
        isFlushing && job.allowRecurse ? flushIndex + 1 : flushIndex
      )) &&
    job !== currentPreFlushParentJob
  ) {
    const pos = findInsertionIndex(job)
    if (pos > -1) {
      queue.splice(pos, 0, job)
    } else { // never be executed
      queue.push(job)
    }
    queueFlush()
  }
}
```

# Solutions
1. Remove the `else` branch of the `queueJob` method
```ts
export function queueJob(job: SchedulerJob) {
  if (
    (!queue.length ||
      !queue.includes(
        job,
        isFlushing && job.allowRecurse ? flushIndex + 1 : flushIndex
      )) &&
    job !== currentPreFlushParentJob
  ) {
    const pos = findInsertionIndex(job)
    queue.splice(pos, 0, job)

    queueFlush()
  }
}
```
2. Or modify the `findInsertionIndex` method to return `-1` when it is not found
```ts
function findInsertionIndex(job: SchedulerJob) {
  let len = queue.length
  let start = flushIndex + 1
  let end = len
  const jobId = getId(job)

  while (start < end) {
    const middle = (start + end) >>> 1
    const middleJobId = getId(queue[middle])
    middleJobId < jobId ? (start = middle + 1) : (end = middle)
  }

  return start !== len ? start : -1
}
```

# Finally
~~I chose the first solution. Because the behavior is more in line with the semantics of `findInsertionIndex`. It’s easier to understand~~.
Choose solution 2. as Evan said: `splice` is significantly slower than `push` though. so I refactor the `findInsertionIndex` to return -1.