### PR TITLE
fix(warn): avoid warning on empty children with Suspense

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -17,9 +17,12 @@ import {
   onUnmounted,
   onErrorCaptured,
   shallowRef,
+  SuspenseProps,
+  resolveDynamicComponent,
   Fragment
 } from '@vue/runtime-test'
 import { createApp, defineComponent } from 'vue'
+import { RawSlots } from 'packages/runtime-core/src/componentSlots'
 
 describe('Suspense', () => {
   const deps: Promise<any>[] = []
@@ -1522,5 +1525,76 @@ describe('Suspense', () => {
     await nextTick()
     expected = `<div>outerB</div><div>innerB</div>`
     expect(serializeInner(root)).toBe(expected)
+  })
+
+  describe('warnings', () => {
+    // base function to check if a combination of solts warns or not
+    function baseCheckWarn(
+      sohuldWarn: boolean,
+      children: RawSlots,
+      props: SuspenseProps | null = null
+    ) {
+      const Comp = {
+        setup() {
+          return () => h(Suspense, props, children)
+        }
+      }
+
+      const root = nodeOps.createElement('div')
+      render(h(Comp), root)
+
+      if (sohuldWarn) {
+        expect(`<Suspense> slots expect a single root node.`).toHaveBeenWarned()
+      } else {
+        expect(
+          `<Suspense> slots expect a single root node.`
+        ).not.toHaveBeenWarned()
+      }
+    }
+
+    // actual function that we use in tests
+    const checkWarn = baseCheckWarn.bind(null, true)
+    const checkNoWarn = baseCheckWarn.bind(null, false)
+
+    test('does not warn on single child', async () => {
+      checkNoWarn({
+        default: h('div'),
+        fallback: h('div')
+      })
+    })
+
+    test('does not warn on null', async () => {
+      checkNoWarn({
+        default: null,
+        fallback: null
+      })
+    })
+
+    test('does not warn on <component :is="null" />', async () => {
+      checkNoWarn({
+        default: () => [resolveDynamicComponent(null)]
+        // fallback: () => null
+      })
+    })
+
+    test('does not warn on empty array', async () => {
+      checkNoWarn({
+        default: [],
+        fallback: () => []
+      })
+    })
+
+    test('warns on multiple children in default', async () => {
+      checkWarn({
+        default: [h('div'), h('div')]
+      })
+    })
+
+    test('warns on multiple children in fallback', async () => {
+      checkWarn({
+        default: h('div'),
+        fallback: [h('div'), h('div')]
+      })
+    })
   })
 })

--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -1530,7 +1530,7 @@ describe('Suspense', () => {
   describe('warnings', () => {
     // base function to check if a combination of solts warns or not
     function baseCheckWarn(
-      sohuldWarn: boolean,
+      shouldWarn: boolean,
       children: RawSlots,
       props: SuspenseProps | null = null
     ) {
@@ -1543,7 +1543,7 @@ describe('Suspense', () => {
       const root = nodeOps.createElement('div')
       render(h(Comp), root)
 
-      if (sohuldWarn) {
+      if (shouldWarn) {
         expect(`<Suspense> slots expect a single root node.`).toHaveBeenWarned()
       } else {
         expect(

--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -22,7 +22,7 @@ import {
   Fragment
 } from '@vue/runtime-test'
 import { createApp, defineComponent } from 'vue'
-import { RawSlots } from 'packages/runtime-core/src/componentSlots'
+import { type RawSlots } from 'packages/runtime-core/src/componentSlots'
 
 describe('Suspense', () => {
   const deps: Promise<any>[] = []
@@ -1528,7 +1528,7 @@ describe('Suspense', () => {
   })
 
   describe('warnings', () => {
-    // base function to check if a combination of solts warns or not
+    // base function to check if a combination of slots warns or not
     function baseCheckWarn(
       shouldWarn: boolean,
       children: RawSlots,
@@ -1572,8 +1572,8 @@ describe('Suspense', () => {
 
     test('does not warn on <component :is="null" />', async () => {
       checkNoWarn({
-        default: () => [resolveDynamicComponent(null)]
-        // fallback: () => null
+        default: () => [resolveDynamicComponent(null)],
+        fallback: () => null
       })
     })
 

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -29,6 +29,7 @@ import {
   assertNumber
 } from '../warning'
 import { handleError, ErrorCodes } from '../errorHandling'
+import { NULL_DYNAMIC_COMPONENT } from '../helpers/resolveAssets'
 
 export interface SuspenseProps {
   onResolve?: () => void
@@ -795,7 +796,11 @@ function normalizeSuspenseSlot(s: any) {
   }
   if (isArray(s)) {
     const singleChild = filterSingleRoot(s)
-    if (__DEV__ && !singleChild) {
+    if (
+      __DEV__ &&
+      !singleChild &&
+      s.filter(child => child !== NULL_DYNAMIC_COMPONENT).length > 0
+    ) {
       warn(`<Suspense> slots expect a single root node.`)
     }
     s = singleChild

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -114,6 +114,7 @@ export type VNodeProps = {
 
 type VNodeChildAtom =
   | VNode
+  | typeof NULL_DYNAMIC_COMPONENT
   | string
   | number
   | boolean


### PR DESCRIPTION
The actual use case comes from Vue Router when doing:

```vue
<router-view v-slot="{ Component }">
    <transition mode="out-in">
      <keep-alive>
        <suspense>
          <component :is="Component"></component>
          <template #fallback>
            <div>
              Loading...
            </div>
          </template>
        </suspense>
      </keep-alive>
    </transition>
</router-view>
```

`Component` will be `null` initially (initial navigation) or when nothing is matched. The warning could be avoided by using `<component v-if="Component" :is="Component" />` but I think having the warn could be confusing for users as they would be looking for a multi-node root they don't have

I also added missing tests for the existing warning