### PR TITLE
fix(runtime-core): ensure custom events are not emitted anymore after unmount. (fix #5674) 

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -73,6 +73,7 @@ export function emit(
   event: string,
   ...rawArgs: any[]
 ) {
+  if (instance.isUnmounted) return
   const props = instance.vnode.props || EMPTY_OBJ
 
   if (__DEV__) {


### PR DESCRIPTION
This change ensures that calling `emit` after the component has unmounted will no longer call any of the registered custom event listeners.

### Considerations

Is it possible/realistic that we have implementations out there that rely on the current behavior where this event would still be triggered?

If so, how do we approach this?

close: #5674