### PR TITLE
fix: ensure document available in window context

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -17,7 +17,8 @@ let _getNow: () => number = Date.now
 
 let skipTimestampCheck = false
 
-if (typeof window !== 'undefined') {
+const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined'
+if (isBrowser) {
   // Determine what event timestamp the browser is using. Annoyingly, the
   // timestamp can either be hi-res (relative to page load) or low-res
   // (relative to UNIX epoch), so in order to compare time we have to use the


### PR DESCRIPTION
This fixes a runtime error where in the javascript context `window` is available but not `document`. (e.g. under react native)