### PR TITLE
fix(shared): Parse string value including a leading number as string value

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -145,9 +145,9 @@ export const def = (obj: object, key: string | symbol, value: any) => {
   })
 }
 
-export const toNumber = (val: any): any => {
-  const n = parseFloat(val)
-  return isNaN(n) ? val : n
+export const toNumber = (value: any): any => {
+  const parsedValue = Number(value)
+  return isNaN(parsedValue) ? value : parsedValue
 }
 
 let _globalThis: any


### PR DESCRIPTION
## Motivation

[`defineCustomElement`](https://github.com/vuejs/vue-next/blob/master/packages/runtime-dom/src/apiCustomElement.ts#L272) uses [`toNumber`](https://github.com/vuejs/vue-next/blob/master/packages/shared/src/index.ts#L148) to parse the attribute value and check if the value is number or not.

Currently, toNumber uses parseFloat and returns  number value if parseFloat does not return a NaN.
However, parseFloat does not parse strictly, values including chars other than numbers will also be parsed as Number.

According to MDN, it is better to use Number() for strict parsing, so I created this PR.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat

## Changes

- parse a value using `Number(value)`

[playground](https://www.typescriptlang.org/play?ssl=17&ssc=1&pln=18&pc=1#code/MYewdgzgLgBFIDkCuBbARgUwE4H1hKywzFgF4YAKANwEMAbALhhrAE8BKJl1mUgPhgBvAFAwYoSLDC8YABxpYIGAGJ0QNKNXrtRMIlALSAlhAQ0EFMOxgB+GLTowmYYQF9hwidDiJUmXLJYMlp0SBhcbJzMbLwCImJesPKKGAAmAGr0YTLI6NghYTpi+oYwJmYWyUoZWRjWdg7ZTFVpmaEYbh5eIHQYAHRqAOYU8Ln+eAREJBQAjAAMc+zsANwwAPRrMPNznuAQPf1DI755uPiExJrbfQszS6sbWws3czMwu5AHAyDDo37YEwu0wARNtgfd1ptth99r1vr8TuNzlNNKDnrdwStIU85i83jCvkc-qdASiKGi5gBaaBYIxgQaYh5QhYwAA85AoNAglJM1jpsiQsEaGDKEBgNLpg3stQANDA0IKYCBBQLYCYYGB-kFhX0untCT9jmMAYFZgsIY9od04UTESasGbcbcLcyna8CTbDcTxqaKYzsVb9Z6EcaAg6KXj-Zb0e7rYcvXaw+TttSoLT6VHNhTU+mGWyOfBKZhrMqoKrmHR9qLxWnJdL2rqgA)

```ts
const toNumber_current = (val: any): any => {
  const n = parseFloat(val)
  return isNaN(n) ? val : n
}

const toNumber_pr = (value: any): any => {
  const parsedValue = Number(value)
  return isNaN(parsedValue) ? value : parsedValue
}

console.log(toNumber_current(100)); // 100
console.log(toNumber_current(100.001)); // 100.001 
console.log(toNumber_current("100")); // 100
console.log(toNumber_current("100.001")); // 100.001 
console.log(toNumber_current("100-string")); // 100 <= (as-is) input value is string value, but output is number value.

console.log(toNumber_pr(100)); // 100
console.log(toNumber_pr(100.001)); // 100.001
console.log(toNumber_pr("100")); // 100
console.log(toNumber_pr("100.001")); // 100.001
console.log(toNumber_pr("100-string")); // "100-string" <= (to-be) output also is string value.
```