### PR TITLE
feat(runtime-core): export `currentInstance` methods

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -79,7 +79,12 @@ export {
 
 // For getting a hold of the internal instance in setup() - useful for advanced
 // plugins
-export { getCurrentInstance } from './component'
+export {
+  currentInstance,
+  getCurrentInstance,
+  setCurrentInstance,
+  unsetCurrentInstance
+} from './component'
 
 // For raw render function users
 export { h } from './h'


### PR DESCRIPTION
Close #4611

Hi, I'm maintainer of [reactivue](https://github.com/antfu/reactivue). I rewrote it from scratch _(not public yet)_ and managed to shrink it down to ~150 lines by using EffectScope API. But to support Vue plugins like `pinia`, `@vueuse/head` I needed to access `setCurrentInstance` method.