### PR TITLE
fix(reactivity): Fixed computed not getting argument types correctly in typescript

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -69,13 +69,13 @@ export class ComputedRefImpl<T> {
 }
 
 export function computed<T>(
-  getter: ComputedGetter<T>,
-  debugOptions?: DebuggerOptions
-): ComputedRef<T>
-export function computed<T>(
   options: WritableComputedOptions<T>,
   debugOptions?: DebuggerOptions
 ): WritableComputedRef<T>
+export function computed<T>(
+  getter: ComputedGetter<T>,
+  debugOptions?: DebuggerOptions
+): ComputedRef<T>
 export function computed<T>(
   getterOrOptions: ComputedGetter<T> | WritableComputedOptions<T>,
   debugOptions?: DebuggerOptions,


### PR DESCRIPTION
when I use the computed API in typescript, it not getting argument types correctly.
ec: when I press ‘ge’ , typescript should give a hint of completion
```javascript
computed({ ge })
```
I down know how function types'overload works in typescript, but swap the two computed type expressions definitions in order does works