### PR TITLE
fix(runtime-core): ensure that errors in slot function execution do not affect block tracking (fix #5657)

### DIFF
--- a/packages/runtime-core/src/componentRenderContext.ts
+++ b/packages/runtime-core/src/componentRenderContext.ts
@@ -1,6 +1,7 @@
 import { ComponentInternalInstance } from './component'
 import { devtoolsComponentUpdated } from './devtools'
 import { setBlockTracking } from './vnode'
+import { handleError, ErrorCodes } from './errorHandling'
 
 /**
  * mark the current rendering instance for asset resolution (e.g.
@@ -89,10 +90,16 @@ export function withCtx(
       setBlockTracking(-1)
     }
     const prevInstance = setCurrentRenderingInstance(ctx)
-    const res = fn(...args)
-    setCurrentRenderingInstance(prevInstance)
-    if (renderFnWithContext._d) {
-      setBlockTracking(1)
+    let res
+    try {
+      res = fn(...args)
+    } catch (e) {
+      handleError(e, prevInstance, ErrorCodes.SLOT_FUNCTION)
+    } finally {
+      setCurrentRenderingInstance(prevInstance)
+      if (renderFnWithContext._d) {
+        setBlockTracking(1)
+      }
     }
 
     if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {

--- a/packages/runtime-core/src/componentRenderContext.ts
+++ b/packages/runtime-core/src/componentRenderContext.ts
@@ -1,7 +1,6 @@
 import { ComponentInternalInstance } from './component'
 import { devtoolsComponentUpdated } from './devtools'
 import { setBlockTracking } from './vnode'
-import { handleError, ErrorCodes } from './errorHandling'
 
 /**
  * mark the current rendering instance for asset resolution (e.g.
@@ -93,8 +92,6 @@ export function withCtx(
     let res
     try {
       res = fn(...args)
-    } catch (e) {
-      handleError(e, prevInstance, ErrorCodes.SLOT_FUNCTION)
     } finally {
       setCurrentRenderingInstance(prevInstance)
       if (renderFnWithContext._d) {

--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -20,8 +20,7 @@ export const enum ErrorCodes {
   APP_WARN_HANDLER,
   FUNCTION_REF,
   ASYNC_COMPONENT_LOADER,
-  SCHEDULER,
-  SLOT_FUNCTION
+  SCHEDULER
 }
 
 export const ErrorTypeStrings: Record<number | string, string> = {
@@ -55,8 +54,7 @@ export const ErrorTypeStrings: Record<number | string, string> = {
   [ErrorCodes.ASYNC_COMPONENT_LOADER]: 'async component loader',
   [ErrorCodes.SCHEDULER]:
     'scheduler flush. This is likely a Vue internals bug. ' +
-    'Please open an issue at https://new-issue.vuejs.org/?repo=vuejs/core',
-  [ErrorCodes.SLOT_FUNCTION]: 'slot function'
+    'Please open an issue at https://new-issue.vuejs.org/?repo=vuejs/core'
 }
 
 export type ErrorTypes = LifecycleHooks | ErrorCodes

--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -20,7 +20,8 @@ export const enum ErrorCodes {
   APP_WARN_HANDLER,
   FUNCTION_REF,
   ASYNC_COMPONENT_LOADER,
-  SCHEDULER
+  SCHEDULER,
+  SLOT_FUNCTION
 }
 
 export const ErrorTypeStrings: Record<number | string, string> = {
@@ -54,7 +55,8 @@ export const ErrorTypeStrings: Record<number | string, string> = {
   [ErrorCodes.ASYNC_COMPONENT_LOADER]: 'async component loader',
   [ErrorCodes.SCHEDULER]:
     'scheduler flush. This is likely a Vue internals bug. ' +
-    'Please open an issue at https://new-issue.vuejs.org/?repo=vuejs/core'
+    'Please open an issue at https://new-issue.vuejs.org/?repo=vuejs/core',
+  [ErrorCodes.SLOT_FUNCTION]: 'slot function'
 }
 
 export type ErrorTypes = LifecycleHooks | ErrorCodes


### PR DESCRIPTION
fix #5657 
ensure that errors in slot function execution do not affect block tracking, and then affect dynamic children and patch