### PR TITLE
fix(compiler-sfc): <script> after <script setup> the script content not end with `\n`

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SFC compile <script setup> <script> after <script setup> the script content not end with \`\\n\` 1`] = `
+"const n = 1
+import { x } from './x'
+    
+export default {
+  setup(__props, { expose }) {
+  expose();
+
+    
+return { n, x }
+}
+
+}"
+`;
+
 exports[`SFC compile <script setup> <script> and <script setup> co-usage script first 1`] = `
 "import { x } from './x'
       

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -168,6 +168,16 @@ defineExpose({ foo: 123 })
     expect(content).toMatch(/\bexpose\(\{ foo: 123 \}\)/)
   })
 
+  test('<script> after <script setup> the script content not end with `\\n`',() => {
+    const { content } = compile(`
+    <script setup>
+    import { x } from './x'
+    </script>
+    <script>const n = 1</script>
+    `)
+    assertCode(content)
+  })
+
   describe('<script> and <script setup> co-usage', () => {
     test('script first', () => {
       const { content } = compile(`

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -881,6 +881,11 @@ export function compileScript(
     // declared before being used in the actual component definition
     if (scriptStartOffset! > startOffset) {
       s.move(scriptStartOffset!, scriptEndOffset!, 0)
+      const content = s.slice(scriptStartOffset!, scriptEndOffset!)
+      // when the script content not end with `\n` we add `\n` for the script content
+      if(!/(\n *$)/.test(content)) {
+        s.overwrite(scriptStartOffset!,scriptEndOffset!,`${content}\n`)
+      }
     }
   }
 


### PR DESCRIPTION
fix this case [sfc.vuejs.org](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmNvbnN0IG1zZyA9IHJlZignSGVsbG8gV29ybGQhJylcbjwvc2NyaXB0PlxuPHNjcmlwdD5jb25zdCBuID0gMTwvc2NyaXB0PlxuPHRlbXBsYXRlPlxuICA8aDE+e3sgbXNnIH19PC9oMT5cbiAgPGgyPnt7IG4gfX08L2gyPlxuICA8aW5wdXQgdi1tb2RlbD1cIm1zZ1wiPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)

```javascript
<script setup>
import { ref } from 'vue'
const msg = ref('Hello World!')
</script>
<script>const n = 1</script>
<template>
  <h1>{{ msg }}</h1>
  <h2>{{ n }}</h2>
  <input v-model="msg">
</template>
```