### PR TITLE
Fix: missing reserved props `ref_key` & `ref_for` (fix #5563)

### DIFF
--- a/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
@@ -16,6 +16,7 @@ describe('ssr: renderAttrs', () => {
       ssrRenderAttrs({
         key: 1,
         ref_key: 'foo',
+        ref_for: 'bar',
         ref: () => {},
         onClick: () => {}
       })

--- a/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
@@ -15,6 +15,7 @@ describe('ssr: renderAttrs', () => {
     expect(
       ssrRenderAttrs({
         key: 1,
+        ref_key: 'foo',
         ref: () => {},
         onClick: () => {}
       })

--- a/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
@@ -12,7 +12,7 @@ import {
 } from '@vue/shared'
 
 // leading comma for empty string ""
-const shouldIgnoreProp = makeMap(`,key,ref,innerHTML,textContent,ref_key`)
+const shouldIgnoreProp = makeMap(`,key,ref,innerHTML,textContent,ref_key,ref_for`)
 
 export function ssrRenderAttrs(
   props: Record<string, unknown>,

--- a/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
@@ -12,7 +12,7 @@ import {
 } from '@vue/shared'
 
 // leading comma for empty string ""
-const shouldIgnoreProp = makeMap(`,key,ref,innerHTML,textContent`)
+const shouldIgnoreProp = makeMap(`,key,ref,innerHTML,textContent,ref_key`)
 
 export function ssrRenderAttrs(
   props: Record<string, unknown>,


### PR DESCRIPTION
Fix missing reserved prop `ref_key` in SSR code output. (fix #5563)