### PR TITLE
refactor(reactivity): simplify if condition

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -283,7 +283,7 @@ export function trigger(
     })
   } else {
     // schedule runs for SET | ADD | DELETE
-    if (key !== void 0) {
+    if (!key) {
       deps.push(depsMap.get(key))
     }
 


### PR DESCRIPTION
The `void 0` will return absolutely value `undefined`, but it's unnecessary

when i tried this, the brower will give me an error
```js
const undefined = 1  // Uncaught SyntaxError: Identifier 'undefined' has already been declared
```
and if i did this, when i access undefined, it will also return `undefined`
```js
undefined = 1
console.log(undefined) // undefined
```
So i think we can simplify if condition in this case

And I passed the unit test