### PR TITLE
types(runtime-dom) add `Set<any>` to checkbox

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -457,7 +457,7 @@ export interface InputHTMLAttributes extends HTMLAttributes {
   autocomplete?: string
   autofocus?: Booleanish
   capture?: boolean | 'user' | 'environment' // https://www.w3.org/tr/html-media-capture/#the-capture-attribute
-  checked?: Booleanish | any[] // for IDE v-model multi-checkbox support
+  checked?: Booleanish | any[] | Set<any> // for IDE v-model multi-checkbox support
   crossorigin?: string
   disabled?: Booleanish
   form?: string


### PR DESCRIPTION
`runtime-dom` types do not account for `Set<any>` as a valid `v-model` type for checkbox input elements when using TS. This is causing "compile-time" errors stating that `Set<any>` is an invalid `v-model` binding.

![image](https://user-images.githubusercontent.com/1657351/163232885-8dd45a67-17c5-4496-9a0d-0b54bc1fe731.png)
![image](https://user-images.githubusercontent.com/1657351/163232949-b594b98c-4ea5-4922-b64d-a02c3a5894ab.png)
![image](https://user-images.githubusercontent.com/1657351/163233360-df73e696-bd97-4b0b-909c-200a74e63269.png)
![image](https://user-images.githubusercontent.com/1657351/163233488-2d7e65ca-d57b-470c-9d0a-6b94e2748a01.png)

