### PR TITLE
fix(5363): fix memory leaks during unmount

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -1,4 +1,4 @@
-import { hyphenate, isArray } from '@vue/shared'
+import { isArray, parseEventName } from '@vue/shared'
 import {
   ComponentInternalInstance,
   callWithAsyncErrorHandling
@@ -75,7 +75,7 @@ export function patchEvent(
     // patch
     existingInvoker.value = nextValue
   } else {
-    const [name, options] = parseName(rawName)
+    const [name, options] = parseEventName(rawName)
     if (nextValue) {
       // add
       const invoker = (invokers[rawName] = createInvoker(nextValue, instance))
@@ -86,22 +86,6 @@ export function patchEvent(
       invokers[rawName] = undefined
     }
   }
-}
-
-const optionsModifierRE = /(?:Once|Passive|Capture)$/
-
-function parseName(name: string): [string, EventListenerOptions | undefined] {
-  let options: EventListenerOptions | undefined
-  if (optionsModifierRE.test(name)) {
-    options = {}
-    let m
-    while ((m = name.match(optionsModifierRE))) {
-      name = name.slice(0, name.length - m[0].length)
-      ;(options as any)[m[0].toLowerCase()] = true
-      options
-    }
-  }
-  return [hyphenate(name.slice(2)), options]
 }
 
 function createInvoker(

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -28,7 +28,7 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
     if (parent) {
       const nodeList = (child as Element).querySelectorAll ? (child as Element).querySelectorAll('*') : []
       for (let i = 0; i < nodeList.length; i ++) {
-        removeVEI(nodeList)
+        removeVEI(nodeList[i])
       }
       removeVEI(child)
       parent.removeChild(child)

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -1,4 +1,5 @@
 import { RendererOptions } from '@vue/runtime-core'
+import { parseEventName } from '@vue/shared'
 
 export const svgNS = 'http://www.w3.org/2000/svg'
 
@@ -13,7 +14,23 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
 
   remove: child => {
     const parent = child.parentNode
+    function removeVEI (node: any) {
+      const _vei = node._vei
+      if (_vei) {
+        Object.keys(_vei).forEach(key => {
+          const [name] = parseEventName(key)
+          node.removeEventListener(name, _vei[key])
+        })
+        node._vei = null
+      }
+    }
+    // #5363
     if (parent) {
+      const nodeList = (child as Element).querySelectorAll ? (child as Element).querySelectorAll('*') : []
+      for (let i = 0; i < nodeList.length; i ++) {
+        removeVEI(nodeList)
+      }
+      removeVEI(child)
       parent.removeChild(child)
     }
   },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -171,3 +171,19 @@ export const getGlobalThis = (): any => {
         : {})
   )
 }
+
+const optionsModifierRE = /(?:Once|Passive|Capture)$/
+
+export function parseEventName(name: string): [string, EventListenerOptions | undefined] {
+  let options: EventListenerOptions | undefined
+  if (optionsModifierRE.test(name)) {
+    options = {}
+    let m
+    while ((m = name.match(optionsModifierRE))) {
+      name = name.slice(0, name.length - m[0].length)
+      ;(options as any)[m[0].toLowerCase()] = true
+      options
+    }
+  }
+  return [hyphenate(name.slice(2)), options]
+}


### PR DESCRIPTION
fix #5363

We created invoker at here and reference component instance.

https://github.com/vuejs/core/blob/c35ec47d73212b1b1fb1abca9004f992c45aa942/packages/runtime-dom/src/modules/events.ts#L107-L132

These elements reference invoker's closure
https://github.com/vuejs/core/blob/c35ec47d73212b1b1fb1abca9004f992c45aa942/packages/runtime-dom/src/modules/events.ts#L81-L82

So after removeChild, these elements become detached, even can't remove component instance.

https://github.com/vuejs/core/blob/9aa5dfd4bb8efac0041e33ef5fdbebab59cc6516/packages/runtime-dom/src/nodeOps.ts#L17

Because we should remove these references before removeChild:
> As long as a reference is kept on the removed child, it still exists in memory, but is no longer part of the DOM. It can still be reused later in the code.  [mdn](https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild)

No idea how to test, but I prepared a repo, you can test on it, just do like #5363

[https://github.com/caozhong1996/v3-memory-leaks/tree/main/abnormal](https://github.com/caozhong1996/v3-memory-leaks/tree/main/abnormal)
![微信图片_20220211000527](https://user-images.githubusercontent.com/26522151/153448149-fb938579-feef-40b7-b244-ba175907471f.png)

[https://github.com/caozhong1996/v3-memory-leaks/tree/main/normal](https://github.com/caozhong1996/v3-memory-leaks/tree/main/normal)
![微信图片_20220211000837](https://user-images.githubusercontent.com/26522151/153448157-83ad5a9a-ac5d-48c8-92e3-1a70ee38d9bb.png)

Not only removed elements, but also removed component instance.

BTW, in the development environment, these code will cause the same problem, but I don't know how to avoid.

https://github.com/vuejs/core/blob/15adf251ab69459fc5713f66921781931f3a517f/packages/runtime-core/src/renderer.ts#L697-L706

## asides

尤大新年好，以下纯属“迷弟”行为：

你一直是我前进路上的榜样，所以我想加上你的微信（单纯加微信，不尬聊，也是我一个新年小愿望）。
这个pr也花了两个晚上追踪（不一定完全正确，但是大体思路是这样的），element-plus也有这个issue [4434](https://github.com/element-plus/element-plus/issues/4434)，vue一直很重视性能，我想这应该算不小的提升，所以趁此机会提一下。

除此之外，我也有10个pr被merge，应该可以筛选出我不是低素质的人，保证不打扰，信息也绝不外泄（我也不太社交）。
虽然这样确实不适合，但是也找不到别的方法。另外这真不是道德绑架，可以直接拒绝的。如有冒犯，希望不要介意，下次不会了。

我的微信: justmilkplease
