### PR TITLE
feat( runtime-core ) : ApiInject

### DIFF
--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -51,7 +51,7 @@ export function inject(
     // fallback to appContext's `provides` if the instance is at root
     const provides =
       instance.parent == null
-        ? instance.vnode.appContext?.provides
+        ? instance.vnode.appContext && instance.vnode.appContext.provides
         : instance.parent.provides
 
     if (provides && (key as string | symbol) in provides) {

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -1,6 +1,5 @@
 import { isFunction } from '@vue/shared'
-import { currentInstance } from './component'
-import { currentRenderingInstance } from './componentRenderContext'
+import { currentInstance, getCurrentInstance } from './component'
 import { warn } from './warning'
 
 export interface InjectionKey<T> extends Symbol {}
@@ -45,14 +44,14 @@ export function inject(
 ) {
   // fallback to `currentRenderingInstance` so that this can be called in
   // a functional component
-  const instance = currentInstance || currentRenderingInstance
+  const instance = getCurrentInstance()
   if (instance) {
     // #2400
     // to support `app.use` plugins,
     // fallback to appContext's `provides` if the instance is at root
     const provides =
       instance.parent == null
-        ? instance.vnode.appContext && instance.vnode.appContext.provides
+        ? instance.vnode.appContext?.provides
         : instance.parent.provides
 
     if (provides && (key as string | symbol) in provides) {


### PR DESCRIPTION
there seems to be a redundant code with `currentInstance || currentRenderingInstance`  and it should be replaced with `getCurrentInstance` 