### PR TITLE
fix(runtime-core): allow spying on proxy methods regression  #5415 #4216

### DIFF
--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -337,11 +337,16 @@ describe('component: proxy', () => {
     Object.defineProperty(instanceProxy, 'toggle', {
       value:'b'
     })
-
     let v2 = instanceProxy.toggle
+
+    Object.defineProperty(instanceProxy, 'toggle', {
+      value:null
+    })
+    let v3 = instanceProxy.toggle
 
     expect(v1).toEqual('a')
     expect(v2).toEqual('b')
+    expect(v3).toBeNull()    
  
   })
 

--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -280,7 +280,7 @@ describe('component: proxy', () => {
     app.mount(nodeOps.createElement('div'))
 
     // access 'toggle' to ensure key is cached
-    let v1 = instanceProxy.toggle()
+    const v1 = instanceProxy.toggle()
     expect(v1).toEqual('a')
 
     // reconfigure "toggle" to be getter based.

--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -314,6 +314,37 @@ describe('component: proxy', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  test('defineProperty on proxy property with value descriptor', () => {
+    let instanceProxy: any
+    const Comp = {
+      render() {},
+      setup() {
+        return {
+          toggle:'a'
+        }
+      },
+      mounted() {
+        instanceProxy = this
+      }
+    }
+
+    const app = createApp(Comp)
+
+    app.mount(nodeOps.createElement('div'))
+    
+    let v1 = instanceProxy.toggle
+
+    Object.defineProperty(instanceProxy, 'toggle', {
+      value:'b'
+    })
+
+    let v2 = instanceProxy.toggle
+
+    expect(v1).toEqual('a')
+    expect(v2).toEqual('b')
+ 
+  })
+
   // #864
   test('should not warn declared but absent props', () => {
     const Comp = {

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -455,7 +455,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     descriptor: PropertyDescriptor
   ) {
     if (descriptor.get != null) {
-      this.set!(target, key, descriptor.get(), null)
+      target.$.accessCache[key] = 0;
     } else if (descriptor.value != null) {
       this.set!(target, key, descriptor.value, null)
     }

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -456,7 +456,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
   ) {
     if (descriptor.get != null) {
       target.$.accessCache[key] = 0;
-    } else if (descriptor.value != null) {
+    } else if (hasOwn(descriptor,'value')) {
       this.set!(target, key, descriptor.value, null)
     }
     return Reflect.defineProperty(target, key, descriptor)

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -455,6 +455,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     descriptor: PropertyDescriptor
   ) {
     if (descriptor.get != null) {
+      // invalidate key cache of a getter based property #5417
       target.$.accessCache[key] = 0;
     } else if (hasOwn(descriptor,'value')) {
       this.set!(target, key, descriptor.value, null)


### PR DESCRIPTION
a getter should not get evaluated when defining a property using `defineProperty`

```js
this.set!(target, key, descriptor.get(), null)
```

instead we invalidate the key `accessCache`
```js
target.$.accessCache[key] = 0;
```

fixes: #5415  #4216