### PR TITLE
fix(runtime-core): custom-element: ensure event names are hyphenated (fix: #5373)

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -234,7 +234,9 @@ describe('defineCustomElement', () => {
           h('div', {
             onClick: () => {
               emit('my-click', 1)
-              emit('myClick', 1) // validate hypenization
+            },
+            onMousedown: () => {
+              emit('myEvent', 1) // validate hypenization
             }
           })
       }
@@ -255,13 +257,25 @@ describe('defineCustomElement', () => {
       const spy = jest.fn()
       e.addEventListener('my-click', spy)
       e.shadowRoot!.childNodes[0].dispatchEvent(new CustomEvent('click'))
-      expect(spy).toHaveBeenCalledTimes(2)
+      expect(spy).toHaveBeenCalledTimes(1)
       expect(spy.mock.calls[0][0]).toMatchObject({
         detail: [1]
       })
-      expect(spy.mock.calls[1][0]).toMatchObject({
-        detail: [1]
-      })
+    })
+
+    // #5373
+    test('case transform for camelCase event', () => {
+      container.innerHTML = `<my-el-emits></my-el-emits>`
+      const e = container.childNodes[0] as VueElement
+      const spy1 = jest.fn()
+      e.addEventListener('myEvent', spy1)
+      const spy2 = jest.fn()
+      // emitting myEvent, but listening for my-event. This happens when
+      // using the custom element in a Vue template
+      e.addEventListener('my-event', spy2)
+      e.shadowRoot!.childNodes[0].dispatchEvent(new CustomEvent('mousedown'))
+      expect(spy1).toHaveBeenCalledTimes(1)
+      expect(spy2).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -232,7 +232,10 @@ describe('defineCustomElement', () => {
         emit('created')
         return () =>
           h('div', {
-            onClick: () => emit('my-click', 1)
+            onClick: () => {
+              emit('my-click', 1)
+              emit('myClick', 1) // validate hypenization
+            }
           })
       }
     })
@@ -252,8 +255,11 @@ describe('defineCustomElement', () => {
       const spy = jest.fn()
       e.addEventListener('my-click', spy)
       e.shadowRoot!.childNodes[0].dispatchEvent(new CustomEvent('click'))
-      expect(spy).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledTimes(2)
       expect(spy.mock.calls[0][0]).toMatchObject({
+        detail: [1]
+      })
+      expect(spy.mock.calls[1][0]).toMatchObject({
         detail: [1]
       })
     })

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -351,13 +351,22 @@ export class VueElement extends BaseClass {
           }
         }
 
-        // intercept emit
-        instance.emit = (event: string, ...args: any[]) => {
+        const dispatch = (event: string, args: any[]) => {
           this.dispatchEvent(
-            new CustomEvent(hyphenate(event), {
+            new CustomEvent(event, {
               detail: args
             })
           )
+        }
+
+        // intercept emit
+        instance.emit = (event: string, ...args: any[]) => {
+          // dispatch both the raw and hyphenated versions of an event
+          // to match Vue behavior
+          dispatch(event, args)
+          if (hyphenate(event) !== event) {
+            dispatch(hyphenate(event), args)
+          }
         }
 
         // locate nearest Vue custom element parent for provide/inject

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -354,7 +354,7 @@ export class VueElement extends BaseClass {
         // intercept emit
         instance.emit = (event: string, ...args: any[]) => {
           this.dispatchEvent(
-            new CustomEvent(event, {
+            new CustomEvent(hyphenate(event), {
               detail: args
             })
           )


### PR DESCRIPTION
close: #5373