### PR TITLE
fix(compiler-sfc): remove first-line indent for pug or jade

### DIFF
--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -153,3 +153,20 @@ test('should generate the correct imports expression', () => {
   expect(code).toMatch(`_ssrRenderAttr(\"src\", _imports_1)`)
   expect(code).toMatch(`_createVNode(\"img\", { src: _imports_1 })`)
 })
+
+test('should remove first-line indent for pug or jade', () => {
+  const template = parse(`
+<template lang="pug">
+  div 1
+    div 2
+</template>
+  `).descriptor.template!
+
+  const result = compile({
+    filename: 'example.vue',
+    source: template.content,
+    preprocessLang: template.lang
+  })
+
+  expect(result.source).toBe('<div>1<div>2</div></div>')
+})

--- a/packages/compiler-sfc/src/compileTemplate.ts
+++ b/packages/compiler-sfc/src/compileTemplate.ts
@@ -122,6 +122,10 @@ export function compileTemplate(
       : require('consolidate')[preprocessLang as keyof typeof consolidate]
     : false
   if (preprocessor) {
+    if (['pug', 'jade'].includes(preprocessLang as keyof typeof consolidate)) {
+      options.source = normalizeTemplate(options.source)
+    }
+
     try {
       return doCompileTemplate({
         ...options,
@@ -314,4 +318,21 @@ function patchErrors(
       }
     }
   })
+}
+
+// for pug / jade template
+function normalizeTemplate(template: string) {
+  // In order to prevent Prettier from reporting error,
+  // one more temporary variable had to be used to reconstruct follow code:
+  // const indent = template.match(/^\n?(\s+)/)?.[1]
+  const temp = template.match(/^\n?(\s+)/)
+  const indent = temp && temp[1]
+
+  if (indent) {
+    return template
+      .split('\n')
+      .map(str => str.replace(indent, ''))
+      .join('\n')
+  }
+  return template
 }


### PR DESCRIPTION
See https://github.com/vuejs/vue-next/issues/3231 。

When we use template, we often need to use indentation to ensure the formatting and readability of the content, also includes pug / jade。

```html
<template lang="pug">
    div hello
        span world
</template>
```

However, when the Vue SFC compiler preprocesses the template, it removes the outer tags and sends the contents directly to the template compiler, while the pug / jade compiler does not recognize indentation.

![image](https://user-images.githubusercontent.com/10683193/120038615-1f403280-c036-11eb-9039-ce7114c12d0e.png)

Correspondingly, Vue will also report an error：

![image](https://user-images.githubusercontent.com/10683193/120038917-95449980-c036-11eb-8822-af7aae34e30f.png)


I had to remove the indentation every time so that there were no spaces in front of the first line of content:

```html
<template lang="pug">
div hello
    span world
</template>
```

After repeating this operation countless times, I realized that something should be done, maybe the logic of the compiler should be modified.

So I do that.

---

In addition, there is another detail. I don't know why Prettier's version is locked at 1.x, which makes it not aware of TypeScript's new syntax:

* https://github.com/vuejs/vue-next/blob/master/package.json#L69
* https://github.com/prettier/prettier/blob/f938ccdd22/package.json#L60

![image](https://user-images.githubusercontent.com/10683193/120039274-359abe00-c037-11eb-9747-342adb16b1b0.png)

I had to change to another approach, which resulted in the definition of an additional variable.
