### PR TITLE
fix(custom-element): handle custom element edge error (fix #5677)

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -210,6 +210,19 @@ describe('defineCustomElement', () => {
       customElements.define('my-el-upgrade', E)
       expect(el.shadowRoot.innerHTML).toBe(`foo: hello`)
     })
+
+    test('handling error with attributes but no props declaration', () => {
+      const E = defineCustomElement({
+        render() {
+          return h('div', null, 'success')
+        }
+      })
+      customElements.define('my-el-no-declare', E)
+      const el = document.createElement('my-el-no-declare') as any
+      el.setAttribute('class', 'foo')
+      container.appendChild(el)
+      expect(el.shadowRoot.childNodes[0].getAttribute('class')).toBe('foo')
+    })
   })
 
   describe('emits', () => {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -216,7 +216,7 @@ export class VueElement extends BaseClass {
 
     const resolve = (def: InnerComponentDef) => {
       const { props, styles } = def
-      const hasOptions = !isArray(props)
+      const hasOptions = !!props && !isArray(props)
       const rawKeys = props ? (hasOptions ? Object.keys(props) : props) : []
 
       // cast Number-type props set before resolve


### PR DESCRIPTION
fix #5677 
CustomElement with attributes but no props declaration will cause an error of number prop casting.