### PR TITLE
types(runtime-core): support typed safe vnode `ref` on the template

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -906,7 +906,7 @@ describe('api: watch', () => {
 
     const Comp = defineComponent({
       setup() {
-        const comp = ref<ComponentPublicInstance | undefined>()
+        const comp = ref<ComponentPublicInstance | null>()
         const show = ref(true)
         _show = show
         return { comp, show }

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -26,7 +26,8 @@ import {
   ComponentPublicInstanceConstructor
 } from './componentPublicInstance'
 
-export type PublicProps = VNodeProps &
+// NOTE omit `ref` since that will be overridden by JSX.d.ts
+export type PublicProps = Omit<VNodeProps, 'ref'> &
   AllowedComponentProps &
   ComponentCustomProps
 

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -52,7 +52,7 @@ h(Component, {}, {}) // named slots
 h(Component, null, {})
 **/
 
-type RawProps = VNodeProps & {
+type RawProps<ComponentInstance = object> = VNodeProps<ComponentInstance> & {
   // used to differ from a single VNode object as children
   __v_isVNode?: never
   // used to differ from Array children

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -65,10 +65,10 @@ export type VNodeTypes =
   | typeof TeleportImpl
   | typeof SuspenseImpl
 
-export type VNodeRef =
+export type VNodeRef<T = object> =
   | string
-  | Ref
-  | ((ref: object | null, refs: Record<string, any>) => void)
+  | Ref<T | null>
+  | ((ref: T | null, refs: Record<string, any>) => void)
 
 export type VNodeNormalizedRefAtom = {
   i: ComponentInternalInstance
@@ -90,9 +90,9 @@ export type VNodeHook =
   | VNodeUpdateHook[]
 
 // https://github.com/microsoft/TypeScript/issues/33099
-export type VNodeProps = {
+export type VNodeProps<ComponentInstance = object> = {
   key?: string | number | symbol
-  ref?: VNodeRef
+  ref?: VNodeRef<ComponentInstance>
   ref_for?: boolean
   ref_key?: string
 

--- a/test-dts/componentRef.test-d.tsx
+++ b/test-dts/componentRef.test-d.tsx
@@ -1,0 +1,69 @@
+import {
+  expectError,
+  Ref,
+  defineComponent,
+  ComponentPublicInstance,
+  FunctionalComponent,
+  expectType
+} from './index'
+
+// html component ref
+declare let videoEl: HTMLVideoElement | null
+declare let videoElRef: Ref<HTMLVideoElement | null>
+;<video ref={e => (videoEl = e)} />
+;<video ref={videoElRef} />
+
+// @ts-expect-error
+expectError(<a ref={e => (videoEl = e)} />)
+// @ts-expect-error
+expectError(<a ref={videoEl} />)
+
+const Comp = defineComponent({
+  props: {
+    test: String
+  }
+})
+
+// Component based ref
+declare let myComp: InstanceType<typeof Comp> | null
+declare let myCompRef: Ref<InstanceType<typeof Comp> | null>
+declare let anyComp: ComponentPublicInstance | null
+expectType<JSX.Element>(<Comp ref={e => (myComp = e)} />)
+expectType<JSX.Element>(<Comp ref={myCompRef} />)
+expectType<JSX.Element>(<Comp ref={e => (anyComp = e)} />)
+
+declare let wrongComponent: ComponentPublicInstance<{ a: string }>
+
+// @ts-expect-error wrong Component type
+expectType<JSX.Element>(<Comp ref={e => (wrongComponent = e)} />)
+
+// Function
+declare function FuncComp(props: { foo: string }): any
+
+expectType<JSX.Element>(<FuncComp foo="test" ref={e => e?.$props.foo} />)
+
+// @ts-expect-error not valid prop
+expectType<JSX.Element>(<FuncComp foo="test" ref={e => e?.$props.bar} />)
+
+declare const FuncEmitComp: FunctionalComponent<{ foo: string }, ['test']>
+
+expectType<JSX.Element>(
+  <FuncEmitComp foo="test" ref={e => e?.$props.foo && e?.$emit('test')} />
+)
+
+// @ts-expect-error not valid prop
+expectType<JSX.Element>(<FuncEmitComp foo="test" ref={e => e?.$props.bar} />)
+
+// @ts-expect-error not valid emit
+expectType<JSX.Element>(<FuncEmitComp foo="test" ref={e => e?.$emit('bar')} />)
+
+// Class
+declare const CustomComp: {
+  new (): { $props: { foo: string } }
+}
+
+declare let customComp: InstanceType<typeof CustomComp> | null
+expectType<JSX.Element>(<CustomComp foo="test" ref={e => (customComp = e)} />)
+
+// @ts-expect-error not valid prop
+expectType<JSX.Element>(<CustomComp foo="test" ref={e => e?.$props.bar} />)


### PR DESCRIPTION
Support typesafe `:ref` property when used on the template.

This PR adds support when you use `<video :ref="(e)=> e?.playsInline">` or type safe with used with `Ref` 

```ts
const videoEl = ref<HTMLVideoElement | null>(null)

// works 
;<video ref={videoEl}/>

// @ts-expect-error HTMLAnchorElement not assigned to HTMLVideoElement
;<a ref={videoEl}/>
```


This also brings type safe to custom components and functional components, altho `functional` components will be converted to `ComponentPublicInstance<Props>` and type safe in that scenario will be a bit trickier for the user. 
```ts
const FuncComp = (props: { foo: string}) => h('div', props.foo);

/* Is not easy to retrieve the correct type when used like a plain function, recommended using ComponentPublicInstance */  
const CompInstance = ref<ComponentPublicInstance<{ foo: string}> | null  >();

;<FuncComp :ref={CompInstance}/>

// or 

// type is correct when using function
;<FuncComp :ref={x=> x?.$props.foo}/>
```


`DefineComponent` works out of the box with the expected type being provided, this might cause some problems on some code bases, depending on how the users are declaring their `refs`, but in most cases it should work

```ts
const Comp = defineComponent({
  props: {
    test: String
  }
})


declare let videoElRef: Ref<HTMLVideoElement | null>

// Recommended way to get the Component type is to get the InstanceType

declare let myComp: InstanceType<typeof Comp> | null
declare let myCompRef: Ref<InstanceType<typeof Comp> | null>
declare let anyComp: ComponentPublicInstance | null


expectType<JSX.Element>(<Comp ref={e => (myComp = e)} />)
expectType<JSX.Element>(<Comp ref={myCompRef} />)
expectType<JSX.Element>(<Comp ref={e => (anyComp = e)} />)
```

