### PR TITLE
fix(runtime-core): Ensure raw Slots are only normalized once by withContext (Fix: #5353)

### DIFF
--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -63,6 +63,10 @@ const normalizeSlot = (
   rawSlot: Function,
   ctx: ComponentInternalInstance | null | undefined
 ): Slot => {
+  if ((rawSlot as any)._n) {
+    // already normalized - #5353
+    return rawSlot as Slot
+  }
   const normalized = withCtx((...args: any[]) => {
     if (__DEV__ && currentInstance) {
       warn(


### PR DESCRIPTION
This PR ensures that an already normalized slot isn't normalized again, which could potentially lead to a "max stack" error from too many nested function calls (aside from simply being unnecessary work).

I didn't add a test case as this change doesn't have a public effect I could test against - if all tests still pass this should be fine.

But I can come up with one if necessary.

close: #5353