### PR TITLE
types(runtime-core): enable plugin option types

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -28,7 +28,7 @@ import { ObjectEmitsOptions } from './componentEmits'
 export interface App<HostElement = any> {
   version: string
   config: AppConfig
-  use(plugin: Plugin, ...options: any[]): this
+  use<Option>(plugin: Plugin<Option>, ...options: Option[]): this
   mixin(mixin: ComponentOptions): this
   component(name: string): Component | undefined
   component(name: string, component: Component): this
@@ -137,12 +137,12 @@ export interface AppContext {
   filters?: Record<string, Function>
 }
 
-type PluginInstallFunction = (app: App, ...options: any[]) => any
+type PluginInstallFunction<Option> = (app: App, ...options: Option[]) => any
 
-export type Plugin =
-  | (PluginInstallFunction & { install?: PluginInstallFunction })
+export type Plugin<Option = any> =
+  | PluginInstallFunction<Option> & { install?: PluginInstallFunction<Option> }
   | {
-      install: PluginInstallFunction
+      install: PluginInstallFunction<Option>
     }
 
 export function createAppContext(): AppContext {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -145,8 +145,6 @@ export interface AppContext {
 
 type PluginInstallFunction<Options> = Options extends unknown[]
   ? (app: App, ...options: Options) => any
-  : Options extends undefined
-  ? (app: App, options?: Options) => any
   : (app: App, options: Options) => any
 
 export type Plugin<Options = any[]> =

--- a/test-dts/appUse.test-d.ts
+++ b/test-dts/appUse.test-d.ts
@@ -9,7 +9,7 @@ type PluginAOptionType = {
 }
 
 const PluginA = {
-  install(app: App, ...options: PluginAOptionType[]) {
+  install(app: App, options: PluginAOptionType) {
     options[0].option1
     options[0].option2
     options[0].option3

--- a/test-dts/appUse.test-d.ts
+++ b/test-dts/appUse.test-d.ts
@@ -1,0 +1,70 @@
+import { createApp } from './index'
+
+type App = ReturnType<typeof createApp>
+
+type PluginAOptionType = {
+  option1?: string
+  option2: number
+  option3: boolean
+}
+
+const PluginA = {
+  install(app: App, ...options: PluginAOptionType[]) {
+    options[0].option1
+    options[0].option2
+    options[0].option3
+  }
+}
+
+const PluginB = {
+  install(app: App) {}
+}
+
+const PluginC = (app: App, ...options: string[]) => {}
+
+createApp({})
+  .use(PluginA)
+  // @ts-expect-error option2 and option3 (required) missing
+  .use(PluginA, {})
+  // @ts-expect-error type mismatch
+  .use(PluginA, true)
+  // @ts-expect-error type mismatch
+  .use(PluginA, undefined)
+  // @ts-expect-error type mismatch
+  .use(PluginA, null)
+  // @ts-expect-error type mismatch
+  .use(PluginA, 'foo')
+  // @ts-expect-error type mismatch
+  .use(PluginA, 1)
+  .use(PluginA, { option2: 1, option3: true })
+  .use(PluginA, { option1: 'foo', option2: 1, option3: true })
+
+  // @ts-expect-error option2 (required) missing
+  .use(PluginA, { option3: true })
+
+  .use(PluginB)
+  // @ts-expect-error unexpected plugin option
+  .use(PluginB, {})
+  // @ts-expect-error unexpected plugin option
+  .use(PluginB, true)
+  // @ts-expect-error unexpected plugin option
+  .use(PluginB, undefined)
+  // @ts-expect-error unexpected plugin option
+  .use(PluginB, null)
+  // @ts-expect-error type mismatch
+  .use(PluginB, 'foo')
+  // @ts-expect-error type mismatch
+  .use(PluginB, 1)
+
+  .use(PluginC)
+  // @ts-expect-error unexpected plugin option
+  .use(PluginC, {})
+  // @ts-expect-error unexpected plugin option
+  .use(PluginC, true)
+  // @ts-expect-error unexpected plugin option
+  .use(PluginC, undefined)
+  // @ts-expect-error unexpected plugin option
+  .use(PluginC, null)
+  .use(PluginC, 'foo')
+  // @ts-expect-error type mismatch
+  .use(PluginC, 1)

--- a/test-dts/appUse.test-d.ts
+++ b/test-dts/appUse.test-d.ts
@@ -9,7 +9,7 @@ type PluginAOptionType = {
 }
 
 const PluginA = {
-  install(app: App, options: PluginAOptionType) {
+  install(app: App, ...options: PluginAOptionType[]) {
     options[0].option1
     options[0].option2
     options[0].option3
@@ -38,6 +38,7 @@ createApp({})
   .use(PluginA, 1)
   .use(PluginA, { option2: 1, option3: true })
   .use(PluginA, { option1: 'foo', option2: 1, option3: true })
+  .use(PluginA, { option1: 'foo', option2: 1, option3: true }, { option2: 1, option3: true })
 
   // @ts-expect-error option2 (required) missing
   .use(PluginA, { option3: true })


### PR DESCRIPTION
This enables type inference for:

 1. The `options` arg of a plugin's `install` function
 2. The options passed to `createApp().use()`

```typescript
/**
 * Plugin
 */
type PluginAOptionType = {
  option1?: string;
  option2: number;
  option3: boolean;
}

const PluginA = {
  install(app: App, ...options: PluginAOptionType[]) {

  }
}

const PluginB = {
  install(app: App) {

  }
}

/**
 * Main
 */
createApp({})
  .use(PluginA, { option3: true }) // ❌ option2 (required) missing
  .use(PluginA, {}) // ❌ option2 and option3 (required) missing
  .use(PluginA) // ✅
  .use(PluginA, { option2: 1, option3: true }) // ✅
  .use(PluginA, { option1: 'foo', option2: 1, option3: true }) // ✅
  
  .use(PluginB) // ✅
  .use(PluginB, {}) // ❌ unexpected plugin option
```

[demo](https://www.typescriptlang.org/play?#code/PQKhFgCgAIWgVAngBwKbQCaoMYBsCGATvgC4CWA9gHYDOUswUWeR6JK6ACrgK4DmZKgH0ATAB4A8snLVoAXmj4qiAHzzo3foICStEvly4AYjyrYZVSdMpU1AMmgBvetFeCa+wwH4AXBt4CVLoeBsam5jZWFioA3FAAvtAAPk4ubnqhfpqBwZ5hZhZRNrEJcZCoAB7IFIQkTv5awiKKNA2B0PFQTDgEhGwcbToZhiYFkVLR6gAU+MjIfgCCcwA00AB0GxTW1DR+EzYA2gC6AJTyakqIZd0sfdCCJKiEAGb42OhLyKkw0MDAPDRUFNkAFBFlQU1Vhs1lsLLtFMpjic-CQABZkGgxX7AaBojHQXCCdAUABuT0IZCwrQARqhcBQAO7QKa07D4AHE54IxAnFwcorUFTAiHgxqiAW2KGbba0PYypEo9GYhJdSCgCAwODZQT0ECMSDsNCDKgLfbUJBGhTOH6wmwARl80A8FKofDKrlt1BEfioPAAtrTCO7oJ6qABmPzUigUXCoJRlTqQKDYHZ1bUm9TW9IhQwzOaLFbraVw0WBU0yi2oJHfFyJxPJ1PGgBCmZc7jyefm0E+Z2ttZVSbVYF10AAsvgdZr9Sm9Io5pnEvhWp9VbNkC41hypumFqtHCGZRHcYQeOh4mc-tBADLkB4szSmfQAjjwyH0MGc-RiaII+Butzu93PbFr1vGxmiUDBQOoMNmSfF83w-L8fz-QFtwhBYLxxQBQchQoEAPqUNvWgO1VlDI8SBPM9MOgHCfk3VD8P3UM7T8AByZ5o1Y0iZSIkioPDFFKI6ajaNcXC0MaJsRPE9Mm0A6ib1MSo0HMVBIJBRp+KAA)