### PR TITLE
fix(ssr): don't warn for missing teleport target if disabled

### DIFF
--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -356,7 +356,9 @@ function renderTeleportVNode(
   const target = vnode.props && vnode.props.to
   const disabled = vnode.props && vnode.props.disabled
   if (!target) {
-    warn(`[@vue/server-renderer] Teleport is missing target prop.`)
+    if (!disabled) {
+      warn(`[@vue/server-renderer] Teleport is missing target prop.`)
+    }
     return []
   }
   if (!isString(target)) {


### PR DESCRIPTION
This warning is spamming my build logs, and already has this condition at runtime:
https://github.com/vuejs/vue-next/blob/44b95276f5c086e1d88fa3c686a5f39eb5bb7821/packages/runtime-core/src/components/Teleport.ts#L58-L60