### PR TITLE
fix(BaseTransition): avoid flat children if fragment is stable and keyed

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -465,9 +465,13 @@ export function getTransitionRawChildren(
     // handle fragment children case, e.g. v-for
     if (child.type === Fragment) {
       if (child.patchFlag & PatchFlags.KEYED_FRAGMENT) keyedFragmentCount++
-      ret = ret.concat(
-        getTransitionRawChildren(child.children as VNode[], keepComment)
-      )
+      if (child.patchFlag & PatchFlags.STABLE_FRAGMENT && child.key != null) {
+        ret.push(child)
+      } else {
+        ret = ret.concat(
+          getTransitionRawChildren(child.children as VNode[], keepComment)
+        )
+      }
     }
     // comment placeholders should be skipped, e.g. v-if
     else if (keepComment || child.type !== Comment) {

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -464,10 +464,10 @@ export function getTransitionRawChildren(
     const child = children[i]
     // handle fragment children case, e.g. v-for
     if (child.type === Fragment) {
-      if (child.patchFlag & PatchFlags.KEYED_FRAGMENT) keyedFragmentCount++
       if (child.patchFlag & PatchFlags.STABLE_FRAGMENT && child.key != null) {
         ret.push(child)
       } else {
+        if (child.patchFlag & PatchFlags.KEYED_FRAGMENT) keyedFragmentCount++
         ret = ret.concat(
           getTransitionRawChildren(child.children as VNode[], keepComment)
         )

--- a/packages/vue/__tests__/TransitionGroup.spec.ts
+++ b/packages/vue/__tests__/TransitionGroup.spec.ts
@@ -508,4 +508,20 @@ describe('e2e: TransitionGroup', () => {
 
     expect(`<TransitionGroup> children must be keyed`).toHaveBeenWarned()
   })
+
+  test('should not warn v-for + template', () => {
+    createApp({
+      template: `
+        <transition-group name="test">
+          <template v-for="item in items" key="item">{{item}}</template>
+        </transition-group>
+            `,
+      setup: () => {
+        const items = ref(['a', 'b', 'c'])
+        return { items }
+      }
+    }).mount(document.createElement('div'))
+
+    expect(`<TransitionGroup> children must be keyed`).not.toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
fix #4718 
Actually, I'm not sure this is the right fix😵