### PR TITLE
test(runtime-core): enhance apiInject test case

### DIFF
--- a/packages/runtime-core/__tests__/apiInject.spec.ts
+++ b/packages/runtime-core/__tests__/apiInject.spec.ts
@@ -134,7 +134,8 @@ describe('api: provide/inject', () => {
         // override parent value
         provide('foo', 'fooOverride')
         provide('baz', 'baz')
-        return () => h(Consumer)
+        const foo = inject('foo')
+        return () => [foo, h(Consumer)]
       }
     }
 
@@ -143,13 +144,13 @@ describe('api: provide/inject', () => {
         const foo = inject('foo')
         const bar = inject('bar')
         const baz = inject('baz')
-        return () => [foo, bar, baz].join(',')
+        return () => [, foo, bar, baz].join(',')
       }
     }
 
     const root = nodeOps.createElement('div')
     render(h(ProviderOne), root)
-    expect(serialize(root)).toBe(`<div>fooOverride,bar,baz</div>`)
+    expect(serialize(root)).toBe(`<div>foo,fooOverride,bar,baz</div>`)
   })
 
   it('reactivity with refs', async () => {


### PR DESCRIPTION
## Steps to reproduce

If I mutate this correct [sentence](https://github.com/vuejs/core/blob/4a3237ad9300693e465f82a6be3552565a1c4be3/packages/runtime-core/src/apiInject.ts#L23) in function `provide` 

```typescript
provide = currentInstance.provides = Object.create(parentProvides)
```

into the following statement:

```typescript
currentInstance.provides = Object.create(parentProvides)
```

There should be failures in the test cases, because at this time `provides` still points to the original `instance.provides`. Modifications to `provides` will affect provides on the prototype chain.

However, all test cases still passed, indicating that some test cases may need to be enhanced.

## expected

Expected to enhance the effectiveness of test cases

## Analysis

In the test case named [nested providers](https://github.com/vuejs/core/blob/4a3237ad9300693e465f82a6be3552565a1c4be3/packages/runtime-core/__tests__/apiInject.spec.ts#L123), `Consumer` considers three paths:

- foo -> ProviderTwo.provides -> `fooOverride` (override parent value)
- bar -> ProviderOne.provides -> `bar` (through prototype chain)

- baz -> ProviderTwo.provides -> `baz`

But in this test case, `foo` in ProviderOne is not being read. So there is no concern whether the `provides` content in `ProviderOne` may be wrongly rewritten. 

I think it may be better to add a path in `ProviderTwo` to enhance this test case:

- foo -> ProviderOne.provides -> `foo`


