### PR TITLE
fix(runtime-core: ensure customElements have set domprop listeners synchronously if possible.

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -215,6 +215,30 @@ describe('defineCustomElement', () => {
       expect(el.hasAttribute('not-prop')).toBe(false)
     })
 
+    test('handle properties set before connecting', () => {
+      const obj = { a: 1 }
+      const E = defineCustomElement({
+        props: {
+          foo: String,
+          post: Object
+        },
+        setup(props) {
+          expect(props.foo).toBe('hello')
+          expect(props.post).toBe(obj)
+        },
+        render() {
+          return JSON.stringify(this.post)
+        }
+      })
+      customElements.define('my-el-preconnect', E)
+      const el = document.createElement('my-el-preconnect') as any
+      el.foo = 'hello'
+      el.post = obj
+
+      container.appendChild(el)
+      expect(el.shadowRoot.innerHTML).toBe(JSON.stringify(obj))
+    })
+
     // https://github.com/vuejs/core/issues/6163
     test('handle components with no props', async () => {
       const E = defineCustomElement({
@@ -246,29 +270,6 @@ describe('defineCustomElement', () => {
       el.maxAge = 50
       expect(el.maxAge).toBe(50)
       expect(el.shadowRoot.innerHTML).toBe('max age: 50/type: number')
-    })
-
-    test('handle properties set before connecting', () => {
-      const obj = {}
-      const E = defineCustomElement({
-        props: {
-          foo: String,
-          post: Object
-        },
-        setup(props) {
-          expect(props.foo).toBe('hello')
-          expect(props.post).toBe(obj)
-        },
-        render() {
-          return `foo: ${this.foo}`
-        }
-      })
-      customElements.define('my-el-preconnect', E)
-      const el = document.createElement('my-el-preconnect') as any
-      el.foo = 'hello'
-      el.post = obj
-
-      container.appendChild(el)
     })
   })
 

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -247,6 +247,29 @@ describe('defineCustomElement', () => {
       expect(el.maxAge).toBe(50)
       expect(el.shadowRoot.innerHTML).toBe('max age: 50/type: number')
     })
+
+    test('handle properties set before connecting', () => {
+      const obj = {}
+      const E = defineCustomElement({
+        props: {
+          foo: String,
+          post: Object
+        },
+        setup(props) {
+          expect(props.foo).toBe('hello')
+          expect(props.post).toBe(obj)
+        },
+        render() {
+          return `foo: ${this.foo}`
+        }
+      })
+      customElements.define('my-el-preconnect', E)
+      const el = document.createElement('my-el-preconnect') as any
+      el.foo = 'hello'
+      el.post = obj
+
+      container.appendChild(el)
+    })
   })
 
   describe('attrs', () => {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -186,6 +186,10 @@ export class VueElement extends BaseClass {
         )
       }
       this.attachShadow({ mode: 'open' })
+      if (!(this._def as ComponentOptions).__asyncLoader) {
+        // for sync component defs we can immediately resolve props
+        this._resolveProps(this._def)
+      }
     }
   }
 
@@ -227,9 +231,8 @@ export class VueElement extends BaseClass {
       }
     }).observe(this, { attributes: true })
 
-    const resolve = (def: InnerComponentDef) => {
+    const resolve = (def: InnerComponentDef, isAsync = false) => {
       const { props, styles } = def
-      const declaredPropKeys = isArray(props) ? props : Object.keys(props || {})
 
       // cast Number-type props set before resolve
       let numberProps
@@ -248,23 +251,10 @@ export class VueElement extends BaseClass {
       }
       this._numberProps = numberProps
 
-      // check if there are props set pre-upgrade or connect
-      for (const key of Object.keys(this)) {
-        if (key[0] !== '_' && declaredPropKeys.includes(key)) {
-          this._setProp(key, this[key as keyof this], true, false)
-        }
-      }
-
-      // defining getter/setters on prototype
-      for (const key of declaredPropKeys.map(camelize)) {
-        Object.defineProperty(this, key, {
-          get() {
-            return this._getProp(key)
-          },
-          set(val) {
-            this._setProp(key, val)
-          }
-        })
+      if (isAsync) {
+        // defining getter/setters on prototype
+        // for sync defs, this already happened in the constructor
+        this._resolveProps(def)
       }
 
       // apply CSS
@@ -276,9 +266,33 @@ export class VueElement extends BaseClass {
 
     const asyncDef = (this._def as ComponentOptions).__asyncLoader
     if (asyncDef) {
-      asyncDef().then(resolve)
+      asyncDef().then(def => resolve(def, true))
     } else {
       resolve(this._def)
+    }
+  }
+
+  private _resolveProps(def: InnerComponentDef) {
+    const { props } = def
+    const declaredPropKeys = isArray(props) ? props : Object.keys(props || {})
+
+    // check if there are props set pre-upgrade or connect
+    for (const key of Object.keys(this)) {
+      if (key[0] !== '_' && declaredPropKeys.includes(key)) {
+        this._setProp(key, this[key as keyof this], true, false)
+      }
+    }
+
+    // defining getter/setters on prototype
+    for (const key of declaredPropKeys.map(camelize)) {
+      Object.defineProperty(this, key, {
+        get() {
+          return this._getProp(key)
+        },
+        set(val) {
+          this._setProp(key, val)
+        }
+      })
     }
   }
 


### PR DESCRIPTION
### Problem

defineCustomElement reflects all props as element properties, but it does so only after the element has connected.

When Vue sets props on elements, it prefers to add them via element properties if if can find a matching property on the element.

But since `defineCustomElement` sets these property getter/setters only after the element has connected, they don't exist when Vue is looking for them during mount.

This means that we can't do this:

```html
<my-el  :object-prop="{ some: 'object' }" />
```
because it will end up as an attribute containing `[object Object]`.

We have to do use the `.prop` modifier:

```html
<my-el  :object-prop.prop="{ some: 'object' }" />
```

...but not all web frameworks support such a feature.

## Solution

This PR is a refactoring that ensures that the element property getter/setters are set synchronously in the constructor in order to solve this problem.

## Limitations

This solution doesn't work for async cusotm elements, as we can only resolve the props after the component definition has been loaded asynchronously.

close: #2343 