### PR TITLE
fix(reactivity): ensure readonly refs can be replaced with new refs in reactive objects  That was the behavior before 171f5e9 (fix #5307)

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -476,7 +476,7 @@ describe('reactivity/readonly', () => {
     expect(isReadonly(rr.foo)).toBe(true)
   })
 
-  test('attemptingt to write to a readonly ref nested in a reactive object should fail', () => {
+  test('attemptingt to write plain value to a readonly ref nested in a reactive object should fail', () => {
     const r = ref(false)
     const ror = readonly(r)
     const obj = reactive({ ror })
@@ -485,5 +485,16 @@ describe('reactivity/readonly', () => {
     } catch (e) {}
 
     expect(obj.ror).toBe(false)
+  })
+  test('replacing a readonly ref nested in a reactive object with a new ref', () => {
+    const r = ref(false)
+    const ror = readonly(r)
+    const obj = reactive({ ror })
+    try {
+      obj.ror = ref(true) as unknown as boolean
+    } catch (e) {}
+
+    expect(obj.ror).toBe(true)
+    expect(toRaw(obj).ror).not.toBe(ror) // ref successfully replaced
   })
 })

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -150,7 +150,7 @@ function createSetter(shallow = false) {
     receiver: object
   ): boolean {
     let oldValue = (target as any)[key]
-    if (isReadonly(oldValue) && isRef(oldValue)) {
+    if (isReadonly(oldValue) && isRef(oldValue) && !isRef(value)) {
       return false
     }
     if (!shallow && !isReadonly(value)) {


### PR DESCRIPTION
in 171f5e9 we fixed a bug concerning reactive objects allowing to write to nested read-only refs.

That fix had the unintended side-effect of also disallowing to *replace* a nested (readonly) ref with a new ref.

This PR fixes that and restores the original behavior to allow refs to be replaced, but still prevents readonly refs to be written to.


fix: #5307