### PR TITLE
types(props): Allow passing `null` on optional props

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -125,7 +125,7 @@ export type ExtractPropTypes<O> = {
   [K in keyof Pick<O, RequiredKeys<O>>]: InferPropType<O[K]>
 } & {
   // use `keyof Pick<O, OptionalKeys<O>>` instead of `OptionalKeys<O>` to support IDE features
-  [K in keyof Pick<O, OptionalKeys<O>>]?: InferPropType<O[K]>
+  [K in keyof Pick<O, OptionalKeys<O>>]?: InferPropType<O[K]> | null
 }
 
 const enum BooleanFlags {
@@ -225,7 +225,7 @@ export function updateProps(
       for (let i = 0; i < propsToUpdate.length; i++) {
         let key = propsToUpdate[i]
         // skip if the prop key is a declared emit event listener
-        if (isEmitListener(instance.emitsOptions, key)){
+        if (isEmitListener(instance.emitsOptions, key)) {
           continue
         }
         // PROPS flag guarantees rawProps to be non-null

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -79,22 +79,22 @@ interface Constructor<P = any> {
 // manually written render functions.
 
 // element
-export function h(type: string, children?: RawChildren): VNode
+export function h(type: string, children?: RawChildren | null): VNode
 export function h(
   type: string,
   props?: RawProps | null,
-  children?: RawChildren | RawSlots
+  children?: RawChildren | RawSlots | null
 ): VNode
 
 // text/comment
 export function h(
   type: typeof Text | typeof Comment,
-  children?: string | number | boolean
+  children?: string | number | boolean | null
 ): VNode
 export function h(
   type: typeof Text | typeof Comment,
   props?: null,
-  children?: string | number | boolean
+  children?: string | number | boolean | null
 ): VNode
 // fragment
 export function h(type: typeof Fragment, children?: VNodeArrayChildren): VNode
@@ -116,42 +116,42 @@ export function h(type: typeof Suspense, children?: RawChildren): VNode
 export function h(
   type: typeof Suspense,
   props?: (RawProps & SuspenseProps) | null,
-  children?: RawChildren | RawSlots
+  children?: RawChildren | RawSlots | null
 ): VNode
 
 // functional component
 export function h<P, E extends EmitsOptions = {}>(
   type: FunctionalComponent<P, E>,
   props?: (RawProps & P) | ({} extends P ? null : never),
-  children?: RawChildren | RawSlots
+  children?: RawChildren | RawSlots | null
 ): VNode
 
 // catch-all for generic component types
-export function h(type: Component, children?: RawChildren): VNode
+export function h(type: Component, children?: RawChildren | null): VNode
 
 // concrete component
 export function h<P>(
   type: ConcreteComponent | string,
-  children?: RawChildren
+  children?: RawChildren | null
 ): VNode
 export function h<P>(
   type: ConcreteComponent<P> | string,
   props?: (RawProps & P) | ({} extends P ? null : never),
-  children?: RawChildren
+  children?: RawChildren | null
 ): VNode
 
 // component without props
 export function h(
   type: Component,
   props: null,
-  children?: RawChildren | RawSlots
+  children?: RawChildren | RawSlots | null
 ): VNode
 
 // exclude `defineComponent` constructors
 export function h<P>(
   type: ComponentOptions<P>,
   props?: (RawProps & P) | ({} extends P ? null : never),
-  children?: RawChildren | RawSlots
+  children?: RawChildren | RawSlots | null
 ): VNode
 
 // fake constructor type returned by `defineComponent` or class component
@@ -159,7 +159,7 @@ export function h(type: Constructor, children?: RawChildren): VNode
 export function h<P>(
   type: Constructor<P>,
   props?: (RawProps & P) | ({} extends P ? null : never),
-  children?: RawChildren | RawSlots
+  children?: RawChildren | RawSlots | null
 ): VNode
 
 // fake constructor type returned by `defineComponent`
@@ -167,7 +167,7 @@ export function h(type: DefineComponent, children?: RawChildren): VNode
 export function h<P>(
   type: DefineComponent<P>,
   props?: (RawProps & P) | ({} extends P ? null : never),
-  children?: RawChildren | RawSlots
+  children?: RawChildren | RawSlots | null
 ): VNode
 
 // Actual implementation

--- a/test-dts/component.test-d.ts
+++ b/test-dts/component.test-d.ts
@@ -24,45 +24,45 @@ declare function extractComponentOptions<Props, RawBindings>(
 
 describe('object props', () => {
   interface ExpectedProps {
-    a?: number | undefined
+    a?: number | undefined | null
     b: string
-    e?: Function
+    e?: Function | null
     bb: string
     bbb: string
-    cc?: string[] | undefined
+    cc?: string[] | undefined | null
     dd: { n: 1 }
-    ee?: () => string
-    ff?: (a: number, b: string) => { a: boolean }
-    ccc?: string[] | undefined
+    ee?: (() => string) | null
+    ff?: ((a: number, b: string) => { a: boolean }) | null
+    ccc?: string[] | undefined | null
     ddd: string[]
     eee: () => { a: string }
     fff: (a: number, b: string) => { a: boolean }
     hhh: boolean
     ggg: 'foo' | 'bar'
     ffff: (a: number, b: string) => { a: boolean }
-    validated?: string
-    object?: object
+    validated?: string | null
+    object?: object | null
   }
 
   interface ExpectedRefs {
-    a: Ref<number | undefined>
+    a: Ref<number | undefined | null>
     b: Ref<string>
-    e: Ref<Function | undefined>
+    e: Ref<Function | undefined | null>
     bb: Ref<string>
     bbb: Ref<string>
-    cc: Ref<string[] | undefined>
+    cc: Ref<string[] | undefined | null>
     dd: Ref<{ n: 1 }>
-    ee: Ref<(() => string) | undefined>
-    ff: Ref<((a: number, b: string) => { a: boolean }) | undefined>
-    ccc: Ref<string[] | undefined>
+    ee: Ref<(() => string) | undefined | null>
+    ff: Ref<((a: number, b: string) => { a: boolean }) | undefined | null>
+    ccc: Ref<string[] | undefined | null>
     ddd: Ref<string[]>
     eee: Ref<() => { a: string }>
     fff: Ref<(a: number, b: string) => { a: boolean }>
     hhh: Ref<boolean>
     ggg: Ref<'foo' | 'bar'>
     ffff: Ref<(a: number, b: string) => { a: boolean }>
-    validated: Ref<string | undefined>
-    object: Ref<object | undefined>
+    validated: Ref<string | undefined | null>
+    object: Ref<object | undefined | null>
     zzz: any
   }
 

--- a/test-dts/componentTypeExtensions.test-d.tsx
+++ b/test-dts/componentTypeExtensions.test-d.tsx
@@ -44,6 +44,7 @@ export const Custom = defineComponent({
 expectType<JSX.Element>(<Custom baz={1} />)
 expectType<JSX.Element>(<Custom custom={1} baz={1} />)
 expectType<JSX.Element>(<Custom bar="bar" baz={1} />)
+expectType<JSX.Element>(<Custom bar={null} baz={1} />)
 
 // @ts-expect-error
 expectType<JSX.Element>(<Custom />)

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -17,34 +17,34 @@ import {
 
 describe('with object props', () => {
   interface ExpectedProps {
-    a?: number | undefined
+    a?: number | undefined | null
     b: string
-    e?: Function
+    e?: Function | null
     h: boolean
-    j: undefined | (() => string | undefined)
+    j: undefined | (() => string | undefined) | null
     bb: string
     bbb: string
-    bbbb: string | undefined
-    bbbbb: string | undefined
-    cc?: string[] | undefined
+    bbbb: string | undefined | null
+    bbbbb: string | undefined | null
+    cc?: string[] | undefined | null
     dd: { n: 1 }
-    ee?: () => string
-    ff?: (a: number, b: string) => { a: boolean }
-    ccc?: string[] | undefined
+    ee?: (() => string) | null
+    ff?: ((a: number, b: string) => { a: boolean }) | null
+    ccc?: string[] | undefined | null
     ddd: string[]
     eee: () => { a: string }
     fff: (a: number, b: string) => { a: boolean }
     hhh: boolean
     ggg: 'foo' | 'bar'
     ffff: (a: number, b: string) => { a: boolean }
-    iii?: (() => string) | (() => number)
+    iii?: (() => string) | (() => number) | null
     jjj: ((arg1: string) => string) | ((arg1: string, arg2: string) => string)
-    kkk?: any
-    validated?: string
-    date?: Date
-    l?: Date
-    ll?: Date | number
-    lll?: string | number
+    kkk?: any | null
+    validated?: string | null
+    date?: Date | null
+    l?: Date | null
+    ll?: Date | number | null
+    lll?: string | number | null
   }
 
   type GT = string & { __brand: unknown }
@@ -162,7 +162,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['ggg']>(props.ggg)
       expectType<ExpectedProps['ffff']>(props.ffff)
       if (typeof props.iii !== 'function') {
-        expectType<undefined>(props.iii)
+        expectType<undefined | null>(props.iii)
       }
       expectType<ExpectedProps['iii']>(props.iii)
       expectType<IsUnion<typeof props.jjj>>(true)
@@ -206,7 +206,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['hhh']>(props.hhh)
       expectType<ExpectedProps['ggg']>(props.ggg)
       if (typeof props.iii !== 'function') {
-        expectType<undefined>(props.iii)
+        expectType<undefined | null>(props.iii)
       }
       expectType<ExpectedProps['iii']>(props.iii)
       expectType<IsUnion<typeof props.jjj>>(true)
@@ -233,7 +233,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['hhh']>(this.hhh)
       expectType<ExpectedProps['ggg']>(this.ggg)
       if (typeof this.iii !== 'function') {
-        expectType<undefined>(this.iii)
+        expectType<undefined | null>(this.iii)
       }
       expectType<ExpectedProps['iii']>(this.iii)
       const { jjj } = this
@@ -398,7 +398,7 @@ describe('type inference w/ options API', () => {
     data() {
       // Limitation: we cannot expose the return result of setup() on `this`
       // here in data() - somehow that would mess up the inference
-      expectType<number | undefined>(this.a)
+      expectType<number | undefined | null>(this.a)
       return {
         c: this.a || 123,
         someRef: ref(0)
@@ -431,7 +431,7 @@ describe('type inference w/ options API', () => {
     },
     created() {
       // props
-      expectType<number | undefined>(this.a)
+      expectType<number | undefined | null>(this.a)
       // returned from setup()
       expectType<number>(this.b)
       // returned from data()
@@ -445,7 +445,7 @@ describe('type inference w/ options API', () => {
     methods: {
       doSomething() {
         // props
-        expectType<number | undefined>(this.a)
+        expectType<number | undefined | null>(this.a)
         // returned from setup()
         expectType<number>(this.b)
         // returned from data()
@@ -461,7 +461,7 @@ describe('type inference w/ options API', () => {
     },
     render() {
       // props
-      expectType<number | undefined>(this.a)
+      expectType<number | undefined | null>(this.a)
       // returned from setup()
       expectType<number>(this.b)
       // returned from data()
@@ -471,7 +471,7 @@ describe('type inference w/ options API', () => {
       // computed get/set
       expectType<number>(this.e)
       // method
-      expectType<() => number | undefined>(this.returnSomething)
+      expectType<() => number | undefined | null>(this.returnSomething)
     }
   })
 })
@@ -1070,7 +1070,7 @@ describe('extract instance type', () => {
 
   expectType<boolean>(compA.a)
   expectType<string>(compA.b)
-  expectType<number | undefined>(compA.c)
+  expectType<number | undefined | null>(compA.c)
   // mixins
   expectType<string>(compA.mA)
   // extends

--- a/test-dts/h.test-d.ts
+++ b/test-dts/h.test-d.ts
@@ -104,6 +104,7 @@ describe('h inference w/ defineComponent', () => {
   h(Foo, { bar: 1, foo: 'ok' })
   // should allow extraneous props (attrs fallthrough)
   h(Foo, { bar: 1, foo: 'ok', class: 'extra' })
+  h(Foo, { bar: 1, foo: null })
   // @ts-expect-error should fail on missing required prop
   expectError(h(Foo, {}))
   //  @ts-expect-error

--- a/test-dts/setupHelpers.test-d.ts
+++ b/test-dts/setupHelpers.test-d.ts
@@ -74,7 +74,7 @@ describe('defineProps w/ runtime declaration', () => {
     }
   })
   expectType<{
-    foo?: string
+    foo?: string | null
     bar: number
     baz: unknown[]
   }>(props)


### PR DESCRIPTION
Allowing passing `null` if the prop is not required.

Currently it's a typescript error



[runtime playground](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmltcG9ydCBDb21wIGZyb20gJy4vQ29tcC52dWUnXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8Q29tcCA6bmFtZT1cIm51bGxcIi8+XG48L3RlbXBsYXRlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiXG4gIH1cbn0iLCJDb21wLnZ1ZSI6IjxzY3JpcHQgc2V0dXA+XG5cbiAgZGVmaW5lUHJvcHMoe1xuIG5hbWU6IFN0cmluZ1xufSlcbjwvc2NyaXB0PlxuPHRlbXBsYXRlPlxuPHA+XG4gIHt7bmFtZSB8fCAnbnVsbGlzaCd9fVxuICA8L3A+XG48L3RlbXBsYXRlPiJ9)