### PR TITLE
fix(types): fix the `VNodeRef` type

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -68,7 +68,7 @@ export type VNodeTypes =
 export type VNodeRef =
   | string
   | Ref
-  | ((ref: object | null, refs: Record<string, any>) => void)
+  | ((ref: any, refs: Record<string, any>) => void)
 
 export type VNodeNormalizedRefAtom = {
   i: ComponentInternalInstance

--- a/test-dts/vnode.test-d.ts
+++ b/test-dts/vnode.test-d.ts
@@ -1,0 +1,16 @@
+import {
+  ref,
+  createElementVNode
+} from './index'
+
+describe('createElementVNode with ref', () => {
+  const divRef = ref<HTMLElement>()
+  
+  // #4954
+  createElementVNode("div", {
+    ref: (_value, _refs) => {
+      _refs['divRef'] = _value
+      divRef.value = _value
+    }
+  }, "Hello World", 512 /* NEED_PATCH */)
+})


### PR DESCRIPTION
Fix: #4954
````vue
<template>
  <div ref="div">Hello World</div>
  <div> </div>
</template>
<script setup lang="ts">
import { ref } from 'vue'

const div = ref<HTMLElement>()
</script>
````
The above code will be compiled to:
![impicture_20211204_211832](https://user-images.githubusercontent.com/26522151/144710946-47200046-1764-43a3-b82e-5c9cf4b08f9f.png)

**Please note that it's TS.**
````ts
import { defineComponent as _defineComponent } from 'vue'
import { createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"

const _hoisted_1 = /*#__PURE__*/_createElementVNode("div", null, null, -1 /* HOISTED */)

_defineComponent({
  setup(__props) {
  
  const div = ref<HTMLElement>()  

  return (_ctx: any,_cache: any) => {
    return (_openBlock(), _createElementBlock(_Fragment, null, [
      _createElementVNode("div", {
        ref: (_value, _refs) => {
          _refs['div'] = _value
          div.value = _value
        }
      }, "Hello World", 512 /* NEED_PATCH */),
      _hoisted_1
      ], 64 /* STABLE_FRAGMENT */))
    }
  }

})
````

We just need generate ast node at here. 
https://github.com/vuejs/vue-next/blob/772574febb95b9ad79d0381455d10dc52880bfb6/packages/compiler-core/src/transforms/transformElement.ts#L477
So `_value`‘s type isn't used for developer, `any` is enough. We don't need accurate type.