### PR TITLE
fix(runtime-core): ensure mergeProps skips undefined event handlers (fix #5296)

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -446,6 +446,10 @@ describe('vnode', () => {
         onClick: [clickHandler1, clickHandler2],
         onFocus: focusHandler2
       })
+      let props3: Data = { onClick: undefined }
+      expect(mergeProps(props1, props3)).toMatchObject({
+        onClick: clickHandler1
+      })
     })
 
     test('default', () => {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -799,7 +799,8 @@ export function mergeProps(...args: (Data & VNodeProps)[]) {
         const incoming = toMerge[key]
         if (
           existing !== incoming &&
-          !(isArray(existing) && existing.includes(incoming))
+          !(isArray(existing) && existing.includes(incoming)) &&
+          incoming
         ) {
           ret[key] = existing
             ? [].concat(existing as any, incoming as any)

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -798,9 +798,9 @@ export function mergeProps(...args: (Data & VNodeProps)[]) {
         const existing = ret[key]
         const incoming = toMerge[key]
         if (
+          incoming &&
           existing !== incoming &&
-          !(isArray(existing) && existing.includes(incoming)) &&
-          incoming
+          !(isArray(existing) && existing.includes(incoming))
         ) {
           ret[key] = existing
             ? [].concat(existing as any, incoming as any)

--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -141,7 +141,7 @@ function patchStopImmediatePropagation(
       originalStop.call(e)
       ;(e as any)._stopped = true
     }
-    return value.map(fn => (e: Event) => !(e as any)._stopped && fn(e))
+    return value.map(fn => (e: Event) => !(e as any)._stopped && fn && fn(e))
   } else {
     return value
   }


### PR DESCRIPTION
closes #5296

Note: The true fix is in `mergeProps`' handling of `on*` props whose values are undefined, but I also added a nonnull check in `patchStopImmediatePropagation` for good measure.