### PR TITLE
fix(runtime-core): calling the `h` function should not mess up the tracking of dynamic children

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -6,7 +6,8 @@ import {
   Fragment,
   Text,
   Comment,
-  isVNode
+  isVNode,
+  setBlockTracking
 } from './vnode'
 import { Teleport, TeleportProps } from './components/Teleport'
 import { Suspense, SuspenseProps } from './components/Suspense'
@@ -173,17 +174,20 @@ export function h<P>(
 // Actual implementation
 export function h(type: any, propsOrChildren?: any, children?: any): VNode {
   const l = arguments.length
+  let vnode: VNode
+  setBlockTracking(-1)
   if (l === 2) {
     if (isObject(propsOrChildren) && !isArray(propsOrChildren)) {
       // single vnode without props
       if (isVNode(propsOrChildren)) {
-        return createVNode(type, null, [propsOrChildren])
+        vnode = createVNode(type, null, [propsOrChildren])
+      } else {
+        // props without children
+        vnode = createVNode(type, propsOrChildren)
       }
-      // props without children
-      return createVNode(type, propsOrChildren)
     } else {
       // omit props
-      return createVNode(type, null, propsOrChildren)
+      vnode = createVNode(type, null, propsOrChildren)
     }
   } else {
     if (l > 3) {
@@ -191,6 +195,8 @@ export function h(type: any, propsOrChildren?: any, children?: any): VNode {
     } else if (l === 3 && isVNode(children)) {
       children = [children]
     }
-    return createVNode(type, propsOrChildren, children)
+    vnode = createVNode(type, propsOrChildren, children)
   }
+  setBlockTracking(1)
+  return vnode!
 }


### PR DESCRIPTION
Fix: #3634 