### PR TITLE
fix(reactivity): mutating a readonly ref nested in a reactive object should fail. (close #5042)

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -474,4 +474,15 @@ describe('reactivity/readonly', () => {
     expect(rr.foo).toBe(r)
     expect(isReadonly(rr.foo)).toBe(true)
   })
+
+  test('attemptingt to write to a readonly ref nested in a reactive object should fail', () => {
+    const r = ref(false)
+    const ror = readonly(r)
+    const obj = reactive({ ror })
+    try {
+      obj.ror = true
+    } catch (e) {}
+
+    expect(obj.ror).toBe(false)
+  })
 })

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -147,6 +147,9 @@ function createSetter(shallow = false) {
     receiver: object
   ): boolean {
     let oldValue = (target as any)[key]
+    if (isReadonly(oldValue) && isRef(oldValue)) {
+      return false
+    }
     if (!shallow && !isReadonly(value)) {
       value = toRaw(value)
       oldValue = toRaw(oldValue)


### PR DESCRIPTION
When we have a readonly _object_ nested in another reactive object, attempting to write to a property of that readonly object fails, as expected.
```js
const state = reactive({
  subState: readonly(reactive({ msg: 'Hello' }))
})
state.subState.msg = 'Bye' // => fails as `subState` is readonly
```

But if we have a readonly _ref_ nested in a reactive object, it successfully writes to it.

```js
const state = reactive({
  msg: readonly(ref('Hello' ))
})
state.msg = 'Bye' // => succeeds even though `msg` is a readonly ref.
```

This PR fixes that edge case.

### Open questions

* Is the behavior introduced by this PR the desired one?
* Is this a "risky fix" as it may break code that works in current user projects?

fix: #5042