### PR TITLE
chore(cleanupEffect): A better method to cleanup effects

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -131,9 +131,6 @@ export class ReactiveEffect<T = any> {
 function cleanupEffect(effect: ReactiveEffect) {
   const { deps } = effect
   if (deps.length) {
-    for (let i = 0; i < deps.length; i++) {
-      deps[i].delete(effect)
-    }
     deps.length = 0
   }
 }


### PR DESCRIPTION
I think we have unnecessary to clean each effect by manually, It will take some time, so why not just make it length to 0?