### PR TITLE
fix(runtime-core): properties start with '_' should not be proxied on component instance. (fix #5716)

### DIFF
--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -290,7 +290,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     // access on a plain object, so we use an accessCache object (with null
     // prototype) to memoize what access type a key corresponds to.
     let normalizedProps
-    if (key[0] !== '$') {
+    if (key[0] !== '$' && key[0] !== '_') {
       const n = accessCache![key]
       if (n !== undefined) {
         switch (n) {


### PR DESCRIPTION
fix #5716 .

### The problem

Properties start with "_" behave differently from properties start with "$".
example: [sfc.vuejs.org/](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdD5cbmV4cG9ydCBkZWZhdWx0IHtcbiAgZGF0YSgpIHtcbiAgICByZXR1cm4ge1xuICAgICAgJG1zZzogJ3N0YXJ0IHdpdGggJCcsXG4gICAgICBfbXNnOiAnc3RhcnQgd2l0aCBfJ1xuICAgIH1cbiAgfVxufVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGgxPnt7IHRoaXMuJG1zZyB9fTwvaDE+XG4gIDxoMT57eyB0aGlzLl9tc2cgfX08L2gxPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)
When accessing "this.$msg", it throw a warning,but "this._msg" does not.

I suspect that a "If statement" lacks jugement for "_".
