### PR TITLE
chore(@vue/shared): add `"sideEffects": false`

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
     "index.js",
     "dist"
   ],
+  "sideEffects": false,
   "buildOptions": {
     "formats": [
       "esm-bundler",


### PR DESCRIPTION
As far as I can tell, all the code in this package is side-effects-free.

Without the `sideEffects` flag, bundlers rely on code analysis and
the `/*#__PURE__*/` comments for tree-shaking.
As bundlers' implementations vary, the analysic may or may not be
exhaustive.

For example, a file that contains only the following line of code:
```js
import { capitalize } from '@vue/shared'
```
If bundled by esbuild (`esbuild --bundle test.js --tree-shaking=true`),
the output would be tens of lines.

(Technically, it's not esbuild's bug, because `Object.freeze` can be overwritten, `Array.isArray` could be overwritten to a getter, `+` can have side effects… Even though we know they *are* side-effects-free, it would require much more work from us to make bundlers happy)

After this PR, the output will be an empty IIFE.

Credit to @hardfist for discovering this issue.