### PR TITLE
fix: ensure element attribute names are always hyphenated (fix: #5477)

### DIFF
--- a/packages/runtime-dom/__tests__/patchAttrs.spec.ts
+++ b/packages/runtime-dom/__tests__/patchAttrs.spec.ts
@@ -53,4 +53,12 @@ describe('runtime-dom: attrs patching', () => {
     patchProp(el, 'onwards', 'a', null)
     expect(el.getAttribute('onwards')).toBe(null)
   })
+
+  test('camelCase attribute name properly hyphenated', () => {
+    const el = document.createElement('div')
+    patchProp(el, 'customAttribute', null, 'a')
+    expect(el.getAttribute('custom-attribute')).toBe('a')
+    patchProp(el, 'custom-attribute', 'a', null)
+    expect(el.getAttribute('custom-attribute')).toBe(null)
+  })
 })

--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -1,4 +1,5 @@
 import {
+  hyphenate,
   includeBooleanAttr,
   isSpecialBooleanAttr,
   makeMap,
@@ -36,7 +37,7 @@ export function patchAttr(
     if (value == null || (isBoolean && !includeBooleanAttr(value))) {
       el.removeAttribute(key)
     } else {
-      el.setAttribute(key, isBoolean ? '' : value)
+      el.setAttribute(hyphenate(key), isBoolean ? '' : value)
     }
   }
 }


### PR DESCRIPTION
This PR ensures that we properly hyphenate camelCased attribute names before we add them to an element using `el.setAttribute()`.


### Questions

Calling `hyphenate`  on every attribute when they usually already are feels wasteful, but I don't see any other way to have this behave consistently.

Are we fine with that? Are there other approaches?

---

close: #5477