### PR TITLE
feat(runtime-core): set currentInstance during hook execution for custom directives(close: #5002)

### DIFF
--- a/packages/runtime-core/__tests__/directives.spec.ts
+++ b/packages/runtime-core/__tests__/directives.spec.ts
@@ -7,7 +7,10 @@ import {
   DirectiveHook,
   VNode,
   DirectiveBinding,
-  nextTick
+  nextTick,
+  Directive,
+  ComponentPublicInstance,
+  getCurrentInstance
 } from '@vue/runtime-test'
 import { currentInstance, ComponentInternalInstance } from '../src/component'
 
@@ -394,5 +397,30 @@ describe('directives', () => {
     await nextTick()
     expect(beforeUpdate).toHaveBeenCalledTimes(1)
     expect(count.value).toBe(1)
+  })
+
+  test('should have currentInstance available', async () => {
+    let instance: ComponentInternalInstance | null
+    let bindingInstance: ComponentPublicInstance | null
+    const beforeMount: Directive = (_, binding) => {
+      instance = getCurrentInstance()
+      bindingInstance = binding.instance
+    }
+    const App = {
+      render() {
+        return withDirectives(h('p', 'Test'), [
+          [
+            {
+              beforeMount
+            }
+          ]
+        ])
+      }
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(App), root)
+    expect(instance!).not.toBe(null)
+    expect(instance!.proxy).toBe(bindingInstance!)
   })
 })

--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -14,7 +14,12 @@ return withDirectives(h(comp), [
 import { VNode } from './vnode'
 import { isFunction, EMPTY_OBJ, makeMap } from '@vue/shared'
 import { warn } from './warning'
-import { ComponentInternalInstance, Data } from './component'
+import {
+  ComponentInternalInstance,
+  Data,
+  setCurrentInstance,
+  unsetCurrentInstance
+} from './component'
 import { currentRenderingInstance } from './componentRenderContext'
 import { callWithAsyncErrorHandling, ErrorCodes } from './errorHandling'
 import { ComponentPublicInstance } from './componentPublicInstance'
@@ -139,12 +144,14 @@ export function invokeDirectiveHook(
       // disable tracking inside all lifecycle hooks
       // since they can potentially be called inside effects.
       pauseTracking()
+      instance && setCurrentInstance(instance)
       callWithAsyncErrorHandling(hook, instance, ErrorCodes.DIRECTIVE_HOOK, [
         vnode.el,
         binding,
         vnode,
         prevVNode
       ])
+      unsetCurrentInstance()
       resetTracking()
     }
   }


### PR DESCRIPTION
This PR sets `currentInstance` before hook calls, unsets it afterwards.

This allows for the following APIS to be used in custom directives:

* `getCurrentInstance()`
* `inject()`
* `provide()`
* lifecycle hooks like `onUpdated()` (not sure if this is a good idea)

### Alternatives

I'm not yet convinced that this is the best solution. 

Specifically, I'm not sure if the breadth of "setup" APIs exposed to custom directives by this is really desirable, or if we should limit it to `provide/inject`, for which we could expose special versions through `binding()` on the binding - i.e binding.inject()? That would require more new code to be introduced though.

close: #5002