### PR TITLE
fix(ssr): hydrate strings in fragments

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@vue/runtime-dom'
 import { renderToString, SSRContext } from '@vue/server-renderer'
 import { PatchFlags } from '../../shared/src'
+import { renderSlot } from '../src/helpers/renderSlot'
 
 function mountWithHydration(html: string, render: () => any) {
   const container = document.createElement('div')
@@ -849,6 +850,26 @@ describe('SSR hydration', () => {
         ])
     )
     expect((container.firstChild!.firstChild as any)._value).toBe(true)
+  })
+
+  test('components with fragments', () => {
+    const { container } = mountWithHydration(
+      '<!--[-->foo<!--]-->',
+      () =>
+        h(defineComponent({
+          props: {
+            title: {
+              type: String,
+              required: true,
+            },
+          },
+
+          render() {
+            return renderSlot(this.$slots, 'title', undefined, () => [this.title])
+          }
+        }), { title: 'foo' })
+    )
+    expect(container.textContent).toBe('foo')
   })
 
   describe('mismatch handling', () => {

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -385,7 +385,6 @@ export function createHydrationFunctions(
     slotScopeIds: string[] | null,
     optimized: boolean
   ): Node | null => {
-    optimized = optimized || !!parentVNode.dynamicChildren
     const children = parentVNode.children as VNode[]
     const l = children.length
     let hasWarned = false


### PR DESCRIPTION
Right now, it seems that the `hydrateChildren` function optimizes too much. When you have a custom component that uses `renderSlot` and that renders a simple string it fails:
![image](https://user-images.githubusercontent.com/5358638/148933640-6cad64d4-d0c9-41c4-847c-253a8d547fe4.png)

![image](https://user-images.githubusercontent.com/5358638/148933557-4c03c483-01e8-48d6-9ee4-498517f848dc.png)

This PR removes the current check `optimized = optimized || !!parentVNode.dynamicChildren` so strings are converted to VNodes before they are compared in `hydrateNode`:
https://github.com/vuejs/vue-next/blob/92f11d6740929f5b591740e30ae5fba50940ec82/packages/runtime-core/src/hydration.ts#L379-L430
