### PR TITLE
fix(runtime-core): always hydrate hosited children for HMR

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -273,7 +273,8 @@ export function createHydrationFunctions(
     // e.g. <option :value="obj">, <input type="checkbox" :true-value="1">
     const forcePatchValue = (type === 'input' && dirs) || type === 'option'
     // skip props & children if this is hoisted static nodes
-    if (forcePatchValue || patchFlag !== PatchFlags.HOISTED) {
+    // #5405 in dev, always hydrate children for HMR
+    if (__DEV__ || forcePatchValue || patchFlag !== PatchFlags.HOISTED) {
       if (dirs) {
         invokeDirectiveHook(vnode, null, parentComponent, 'created')
       }


### PR DESCRIPTION
fix #5405
fix https://github.com/nuxt/framework/issues/1036

In Dev, hoisted nodes are not always "static" as developers might change it with HMR. We shouldn't skip the children's hydration.

Not sure if tests are required in this case