### PR TITLE
fix(ssr): render teleport inside async component

### DIFF
--- a/packages/server-renderer/__tests__/ssrTeleport.spec.ts
+++ b/packages/server-renderer/__tests__/ssrTeleport.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { createApp, h, Teleport } from 'vue'
+import { createApp, createSSRApp, h, Teleport } from 'vue'
 import { renderToString } from '../src/renderToString'
 import { SSRContext } from '../src/render'
 import { ssrRenderTeleport } from '../src/helpers/ssrRenderTeleport'
@@ -116,5 +116,22 @@ describe('ssrRenderTeleport', () => {
     expect(ctx.teleports!['#target']).toBe(
       '<span>hello</span><!---->world<!---->'
     )
+  })
+
+  test('teleport inside async component', async () => {
+    const ctx: SSRContext = {}
+    const asyncComponent = {
+      template: '<teleport to="#target"><div>content</div></teleport>',
+      async setup() {}
+    }
+    const html = await renderToString(
+      createSSRApp({
+        template: '<async-component />',
+        components: { asyncComponent }
+      }),
+      ctx
+    )
+    expect(html).toBe('<!--teleport start--><!--teleport end-->')
+    expect(ctx.teleports!['#target']).toBe(`<div>content</div><!---->`)
   })
 })

--- a/packages/server-renderer/__tests__/ssrTeleport.spec.ts
+++ b/packages/server-renderer/__tests__/ssrTeleport.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { createApp, createSSRApp, h, Teleport } from 'vue'
+import { createApp, h, Teleport } from 'vue'
 import { renderToString } from '../src/renderToString'
 import { SSRContext } from '../src/render'
 import { ssrRenderTeleport } from '../src/helpers/ssrRenderTeleport'
@@ -125,7 +125,7 @@ describe('ssrRenderTeleport', () => {
       async setup() {}
     }
     const html = await renderToString(
-      createSSRApp({
+      h({
         template: '<async-component />',
         components: { asyncComponent }
       }),

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -63,9 +63,11 @@ export async function renderToString(
   input.provide(ssrContextKey, context)
   const buffer = await renderComponentVNode(vnode)
 
+  const result = await unrollBuffer(buffer as SSRBuffer)
+
   await resolveTeleports(context)
 
-  return unrollBuffer(buffer as SSRBuffer)
+  return result
 }
 
 async function resolveTeleports(context: SSRContext) {


### PR DESCRIPTION
Teleports inside async components weren't SSR rendered into the `ctx.teleports` but were in the `ctx.__teleportBuffers`. This PR fixes the issue.