### PR TITLE
feat(types): expose jsx prop types for outside expand

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -89,7 +89,7 @@ export type VNodeHook =
   | VNodeUpdateHook[]
 
 // https://github.com/microsoft/TypeScript/issues/33099
-export type VNodeProps = {
+export interface VNodeProps {
   key?: string | number | symbol
   ref?: VNodeRef
 

--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1306,7 +1306,7 @@ type EventHandlers<E> = {
 // named imports.
 import * as RuntimeCore from '@vue/runtime-core'
 
-type ReservedProps = {
+export interface ReservedProps {
   key?: string | number | symbol
   ref?:
     | string

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -327,7 +327,7 @@ function applySSRDirectives(
   rawProps: VNodeProps | null,
   dirs: DirectiveBinding[]
 ): VNodeProps {
-  const toMerge: VNodeProps[] = []
+  const toMerge: Record<string, unknown>[] = []
   for (let i = 0; i < dirs.length; i++) {
     const binding = dirs[i]
     const {
@@ -338,7 +338,7 @@ function applySSRDirectives(
       if (props) toMerge.push(props)
     }
   }
-  return mergeProps(rawProps || {}, ...toMerge)
+  return mergeProps((rawProps || {}) as Record<string, unknown>, ...toMerge)
 }
 
 function renderTeleportVNode(


### PR DESCRIPTION
expose jsx prop types so we can expand it outside.

``` typescript
declare module 'vue' {
  interface VNodeProps {
    'v-show'?: boolean
  }
  interface ReservedProps {
    'v-show'?: boolean
  }
}
```
now we can get intelligent in ide

![image](https://user-images.githubusercontent.com/11799110/144733011-3d9f0545-29e0-4a17-88c7-07bbd2f7a1d0.png)

