### PR TITLE
fix(compiler-sfc): pass options directly to stylus

### DIFF
--- a/packages/compiler-sfc/src/style/preprocessors.ts
+++ b/packages/compiler-sfc/src/style/preprocessors.ts
@@ -98,8 +98,7 @@ const less: StylePreprocessor = (source, map, options, load = require) => {
 const styl: StylePreprocessor = (source, map, options, load = require) => {
   const nodeStylus = load('stylus')
   try {
-    const ref = nodeStylus(source)
-    Object.keys(options).forEach(key => ref.set(key, options[key]))
+    const ref = nodeStylus(source, options)
     if (map) ref.set('sourcemap', { inline: false, comment: false })
 
     const result = ref.render()


### PR DESCRIPTION
Custom preprocessor options to stylus doesnot work.

reference: https://github.com/stylus/stylus/issues/2585 https://github.com/vitejs/vite/issues/2857