### PR TITLE
compat: Simulate Vue 2.6.14 version in vue-compat

### DIFF
--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -170,7 +170,7 @@ export function createCompatVue(
     }
   }
 
-  Vue.version = __VERSION__
+  Vue.version = `2.6.14-compat:${__VERSION__}`
   Vue.config = singletonApp.config
 
   Vue.use = (p, ...options) => {


### PR DESCRIPTION
Some Vue plugins that are actually compatible with the `vue-compat` won't work because of the version check ([an example from vue apollo](https://github.com/vuejs/apollo/blob/029d934cce8d28e1a5454956909f57cc3e2349a1/packages/vue-apollo/src/mixin.js)). Right now `vue-compat` returns 3x version for the legacy method of checking Vue version via `Vue.version`. This PR instends to simulate Vue 2 version in those instances and instead return a 2x-compatible version: `2.6.14-compat:3.x.x`.