### PR TITLE
workflow: Fix vscode debug caused by node run shell

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,13 +8,11 @@
       "name": "Jest",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/.bin/jest",
       "stopOnEntry": false,
       "args": ["${fileBasename}", "--runInBand", "--detectOpenHandles"],
       "cwd": "${workspaceFolder}",
       "preLaunchTask": null,
-      "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy"],
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/jest",
       "env": {
         "NODE_ENV": "development"
       },


### PR DESCRIPTION
environment：
- VS Code Version: 1.64
- OS Version: macOS big sur 11.4
- OS chip: Apple M1
- node Version: 16.13.1

Use the original launch json debugger:
![image](https://user-images.githubusercontent.com/45714422/154183838-c7ace09e-06ca-4db2-9f83-85d3027f5ff4.png)

This fails because VS Code's node debugger cannot debug shell scripts. The reason is that pnpm is used for installation node_modules/.bin/jest is a shell file, so the error in the figure above is reported.[vscode-issues](https://github.com/microsoft/vscode/issues/142950)

I work fine in the config, but i didn't test other systems.