### PR TITLE
fix(ssr/renderToStream): A Readable object should at least implement an empty _read method.

### DIFF
--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -47,6 +47,10 @@ function unrollBufferSync(buffer: SSRBuffer, stream: Readable) {
   }
 }
 
+class PushSafeReadable extends Readable {
+  _read() {}
+}
+
 export function renderToStream(
   input: App | VNode,
   context: SSRContext = {}
@@ -62,7 +66,7 @@ export function renderToStream(
   // provide the ssr context to the tree
   input.provide(ssrContextKey, context)
 
-  const stream = new Readable()
+  const stream = new PushSafeReadable()
 
   Promise.resolve(renderComponentVNode(vnode))
     .then(buffer => unrollBuffer(buffer, stream))

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -47,10 +47,6 @@ function unrollBufferSync(buffer: SSRBuffer, stream: Readable) {
   }
 }
 
-class PushSafeReadable extends Readable {
-  _read() {}
-}
-
 export function renderToStream(
   input: App | VNode,
   context: SSRContext = {}
@@ -66,7 +62,7 @@ export function renderToStream(
   // provide the ssr context to the tree
   input.provide(ssrContextKey, context)
 
-  const stream = new PushSafeReadable()
+  const stream = new Readable({ read() {} })
 
   Promise.resolve(renderComponentVNode(vnode))
     .then(buffer => unrollBuffer(buffer, stream))


### PR DESCRIPTION
Nor it will throw errors.

See https://github.com/nodejs/node/issues/38865.

The tests passes in jest before because jest mock the global promise and causes inconsistant behavior compared with native nodejs.
https://github.com/facebook/jest/issues/11497

fix #3846