### PR TITLE
feat(types): avoid props JSDocs loss due to `default` option

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -135,7 +135,8 @@ const enum BooleanFlags {
 
 // extract props which defined with default from prop options
 export type ExtractDefaultPropTypes<O> = O extends object
-  ? { [K in DefaultKeys<O>]: InferPropType<O[K]> }
+  // use `keyof Pick<O, DefaultKeys<O>>` instead of `DefaultKeys<O>` to support IDE features
+  ? { [K in keyof Pick<O, DefaultKeys<O>>]: InferPropType<O[K]> }
   : {}
 
 type NormalizedProp =


### PR DESCRIPTION
Fixed https://github.com/johnsoncodehk/volar/issues/1261.

- Before the fix
<img width="398" alt="螢幕截圖 2022-05-06 18 33 39" src="https://user-images.githubusercontent.com/16279759/167115878-3fdce400-b090-4469-a450-423f89b1c33c.png">

- After the fix
<img width="432" alt="螢幕截圖 2022-05-06 18 34 18" src="https://user-images.githubusercontent.com/16279759/167115904-202b4368-b5c0-4123-9602-1f1387a35dd0.png">
