### PR TITLE
fix(runtime-dom): properly handle custom style properties with falsy values (fix: #5322)

### DIFF
--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -39,15 +39,15 @@ describe(`runtime-dom: style patching`, () => {
     const el = document.createElement('div')
     patchProp(el, 'style', null, {
       color: undefined,
-      '--color': false,
       borderRadius: null
     })
     expect(el.style.cssText.replace(/\s/g, '')).toBe('')
+
     patchProp(
       el,
       'style',
       { color: 'red' },
-      { color: undefined, '--color': false, borderRadius: false }
+      { color: null, borderRadius: undefined }
     )
     expect(el.style.cssText.replace(/\s/g, '')).toBe('')
   })

--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -37,7 +37,18 @@ describe(`runtime-dom: style patching`, () => {
 
   it('remove if falsy value', () => {
     const el = document.createElement('div')
-    patchProp(el, 'style', { color: 'red' }, { color: undefined })
+    patchProp(el, 'style', null, {
+      color: undefined,
+      '--color': false,
+      borderRadius: null
+    })
+    expect(el.style.cssText.replace(/\s/g, '')).toBe('')
+    patchProp(
+      el,
+      'style',
+      { color: 'red' },
+      { color: undefined, '--color': false, borderRadius: false }
+    )
     expect(el.style.cssText.replace(/\s/g, '')).toBe('')
   })
 

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -42,6 +42,7 @@ function setStyle(
   name: string,
   val: string | string[]
 ) {
+  val = val == null || (val as any) === false ? '' : val
   if (isArray(val)) {
     val.forEach(v => setStyle(style, name, v))
   } else {

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -42,10 +42,10 @@ function setStyle(
   name: string,
   val: string | string[]
 ) {
-  val = val == null || (val as any) === false ? '' : val
   if (isArray(val)) {
     val.forEach(v => setStyle(style, name, v))
   } else {
+    if (val == null) val = ''
     if (name.startsWith('--')) {
       // custom property definition
       style.setProperty(name, val)


### PR DESCRIPTION
style definition objects that had an initially falsy value for a custom property would add that custom property with the stringified falsy value:

```vue
<div :style="{ '--color': undefined }">

<!-- was rendered as: -->
<div style="--color: undefined;"> 
```

Note that this only affected *initial* values. if the falsy value was added in an update, the property was properly removed.

After this PR, the custom property would not be added in the first place on mount:

```html
<div style>
```

close: #5322 