### PR TITLE
fix(runtime-core): fix immediate callback not triggered bug for multisource

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -713,6 +713,24 @@ describe('api: watch', () => {
     expect(spy).toHaveBeenCalledTimes(3)
   })
 
+  it('immediate: triggers with multisource when initial value is undefined', async () => {
+    const state = ref()
+    const spy = jest.fn()
+    watch([state], spy, { immediate: true })
+    expect(spy).toHaveBeenCalled()
+    state.value = 3
+    await nextTick()
+    expect(spy).toHaveBeenCalledTimes(2)
+    // testing if undefined can trigger the watcher
+    state.value = undefined
+    await nextTick()
+    expect(spy).toHaveBeenCalledTimes(3)
+    // it shouldn't trigger if the same value is set
+    state.value = undefined
+    await nextTick()
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
   it('warn immediate option when using effect', async () => {
     const count = ref(0)
     let dummy

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -295,8 +295,7 @@ function doWatch(
     }
     return NOOP
   }
-
-  let oldValue = isMultiSource ? [] : INITIAL_WATCHER_VALUE
+  let oldValue = INITIAL_WATCHER_VALUE
   const job: SchedulerJob = () => {
     if (!effect.active) {
       return
@@ -309,7 +308,8 @@ function doWatch(
         forceTrigger ||
         (isMultiSource
           ? (newValue as any[]).some((v, i) =>
-              hasChanged(v, (oldValue as any[])[i])
+              // keep hasChanged result consistency(return true) between both multi source and single source cases for the first time
+              hasChanged(v, oldValue === INITIAL_WATCHER_VALUE ? INITIAL_WATCHER_VALUE : (oldValue as any[])[i])
             )
           : hasChanged(newValue, oldValue)) ||
         (__COMPAT__ &&
@@ -322,8 +322,8 @@ function doWatch(
         }
         callWithAsyncErrorHandling(cb, instance, ErrorCodes.WATCH_CALLBACK, [
           newValue,
-          // pass undefined as the old value when it's changed for the first time
-          oldValue === INITIAL_WATCHER_VALUE ? undefined : oldValue,
+          // pass undefined(and [] for multisource) as the old value when it's changed for the first time
+          oldValue === INITIAL_WATCHER_VALUE ? (isMultiSource ? [] : undefined) : oldValue,
           onCleanup
         ])
         oldValue = newValue


### PR DESCRIPTION
Fix this bug:
1. when watching multi-source with `{ immediate: true }` option
2. and the init value of the ref value is `undefined`

**the callback won't get called immediately as expected.**

See reproduce buggy code detailed below( or [sfc playground link](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiwgd2F0Y2ggfSBmcm9tICd2dWUnXG5cbi8vIGltcG9ydGFudCB0byByZXByb2R1Y2U6IHNldCBpbml0IHZhbHVlIHRvIFJlZjx1bmRlZmluZWQ+XG5jb25zdCBtc2cgPSByZWYoKVxuXG53YXRjaChtc2csICgpID0+IHtcbiAgY29uc29sZS5sb2coJ3RoaXMgd2lsbCBiZSBjYWxsZWQgaW1tZWRpYXRlbHkgYXMgZXhwZWN0ZWQnKVxufSwgeyBpbW1lZGlhdGU6IHRydWUgfSlcbiAgXG53YXRjaChbbXNnXSwgKCkgPT4ge1xuICBjb25zb2xlLmxvZyhcImJ1dCB0aGlzIHdvbid0XCIpXG59LCB7IGltbWVkaWF0ZTogdHJ1ZSB9KVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGgxPnt7IG1zZyB9fTwvaDE+XG4gIDxpbnB1dCB2LW1vZGVsPVwibXNnXCI+XG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9zZmMudnVlanMub3JnL3Z1ZS5ydW50aW1lLmVzbS1icm93c2VyLmpzXCJcbiAgfVxufSJ9)):


```js
// important to reproduce: set init value to Ref<undefined>
const msg = ref()

watch(msg, () => {
  console.log('this will be called immediately as expected')
}, { immediate: true })
  
watch([msg], () => {
  console.log("but this won't")
}, { immediate: true })
```


When determining if callback should be called immediately for the first time ( [relative code here](https://github.com/vuejs/core/blob/main/packages/runtime-core/src/apiWatch.ts#L310) ) ,  the `hasChanged` get `false` for multi source(`newValue` is`[undefined]` and `oldValue` is `[]`, `[undefined][0]===[][0]` ) while get `true` for single source, which cause different behaviors.

This PR fix it by compare the reference value`INITIAL_WATCHER_VALUE ` to `newValue` for multi source, just like what single source case do.
And when we call callback, pass `undefined` for single source and `[]` for multi source for the first time, keep this correct behavior.


