### PR TITLE
fix: Ref or computed inside non-wrappable variables (objects, arrays) should return a string without quotes(#5578)

### DIFF
--- a/packages/shared/__tests__/toDisplayString.spec.ts
+++ b/packages/shared/__tests__/toDisplayString.spec.ts
@@ -70,6 +70,9 @@ describe('toDisplayString', () => {
         np
       })
     ).toBe(JSON.stringify({ n: 1, np: 2 }, null, 2))
+    // #5578
+    const nums = [ref('text')]
+    expect(toDisplayString(nums[0])).toBe('text')
   })
 
   test('objects with custom toString', () => {

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -13,7 +13,11 @@ import {
  * For converting {{ interpolation }} values to displayed strings.
  * @private
  */
-export const toDisplayString = (val: unknown): string => {
+export const toDisplayString = (val: any): string => {
+  //fix #5578
+  if (val && val.__v_isRef) {
+    return toDisplayString(val.value)
+  }
   return isString(val)
     ? val
     : val == null


### PR DESCRIPTION
fix: Ref or computed inside non-wrappable variables (objects, arrays) should return a string without quotes(#5578)