### PR TITLE
fix(runtime-dom): patchstyle should not overwritten the same value

### DIFF
--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -87,6 +87,16 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.cssText).toBe('')
   })
 
+  it('should not overwritten the same value', () => {
+    const el = document.createElement('div')
+    patchProp(el, 'style', {}, { left: '10px' })
+    expect(el.style.getPropertyValue('left')).toBe('10px')
+    el.style.left = '20px'
+    expect(el.style.getPropertyValue('left')).toBe('20px')
+    patchProp(el, 'style', { left: '10px' }, { left: '10px' })
+    expect(el.style.getPropertyValue('left')).toBe('20px')
+  })
+
   // JSDOM doesn't support custom properties on style object so we have to
   // mock it here.
   function mockElementWithStyle() {

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -7,21 +7,27 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   const style = (el as HTMLElement).style
   const isCssString = isString(next)
   if (next && !isCssString) {
-    for (const key in next) {
-      setStyle(style, key, next[key])
-    }
     if (prev && !isString(prev)) {
       for (const key in prev) {
         if (next[key] == null) {
           setStyle(style, key, '')
         }
       }
+      for (const key in next) {
+        if (next[key] !== prev[key]) {
+          setStyle(style, key, next[key])
+        }
+      }
+    } else {
+      for (const key in next) {
+        setStyle(style, key, next[key])
+      }
     }
   } else {
     const currentDisplay = style.display
     if (isCssString) {
       if (prev !== next) {
-        style.cssText = next as string
+        style.cssText = next
       }
     } else if (prev) {
       el.removeAttribute('style')


### PR DESCRIPTION
Open the [link](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiwgcmVhY3RpdmUgfSBmcm9tICd2dWUnXG5cbmNvbnN0IGxpc3QgPSByZWFjdGl2ZShbXG4gIHtuYW1lOiAnYScsIGxlZnQ6ICcxMHB4J30sXG5dKSBcbmNvbnN0IGFkZCA9ICgpID0+IHtcbiAgbGlzdC5wdXNoKHtcbiAgICBuYW1lOiAnYicsXG4gICAgbGVmdDogJzEwMHB4J1xuICB9KVxufVxuY29uc3QgbW92ZSA9ICgpID0+IHtcbiBcdGNvbnN0IGVscyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJy50ZXh0JylcbiAgQXJyYXkuZnJvbShlbHMpLmZvckVhY2goaXRlbSA9PiB7XG4gICAgaXRlbS5zdHlsZS5sZWZ0ID0gcGFyc2VJbnQoaXRlbS5zdHlsZS5sZWZ0KSArIDEwICsgJ3B4J1xuICB9KVxufVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGJ1dHRvbiBAY2xpY2s9XCJtb3ZlXCI+bW92ZTwvYnV0dG9uPjxidXR0b24gQGNsaWNrPVwiYWRkXCI+YWRkPC9idXR0b24+XG4gIDxkaXYgY2xhc3M9XCJ0ZXh0XCIgdi1mb3I9XCJpdGVtIGluIGxpc3RcIiA6a2V5PVwiaXRlbS5uYW1lXCIgOnN0eWxlPVwie2xlZnQ6IGl0ZW0ubGVmdH1cIj57e2l0ZW0ubmFtZX19PC9kaXY+XG48L3RlbXBsYXRlPlxuPHN0eWxlPlxuICAudGV4dCB7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB9XG48L3N0eWxlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0B2dWUvcnVudGltZS1kb21AMy4yLjMzL2Rpc3QvcnVudGltZS1kb20uZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=) and follow the steps below: 
1、Click the `move` button, and the left value of div tag will become `20px`.
2、Click the `add` button, the left value of the first div tag should also be `20px`.