### PR TITLE
types(runtime-core): added `ComponentCustomProperties` type to `globalProperties`

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -64,13 +64,42 @@ export interface App<HostElement = any> {
 
 export type OptionMergeFunction = (to: unknown, from: unknown) => any
 
+/**
+ * Custom properties added to globalProperties object.
+ *
+ * @example
+ * Here is an example of adding a property `$myAttribute` to the global instance:
+ * ```ts
+ * import { createApp, ref } from 'vue'
+ * import type { Ref } from 'vue'
+ *
+ * declare module '@vue/runtime-core' {
+ *   interface GlobalProperties {
+ *     $myAttribute: Ref<boolean>
+ *   }
+ * }
+ *
+ * const app = createApp({})
+ * app.config.globalProperties.$myAttribute = ref(false);
+ *
+ * const vm = app.mount('#app')
+ * // we can access the property on the app
+ * app.config.globalProperties.$myAttribute
+ * // or when using `getCurrentInstance()`
+ * getCurrentInstance()!.appContext.config.globalProperties.$myAttribute
+ * ```
+ */
+export interface GlobalProperties {
+  [key: string]: any
+}
+
 export interface AppConfig {
   // @private
   readonly isNativeTag?: (tag: string) => boolean
 
   performance: boolean
   optionMergeStrategies: Record<string, OptionMergeFunction>
-  globalProperties: Record<string, any>
+  globalProperties: GlobalProperties
   errorHandler?: (
     err: unknown,
     instance: ComponentPublicInstance | null,

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -11,7 +11,10 @@ import {
   MergedComponentOptions,
   RuntimeCompilerOptions
 } from './componentOptions'
-import { ComponentPublicInstance } from './componentPublicInstance'
+import {
+  ComponentCustomProperties,
+  ComponentPublicInstance
+} from './componentPublicInstance'
 import { Directive, validateDirectiveName } from './directives'
 import { RootRenderFunction } from './renderer'
 import { InjectionKey } from './apiInject'
@@ -64,42 +67,13 @@ export interface App<HostElement = any> {
 
 export type OptionMergeFunction = (to: unknown, from: unknown) => any
 
-/**
- * Custom properties added to globalProperties object.
- *
- * @example
- * Here is an example of adding a property `$myAttribute` to the global instance:
- * ```ts
- * import { createApp, ref } from 'vue'
- * import type { Ref } from 'vue'
- *
- * declare module '@vue/runtime-core' {
- *   interface GlobalProperties {
- *     $myAttribute: Ref<boolean>
- *   }
- * }
- *
- * const app = createApp({})
- * app.config.globalProperties.$myAttribute = ref(false);
- *
- * const vm = app.mount('#app')
- * // we can access the property on the app
- * app.config.globalProperties.$myAttribute
- * // or when using `getCurrentInstance()`
- * getCurrentInstance()!.appContext.config.globalProperties.$myAttribute
- * ```
- */
-export interface GlobalProperties {
-  [key: string]: any
-}
-
 export interface AppConfig {
   // @private
   readonly isNativeTag?: (tag: string) => boolean
 
   performance: boolean
   optionMergeStrategies: Record<string, OptionMergeFunction>
-  globalProperties: GlobalProperties
+  globalProperties: ComponentCustomProperties
   errorHandler?: (
     err: unknown,
     instance: ComponentPublicInstance | null,

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -73,7 +73,7 @@ export interface AppConfig {
 
   performance: boolean
   optionMergeStrategies: Record<string, OptionMergeFunction>
-  globalProperties: ComponentCustomProperties
+  globalProperties: ComponentCustomProperties & Record<string, any>
   errorHandler?: (
     err: unknown,
     instance: ComponentPublicInstance | null,

--- a/test-dts/component.test-d.ts
+++ b/test-dts/component.test-d.ts
@@ -11,7 +11,9 @@ import {
   FunctionalComponent,
   ComponentPublicInstance,
   toRefs,
-  IsAny
+  IsAny,
+  getCurrentInstance,
+  ComponentCustomProperties
 } from './index'
 
 declare function extractComponentOptions<Props, RawBindings>(
@@ -475,4 +477,13 @@ describe('class', () => {
   const { props } = extractComponentOptions(MyComponent)
 
   expectType<number>(props.foo)
+})
+
+describe('getCurrentInstance', () => {
+  const instance = getCurrentInstance()!
+
+  expectType<ComponentCustomProperties>(
+    instance.appContext.config.globalProperties
+  )
+  expectType<ComponentCustomProperties>(instance.proxy!)
 })

--- a/test-dts/component.test-d.ts
+++ b/test-dts/component.test-d.ts
@@ -11,9 +11,7 @@ import {
   FunctionalComponent,
   ComponentPublicInstance,
   toRefs,
-  IsAny,
-  getCurrentInstance,
-  ComponentCustomProperties
+  IsAny
 } from './index'
 
 declare function extractComponentOptions<Props, RawBindings>(
@@ -477,13 +475,4 @@ describe('class', () => {
   const { props } = extractComponentOptions(MyComponent)
 
   expectType<number>(props.foo)
-})
-
-describe('getCurrentInstance', () => {
-  const instance = getCurrentInstance()!
-
-  expectType<ComponentCustomProperties>(
-    instance.appContext.config.globalProperties
-  )
-  expectType<ComponentCustomProperties>(instance.proxy!)
 })

--- a/test-dts/componentTypeExtensions.test-d.tsx
+++ b/test-dts/componentTypeExtensions.test-d.tsx
@@ -1,11 +1,4 @@
-import {
-  ComponentCustomProperties,
-  defineComponent,
-  describe,
-  expectError,
-  expectType,
-  getCurrentInstance
-} from './index'
+import { defineComponent, expectError, expectType } from './index'
 
 declare module '@vue/runtime-core' {
   interface ComponentCustomOptions {
@@ -13,7 +6,7 @@ declare module '@vue/runtime-core' {
   }
 
   interface ComponentCustomProperties {
-    state: 'stopped' | 'running'
+    state?: 'stopped' | 'running'
   }
 
   interface ComponentCustomProps {
@@ -42,6 +35,14 @@ export const Custom = defineComponent({
       expectError(this.notExisting)
       this.counter++
       this.state = 'running'
+
+      this.$.appContext.config.globalProperties.state = 'running'
+
+      expectError(
+        // @ts-expect-error
+        (this.$.appContext.config.globalProperties.state = 'not valid')
+      )
+
       // @ts-expect-error
       expectError((this.state = 'not valid'))
     }
@@ -62,15 +63,3 @@ expectError(<Custom baz="baz" />)
 expectError(<Custom baz={1} notExist={1} />)
 // @ts-expect-error
 expectError(<Custom baz={1} custom="custom" />)
-
-describe('getCurrentInstance', () => {
-  const instance = getCurrentInstance()!
-
-  expectType<ComponentCustomProperties>(
-    instance.appContext.config.globalProperties
-  )
-  expectType<ComponentCustomProperties>(instance.proxy!)
-  expectType<'stopped' | 'running'>(
-    instance.appContext.config.globalProperties.state
-  )
-})

--- a/test-dts/componentTypeExtensions.test-d.tsx
+++ b/test-dts/componentTypeExtensions.test-d.tsx
@@ -1,4 +1,11 @@
-import { defineComponent, expectError, expectType } from './index'
+import {
+  ComponentCustomProperties,
+  defineComponent,
+  describe,
+  expectError,
+  expectType,
+  getCurrentInstance
+} from './index'
 
 declare module '@vue/runtime-core' {
   interface ComponentCustomOptions {
@@ -55,3 +62,15 @@ expectError(<Custom baz="baz" />)
 expectError(<Custom baz={1} notExist={1} />)
 // @ts-expect-error
 expectError(<Custom baz={1} custom="custom" />)
+
+describe('getCurrentInstance', () => {
+  const instance = getCurrentInstance()!
+
+  expectType<ComponentCustomProperties>(
+    instance.appContext.config.globalProperties
+  )
+  expectType<ComponentCustomProperties>(instance.proxy!)
+  expectType<'stopped' | 'running'>(
+    instance.appContext.config.globalProperties.state
+  )
+})


### PR DESCRIPTION
This pull request adds support for customising the attributes of `globalProperties`.

This isn't breaking as the string index signature is still there.

Currently there's no way to augment the `globalProperties` type as
```ts
declare module '@vue/runtime-core' {
    interface AppConfig {
        globalProperties: {
            $myAttr: Ref<boolean>;
        };
    }
}
```
gives the error of: `TS2717: Subsequent property declarations must have the same type. Property 'globalProperties' must be of type 'Record<string, any>', but here has type...`
and
```ts
declare module '@vue/runtime-core' {
    type AppConfig = Omit<BaseAppConfig, 'globalProperties'> & {
        globalProperties: Record<string, any> & { $myAttribute: Ref<boolean> };
    };
}
```
give the error of: `TS2300: Duplicate identifier 'AppConfig'.`