### PR TITLE
fix(types): ensure createBlock() helper accepts Teleport and Supsense types (fix: #2855)

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -24,6 +24,7 @@ import { RawSlots } from './componentSlots'
 import { isProxy, Ref, toRaw, ReactiveFlags, isRef } from '@vue/reactivity'
 import { AppContext } from './apiCreateApp'
 import {
+  Suspense,
   SuspenseImpl,
   isSuspense,
   SuspenseBoundary
@@ -31,7 +32,7 @@ import {
 import { DirectiveBinding } from './directives'
 import { TransitionHooks } from './components/BaseTransition'
 import { warn } from './warning'
-import { TeleportImpl, isTeleport } from './components/Teleport'
+import { Teleport, TeleportImpl, isTeleport } from './components/Teleport'
 import {
   currentRenderingInstance,
   currentScopeId
@@ -62,7 +63,9 @@ export type VNodeTypes =
   | typeof Static
   | typeof Comment
   | typeof Fragment
+  | typeof Teleport
   | typeof TeleportImpl
+  | typeof Suspense
   | typeof SuspenseImpl
 
 export type VNodeRef =

--- a/test-dts/compiler.test-d.ts
+++ b/test-dts/compiler.test-d.ts
@@ -1,0 +1,20 @@
+import {
+  expectType,
+  createBlock,
+  VNode,
+  Teleport,
+  Text,
+  Static,
+  Comment,
+  Fragment,
+  Suspense,
+  defineComponent
+} from './index'
+
+expectType<VNode>(createBlock(Teleport))
+expectType<VNode>(createBlock(Text))
+expectType<VNode>(createBlock(Static))
+expectType<VNode>(createBlock(Comment))
+expectType<VNode>(createBlock(Fragment))
+expectType<VNode>(createBlock(Suspense))
+expectType<VNode>(createBlock(defineComponent({})))


### PR DESCRIPTION
ensure createBlock() helper accepts Teleport and Supsense types, not their internal counterparts (TeleportImpl and SupenseImpl).

`createBlock()` only accepts `VNodeTypes` as first argument, and this type only included the internal types of Teleport and Suspense - `TeleportImpl` and `SuspenseImpl`.

This PR ads the public types `Teleport` and `Suspense` and thus ensures that the following, compiler-generated code now passes in vue-tsc and Volar:

```js
return (_ctx, _cache) => {
  return (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
    _createTextVNode(" Foo " + _toDisplayString(_ctx.title), 1 /* TEXT */)
  ]))
}
```

fix: #2855