### PR TITLE
fix(runtime-dom): Ensure custom Elements can inherit provides from ancestors (fix: #5096)

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -354,6 +354,7 @@ export class VueElement extends BaseClass {
         ) {
           if (parent instanceof VueElement) {
             instance.parent = parent._instance
+            instance.provides = parent._instance!.provides
             break
           }
         }


### PR DESCRIPTION
Without this patch, components in custom element mode would only be able to inherit provides from the first ancestor instance, anything provided further up the tree would not be available.

This PR ensures that each instance inherits its ancestors `provides`, ensureing any descendants have access to all provides.

fix: #5096