### PR TITLE
types: relax TextareaHTMLAttributes.value type requirement

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -707,7 +707,7 @@ export interface TextareaHTMLAttributes extends HTMLAttributes {
   readonly?: Booleanish
   required?: Booleanish
   rows?: Numberish
-  value?: string | string[] | number
+  value?: any // we support :value to be bound to anything w/ v-model
   wrap?: string
 }
 


### PR DESCRIPTION
Similar to 93949ed2 and 6171aecd but this time to allow `textarea` to have a `v-model` with a null value for example.