### PR TITLE
types(reactivity): disallow using functions with arguments as a computed getter (fix #5692)

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -15,7 +15,7 @@ export interface WritableComputedRef<T> extends Ref<T> {
   readonly effect: ReactiveEffect<T>
 }
 
-export type ComputedGetter<T> = (...args: any[]) => T
+export type ComputedGetter<T> = () => T
 export type ComputedSetter<T> = (v: T) => void
 
 export interface WritableComputedOptions<T> {

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -16,7 +16,7 @@ export interface WritableComputedRef<T> extends Ref<T> {
 }
 
 export type ComputedGetter<T> = () => T
-export type ComputedGetterWithVModel<T> = (...args: any[]) => T
+export type ComputedGetterWithInstance<T> = (...args: any[]) => T
 export type ComputedSetter<T> = (v: T) => void
 
 export interface WritableComputedOptions<T> {
@@ -24,8 +24,8 @@ export interface WritableComputedOptions<T> {
   set: ComputedSetter<T>
 }
 
-export interface WritableComputedOptionsWithVModel<T> {
-  get: ComputedGetterWithVModel<T>
+export interface WritableComputedOptionsWithInstance<T> {
+  get: ComputedGetterWithInstance<T>
   set: ComputedSetter<T>
 }
 

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -16,7 +16,7 @@ export interface WritableComputedRef<T> extends Ref<T> {
 }
 
 export type ComputedGetter<T> = () => T
-export type ComputedGetterWithVModel<T> = (vm: any) => T
+export type ComputedGetterWithVModel<T> = (...args: any[]) => T
 export type ComputedSetter<T> = (v: T) => void
 
 export interface WritableComputedOptions<T> {

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -16,10 +16,16 @@ export interface WritableComputedRef<T> extends Ref<T> {
 }
 
 export type ComputedGetter<T> = () => T
+export type ComputedGetterWithVModel<T> = (vm: any) => T
 export type ComputedSetter<T> = (v: T) => void
 
 export interface WritableComputedOptions<T> {
   get: ComputedGetter<T>
+  set: ComputedSetter<T>
+}
+
+export interface WritableComputedOptionsWithVModel<T> {
+  get: ComputedGetterWithVModel<T>
   set: ComputedSetter<T>
 }
 

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -38,7 +38,9 @@ export {
   ComputedRef,
   WritableComputedRef,
   WritableComputedOptions,
+  WritableComputedOptionsWithVModel,
   ComputedGetter,
+  ComputedGetterWithVModel,
   ComputedSetter
 } from './computed'
 export { deferredComputed } from './deferredComputed'

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -38,9 +38,9 @@ export {
   ComputedRef,
   WritableComputedRef,
   WritableComputedOptions,
-  WritableComputedOptionsWithVModel,
+  WritableComputedOptionsWithInstance,
   ComputedGetter,
-  ComputedGetterWithVModel,
+  ComputedGetterWithInstance,
   ComputedSetter
 } from './computed'
 export { deferredComputed } from './deferredComputed'

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -46,8 +46,8 @@ import {
 } from './apiLifecycle'
 import {
   reactive,
-  ComputedGetter,
-  WritableComputedOptions
+  ComputedGetterWithVModel,
+  WritableComputedOptionsWithVModel
 } from '@vue/reactivity'
 import {
   ComponentObjectPropsOptions,
@@ -360,7 +360,7 @@ export type ComponentOptionsMixin = ComponentOptionsBase<
 
 export type ComputedOptions = Record<
   string,
-  ComputedGetter<any> | WritableComputedOptions<any>
+  ComputedGetterWithVModel<any> | WritableComputedOptionsWithVModel<any>
 >
 
 export interface MethodOptions {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -46,8 +46,8 @@ import {
 } from './apiLifecycle'
 import {
   reactive,
-  ComputedGetterWithVModel,
-  WritableComputedOptionsWithVModel
+  ComputedGetterWithInstance,
+  WritableComputedOptionsWithInstance
 } from '@vue/reactivity'
 import {
   ComponentObjectPropsOptions,
@@ -360,7 +360,7 @@ export type ComponentOptionsMixin = ComponentOptionsBase<
 
 export type ComputedOptions = Record<
   string,
-  ComputedGetterWithVModel<any> | WritableComputedOptionsWithVModel<any>
+  ComputedGetterWithInstance<any> | WritableComputedOptionsWithInstance<any>
 >
 
 export interface MethodOptions {


### PR DESCRIPTION
See #5692 

This came up during refactoring: I had a computed that was using a vuex getter.

```typescript
declare const getItems: () => Item[];

const items = computed(getItems);
```

Then I refactored getItems to require a parent id.

```typescript
declare const getItems: (parentId: string) => Item[];

const items = computed(getItems);
```

And typescript didn't notify me that getItems was used incorrectly.

I ended up banning passing functions into `computed` directly with `no-restricted-syntax` eslint rule.

```js
            {
                selector: 'CallExpression[callee.name=computed] > Identifier.arguments',
                message: 'Using computed(callback) is unsafe. Use computed(() => callback()) instead.',
            }
```

But I don't see why the type for ComputedGetter is declared as it is. Surely there can't be a case where doing the following is valid:

```typescript
const foo = computed((bar: string) => bar);
```
