### PR TITLE
fix(reactivity): calling unref() with ref(value: object) should not return reactive

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -194,6 +194,12 @@ describe('reactivity/ref', () => {
   test('unref', () => {
     expect(unref(1)).toBe(1)
     expect(unref(ref(1))).toBe(1)
+
+    const foo = {
+      bar: 1
+    }
+    expect(isReactive(unref(ref(foo)))).toBe(false) // should not be reactive
+    expect(unref(ref(foo))).toBe(foo)
   })
 
   test('shallowRef', () => {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -127,11 +127,7 @@ export function triggerRef(ref: Ref) {
 }
 
 export function unref<T>(ref: T | Ref<T>): T {
-  if (isRef(ref)) {
-    return ref._shallow ? ref.value : toRaw(ref.value)
-  } else {
-    return ref
-  }
+  return isRef(ref) ? (toRaw(ref.value) as any) : ref
 }
 
 const shallowUnwrapHandlers: ProxyHandler<any> = {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -127,7 +127,11 @@ export function triggerRef(ref: Ref) {
 }
 
 export function unref<T>(ref: T | Ref<T>): T {
-  return isRef(ref) ? (ref.value as any) : ref
+  if (isRef(ref)) {
+    return ref._shallow ? ref.value : toRaw(ref.value)
+  } else {
+    return ref
+  }
 }
 
 const shallowUnwrapHandlers: ProxyHandler<any> = {


### PR DESCRIPTION
I think the return value of the calling unref() with ref(value: object) should be normal object.
like
```ts
test('unref', () => {
  const foo = {
    bar: 1
  }
  expect(isReactive(unref(ref(foo)))).toBe(false) // should not be reactive
  expect(unref(ref(foo))).toBe(foo)
})
```