### PR TITLE
fix(runtime-dom): warnings should be ignored when property value is undefined

### DIFF
--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -18,6 +18,7 @@ export function patchDOMProp(
   parentSuspense: any,
   unmountChildren: any
 ) {
+  const originValue = value
   if (key === 'innerHTML' || key === 'textContent') {
     if (prevChildren) {
       unmountChildren(prevChildren, parentComponent, parentSuspense)
@@ -96,7 +97,7 @@ export function patchDOMProp(
   try {
     el[key] = value
   } catch (e: any) {
-    if (__DEV__) {
+    if (__DEV__ && !Object.is(originValue, undefined)) {
       warn(
         `Failed setting prop "${key}" on <${el.tagName.toLowerCase()}>: ` +
           `value ${value} is invalid.`,


### PR DESCRIPTION
fixed: #5784

When the value of the property is `undefined`, its value should not be set to `0`

![image](https://user-images.githubusercontent.com/39730999/163690354-7a5fa457-e6e3-429c-ac5c-b0a5c37ea6e8.png)

simple reproduction code：
```vue
<template>
   <input v-bind="inputProps" />
</template>

<script setup>
  import { reactive } from 'vue'

  const inputProps = reactive({ size: undefined })
</script>
```