### PR TITLE
fix(runtime-core): fix event listener as dynamicProp is added erroneously  to props

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -224,6 +224,11 @@ export function updateProps(
       const propsToUpdate = instance.vnode.dynamicProps!
       for (let i = 0; i < propsToUpdate.length; i++) {
         let key = propsToUpdate[i]
+      // if the prop key is a declared emit event listener.
+      // use continue to skip this prop
+        if (isEmitListener(instance.emitsOptions, key)){
+          continue
+        }
         // PROPS flag guarantees rawProps to be non-null
         const value = rawProps![key]
         if (options) {

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -224,8 +224,7 @@ export function updateProps(
       const propsToUpdate = instance.vnode.dynamicProps!
       for (let i = 0; i < propsToUpdate.length; i++) {
         let key = propsToUpdate[i]
-      // if the prop key is a declared emit event listener.
-      // use continue to skip this prop
+        // skip if the prop key is a declared emit event listener
         if (isEmitListener(instance.emitsOptions, key)){
           continue
         }


### PR DESCRIPTION
when event listener as dynamicProp  on updateProps, it is added to the  instance’s props and it can be implicit binded to other components again by "v-bind=$props".  it maybe trigger the callback function multiple times.

close https://github.com/vuejs/core/issues/5520