### PR TITLE
fix: the same component into the same container #5571

### DIFF
--- a/packages/runtime-dom/__tests__/createApp.spec.ts
+++ b/packages/runtime-dom/__tests__/createApp.spec.ts
@@ -3,7 +3,7 @@ import { nodeOps } from '../src/nodeOps'
 
 describe('createApp for dom', () => {
   // #5571 the same component into the same container
-  test.only('mount', () => {
+  test('mount', () => {
     const Comp = defineComponent({
       props: {
         count: {

--- a/packages/runtime-dom/__tests__/createApp.spec.ts
+++ b/packages/runtime-dom/__tests__/createApp.spec.ts
@@ -1,6 +1,27 @@
-import { createApp, h } from '../src'
+import { createApp, defineComponent, h } from '../src'
+import { nodeOps } from '../src/nodeOps'
 
 describe('createApp for dom', () => {
+  // #5571 the same component into the same container
+  test.only('mount', () => {
+    const Comp = defineComponent({
+      props: {
+        count: {
+          default: 'Comp'
+        }
+      },
+      setup(props) {
+        return () => props.count
+      }
+    })
+
+    const root1 = nodeOps.createElement('div')
+    createApp(Comp).mount(root1)
+    expect(root1.textContent).toBe(`Comp`)
+    createApp(Comp).mount(root1)
+    expect(`Please do not mount two identical apps on the same node.`).toHaveBeenWarned()
+    expect(root1.textContent).toBe(`Comp`)
+  })
   // #2926
   test('mount to SVG container', () => {
     const root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')

--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -84,7 +84,7 @@ export const createApp = ((...args) => {
         if (__DEV__) {
           warn(`Please do not mount two identical apps on the same node.`)
         }
-        return (container as any)._vnode.component!.proxy
+        (container as any).__vue_app__.unmount()
       }
     }
     if (!isFunction(component) && !component.render && !component.template) {

--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -77,6 +77,16 @@ export const createApp = ((...args) => {
     if (!container) return
 
     const component = app._component
+    // #5571 the same component into the same container
+    if ((container as any).__vue_app__) {
+      const prevComponent = (container as any).__vue_app__._component
+      if (prevComponent === component) {
+        if (__DEV__) {
+          warn(`Please do not mount two identical apps on the same node.`)
+        }
+        return (container as any)._vnode.component!.proxy
+      }
+    }
     if (!isFunction(component) && !component.render && !component.template) {
       // __UNSAFE__
       // Reason: potential execution of JS expressions in in-DOM template.


### PR DESCRIPTION
The same components are mounted in the same container. No update is found due to diff comparison, so the content remains unchanged However, in the DOM renderer, 'innerHTML' will be emptied, resulting in blank pages

Close #5571 