### PR TITLE
workflow: recover version when error occurred

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -232,5 +232,6 @@ async function publishPackage(pkgName, version, runIfNotDry) {
 }
 
 main().catch(err => {
+  updateVersions(currentVersion)
   console.error(err)
 })


### PR DESCRIPTION
Running release script again when it failed previously will get a wrong `currentVersion`.