### PR TITLE
feat(compiler-core): improve the plugin system

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
@@ -94,6 +94,18 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: codegen custom gen 1`] = `
+"
+return function render(_ctx, _cache) {
+  with (_ctx) {
+    return (obj) => {
+      const count = obj.foo
+      return count
+    }
+  }
+}"
+`;
+
 exports[`compiler: codegen forNode 1`] = `
 "
 return function render(_ctx, _cache) {

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -673,6 +673,7 @@ export function createCallExpression<T extends CallExpression['callee']>(
 export function createFunctionExpression(
   params: FunctionExpression['params'],
   returns: FunctionExpression['returns'] = undefined,
+  body: FunctionExpression['body'] = undefined,
   newline: boolean = false,
   isSlot: boolean = false,
   loc: SourceLocation = locStub
@@ -681,6 +682,7 @@ export function createFunctionExpression(
     type: NodeTypes.JS_FUNCTION_EXPRESSION,
     params,
     returns,
+    body,
     newline,
     isSlot,
     loc

--- a/packages/compiler-core/src/index.ts
+++ b/packages/compiler-core/src/index.ts
@@ -21,7 +21,7 @@ export {
   StructuralDirectiveTransform,
   DirectiveTransform
 } from './transform'
-export { generate, CodegenContext, CodegenResult } from './codegen'
+export { generate, CodegenContext, CodegenResult, genNode } from './codegen'
 export {
   ErrorCodes,
   CoreCompilerError,

--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -1,4 +1,10 @@
-import { ElementNode, Namespace, TemplateChildNode, ParentNode } from './ast'
+import {
+  ElementNode,
+  Namespace,
+  TemplateChildNode,
+  ParentNode,
+  Node
+} from './ast'
 import { TextModes } from './parse'
 import { CompilerError } from './errors'
 import {
@@ -7,6 +13,7 @@ import {
   TransformContext
 } from './transform'
 import { ParserPlugin } from '@babel/parser'
+import { CodegenContext } from '@vue/compiler-dom/src'
 
 export interface ParserOptions {
   /**
@@ -253,6 +260,13 @@ export interface CodegenOptions extends SharedTransformCodegenOptions {
    * @default 'Vue'
    */
   runtimeGlobalName?: string
+  /**
+   * Since the AST of the generated code is only a subset of JS AST,
+   * and the `genNode` function can only process nodes of the types contained in this subset,
+   * however, some compiler plugins may extend the type of JS AST nodes,
+   * for these nodes, they will be passed as parameters to the `customGen` function
+   */
+  customGen?: (node: Node & { type: any }, context: CodegenContext) => void
 }
 
 export type CompilerOptions = ParserOptions & TransformOptions & CodegenOptions

--- a/packages/compiler-core/src/transforms/transformSlotOutlet.ts
+++ b/packages/compiler-core/src/transforms/transformSlotOutlet.ts
@@ -31,7 +31,9 @@ export const transformSlotOutlet: NodeTransform = (node, context) => {
       if (!slotProps) {
         slotArgs.push(`{}`)
       }
-      slotArgs.push(createFunctionExpression([], children, false, false, loc))
+      slotArgs.push(
+        createFunctionExpression([], children, undefined, false, false, loc)
+      )
     }
 
     if (context.scopeId && !context.slotted) {

--- a/packages/compiler-core/src/transforms/vFor.ts
+++ b/packages/compiler-core/src/transforms/vFor.ts
@@ -188,6 +188,7 @@ export const transformFor = createStructuralDirectiveTransform(
         renderExp.arguments.push(createFunctionExpression(
           createForLoopParams(forNode.parseResult),
           childBlock,
+          undefined,
           true /* force newline */
         ) as ForIteratorExpression)
       }

--- a/packages/compiler-core/src/transforms/vSlot.ts
+++ b/packages/compiler-core/src/transforms/vSlot.ts
@@ -108,6 +108,7 @@ const buildClientSlotFn: SlotFnBuilder = (props, children, loc) =>
   createFunctionExpression(
     props,
     children,
+    undefined,
     false /* newline */,
     true /* isSlot */,
     children.length ? children[0].loc : loc
@@ -271,6 +272,7 @@ export function buildSlots(
             createFunctionExpression(
               createForLoopParams(parseResult),
               buildDynamicSlot(slotName, slotFunction),
+              undefined,
               true /* force newline */
             )
           ])

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -123,7 +123,8 @@ export const ssrTransformComponent: NodeTransform = (node, context) => {
     const buildSSRSlotFn: SlotFnBuilder = (props, children, loc) => {
       const fn = createFunctionExpression(
         [props || `_`, `_push`, `_parent`, `_scopeId`],
-        undefined, // no return, assign body later
+        undefined, // no return
+        undefined, // assign body later
         true, // newline
         true, // isSlot
         loc

--- a/packages/compiler-ssr/src/transforms/ssrTransformSuspense.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformSuspense.ts
@@ -39,7 +39,8 @@ export function ssrTransformSuspense(
       wipEntry.slotsExp = buildSlots(node, context, (_props, children, loc) => {
         const fn = createFunctionExpression(
           [],
-          undefined, // no return, assign body later
+          undefined, // no return
+          undefined, // assign body later
           true, // newline
           false, // suspense slots are not treated as normal slots
           loc

--- a/packages/compiler-ssr/src/transforms/ssrTransformTeleport.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformTeleport.ts
@@ -53,6 +53,7 @@ export function ssrProcessTeleport(
 
   const contentRenderFn = createFunctionExpression(
     [`_push`],
+    undefined, // no return
     undefined, // Body is added later
     true, // newline
     false, // isSlot


### PR DESCRIPTION
Since the AST of the generated code is only a subset of JS AST, and the `genNode` function can only process nodes of the types contained in this subset, however, some compiler plugins may extend the type of JS AST nodes, for these nodes, they will be passed as parameters to the `customGen` function.

The test case demonstrates how to extend the compiler with `customGen`, basically, I tried to write some compiler plugins, but found that I couldn’t do that without touching the core. e.g.

![image](https://user-images.githubusercontent.com/14146560/115563037-b0aadf00-a2e9-11eb-9f6c-5641b617f638.png)
