### PR TITLE
feat(types): add v-model to props

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -25,36 +25,10 @@ import {
   CreateComponentPublicInstance,
   ComponentPublicInstanceConstructor
 } from './componentPublicInstance'
-import { UnionToIntersection } from './helpers/typeUtils'
 
 export type PublicProps = VNodeProps &
   AllowedComponentProps &
   ComponentCustomProps
-
-
-type Flatten<T> = { [K in keyof T]: T[K] }
-
-type MakeModelTypes<Props extends {}> = Flatten<UnionToIntersection<
-{
-  [K in keyof Props]: { [k in K]: Props[k] } & (
-    K extends `onUpdate:${infer U}`         // has update event
-      ? Props extends { [k in U]: infer V } // and matching prop
-        ? U extends 'modelValue'            // and prop is the default v-model
-          ? { [k in `v-model:${U}`]: V } & { 'v-model': V }
-          : { [k in `v-model:${U}`]: V }
-        : Props extends { [k in U]?: infer V } // and matching prop (optional)
-          ? U extends 'modelValue'             // and prop is the default v-model
-            ? { [k in `v-model:${U}`]?: V } & { 'v-model'?: V }
-            : { [k in `v-model:${U}`]?: V }
-          : {}
-      : {}
-  )
-}[keyof Props] & {}>>
-
-type T = MakeModelTypes<{
-  modelValue: string,
-  'onUpdate:modelValue': (v: string) => any
-}>
 
 export type DefineComponent<
   PropsOrPropOptions = {},
@@ -80,7 +54,7 @@ export type DefineComponent<
     Mixin,
     Extends,
     E,
-    PP & MakeModelTypes<Props>,
+    PP & Props,
     Defaults,
     true
   > &

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -971,25 +971,118 @@ describe('emits', () => {
 
   // with tsx
   const Component = defineComponent({
-    props: {
-      modelValue: {
-        type: String,
-        required: true,
-      },
-    },
     emits: {
-      'update:modelValue': (n: string) => typeof n === 'string',
+      click: (n: number) => typeof n === 'number'
+    },
+    setup(props, { emit }) {
+      expectType<((n: number) => any) | undefined>(props.onClick)
+      emit('click', 1)
+      //  @ts-expect-error
+      expectError(emit('click'))
+      //  @ts-expect-error
+      expectError(emit('click', 'foo'))
     }
   })
 
   defineComponent({
     render() {
-      const model = { value: '2' }
       return (
-        <Component v-model={ model.value } />
+        <Component
+          onClick={(n: number) => {
+            return n + 1
+          }}
+        />
       )
     }
   })
+
+  // Optional model
+  {
+    const Component = defineComponent({
+      props: {
+        modelValue: String,
+        value: Number
+      },
+      emits: {
+        'update:modelValue': (n: string) => typeof n === 'string',
+      },
+      setup (props) {
+        // @ts-expect-error
+        props['v-model']
+      }
+    })
+    ;[
+      <Component />,
+      <Component value={ 3 } />,
+      <Component v-model="3" />,
+      <Component modelValue="3" />,
+      <Component v-model:modelValue="3" />,
+      <Component v-model="3" value={ 3 } />,
+      <Component modelValue="3" value={ 3 } />,
+      <Component v-model:modelValue="3" value={ 3 } />,
+    ]
+  }
+
+  // Required model
+  {
+    const Component = defineComponent({
+      props: {
+        modelValue: {
+          type: String,
+          required: true,
+        },
+        value: Number
+      },
+      emits: {
+        'update:modelValue': (n: string) => typeof n === 'string',
+      },
+      setup (props) {
+        // @ts-expect-error
+        props['v-model']
+      }
+    })
+    ;[
+      // @ts-expect-error
+      <Component />,
+      // @ts-expect-error
+      <Component value={ 3 } />,
+      <Component v-model="3" />,
+      <Component modelValue="3" />,
+      <Component v-model:modelValue="3" />,
+      <Component v-model="3" value={ 3 } />,
+      <Component modelValue="3" value={ 3 } />,
+      <Component v-model:modelValue="3" value={ 3 } />,
+    ]
+  }
+
+  // Multiple models
+  {
+    const Component = defineComponent({
+      props: {
+        modelValue: {
+          type: String,
+          required: true,
+        },
+        value: {
+          type: Number,
+          required: true,
+        }
+      },
+      emits: {
+        'update:modelValue': (n: string) => typeof n === 'string',
+        'update:value': (n: number) => typeof n === 'number',
+      }
+    })
+    ;[
+      // @ts-expect-error
+      <Component />,
+      // @ts-expect-error
+      <Component value={ 3 } />,
+      // @ts-expect-error
+      <Component modelValue="3" />,
+      <Component v-model="3" v-model:value={ 3 } />,
+    ]
+  }
 
   // without emits
   defineComponent({

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -891,15 +891,6 @@ describe('defineComponent', () => {
 })
 
 describe('emits', () => {
-  // Note: for TSX inference, ideally we want to map emits to onXXX props,
-  // but that requires type-level string constant concatenation as suggested in
-  // https://github.com/Microsoft/TypeScript/issues/12754
-
-  // The workaround for TSX users is instead of using emits, declare onXXX props
-  // and call them instead. Since `v-on:click` compiles to an `onClick` prop,
-  // this would also support other users consuming the component in templates
-  // with `v-on` listeners.
-
   // with object emits
   defineComponent({
     emits: {
@@ -980,27 +971,22 @@ describe('emits', () => {
 
   // with tsx
   const Component = defineComponent({
-    emits: {
-      click: (n: number) => typeof n === 'number'
+    props: {
+      modelValue: {
+        type: String,
+        required: true,
+      },
     },
-    setup(props, { emit }) {
-      expectType<((n: number) => any) | undefined>(props.onClick)
-      emit('click', 1)
-      //  @ts-expect-error
-      expectError(emit('click'))
-      //  @ts-expect-error
-      expectError(emit('click', 'foo'))
+    emits: {
+      'update:modelValue': (n: string) => typeof n === 'string',
     }
   })
 
   defineComponent({
     render() {
+      const model = { value: '2' }
       return (
-        <Component
-          onClick={(n: number) => {
-            return n + 1
-          }}
-        />
+        <Component v-model={ model.value } />
       )
     }
   })


### PR DESCRIPTION
Related: https://github.com/vuejs/jsx-next/pull/496

Any prop with a corresponding `onUpdate:` prop will be converted to a union of itself and `v-model:${name}`

There was some concern about this adding unwanted `v-bind:v-model` suggestions in volar, that may need to be addressed separately. 