### PR TITLE
fix(runtime-core): Make transition behavior in KeepAlive in dev-mode consistent with production-mode.

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1996,7 +1996,17 @@ function baseCreateRenderer(
     moveType,
     parentSuspense = null
   ) => {
-    const { el, type, transition, children, shapeFlag } = vnode
+    const { el, type, transition, children, shapeFlag, patchFlag } = vnode
+
+    if (
+      __DEV__ &&
+      patchFlag > 0 &&
+      patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
+    ) {
+      const root = filterSingleRoot(children as VNodeArrayChildren)
+      root && (root.transition = transition)
+    }
+
     if (shapeFlag & ShapeFlags.COMPONENT) {
       move(vnode.component!.subTree, container, anchor, moveType)
       return


### PR DESCRIPTION
In this [example](https://stackblitz.com/edit/vitejs-vite-sqb7xl?file=src/App.vue), click Page A and then click Page B. Page A moves to the left, which is inconsistent with the name of the Transition node.This is due to the fact that https://github.com/vuejs/core/blob/5898629d723e82b68e9b17b91bf8b1a8390a3912/packages/runtime-core/src/componentRenderUtils.ts#L221-L229

It adjusts the position of the transition, so the last transition is used when moving. Now let's update it manually