### PR TITLE
fix(vue-compat): remove test.only

### DIFF
--- a/packages/vue-compat/__tests__/global.spec.ts
+++ b/packages/vue-compat/__tests__/global.spec.ts
@@ -285,7 +285,7 @@ describe('GLOBAL_PROTOTYPE', () => {
     delete Vue.prototype.$test
   })
 
-  test.only('functions keeps additional properties', () => {
+  test('functions keeps additional properties', () => {
     function test(this: any) {
       return this.msg
     }


### PR DESCRIPTION
A `test.only`has been introduced in 16129714714e19c5c6bfbd05c439ff68bcac00b9

cc @LinusBorg 