### PR TITLE
fix(shared): missed Symbol judge in looseEqual

### DIFF
--- a/packages/shared/__tests__/looseEqual.spec.ts
+++ b/packages/shared/__tests__/looseEqual.spec.ts
@@ -49,6 +49,18 @@ describe('utils/looseEqual', () => {
     expect(looseEqual(date1, date4)).toBe(false)
   })
 
+  test('compares symbols correctly', () => {
+    const symbol1 = Symbol('a')
+    const symbol2 = Symbol('a')
+    const symbol3 = Symbol('b')
+    const notSymbol = 0
+
+    expect(looseEqual(symbol1, symbol1)).toBe(true)
+    expect(looseEqual(symbol1, symbol2)).toBe(false)
+    expect(looseEqual(symbol1, symbol3)).toBe(false)
+    expect(looseEqual(symbol1, notSymbol)).toBe(false)
+  })
+
   test('compares files correctly', () => {
     const date1 = new Date(2019, 1, 2, 3, 4, 5, 6)
     const date2 = new Date(2019, 1, 2, 3, 4, 5, 7)

--- a/packages/shared/src/looseEqual.ts
+++ b/packages/shared/src/looseEqual.ts
@@ -1,4 +1,4 @@
-import { isArray, isDate, isObject } from './'
+import { isArray, isDate, isObject, isSymbol } from './'
 
 function looseCompareArrays(a: any[], b: any[]) {
   if (a.length !== b.length) return false
@@ -15,6 +15,11 @@ export function looseEqual(a: any, b: any): boolean {
   let bValidType = isDate(b)
   if (aValidType || bValidType) {
     return aValidType && bValidType ? a.getTime() === b.getTime() : false
+  }
+  aValidType = isSymbol(a)
+  bValidType = isSymbol(b)
+  if (aValidType || bValidType) {
+    return a === b
   }
   aValidType = isArray(a)
   bValidType = isArray(b)


### PR DESCRIPTION
https://github.com/vuejs/vue-next/blob/4fe4de0a49ffc2461b0394e74674af38ff5e2a20/packages/shared/src/looseEqual.ts#L12

I think the `looseEqual` function of above code should work like this:
`looseEqual(Symbol('a'), Symbol('a')) // false`

But `looseEqual(Symbol('a'), Symbol('a'))` returns `true` now.