### PR TITLE
fix: The withDefaults function loses arguments when assigning a function default value #5253

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1420,12 +1420,14 @@ export default /*#__PURE__*/_defineComponent({
     foo: { type: String, required: false, default: 'hi' },
     bar: { type: Number, required: false },
     baz: { type: Boolean, required: true },
-    qux: { type: Function, required: false, default() { return 1 } }
+    qux: { type: Function, required: false, default() { return 1 } },
+    toLowerCase: { type: Function, required: true, default: (str: string) => str.toLowerCase() },
+    toUpperCase: { type: Function, required: true, default(str: string) { return str.toUpperCase() } }
   },
   setup(__props: any, { expose }) {
   expose();
 
-const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number }
+const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number, toLowerCase: (str: string) => string, toUpperCase: (str: string) => string }
 
       
       

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -902,10 +902,14 @@ const emit = defineEmits(['a', 'b'])
         foo?: string
         bar?: number;
         baz: boolean;
-        qux?(): number
+        qux?(): number;
+				toLowerCase: (str: string) => string
+				toUpperCase: (str: string) => string
       }>(), {
         foo: 'hi',
-        qux() { return 1 }
+        qux() { return 1 },
+        toLowerCase: (str: string) => str.toLowerCase(),
+        toUpperCase(str: string){ return str.toUpperCase() } 
       })
       </script>
       `)
@@ -918,8 +922,14 @@ const emit = defineEmits(['a', 'b'])
       expect(content).toMatch(
         `qux: { type: Function, required: false, default() { return 1 } }`
       )
+	    expect(content).toMatch(
+		    `toLowerCase: { type: Function, required: true, default: (str: string) => str.toLowerCase() }`
+	    )
+	    expect(content).toMatch(
+		    `toUpperCase: { type: Function, required: true, default(str: string) { return str.toUpperCase() } }`
+	    )
       expect(content).toMatch(
-        `{ foo: string, bar?: number, baz: boolean, qux(): number }`
+        `{ foo: string, bar?: number, baz: boolean, qux(): number, toLowerCase: (str: string) => string, toUpperCase: (str: string) => string }`
       )
       expect(content).toMatch(`const props = __props`)
       expect(bindings).toStrictEqual({
@@ -927,6 +937,8 @@ const emit = defineEmits(['a', 'b'])
         bar: BindingTypes.PROPS,
         baz: BindingTypes.PROPS,
         qux: BindingTypes.PROPS,
+	      toLowerCase: BindingTypes.PROPS,
+	      toUpperCase: BindingTypes.PROPS,
         props: BindingTypes.SETUP_CONST
       })
     })

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -922,12 +922,12 @@ const emit = defineEmits(['a', 'b'])
       expect(content).toMatch(
         `qux: { type: Function, required: false, default() { return 1 } }`
       )
-	    expect(content).toMatch(
-		    `toLowerCase: { type: Function, required: true, default: (str: string) => str.toLowerCase() }`
-	    )
-	    expect(content).toMatch(
-		    `toUpperCase: { type: Function, required: true, default(str: string) { return str.toUpperCase() } }`
-	    )
+      expect(content).toMatch(
+        `toLowerCase: { type: Function, required: true, default: (str: string) => str.toLowerCase() }`
+      )
+      expect(content).toMatch(
+        `toUpperCase: { type: Function, required: true, default(str: string) { return str.toUpperCase() } }`
+      )
       expect(content).toMatch(
         `{ foo: string, bar?: number, baz: boolean, qux(): number, toLowerCase: (str: string) => string, toUpperCase: (str: string) => string }`
       )
@@ -937,8 +937,8 @@ const emit = defineEmits(['a', 'b'])
         bar: BindingTypes.PROPS,
         baz: BindingTypes.PROPS,
         qux: BindingTypes.PROPS,
-	      toLowerCase: BindingTypes.PROPS,
-	      toUpperCase: BindingTypes.PROPS,
+        toLowerCase: BindingTypes.PROPS,
+        toUpperCase: BindingTypes.PROPS,
         props: BindingTypes.SETUP_CONST
       })
     })

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -660,6 +660,15 @@ export function compileScript(
     )
   }
 
+	function genRuntimeFunctionPropParameters(params: ObjectMethod['params'], source: string) {
+		if (!params.length) {
+			return ''
+		}
+		return params.reduce((result, paramNode) => {
+			return `${result}${result ? ',' : ''}${ source.slice(paramNode.start!, paramNode.end!)}`
+		}, '')
+	}
+
   function genRuntimeProps(props: Record<string, PropTypeData>) {
     const keys = Object.keys(props)
     if (!keys.length) {
@@ -686,7 +695,7 @@ export function compileScript(
                 prop.value.end!
               )}`
             } else {
-              defaultString = `default() ${scriptSetupSource.slice(
+              defaultString = `default(${genRuntimeFunctionPropParameters(prop.params, scriptSetupSource)}) ${scriptSetupSource.slice(
                 prop.body.start!,
                 prop.body.end!
               )}`

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -660,14 +660,20 @@ export function compileScript(
     )
   }
 
-	function genRuntimeFunctionPropParameters(params: ObjectMethod['params'], source: string) {
-		if (!params.length) {
-			return ''
-		}
-		return params.reduce((result, paramNode) => {
-			return `${result}${result ? ',' : ''}${ source.slice(paramNode.start!, paramNode.end!)}`
-		}, '')
-	}
+  function genRuntimeFunctionPropParameters(
+    params: ObjectMethod['params'],
+    source: string
+  ) {
+    if (!params.length) {
+      return ''
+    }
+    return params.reduce((result, paramNode) => {
+      return `${result}${result ? ',' : ''}${source.slice(
+        paramNode.start!,
+        paramNode.end!
+      )}`
+    }, '')
+  }
 
   function genRuntimeProps(props: Record<string, PropTypeData>) {
     const keys = Object.keys(props)
@@ -695,10 +701,10 @@ export function compileScript(
                 prop.value.end!
               )}`
             } else {
-              defaultString = `default(${genRuntimeFunctionPropParameters(prop.params, scriptSetupSource)}) ${scriptSetupSource.slice(
-                prop.body.start!,
-                prop.body.end!
-              )}`
+              defaultString = `default(${genRuntimeFunctionPropParameters(
+                prop.params,
+                scriptSetupSource
+              )}) ${scriptSetupSource.slice(prop.body.start!, prop.body.end!)}`
             }
           }
         }


### PR DESCRIPTION
fix: The withDefaults function loses arguments when assigning a function default value 

Fix #5253