### PR TITLE
fix(compat): ensure fallthrough *Native events are not dropped during props update (fix #5222)

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -303,7 +303,11 @@ export function updateProps(
     // attrs point to the same object so it should already have been updated.
     if (attrs !== rawCurrentProps) {
       for (const key in attrs) {
-        if (!rawProps || !hasOwn(rawProps, key)) {
+        if (
+          !rawProps ||
+          (!hasOwn(rawProps, key) &&
+            (!__COMPAT__ || !hasOwn(rawProps, key + 'Native')))
+        ) {
           delete attrs[key]
           hasAttrsChanged = true
         }


### PR DESCRIPTION
This PR solves #5222 where a fallthrough event listener from a Vue 2 `v-bind.native` was removed on a component re-render.

I would need some guidance regarding how to add a test for this.