### PR TITLE
fix(types): correctly unwrap the type of array in data

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -252,4 +252,7 @@ type SymbolExtract<T> = (T extends { [Symbol.asyncIterator]: infer V }
     ? { [Symbol.unscopables]: V }
     : {})
 
-type UnwrappedObject<T> = { [P in keyof T]: UnwrapRef<T[P]> } & SymbolExtract<T>
+type UnwrappedObject<T> = {
+  [P in keyof T]: UnwrapRef<T[P]> & SymbolExtract<T[P]>
+} &
+  SymbolExtract<T>

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -220,7 +220,7 @@ type UnwrapRefSimple<T> = T extends
   | RefUnwrapBailTypes[keyof RefUnwrapBailTypes]
   ? T
   : T extends Array<any>
-    ? { [K in keyof T]: UnwrapRefSimple<T[K]> }
+    ? { [K in keyof T]: UnwrapRefSimple<T[K]> } & SymbolExtract<T>
     : T extends object ? UnwrappedObject<T> : T
 
 // Extract all known symbols from an object
@@ -252,7 +252,4 @@ type SymbolExtract<T> = (T extends { [Symbol.asyncIterator]: infer V }
     ? { [Symbol.unscopables]: V }
     : {})
 
-type UnwrappedObject<T> = {
-  [P in keyof T]: UnwrapRef<T[P]> & SymbolExtract<T[P]>
-} &
-  SymbolExtract<T>
+type UnwrappedObject<T> = { [P in keyof T]: UnwrapRef<T[P]> } & SymbolExtract<T>

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -378,9 +378,12 @@ describe('type inference w/ options API', () => {
       // Limitation: we cannot expose the return result of setup() on `this`
       // here in data() - somehow that would mess up the inference
       expectType<number | undefined>(this.a)
+
+      interface MyArray extends Array<number> {}
       return {
         c: this.a || 123,
-        someRef: ref(0)
+        someRef: ref(0),
+        arr: [] as MyArray
       }
     },
     computed: {
@@ -420,6 +423,7 @@ describe('type inference w/ options API', () => {
       // computed get/set
       expectType<number>(this.e)
       expectType<number>(this.someRef)
+      expectType<number[]>(this.arr)
     },
     methods: {
       doSomething() {
@@ -433,6 +437,7 @@ describe('type inference w/ options API', () => {
         expectType<number>(this.d)
         // computed get/set
         expectType<number>(this.e)
+        expectType<number[]>(this.arr)
       },
       returnSomething() {
         return this.a
@@ -451,6 +456,7 @@ describe('type inference w/ options API', () => {
       expectType<number>(this.e)
       // method
       expectType<() => number | undefined>(this.returnSomething)
+      expectType<number[]>(this.arr)
     }
   })
 })


### PR DESCRIPTION
Fix: #3535 , #3805

Caused by https://github.com/vuejs/vue-next/commit/2b588cf1bc03329576b8759c9072e3e551b739f1