### PR TITLE
fix(runtime-core): remove judgement in patchProps

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1004,7 +1004,6 @@ function baseCreateRenderer(
     parentSuspense: SuspenseBoundary | null,
     isSVG: boolean
   ) => {
-    if (oldProps !== newProps) {
       for (const key in newProps) {
         // empty string is not valid prop
         if (isReservedProp(key)) continue
@@ -1045,7 +1044,6 @@ function baseCreateRenderer(
       if ('value' in newProps) {
         hostPatchProp(el, 'value', oldProps.value, newProps.value)
       }
-    }
   }
 
   const processFragment = (


### PR DESCRIPTION
Since we have entered the patch process, the oldProps and the newProps can't be equal because they are all reference type.So i think we can remove this `oldProps !== newProps` judgement.