### PR TITLE
feat:Using interface  give defineComponent type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,15 @@
 {
   // Use the project's typescript version
   "typescript.tsdk": "node_modules/typescript/lib",
-
-  "cSpell.enabledLanguageIds": ["markdown", "plaintext", "text", "yml"],
-
+  "cSpell.enabledLanguageIds": [
+    "markdown",
+    "plaintext",
+    "text",
+    "yml"
+  ],
   // Use prettier to format typescript, javascript and JSON files
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -117,6 +117,37 @@ describe('api: options', () => {
     expect(serializeInner(root)).toBe(`<div>4</div>`)
   })
 
+
+  test('methods item type', () => {
+
+    interface IComp {
+      data: { foo: number, baz: number },
+      methods: {
+        inc(): void,
+        getNumber(): number,
+      }
+    }
+
+    //Using interface IComp give defineComponent type
+    const Comp = defineComponent<IComp>({
+      data() {
+        return {
+          foo: 1,
+          // baz type is getNumber type
+          baz: this.getNumber()
+        }
+      },
+      methods: {
+        inc() {
+          this.foo++
+        },
+        getNumber(): number {
+          return 1
+        },
+      },
+    })
+  })
+
   test('component’s own methods have higher priority than global properties', async () => {
     const app = createApp({
       methods: {
@@ -315,7 +346,7 @@ describe('api: options', () => {
 
     let vm: any
     const Comp = {
-      render() {},
+      render() { },
       mixins: [mixinA, mixinB],
       data: () => ({
         obj: 'foo',
@@ -372,12 +403,12 @@ describe('api: options', () => {
     })
 
     const defineChild = (injectOptions: any, injectedKey = 'b') =>
-      ({
-        inject: injectOptions,
-        render() {
-          return this[injectedKey]
-        }
-      } as any)
+    ({
+      inject: injectOptions,
+      render() {
+        return this[injectedKey]
+      }
+    } as any)
 
     const ChildA = defineChild(['a'], 'a')
     const ChildB = defineChild({ b: 'a' })
@@ -866,7 +897,7 @@ describe('api: options', () => {
         }
       },
       methods: {
-        sayA() {}
+        sayA() { }
       },
       mounted(this: any) {
         expect(this.a).toBe(1)
@@ -903,7 +934,7 @@ describe('api: options', () => {
         }
       },
       methods: {
-        sayA() {}
+        sayA() { }
       },
       mounted(this: any) {
         expect(this.a).toBe(1)
@@ -993,7 +1024,7 @@ describe('api: options', () => {
       created() {
         calls.push('selfCreated')
       },
-      render() {}
+      render() { }
     }
 
     renderToString(h(Comp))
@@ -1126,7 +1157,7 @@ describe('api: options', () => {
     let vm: any
     const Comp = {
       mixins: [mixin1, mixin2, mixin3],
-      render() {},
+      render() { },
       created() {
         vm = this
       }
@@ -1265,15 +1296,15 @@ describe('api: options', () => {
 
     test('this.$options[lifecycle-name]', () => {
       const mixin = {
-        mounted() {},
-        beforeUnmount() {},
-        unmounted() {}
+        mounted() { },
+        beforeUnmount() { },
+        unmounted() { }
       }
       createApp({
         mixins: [mixin],
-        mounted() {},
-        beforeUnmount() {},
-        unmounted() {},
+        mounted() { },
+        beforeUnmount() { },
+        unmounted() { },
         created() {
           expect(this.$options.mounted).toBeInstanceOf(Array)
           expect(this.$options.mounted.length).toBe(2)
@@ -1316,13 +1347,13 @@ describe('api: options', () => {
     test('this.$options.methods', () => {
       const mixin = {
         methods: {
-          fn1() {}
+          fn1() { }
         }
       }
       createApp({
         mixins: [mixin],
         methods: {
-          fn2() {}
+          fn2() { }
         },
         created() {
           expect(this.$options.methods.fn1).toBeInstanceOf(Function)
@@ -1335,13 +1366,13 @@ describe('api: options', () => {
     test('this.$options.computed', () => {
       const mixin = {
         computed: {
-          c1() {}
+          c1() { }
         }
       }
       createApp({
         mixins: [mixin],
         computed: {
-          c2() {}
+          c2() { }
         },
         created() {
           expect(this.$options.computed.c1).toBeInstanceOf(Function)
@@ -1390,7 +1421,7 @@ describe('api: options', () => {
             handler: 'notExistingMethod2'
           }
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1407,7 +1438,7 @@ describe('api: options', () => {
     test('Invalid watch option', () => {
       const Comp = {
         watch: { foo: true },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1421,10 +1452,10 @@ describe('api: options', () => {
       const Comp = {
         computed: {
           foo: {
-            set() {}
+            set() { }
           }
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1437,13 +1468,13 @@ describe('api: options', () => {
       const Comp = {
         computed: {
           foo: {
-            get() {}
+            get() { }
           }
         },
         mounted() {
           instance = this
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1490,14 +1521,14 @@ describe('api: options', () => {
         methods: {
           foo: 1
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
       render(h(Comp), root)
       expect(
         `Method "foo" has type "number" in the component definition. ` +
-          `Did you reference the function correctly?`
+        `Did you reference the function correctly?`
       ).toHaveBeenWarned()
     })
 
@@ -1507,9 +1538,9 @@ describe('api: options', () => {
           foo: Number
         },
         methods: {
-          foo() {}
+          foo() { }
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1558,7 +1589,7 @@ describe('api: options', () => {
         data: () => ({
           foo: 1
         }),
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1609,9 +1640,9 @@ describe('api: options', () => {
           foo: 1
         }),
         methods: {
-          foo() {}
+          foo() { }
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1625,9 +1656,9 @@ describe('api: options', () => {
       const Comp = {
         props: { foo: Number },
         computed: {
-          foo() {}
+          foo() { }
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1656,8 +1687,8 @@ describe('api: options', () => {
       const ChildA = {
         computed: {
           a: {
-            get() {},
-            set() {}
+            get() { },
+            set() { }
           }
         },
         inject: ['a'],
@@ -1676,12 +1707,12 @@ describe('api: options', () => {
     test('computed property is already declared in methods', () => {
       const Comp = {
         computed: {
-          foo() {}
+          foo() { }
         },
         methods: {
-          foo() {}
+          foo() { }
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')
@@ -1697,9 +1728,9 @@ describe('api: options', () => {
           foo: 1
         }),
         computed: {
-          foo() {}
+          foo() { }
         },
-        render() {}
+        render() { }
       }
 
       const root = nodeOps.createElement('div')

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -26,6 +26,25 @@ import {
   ComponentPublicInstanceConstructor
 } from './componentPublicInstance'
 
+type NoItem2Default<T, Key, Default> = Key extends keyof T ? NonNullable<T[Key]> : Default
+
+type TPropsType = 'PROPS' | 'ARRAYPROPS' | 'OBJECTPROPS';
+
+interface IDefineComponentGeneric<PropsType extends TPropsType> {
+  props?: PropsType extends 'PROPS' ? {}
+  : PropsType extends 'ARRAYPROPS' ? string
+  : PropsType extends 'OBJECTPROPS' ? Readonly<ComponentPropsOptions>
+  : never,
+  RawBindings?: {},
+  data?: {},
+  computed?: ComputedOptions,
+  methods?: MethodOptions,
+  mixin?: ComponentOptionsMixin,
+  extends?: ComponentOptionsMixin,
+  emits?: EmitsOptions,
+  ee?: string,
+}
+
 export type PublicProps = VNodeProps &
   AllowedComponentProps &
   ComponentCustomProps
@@ -43,27 +62,27 @@ export type DefineComponent<
   PP = PublicProps,
   Props = Readonly<
     PropsOrPropOptions extends ComponentPropsOptions
-      ? ExtractPropTypes<PropsOrPropOptions>
-      : PropsOrPropOptions
+    ? ExtractPropTypes<PropsOrPropOptions>
+    : PropsOrPropOptions
   > &
-    ({} extends E ? {} : EmitsToProps<E>),
+  ({} extends E ? {} : EmitsToProps<E>),
   Defaults = ExtractDefaultPropTypes<PropsOrPropOptions>
-> = ComponentPublicInstanceConstructor<
-  CreateComponentPublicInstance<
-    Props,
-    RawBindings,
-    D,
-    C,
-    M,
-    Mixin,
-    Extends,
-    E,
-    PP & Props,
-    Defaults,
-    true
-  > &
+  > = ComponentPublicInstanceConstructor<
+    CreateComponentPublicInstance<
+      Props,
+      RawBindings,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      E,
+      PP & Props,
+      Defaults,
+      true
+    > &
     Props
-> &
+  > &
   ComponentOptionsBase<
     Props,
     RawBindings,
@@ -96,93 +115,88 @@ export function defineComponent<Props, RawBindings = object>(
 // (uses user defined props interface)
 // return type is for Vetur and TSX support
 export function defineComponent<
-  Props = {},
-  RawBindings = {},
-  D = {},
-  C extends ComputedOptions = {},
-  M extends MethodOptions = {},
-  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = EmitsOptions,
-  EE extends string = string
->(
-  options: ComponentOptionsWithoutProps<
-    Props,
-    RawBindings,
-    D,
-    C,
-    M,
-    Mixin,
-    Extends,
-    E,
-    EE
+  T extends IDefineComponentGeneric<'PROPS'>,
+  >(
+    options: ComponentOptionsWithoutProps<
+      NoItem2Default<T, 'props', {}>,
+      NoItem2Default<T, 'RawBindings', {}>,
+      NoItem2Default<T, 'data', {}>,
+      NoItem2Default<T, 'computed', {}>,
+      NoItem2Default<T, 'methods', {}>,
+      NoItem2Default<T, 'mixin', ComponentOptionsMixin>,
+      NoItem2Default<T, 'extends', ComponentOptionsMixin>,
+      NoItem2Default<T, 'emits', EmitsOptions>,
+      NoItem2Default<T, 'ee', string>
+    >
+  ): DefineComponent<
+    NoItem2Default<T, 'props', {}>,
+    NoItem2Default<T, 'RawBindings', {}>,
+    NoItem2Default<T, 'data', {}>,
+    NoItem2Default<T, 'computed', {}>,
+    NoItem2Default<T, 'methods', {}>,
+    NoItem2Default<T, 'mixin', ComponentOptionsMixin>,
+    NoItem2Default<T, 'extends', ComponentOptionsMixin>,
+    NoItem2Default<T, 'emits', EmitsOptions>,
+    NoItem2Default<T, 'ee', string>
   >
-): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
 
 // overload 3: object format with array props declaration
 // props inferred as { [key in PropNames]?: any }
 // return type is for Vetur and TSX support
 export function defineComponent<
-  PropNames extends string,
-  RawBindings,
-  D,
-  C extends ComputedOptions = {},
-  M extends MethodOptions = {},
-  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = Record<string, any>,
-  EE extends string = string
->(
-  options: ComponentOptionsWithArrayProps<
-    PropNames,
-    RawBindings,
-    D,
-    C,
-    M,
-    Mixin,
-    Extends,
-    E,
-    EE
+  T extends IDefineComponentGeneric<'ARRAYPROPS'>,
+  >(
+    options: ComponentOptionsWithArrayProps<
+      NoItem2Default<T, 'props', string>,
+      NoItem2Default<T, 'RawBindings', {}>,
+      NoItem2Default<T, 'data', {}>,
+      NoItem2Default<T, 'computed', {}>,
+      NoItem2Default<T, 'methods', {}>,
+      NoItem2Default<T, 'mixin', ComponentOptionsMixin>,
+      NoItem2Default<T, 'extends', ComponentOptionsMixin>,
+      NoItem2Default<T, 'emits', EmitsOptions>,
+      NoItem2Default<T, 'ee', string>
+    >
+  ): DefineComponent<
+    NoItem2Default<T, 'props', {}>,
+    NoItem2Default<T, 'RawBindings', {}>,
+    NoItem2Default<T, 'data', {}>,
+    NoItem2Default<T, 'computed', {}>,
+    NoItem2Default<T, 'methods', {}>,
+    NoItem2Default<T, 'mixin', ComponentOptionsMixin>,
+    NoItem2Default<T, 'extends', ComponentOptionsMixin>,
+    NoItem2Default<T, 'emits', EmitsOptions>,
+    NoItem2Default<T, 'ee', string>
   >
-): DefineComponent<
-  Readonly<{ [key in PropNames]?: any }>,
-  RawBindings,
-  D,
-  C,
-  M,
-  Mixin,
-  Extends,
-  E,
-  EE
->
 
 // overload 4: object format with object props declaration
 // see `ExtractPropTypes` in ./componentProps.ts
 export function defineComponent<
   // the Readonly constraint allows TS to treat the type of { required: true }
   // as constant instead of boolean.
-  PropsOptions extends Readonly<ComponentPropsOptions>,
-  RawBindings,
-  D,
-  C extends ComputedOptions = {},
-  M extends MethodOptions = {},
-  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = Record<string, any>,
-  EE extends string = string
+  T extends IDefineComponentGeneric<'OBJECTPROPS'>
 >(
   options: ComponentOptionsWithObjectProps<
-    PropsOptions,
-    RawBindings,
-    D,
-    C,
-    M,
-    Mixin,
-    Extends,
-    E,
-    EE
+    NoItem2Default<T, 'props', Readonly<ComponentPropsOptions>>,
+    NoItem2Default<T, 'RawBindings', {}>,
+    NoItem2Default<T, 'data', {}>,
+    NoItem2Default<T, 'computed', {}>,
+    NoItem2Default<T, 'methods', {}>,
+    NoItem2Default<T, 'mixin', ComponentOptionsMixin>,
+    NoItem2Default<T, 'extends', ComponentOptionsMixin>,
+    NoItem2Default<T, 'emits', EmitsOptions>,
+    NoItem2Default<T, 'ee', string>
   >
-): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE>
+): DefineComponent<
+  NoItem2Default<T, 'props', {}>,
+  NoItem2Default<T, 'RawBindings', {}>,
+  NoItem2Default<T, 'data', {}>,
+  NoItem2Default<T, 'computed', {}>,
+  NoItem2Default<T, 'methods', {}>,
+  NoItem2Default<T, 'mixin', ComponentOptionsMixin>,
+  NoItem2Default<T, 'extends', ComponentOptionsMixin>,
+  NoItem2Default<T, 'emits', EmitsOptions>,
+  NoItem2Default<T, 'ee', string>>
 
 // implementation, close to no-op
 export function defineComponent(options: unknown) {


### PR DESCRIPTION
![wecom-temp-b0dcbf976841cb9f401dd513f4de253f](https://user-images.githubusercontent.com/73146951/163991021-3b327151-fb43-4623-99a9-eadcf71043e6.png)
vue2.6的options类型issus[#12427](https://github.com/vuejs/vue/issues/12427)。
该issus再defineComponent也同样存在，这里更改了defineComponent的范型如下
![image](https://user-images.githubusercontent.com/73146951/163991767-ed0a88a1-f202-464a-9713-28333bf85444.png)
使得在defineComponent传入option的定义即可，而无需一个个传入data，methods等类型