### PR TITLE
fix(reactivity): ios10.x TypeError "arguments","callee" and "caller" …

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -33,6 +33,12 @@ const isNonTrackableKeys = /*#__PURE__*/ makeMap(`__proto__,__v_isRef,__isVue`)
 
 const builtInSymbols = new Set(
   Object.getOwnPropertyNames(Symbol)
+    .filter(key => {
+      // ios10.x Object.getOwnPropertyNames(Symbol) can enumerate 'arguments' and 'caller'
+      // fix TypeError "arguments","callee" and "caller" cannot be accessed in strict mode vue
+      const excludes = ['arguments', 'caller'];
+      return !excludes.includes(key);
+    })
     .map(key => (Symbol as any)[key])
     .filter(isSymbol)
 )

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -33,12 +33,10 @@ const isNonTrackableKeys = /*#__PURE__*/ makeMap(`__proto__,__v_isRef,__isVue`)
 
 const builtInSymbols = new Set(
   Object.getOwnPropertyNames(Symbol)
-    .filter(key => {
-      // ios10.x Object.getOwnPropertyNames(Symbol) can enumerate 'arguments' and 'caller'
-      // fix TypeError "arguments","callee" and "caller" cannot be accessed in strict mode vue
-      const excludes = ['arguments', 'caller'];
-      return !excludes.includes(key);
-    })
+    // ios10.x Object.getOwnPropertyNames(Symbol) can enumerate 'arguments' and 'caller'
+    // but accessing them on Symbol leads to TypeError because Symbol is a strict mode
+    // function
+    .filter(key => key !== 'arguments' && key !== 'caller')
     .map(key => (Symbol as any)[key])
     .filter(isSymbol)
 )


### PR DESCRIPTION
### Problem

use babel handle vue3 source to ES5:

```JavaScript
// vue.config.js
module.exports = {
  transpileDependencies: [/@vue\/*/],
}
```

in ios10.x create blank html，because Object.getOwnPropertyNames(Symbol) can enumerate 'arguments' and 'caller'

the browser threw an exception TypeError "arguments","callee" and "caller" cannot be accessed in strict mode

fix #2457