### PR TITLE
fix(runtime-core): v-memo dependency is NaN should be equal

### DIFF
--- a/packages/runtime-core/__tests__/helpers/withMemo.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/withMemo.spec.ts
@@ -210,4 +210,17 @@ describe('v-memo', () => {
     // should update
     expect(el.innerHTML).toBe(`<div>2</div><div>2</div><div>2</div>`)
   })
+
+  test('v-memo dependency is NaN should be equal', async () => {
+    const [el, vm] = mount({
+      template: `<div v-memo="[x]">{{ y }}</div>`,
+      data: () => ({ x: NaN, y: 0 })
+    })
+    expect(el.innerHTML).toBe(`<div>0</div>`)
+
+    vm.y++
+    // should not update
+    await nextTick()
+    expect(el.innerHTML).toBe(`<div>0</div>`)
+  })
 })

--- a/packages/runtime-core/src/helpers/withMemo.ts
+++ b/packages/runtime-core/src/helpers/withMemo.ts
@@ -1,3 +1,4 @@
+import { hasChanged } from '@vue/shared'
 import { currentBlock, isBlockTreeEnabled, VNode } from '../vnode'
 
 export function withMemo(
@@ -22,8 +23,9 @@ export function isMemoSame(cached: VNode, memo: any[]) {
   if (prev.length != memo.length) {
     return false
   }
+  
   for (let i = 0; i < prev.length; i++) {
-    if (prev[i] !== memo[i]) {
+    if (hasChanged(prev[i], memo[i])) {
       return false
     }
   }


### PR DESCRIPTION
fix #5853
The case where the v-memo dependency is Nan is not equal.