### PR TITLE
fix(runtime-core): catch undefined element

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -335,10 +335,10 @@ export function resolveTransitionHooks(
       if (
         leavingVNode &&
         isSameVNodeType(vnode, leavingVNode) &&
-        leavingVNode.el!._leaveCb
+        leavingVNode.el?._leaveCb
       ) {
         // force early removal (not cancelled)
-        leavingVNode.el!._leaveCb()
+        leavingVNode.el._leaveCb()
       }
       callHook(hook, [el])
     },


### PR DESCRIPTION
Right now, when the element of `leavingVNode` is null it will fail and throw an exception. This PR will only call the callback if the element is set.