### PR TITLE
test(reactivity): delete unnecessary async in tests

### DIFF
--- a/packages/reactivity/__tests__/deferredComputed.spec.ts
+++ b/packages/reactivity/__tests__/deferredComputed.spec.ts
@@ -107,7 +107,7 @@ describe('deferred computed', () => {
     expect(effectSpy).toHaveBeenCalledTimes(1)
   })
 
-  test('chained computed value invalidation', async () => {
+  test('chained computed value invalidation', () => {
     const effectSpy = jest.fn()
     const c1Spy = jest.fn()
     const c2Spy = jest.fn()


### PR DESCRIPTION
delete unnecessary async in the deferredComputed test