### PR TITLE
fix(hmr): force full diff props for nested component coming from npm. (fix: #5767)

### DIFF
--- a/packages/runtime-core/__tests__/hmr.spec.ts
+++ b/packages/runtime-core/__tests__/hmr.spec.ts
@@ -469,4 +469,28 @@ describe('hot module replacement', () => {
     render(h(Foo), root)
     expect(serializeInner(root)).toBe('bar')
   })
+
+  // #5767  
+  test('rerender for nested component coming from an external npm package with static props', () => {
+    const id = 'parent'
+    const Child: ComponentOptions = {
+      props: {
+        msg: String
+      },
+      render: compileToFunction(`<div>{{msg}}</div><slot/>`)
+    }
+    const Parent: ComponentOptions = {
+      __hmrId: id,
+      components: { Child },
+      render: compileToFunction(`<Child msg="outer"><Child msg="inner" /></Child>`)
+    }
+
+    createRecord(id, Parent)
+    const root = nodeOps.createElement('div')
+    render(h(Parent), root)
+    expect(serializeInner(root)).toBe(`<div>outer</div><div>inner</div>`)
+
+    rerender(id, compileToFunction(`<Child msg="outer"><Child msg="in" /></Child>`))
+    expect(serializeInner(root)).toBe(`<div>outer</div><div>in</div>`)
+  })
 })

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -40,6 +40,7 @@ import { createPropsDefaultThis } from './compat/props'
 import { isCompatEnabled, softAssertCompatEnabled } from './compat/compatConfig'
 import { DeprecationTypes } from './compat/compatConfig'
 import { shouldSkipAttr } from './compat/attrsFallthrough'
+import { isHmrUpdating } from './hmr'
 
 export type ComponentPropsOptions<P = Data> =
   | ComponentObjectPropsOptions<P>
@@ -211,7 +212,7 @@ export function updateProps(
     // - #1942 if hmr is enabled with sfc component
     // - vite#872 non-sfc component used by sfc component
     !(
-      __DEV__ && isHmr(instance)
+      __DEV__ && isHmrUpdating
     ) &&
     (optimized || patchFlag > 0) &&
     !(patchFlag & PatchFlags.FULL_PROPS)
@@ -724,17 +725,4 @@ function isExplicable(type: string): boolean {
  */
 function isBoolean(...args: string[]): boolean {
   return args.some(elem => elem.toLowerCase() === 'boolean')
-}
-
-/**
- * dev only
- */
- function isHmr(instance:ComponentInternalInstance|null): boolean {
-   while(instance) {
-      if(instance.type.__hmrId) {
-        return true
-      }
-      instance = instance.parent
-   }
-  return false
 }

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -211,9 +211,7 @@ export function updateProps(
     // - #1942 if hmr is enabled with sfc component
     // - vite#872 non-sfc component used by sfc component
     !(
-      __DEV__ &&
-      (instance.type.__hmrId ||
-        (instance.parent && instance.parent.type.__hmrId))
+      __DEV__ && isHmr(instance)
     ) &&
     (optimized || patchFlag > 0) &&
     !(patchFlag & PatchFlags.FULL_PROPS)
@@ -726,4 +724,17 @@ function isExplicable(type: string): boolean {
  */
 function isBoolean(...args: string[]): boolean {
   return args.some(elem => elem.toLowerCase() === 'boolean')
+}
+
+/**
+ * dev only
+ */
+ function isHmr(instance:ComponentInternalInstance|null): boolean {
+   while(instance) {
+      if(instance.type.__hmrId) {
+        return true
+      }
+      instance = instance.parent
+   }
+  return false
 }


### PR DESCRIPTION
fix #5767 
I'm not sure if `isHmrUpdating` can be used here, so follow the previous logic.