### PR TITLE
fix(compile-script):two script blocks complier err

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -167,7 +167,26 @@ defineExpose({ foo: 123 })
     // should replace callee
     expect(content).toMatch(/\bexpose\(\{ foo: 123 \}\)/)
   })
-
+  test('between two blocks should have "\n"', () => {
+    const { content } = compile(`
+    <script setup>
+    import foo from './foo'
+    </script>
+    // <script>
+    // const bar = 1;
+    // </script>
+      `)
+      expect(content).not.toMatch('// import foo')
+  })
+  test('between two blocks should have "\n"', () => {
+      const { content } = compile(`
+      <script setup>
+      import foo from './foo'
+      </script>
+      <script>const bar = 1</script>
+        `)
+      expect(content).not.toMatch(`const bar = 1import foo from './foo'`)
+  })
   describe('<script> and <script setup> co-usage', () => {
     test('script first', () => {
       const { content } = compile(`

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -879,8 +879,10 @@ export function compileScript(
     // <script> after <script setup>
     // we need to move the block up so that `const __default__` is
     // declared before being used in the actual component definition
+    // between two blocks should have '\n'
     if (scriptStartOffset! > startOffset) {
-      s.move(scriptStartOffset!, scriptEndOffset!, 0)
+        s.overwrite(scriptStartOffset!,scriptEndOffset!,s.slice(scriptStartOffset!, scriptEndOffset!)+'\n')
+        s.move(scriptStartOffset!, scriptEndOffset!, 0)
     }
   }
 
@@ -1445,7 +1447,7 @@ export function compileScript(
     )
   }
 
-  s.trim()
+  s.trim('\s[^\n]')
 
   return {
     ...scriptSetup,


### PR DESCRIPTION
[vue sfc playground](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgbXNnID0gcmVmKCdIZWxsbyBXb3JsZCEnKVxuPC9zY3JpcHQ+XG4vLyA8c2NyaXB0PlxuLy8gY29uc3QgYSA9IDFcbi8vIDwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxoMT57eyBtc2cgfX08L2gxPlxuICA8aW5wdXQgdi1tb2RlbD1cIm1zZ1wiPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)

When you comment out the old script refactor it to script setup. It's seems like a problem.

And this test cant pass too .
```javasciript
test('between two blocks should have "\n"', () => {
      const { content } = compile(`
      <script setup>
      import foo from './foo'
      </script>
      <script>const bar = 1</script>
        `)
      expect(content).not.toMatch(`const bar = 1import foo from './foo'`)
  })
```