### PR TITLE
fix(compiler-sfc): check parent as well as other nodes

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -262,6 +262,29 @@ return {  }
 }"
 `;
 
+exports[`SFC compile <script setup> async/await detection nested statements with preceding statements 1`] = `
+"import { withAsyncContext as _withAsyncContext } from 'vue'
+
+export default {
+  async setup(__props, { expose }) {
+  expose();
+
+let __temp, __restore
+
+      if (ok) {
+        const a = 'test'
+        ;(
+  ([__temp,__restore] = _withAsyncContext(() => foo)),
+  await __temp,
+  __restore()
+)
+      }
+return {  }
+}
+
+}"
+`;
+
 exports[`SFC compile <script setup> async/await detection ref 1`] = `
 "import { withAsyncContext as _withAsyncContext, ref as _ref } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1164,6 +1164,14 @@ const emit = defineEmits(['a', 'b'])
       assertAwaitDetection(`if (ok) { await foo } else { await bar }`)
     })
 
+    test('nested statements with preceding statements', () => {
+      assertAwaitDetection(`
+      if (ok) {
+        const a = 'test'
+        await foo
+      }`)
+    })
+
     test('should ignore await inside functions', () => {
       // function declaration
       assertAwaitDetection(`async function foo() { await bar }`, false)

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -627,6 +627,13 @@ export function compileScript(
     )
 
     const containsNestedAwait = /\bawait\b/.test(argumentStr)
+    for (let pos = startOffset + node.start! - 1; pos > 0; pos--) {
+      if (/\s/.test(source[pos])) {
+        continue
+      }
+      needSemi = needSemi || /['"`A-Za-z0-9_$\]]/.test(source[pos])
+      break
+    }
 
     s.overwrite(
       node.start! + startOffset,
@@ -1067,7 +1074,7 @@ export function compileScript(
           }
           if (child.type === 'AwaitExpression') {
             hasAwait = true
-            const needsSemi = [parent, ...scriptSetupAst.body].some(n => {
+            const needsSemi = scriptSetupAst.body.some(n => {
               return n.type === 'ExpressionStatement' && n.start === child.start
             })
             processAwait(

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1067,7 +1067,7 @@ export function compileScript(
           }
           if (child.type === 'AwaitExpression') {
             hasAwait = true
-            const needsSemi = scriptSetupAst.body.some(n => {
+            const needsSemi = [parent, ...scriptSetupAst.body].some(n => {
               return n.type === 'ExpressionStatement' && n.start === child.start
             })
             processAwait(


### PR DESCRIPTION
resolves #5808

It's possible to have an AST where the preceding node isn't at the top level, for example with a nested if statement.

I don't feel great about this solution, which is basically special-casing known-bad characters; other solutions welcome.