### PR TITLE
fix(runtime-dom): "el._assign is not a function" in compat mode

### DIFF
--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -18,7 +18,7 @@ import {
 type AssignerFn = (value: any) => void
 
 const getModelAssigner = (vnode: VNode): AssignerFn => {
-  const fn = vnode.props!['onUpdate:modelValue'] || vnode.props!['onModelCompat:input']
+  const fn = vnode.props!['onUpdate:modelValue'] || (__COMPAT__ && vnode.props!['onModelCompat:input'])
   return isArray(fn) ? value => invokeArrayFns(fn, value) : fn
 }
 

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -18,7 +18,7 @@ import {
 type AssignerFn = (value: any) => void
 
 const getModelAssigner = (vnode: VNode): AssignerFn => {
-  const fn = vnode.props!['onUpdate:modelValue']
+  const fn = vnode.props!['onUpdate:modelValue'] || vnode.props!['onModelCompat:input']
   return isArray(fn) ? value => invokeArrayFns(fn, value) : fn
 }
 


### PR DESCRIPTION
In compat mode `el._assign is not a function` is thrown when you bind a model to a radio button because `onUpdate:modelValue` does not exist in the props. As far as I could see in compat mode it's called `onModelCompat:input` instead:
https://github.com/vuejs/vue-next/blob/4f17be7b1ce4872ded085a36b95c1897d8c1f299/packages/runtime-core/src/compat/componentVModel.ts#L38-L40

I created a reproducible repository here:
https://github.com/jaulz/vue-repro