### PR TITLE
docs(contributing): keep documentation and engines in sync [ci skip]

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -40,7 +40,7 @@ Hi! I'm really excited that you are interested in contributing to Vue.js. Before
 
 ## Development Setup
 
-You will need [Node.js](https://nodejs.org) **version 10+**, and [PNPM](https://pnpm.io).
+You will need [Node.js](https://nodejs.org) **version 16.5+**, and [PNPM](https://pnpm.io).
 
 We also recommend installing [ni](https://github.com/antfu/ni) to help switching between repos using different package managers. `ni` also provides the handy `nr` command which running npm scripts easier.
 


### PR DESCRIPTION
development documentation should be updated synchronously with package.json[engines]?

https://github.com/vuejs/core/blob/1574edd490bd5cc0a213bc9f48ff41a1dc43ab22/package.json#L46-L48