### PR TITLE
fix(runtime-dom): fix an update error when the style changed from str…

### DIFF
--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -7,15 +7,19 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   const style = (el as HTMLElement).style
   const isCssString = isString(next)
   if (next && !isCssString) {
-    for (const key in next) {
-      setStyle(style, key, next[key])
-    }
-    if (prev && !isString(prev)) {
-      for (const key in prev) {
-        if (next[key] == null) {
-          setStyle(style, key, '')
+    if (prev) {
+      if (isString(prev)) {
+        style.cssText = ''
+      } else {
+        for (const key in prev) {
+          if (next[key] == null) {
+            setStyle(style, key, '');
+          }
         }
       }
+    }
+    for (const key in next) {
+      setStyle(style, key, next[key])
     }
   } else {
     const currentDisplay = style.display


### PR DESCRIPTION
When I changed the style from string to object, the properties of the original string were not removed:
```vue
<div :style="flag ? `color: red;` : { backgroundColor: 'green' }">

<!-- flag changes from true to false and is rendered as: -->
<div style="color: red; background-color: green;"> 
```
After this PR, the rendering style displays normally:
```vue
<div style="background-color: green;"> 
```