### PR TITLE
Safely access old bindings on directive hooks

### DIFF
--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -128,7 +128,7 @@ export function invokeDirectiveHook(
   const oldBindings = prevVNode && prevVNode.dirs!
   for (let i = 0; i < bindings.length; i++) {
     const binding = bindings[i]
-    if (oldBindings) {
+    if (oldBindings && oldBindings[i]) {
       binding.oldValue = oldBindings[i].value
     }
     let hook = binding.dir[name] as DirectiveHook | DirectiveHook[] | undefined


### PR DESCRIPTION
I'm not exactly sure how I got to this state, but when debugging the code I see `bindings` having two items while `oldBindings` only have one item.

There is really nothing special on my code, just a common directive used normally.