### PR TITLE
chore(effect): remove useless judgment

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -86,7 +86,6 @@ function createReactiveEffect<T = any>(
     if (!effect.active) {
       return options.scheduler ? undefined : fn()
     }
-    if (!effectStack.includes(effect)) {
       cleanup(effect)
       try {
         enableTracking()
@@ -98,7 +97,6 @@ function createReactiveEffect<T = any>(
         resetTracking()
         activeEffect = effectStack[effectStack.length - 1]
       }
-    }
   } as ReactiveEffect
   effect.id = uid++
   effect.allowRecurse = !!options.allowRecurse


### PR DESCRIPTION
in `effect`, there are two judgments that have the same effect 
```js
// tigger()
if (effect !== activeEffect || effect.allowRecurse) {
    effects.add(effect)
}
```
```js
// createReactiveEffect()
if (!effectStack.includes(effect)) {
   ...
}
```
we can remove one of them