### PR TITLE
fix(runtime-core): fix the component instance returned by app.mount

### DIFF
--- a/packages/runtime-core/__tests__/apiCreateApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiCreateApp.spec.ts
@@ -11,7 +11,8 @@ import {
   Plugin,
   ref,
   getCurrentInstance,
-  defineComponent
+  defineComponent,
+  defineAsyncComponent
 } from '@vue/runtime-test'
 
 describe('api: createApp', () => {
@@ -360,6 +361,30 @@ describe('api: createApp', () => {
     app.config.warnHandler = handler
     app.mount(nodeOps.createElement('div'))
     expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  describe('instance returned by the mount function', () => {
+    test('return public instance when stateful component is the root of the app', () => {
+      const app = createApp({ render: () => h('h1') })
+      expect(app.mount(nodeOps.createElement('div'))).toBeDefined()
+    })
+
+    test('return null when functional component is the root of the app', () => {
+      const app = createApp(() => h('h1'))
+      expect(app.mount(nodeOps.createElement('div'))).toBe(null)
+    })
+
+    test('return null when async component wrapper is the root of the app', () => {
+      const app = createApp(
+        defineAsyncComponent(
+          () =>
+            new Promise(resolve => {
+              resolve({ render: () => h('h1') })
+            })
+        )
+      )
+      expect(app.mount(nodeOps.createElement('div'))).toBe(null)
+    })
   })
 
   describe('config.isNativeTag', () => {

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -21,7 +21,7 @@ function mountWithHydration(html: string, render: () => any) {
     render
   })
   return {
-    vnode: app.mount(container).$.subTree as VNode<Node, Element> & {
+    vnode: app.mount(container)!.$.subTree as VNode<Node, Element> & {
       el: Element
     },
     container
@@ -704,7 +704,7 @@ describe('SSR hydration', () => {
     })
 
     expect(
-      (app.mount(svgContainer).$.subTree as VNode<Node, Element> & {
+      (app.mount(svgContainer)!.$.subTree as VNode<Node, Element> & {
         el: Element
       }).el instanceof SVGElement
     )

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -5,7 +5,10 @@ import {
   Component
 } from './component'
 import { ComponentOptions, RuntimeCompilerOptions } from './componentOptions'
-import { ComponentPublicInstance } from './componentPublicInstance'
+import {
+  ComponentPublicInstance,
+  getPublicInstance
+} from './componentPublicInstance'
 import { Directive, validateDirectiveName } from './directives'
 import { RootRenderFunction } from './renderer'
 import { InjectionKey } from './apiInject'
@@ -16,6 +19,7 @@ import { devtoolsInitApp, devtoolsUnmountApp } from './devtools'
 import { isFunction, NO, isObject } from '@vue/shared'
 import { version } from '.'
 import { installAppCompatProperties } from './compat/global'
+import { isAsyncWrapper } from './apiAsyncComponent'
 
 export interface App<HostElement = any> {
   version: string
@@ -30,7 +34,7 @@ export interface App<HostElement = any> {
     rootContainer: HostElement | string,
     isHydrate?: boolean,
     isSVG?: boolean
-  ): ComponentPublicInstance
+  ): ComponentPublicInstance | null
   unmount(): void
   provide<T>(key: InjectionKey<T> | string, value: T): this
 
@@ -287,7 +291,9 @@ export function createAppAPI<HostElement>(
             devtoolsInitApp(app, version)
           }
 
-          return vnode.component!.proxy
+          return isAsyncWrapper(vnode)
+            ? null
+            : getPublicInstance(vnode.component)
         } else if (__DEV__) {
           warn(
             `App has already been mounted.\n` +

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -213,7 +213,7 @@ export type PublicPropertiesMap = Record<
  * they exist in the internal parent chain. For code that relies on traversing
  * public $parent chains, skip functional ones and go to the parent instead.
  */
-const getPublicInstance = (
+export const getPublicInstance = (
   i: ComponentInternalInstance | null
 ): ComponentPublicInstance | ComponentInternalInstance['exposed'] | null => {
   if (!i) return null


### PR DESCRIPTION
Fix: #3451

- Currently, `app.mount` will return `null` if the functional component is the `App`'s root, because the functional component has no instance. 
- For the async component wrapper as the `App`'s root, an instance will be created for it when doing client-side rendering, but the instance will not be created when doing hydration.
- The instance of the async component wrapper is of little significance to the user

Combining the above three points, I think that when a functional component or an async component wrapper is used as the `App`'s root, then the `app.mount` only needs to return `null`.