### PR TITLE
fix(sfc-playground): default selected app on devtools

### DIFF
--- a/packages/sfc-playground/src/main.ts
+++ b/packages/sfc-playground/src/main.ts
@@ -4,7 +4,7 @@ import '@vue/repl/style.css'
 
 // @ts-expect-error Custom window property
 window.VUE_DEVTOOLS_CONFIG = {
-  defaultSelectedAppId: 'id:repl'
+  defaultSelectedAppId: 'repl'
 }
 
 createApp(App).mount('#app')


### PR DESCRIPTION
The correct appid of devtools is `repl`