### PR TITLE
fix(custom-elements): ensure props are available before initial render (fix #4716))

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -191,13 +191,21 @@ describe('defineCustomElement', () => {
 
     test('handling properties set before upgrading', () => {
       const E = defineCustomElement({
-        props: ['foo'],
+        props: {
+          foo: String,
+          dataAge: Number
+        },
+        setup(props) {
+          expect(props.foo).toBe('hello')
+          expect(props.dataAge).toBe(5)
+        },
         render() {
           return `foo: ${this.foo}`
         }
       })
       const el = document.createElement('my-el-upgrade') as any
       el.foo = 'hello'
+      el.dataset.age = 5
       container.appendChild(el)
       customElements.define('my-el-upgrade', E)
       expect(el.shadowRoot.innerHTML).toBe(`foo: hello`)

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -233,7 +233,7 @@ export class VueElement extends BaseClass {
       }
       if (numberProps) {
         this._numberProps = numberProps
-        this._update()
+        // this._update()
       }
 
       // check if there are props set pre-upgrade or connect
@@ -258,7 +258,9 @@ export class VueElement extends BaseClass {
 
     const asyncDef = (this._def as ComponentOptions).__asyncLoader
     if (asyncDef) {
-      asyncDef().then(resolve)
+      asyncDef()
+        .then(resolve)
+        .then(() => this._update())
     } else {
       resolve(this._def)
     }


### PR DESCRIPTION
This PR fixes a case where props with type "Number" lead to a premature first render - before the initial component props have been collected from the DOM element properties that have been set.


close #4716