### PR TITLE
perf(scheduler): remove unnecessary statement currentPreParentJob

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -211,6 +211,8 @@ describe('scheduler', () => {
 
     it('preFlushCb inside queueJob', async () => {
       const calls: string[] = []
+
+      // job1.allowRecurse is undefined, so it equal to false
       const job1 = () => {
         // the only case where a pre-flush cb can be queued inside a job is
         // when updating the props of a child component. This is handled
@@ -218,12 +220,12 @@ describe('scheduler', () => {
         // cb triggers (#1763)
         queuePreFlushCb(cb1)
         queuePreFlushCb(cb2)
-        flushPreFlushCbs(undefined, job1)
+        flushPreFlushCbs()
         calls.push('job1')
       }
       const cb1 = () => {
         calls.push('cb1')
-        // a cb triggers its parent job, which should be skipped
+        // with job1.allowRecurse false,it won't be added into queue again
         queueJob(job1)
       }
       const cb2 = () => {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1593,7 +1593,7 @@ function baseCreateRenderer(
     pauseTracking()
     // props update may have triggered pre-flush watchers.
     // flush them before the render update.
-    flushPreFlushCbs(undefined, instance.update)
+    flushPreFlushCbs()
     resetTracking()
   }
 


### PR DESCRIPTION
`currentPreParentJob` added in [#1777](https://github.com/vuejs/vue-next/issues/1777),it aims to resolve the duplicate render by pre-flush watchers.But in v3.2.0 the example of [#1777](https://github.com/vuejs/vue-next/issues/1777), it still render twice when prop `value` change.(because in function `triggerEffect()`, it'll be added into queue by effect.allowRecurse)

Later in v3.2.4, this issue fixed by set `allowRecurse` to `false` before function `updateComponentPreRender()`.

So it's time to delete it.