### PR TITLE
docs(contributing): change node version

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -40,7 +40,7 @@ Hi! I'm really excited that you are interested in contributing to Vue.js. Before
 
 ## Development Setup
 
-You will need [Node.js](https://nodejs.org) **version 10+**, and [PNPM](https://pnpm.io).
+You will need [Node.js](https://nodejs.org) **version 14+**, and [PNPM](https://pnpm.io).
 
 We also recommend installing [ni](https://github.com/antfu/ni) to help switching between repos using different package managers. `ni` also provides the handy `nr` command which running npm scripts easier.
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -40,7 +40,7 @@ Hi! I'm really excited that you are interested in contributing to Vue.js. Before
 
 ## Development Setup
 
-You will need [Node.js](https://nodejs.org) **version 14+**, and [PNPM](https://pnpm.io).
+You will need [Node.js](https://nodejs.org) **version 16+**, and [PNPM](https://pnpm.io).
 
 We also recommend installing [ni](https://github.com/antfu/ni) to help switching between repos using different package managers. `ni` also provides the handy `nr` command which running npm scripts easier.
 


### PR DESCRIPTION
I noticed that optional operator(?.) is used in scripts/dev, but it only supports node 14+, so should node 14 be the minimum version limit for developers?