### PR TITLE
fix(runtime-core): ensure track block when createVNode receiving an existing vnode

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -504,6 +504,13 @@ function _createVNode(
     if (children) {
       normalizeChildren(cloned, children)
     }
+
+    // #4903 should track as a block if receiving an existing vnode and
+    // force bail out of optimized mode when patching it.
+    if (isBlockTreeEnabled > 0 && currentBlock) {
+      cloned.patchFlag |= PatchFlags.BAIL
+      currentBlock.push(cloned)
+    }
     return cloned
   }
 


### PR DESCRIPTION
fix #4903 