### PR TITLE
fix(compiler-sfc): v-bind using // to comment will still compile

### DIFF
--- a/packages/compiler-sfc/src/style/cssVars.ts
+++ b/packages/compiler-sfc/src/style/cssVars.ts
@@ -53,8 +53,8 @@ export function parseCssVars(sfc: SFCDescriptor): string[] {
   const vars: string[] = []
   sfc.styles.forEach(style => {
     let match
-    // ignore v-bind() in comments /* ... */
-    const content = style.content.replace(/\/\*([\s\S]*?)\*\//g, '')
+    // ignore v-bind() in comments, eg /* ... */ and // (Less, Sass and Stylus all support the use of // to comment.)
+    const content = style.content.replace(/\/\*([\s\S]*?)\*\/|\/\/.*/g, '')
     while ((match = vBindRE.exec(content))) {
       const start = match.index + match[0].length
       const end = lexBinding(content, start)

--- a/packages/compiler-sfc/src/style/cssVars.ts
+++ b/packages/compiler-sfc/src/style/cssVars.ts
@@ -53,7 +53,8 @@ export function parseCssVars(sfc: SFCDescriptor): string[] {
   const vars: string[] = []
   sfc.styles.forEach(style => {
     let match
-    // ignore v-bind() in comments, eg /* ... */ and // (Less, Sass and Stylus all support the use of // to comment.)
+    // ignore v-bind() in comments, eg /* ... */
+    // and // (Less, Sass and Stylus all support the use of // to comment)
     const content = style.content.replace(/\/\*([\s\S]*?)\*\/|\/\/.*/g, '')
     while ((match = vBindRE.exec(content))) {
       const start = match.index + match[0].length


### PR DESCRIPTION
When I use scss, if I write v-bind and comment it out, the v-bind line of css is still compiled as a css variable

Here is a default project I created using "@vue/cli 4.5.15"
```
<template>
  <div id="nav">
    <router-link to="/">Home</router-link>|
    <router-link to="/about">About</router-link>
  </div>
  <router-view />
</template>

<script setup>
const color =  "yellow"
</script>

<style lang="scss">
#app {
  font-family: Avenir, Helvetica, Arial, sans-serif;
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
  text-align: center;
  color: #2c3e50;
}

#nav {
  padding: 30px;
  // background-color: v-bind(color); 

  a {
    font-weight: bold;
    color: #2c3e50;

    &.router-link-exact-active {
      color: #42b983;
    }
  }
}
</style>


```
The line is actually commented out by css, but the v-bind variables are still compiled into the styles of the nav tag

```
<div id="nav" style="--7ba5bd90-color:yellow;">
  ... 
</div>
```
<img width="2206" alt="iShot2022-02-11 23 17 53" src="https://user-images.githubusercontent.com/6800487/153619701-ba65ddc7-b9f1-4c91-a35d-2859f70c66f5.png">

[Comments about sass](https://sass-lang.com/documentation/syntax/comments)