### PR TITLE
feat(shared): use the shared methods to judge the type and replace the place where the type is judged in the code

### DIFF
--- a/packages/compiler-core/src/compat/compatConfig.ts
+++ b/packages/compiler-core/src/compat/compatConfig.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@vue/shared'
 import { SourceLocation } from '../ast'
 import { CompilerError } from '../errors'
 import { ParserContext } from '../parse'
@@ -149,7 +150,7 @@ export function warnDeprecation(
   }
   const { message, link } = deprecationData[key]
   const msg = `(deprecation ${key}) ${
-    typeof message === 'function' ? message(...args) : message
+    isFunction(message) ? message(...args) : message
   }${link ? `\n  Details: ${link}` : ``}`
 
   const err = new SyntaxError(msg) as CompilerError

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -13,7 +13,7 @@ import {
 } from '@vue/compiler-dom'
 import { SFCDescriptor, SFCScriptBlock } from './parse'
 import { parse as _parse, ParserOptions, ParserPlugin } from '@babel/parser'
-import { camelize, capitalize, generateCodeFrame, makeMap } from '@vue/shared'
+import { camelize, capitalize, generateCodeFrame, isString, makeMap } from '@vue/shared'
 import {
   Node,
   Declaration,
@@ -1304,7 +1304,7 @@ export function compileScript(
         tips.forEach(warnOnce)
       }
       const err = errors[0]
-      if (typeof err === 'string') {
+      if (isString(err)) {
         throw new Error(err)
       } else if (err) {
         if (err.loc) {
@@ -1804,7 +1804,7 @@ function isCallOf(
     node &&
     node.type === 'CallExpression' &&
     node.callee.type === 'Identifier' &&
-    (typeof test === 'string'
+    (isString(test)
       ? node.callee.name === test
       : test(node.callee.name))
   )

--- a/packages/compiler-sfc/src/cssVars.ts
+++ b/packages/compiler-sfc/src/cssVars.ts
@@ -10,6 +10,7 @@ import {
 import { SFCDescriptor } from './parse'
 import { PluginCreator } from 'postcss'
 import hash from 'hash-sum'
+import { isString } from '@vue/shared'
 
 export const CSS_VARS_HELPER = `useCssVars`
 // match v-bind() with max 2-levels of nested parens.
@@ -101,7 +102,7 @@ export function genCssVarsCode(
       ? transformed.content
       : transformed.children
           .map(c => {
-            return typeof c === 'string'
+            return isString(c)
               ? c
               : (c as SimpleExpressionNode).content
           })

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -48,7 +48,7 @@ import {
   ssrTransformSuspense
 } from './ssrTransformSuspense'
 import { ssrProcessTransitionGroup } from './ssrTransformTransitionGroup'
-import { isSymbol, isObject, isArray } from '@vue/shared'
+import { isSymbol, isObject, isArray, isString } from '@vue/shared'
 import { buildSSRProps } from './ssrTransformElement'
 
 // We need to construct the slot functions in the 1st pass to ensure proper
@@ -146,7 +146,7 @@ export const ssrTransformComponent: NodeTransform = (node, context) => {
       ? buildSlots(node, context, buildSSRSlotFn).slots
       : `null`
 
-    if (typeof component !== 'string') {
+    if (!isString(component)) {
       // dynamic component that resolved to a `resolveDynamicComponent` call
       // expression - since the resolved result may be a plain element (string)
       // or a VNode, handle it with `renderVNode`.
@@ -215,7 +215,7 @@ export function ssrProcessComponent(
       node.ssrCodegenNode.arguments.push(`_scopeId`)
     }
 
-    if (typeof component === 'string') {
+    if (isString(component)) {
       // static component
       context.pushStatement(
         createCallExpression(`_push`, [node.ssrCodegenNode])

--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -36,6 +36,7 @@ import {
   isBooleanAttr,
   isBuiltInDirective,
   isSSRSafeAttrName,
+  isString,
   NO,
   propsToAttrMap
 } from '@vue/shared'
@@ -391,7 +392,7 @@ function removeStaticBinding(
 ) {
   const regExp = new RegExp(`^ ${binding}=".+"$`)
 
-  const i = tag.findIndex(e => typeof e === 'string' && regExp.test(e))
+  const i = tag.findIndex(e => isString(e) && regExp.test(e))
 
   if (i > -1) {
     tag.splice(i, 1)

--- a/packages/reactivity-transform/src/reactivityTransform.ts
+++ b/packages/reactivity-transform/src/reactivityTransform.ts
@@ -21,7 +21,7 @@ import {
   walkFunctionParams
 } from '@vue/compiler-core'
 import { parse, ParserPlugin } from '@babel/parser'
-import { hasOwn, isArray, isString } from '@vue/shared'
+import { hasOwn, isArray, isNumber, isString } from '@vue/shared'
 
 const CONVERT_SYMBOL = '$'
 const ESCAPE_SYMBOL = '$$'
@@ -460,7 +460,7 @@ export function transformAST(
   }
 
   function segToString(seg: PathSegmentAtom): string {
-    if (typeof seg === 'number') {
+    if (isNumber(seg)) {
       return `[${seg}]`
     } else if (typeof seg === 'string') {
       return `.${seg}`

--- a/packages/reactivity-transform/src/reactivityTransform.ts
+++ b/packages/reactivity-transform/src/reactivityTransform.ts
@@ -462,7 +462,7 @@ export function transformAST(
   function segToString(seg: PathSegmentAtom): string {
     if (isNumber(seg)) {
       return `[${seg}]`
-    } else if (typeof seg === 'string') {
+    } else if (isString(seg)) {
       return `.${seg}`
     } else {
       return snip(seg)

--- a/packages/runtime-core/src/compat/compatConfig.ts
+++ b/packages/runtime-core/src/compat/compatConfig.ts
@@ -481,7 +481,7 @@ export function warnDeprecation(
   const { message, link } = deprecationData[key]
   warn(
     `(deprecation ${key}) ${
-      typeof message === 'function' ? message(...args) : message
+      isFunction(message) ? message(...args) : message
     }${link ? `\n  Details: ${link}` : ``}`
   )
   if (!isCompatEnabled(key, instance, true)) {

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -486,7 +486,7 @@ function installCompatMount(
       }
 
       let container: Element
-      if (typeof selectorOrEl === 'string') {
+      if (isString(selectorOrEl)) {
         // eslint-disable-next-line
         const result = document.querySelector(selectorOrEl)
         if (!result) {

--- a/packages/runtime-core/src/compat/renderFn.ts
+++ b/packages/runtime-core/src/compat/renderFn.ts
@@ -127,7 +127,7 @@ export function compatH(
   }
 
   // to support v2 string component name look!up
-  if (typeof type === 'string') {
+  if (isString(type)) {
     const t = hyphenate(type)
     if (t === 'transition' || t === 'transition-group' || t === 'keep-alive') {
       // since transition and transition-group are runtime-dom-specific,

--- a/packages/runtime-core/src/compat/renderHelpers.ts
+++ b/packages/runtime-core/src/compat/renderHelpers.ts
@@ -5,6 +5,7 @@ import {
   isArray,
   isObject,
   isReservedProp,
+  isString,
   normalizeClass
 } from '@vue/shared'
 import { ComponentInternalInstance } from '../component'
@@ -170,7 +171,7 @@ export function legacyMarkOnce(tree: VNode) {
 export function legacyBindDynamicKeys(props: any, values: any[]) {
   for (let i = 0; i < values.length; i += 2) {
     const key = values[i]
-    if (typeof key === 'string' && key) {
+    if (isString(key) && key) {
       props[values[i]] = values[i + 1]
     }
   }
@@ -178,5 +179,5 @@ export function legacyBindDynamicKeys(props: any, values: any[]) {
 }
 
 export function legacyPrependModifier(value: any, symbol: string) {
-  return typeof value === 'string' ? symbol + value : value
+  return isString(value) ? symbol + value : value
 }

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -10,7 +10,7 @@ import {
   createVNode,
   isBlockTreeEnabled
 } from '../vnode'
-import { isFunction, isArray, ShapeFlags, toNumber } from '@vue/shared'
+import { isFunction, isArray, ShapeFlags, toNumber, isNumber } from '@vue/shared'
 import { ComponentInternalInstance, handleSetupResult } from '../component'
 import { Slots } from '../componentSlots'
 import {
@@ -427,7 +427,7 @@ function createSuspenseBoundary(
     anchor,
     deps: 0,
     pendingId: 0,
-    timeout: typeof timeout === 'number' ? timeout : -1,
+    timeout: isNumber(timeout) ? timeout : -1,
     activeBranch: null,
     pendingBranch: null,
     isInFallback: true,

--- a/packages/runtime-core/src/customFormatter.ts
+++ b/packages/runtime-core/src/customFormatter.ts
@@ -1,5 +1,5 @@
 import { isReactive, isReadonly, isRef, Ref, toRaw } from '@vue/reactivity'
-import { EMPTY_OBJ, extend, isArray, isBoolean, isFunction, isNumber, isObject } from '@vue/shared'
+import { EMPTY_OBJ, extend, isArray, isBoolean, isFunction, isNumber, isObject, isString } from '@vue/shared'
 import { isShallow } from '../../reactivity/src/reactive'
 import { ComponentInternalInstance, ComponentOptions } from './component'
 import { ComponentPublicInstance } from './componentPublicInstance'
@@ -140,7 +140,7 @@ export function initCustomFormatter() {
   function formatValue(v: unknown, asRaw = true) {
     if (isNumber(v)) {
       return ['span', numberStyle, v]
-    } else if (typeof v === 'string') {
+    } else if (isString(v)) {
       return ['span', stringStyle, JSON.stringify(v)]
     } else if (isBoolean(v)) {
       return ['span', keywordStyle, v]

--- a/packages/runtime-core/src/customFormatter.ts
+++ b/packages/runtime-core/src/customFormatter.ts
@@ -1,5 +1,5 @@
 import { isReactive, isReadonly, isRef, Ref, toRaw } from '@vue/reactivity'
-import { EMPTY_OBJ, extend, isArray, isFunction, isObject } from '@vue/shared'
+import { EMPTY_OBJ, extend, isArray, isFunction, isNumber, isObject } from '@vue/shared'
 import { isShallow } from '../../reactivity/src/reactive'
 import { ComponentInternalInstance, ComponentOptions } from './component'
 import { ComponentPublicInstance } from './componentPublicInstance'
@@ -138,7 +138,7 @@ export function initCustomFormatter() {
   }
 
   function formatValue(v: unknown, asRaw = true) {
-    if (typeof v === 'number') {
+    if (isNumber(v)) {
       return ['span', numberStyle, v]
     } else if (typeof v === 'string') {
       return ['span', stringStyle, JSON.stringify(v)]

--- a/packages/runtime-core/src/customFormatter.ts
+++ b/packages/runtime-core/src/customFormatter.ts
@@ -1,5 +1,5 @@
 import { isReactive, isReadonly, isRef, Ref, toRaw } from '@vue/reactivity'
-import { EMPTY_OBJ, extend, isArray, isFunction, isNumber, isObject } from '@vue/shared'
+import { EMPTY_OBJ, extend, isArray, isBoolean, isFunction, isNumber, isObject } from '@vue/shared'
 import { isShallow } from '../../reactivity/src/reactive'
 import { ComponentInternalInstance, ComponentOptions } from './component'
 import { ComponentPublicInstance } from './componentPublicInstance'
@@ -142,7 +142,7 @@ export function initCustomFormatter() {
       return ['span', numberStyle, v]
     } else if (typeof v === 'string') {
       return ['span', stringStyle, JSON.stringify(v)]
-    } else if (typeof v === 'boolean') {
+    } else if (isBoolean(v)) {
       return ['span', keywordStyle, v]
     } else if (isObject(v)) {
       return ['object', { object: asRaw ? toRaw(v) : v }]

--- a/packages/runtime-core/src/featureFlags.ts
+++ b/packages/runtime-core/src/featureFlags.ts
@@ -1,4 +1,4 @@
-import { getGlobalThis } from '@vue/shared'
+import { getGlobalThis, isBoolean } from '@vue/shared'
 
 /**
  * This is only called in esm-bundler builds.
@@ -10,12 +10,12 @@ import { getGlobalThis } from '@vue/shared'
 export function initFeatureFlags() {
   const needWarn = []
 
-  if (typeof __FEATURE_OPTIONS_API__ !== 'boolean') {
+  if (!isBoolean(__FEATURE_OPTIONS_API__)) {
     __DEV__ && needWarn.push(`__VUE_OPTIONS_API__`)
     getGlobalThis().__VUE_OPTIONS_API__ = true
   }
 
-  if (typeof __FEATURE_PROD_DEVTOOLS__ !== 'boolean') {
+  if (!isBoolean(__FEATURE_PROD_DEVTOOLS__)) {
     __DEV__ && needWarn.push(`__VUE_PROD_DEVTOOLS__`)
     getGlobalThis().__VUE_PROD_DEVTOOLS__ = false
   }

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,5 +1,5 @@
 import { VNode, VNodeChild } from '../vnode'
-import { isArray, isString, isObject } from '@vue/shared'
+import { isArray, isString, isObject, isNumber } from '@vue/shared'
 import { warn } from '../warning'
 
 /**
@@ -64,7 +64,7 @@ export function renderList(
     for (let i = 0, l = source.length; i < l; i++) {
       ret[i] = renderItem(source[i], i, undefined, cached && cached[i])
     }
-  } else if (typeof source === 'number') {
+  } else if (isNumber(source)) {
     if (__DEV__ && !Number.isInteger(source)) {
       warn(`The v-for range expect an integer value but got ${source}.`)
       return []

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -714,7 +714,7 @@ export function normalizeVNode(child: VNodeChild): VNode {
       // #3666, avoid reference pollution when reusing vnode
       child.slice()
     )
-  } else if (typeof child === 'object') {
+  } else if (isObject(child)) {
     // already vnode, this should be the most common since compiled templates
     // always produce all-vnode children arrays
     return cloneIfMounted(child)
@@ -736,7 +736,7 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
     children = null
   } else if (isArray(children)) {
     type = ShapeFlags.ARRAY_CHILDREN
-  } else if (typeof children === 'object') {
+  } else if (isObject(children)) {
     if (shapeFlag & (ShapeFlags.ELEMENT | ShapeFlags.TELEPORT)) {
       // Normalize slot to plain children for plain element and Teleport
       const slot = (children as any).default

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -10,7 +10,8 @@ import {
   PatchFlags,
   ShapeFlags,
   SlotFlags,
-  isOn
+  isOn,
+  isBoolean
 } from '@vue/shared'
 import {
   ComponentInternalInstance,
@@ -702,7 +703,7 @@ export function createCommentVNode(
 }
 
 export function normalizeVNode(child: VNodeChild): VNode {
-  if (child == null || typeof child === 'boolean') {
+  if (child == null || isBoolean(child)) {
     // empty placeholder
     return createVNode(Comment)
   } else if (isArray(child)) {

--- a/packages/runtime-core/src/warning.ts
+++ b/packages/runtime-core/src/warning.ts
@@ -5,7 +5,7 @@ import {
   ConcreteComponent,
   formatComponentName
 } from './component'
-import { isString, isFunction } from '@vue/shared'
+import { isString, isFunction, isNumber } from '@vue/shared'
 import { toRaw, isRef, pauseTracking, resetTracking } from '@vue/reactivity'
 import { callWithErrorHandling, ErrorCodes } from './errorHandling'
 
@@ -145,7 +145,7 @@ function formatProp(key: string, value: unknown, raw?: boolean): any {
     value = JSON.stringify(value)
     return raw ? value : [`${key}=${value}`]
   } else if (
-    typeof value === 'number' ||
+    isNumber(value) ||
     typeof value === 'boolean' ||
     value == null
   ) {

--- a/packages/runtime-core/src/warning.ts
+++ b/packages/runtime-core/src/warning.ts
@@ -5,7 +5,7 @@ import {
   ConcreteComponent,
   formatComponentName
 } from './component'
-import { isString, isFunction, isNumber } from '@vue/shared'
+import { isString, isFunction, isNumber, isBoolean } from '@vue/shared'
 import { toRaw, isRef, pauseTracking, resetTracking } from '@vue/reactivity'
 import { callWithErrorHandling, ErrorCodes } from './errorHandling'
 
@@ -146,7 +146,7 @@ function formatProp(key: string, value: unknown, raw?: boolean): any {
     return raw ? value : [`${key}=${value}`]
   } else if (
     isNumber(value) ||
-    typeof value === 'boolean' ||
+    isBoolean(value) ||
     value == null
   ) {
     return raw ? value : [`${key}=${value}`]

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -21,7 +21,7 @@ import {
   ConcreteComponent,
   ComponentOptions
 } from '@vue/runtime-core'
-import { camelize, extend, hyphenate, isArray, toNumber } from '@vue/shared'
+import { camelize, extend, hyphenate, isArray, isNumber, toNumber } from '@vue/shared'
 import { hydrate, render } from '.'
 
 export type VueElementConstructor<P = {}> = {
@@ -299,7 +299,7 @@ export class VueElement extends BaseClass {
       if (shouldReflect) {
         if (val === true) {
           this.setAttribute(hyphenate(key), '')
-        } else if (typeof val === 'string' || typeof val === 'number') {
+        } else if (typeof val === 'string' || isNumber(val)) {
           this.setAttribute(hyphenate(key), val + '')
         } else if (!val) {
           this.removeAttribute(hyphenate(key))

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -21,7 +21,7 @@ import {
   ConcreteComponent,
   ComponentOptions
 } from '@vue/runtime-core'
-import { camelize, extend, hyphenate, isArray, isNumber, toNumber } from '@vue/shared'
+import { camelize, extend, hyphenate, isArray, isNumber, isString, toNumber } from '@vue/shared'
 import { hydrate, render } from '.'
 
 export type VueElementConstructor<P = {}> = {
@@ -299,7 +299,7 @@ export class VueElement extends BaseClass {
       if (shouldReflect) {
         if (val === true) {
           this.setAttribute(hyphenate(key), '')
-        } else if (typeof val === 'string' || isNumber(val)) {
+        } else if (isString(val) || isNumber(val)) {
           this.setAttribute(hyphenate(key), val + '')
         } else if (!val) {
           this.removeAttribute(hyphenate(key))

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -7,7 +7,7 @@ import {
   compatUtils,
   DeprecationTypes
 } from '@vue/runtime-core'
-import { isObject, toNumber, extend, isArray } from '@vue/shared'
+import { isObject, toNumber, extend, isArray, isNumber } from '@vue/shared'
 
 const TRANSITION = 'transition'
 const ANIMATION = 'animation'
@@ -276,7 +276,7 @@ function NumberOf(val: unknown): number {
 }
 
 function validateDuration(val: unknown) {
-  if (typeof val !== 'number') {
+  if (!isNumber(val)) {
     warn(
       `<transition> explicit duration is not a valid number - ` +
         `got ${JSON.stringify(val)}.`

--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -1,5 +1,6 @@
 import {
   includeBooleanAttr,
+  isBoolean,
   isSpecialBooleanAttr,
   makeMap,
   NOOP
@@ -56,7 +57,7 @@ export function compatCoerceAttr(
     const v2CocercedValue =
       value === null
         ? 'false'
-        : typeof value !== 'boolean' && value !== undefined
+        : !isBoolean(value) && value !== undefined
         ? 'true'
         : null
     if (

--- a/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
+++ b/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
@@ -1,4 +1,5 @@
 import { ComponentPublicInstance, Directive } from '@vue/runtime-core'
+import { isFunction } from '@vue/shared'
 
 export function ssrGetDirectiveProps(
   instance: ComponentPublicInstance,
@@ -7,7 +8,7 @@ export function ssrGetDirectiveProps(
   arg?: string,
   modifiers: Record<string, boolean> = {}
 ): Record<string, any> {
-  if (typeof dir !== 'function' && dir.getSSRProps) {
+  if (!isFunction(dir) && dir.getSSRProps) {
     return (
       dir.getSSRProps(
         {

--- a/packages/server-renderer/src/helpers/ssrRenderList.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderList.ts
@@ -1,4 +1,4 @@
-import { isArray, isString, isObject } from '@vue/shared'
+import { isArray, isString, isObject, isNumber } from '@vue/shared'
 import { warn } from '@vue/runtime-core'
 
 export function ssrRenderList(
@@ -9,7 +9,7 @@ export function ssrRenderList(
     for (let i = 0, l = source.length; i < l; i++) {
       renderItem(source[i], i)
     }
-  } else if (typeof source === 'number') {
+  } else if (isNumber(source)) {
     if (__DEV__ && !Number.isInteger(source)) {
       warn(`The v-for range expect an integer value but got ${source}.`)
       return

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -1,6 +1,6 @@
 import { ComponentInternalInstance, Slots } from 'vue'
 import { Props, PushFn, renderVNodeChildren, SSRBufferItem } from '../render'
-import { isArray } from '@vue/shared'
+import { isArray, isString } from '@vue/shared'
 
 export type SSRSlots = Record<string, SSRSlot>
 export type SSRSlot = (
@@ -64,5 +64,5 @@ export function ssrRenderSlot(
 
 const commentRE = /^<!--.*-->$/
 function isComment(item: SSRBufferItem) {
-  return typeof item === 'string' && commentRE.test(item)
+  return isString(item) && commentRE.test(item)
 }

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -6,7 +6,7 @@ import {
   createApp,
   ssrContextKey
 } from 'vue'
-import { isString, isPromise } from '@vue/shared'
+import { isString, isPromise, isFunction } from '@vue/shared'
 import { renderComponentVNode, SSRBuffer, SSRContext } from './render'
 import { Readable, Writable } from 'stream'
 
@@ -137,7 +137,7 @@ export function renderToWebStream(
   input: App | VNode,
   context: SSRContext = {}
 ): ReadableStream {
-  if (typeof ReadableStream !== 'function') {
+  if (!isFunction(ReadableStream)) {
     throw new Error(
       `ReadableStream constructor is not available in the global scope. ` +
         `If the target environment does support web streams, consider using ` +

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,6 +57,7 @@ export const isFunction = (val: unknown): val is Function =>
   typeof val === 'function'
 export const isString = (val: unknown): val is string => typeof val === 'string'
 export const isNumber = (val: unknown): val is number => typeof val === 'number'
+export const isBoolean = (val: unknown): val is boolean => typeof val === 'boolean'
 export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
 export const isObject = (val: unknown): val is Record<any, any> =>
   val !== null && typeof val === 'object'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -56,6 +56,7 @@ export const isDate = (val: unknown): val is Date => val instanceof Date
 export const isFunction = (val: unknown): val is Function =>
   typeof val === 'function'
 export const isString = (val: unknown): val is string => typeof val === 'string'
+export const isNumber = (val: unknown): val is number => typeof val === 'number'
 export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
 export const isObject = (val: unknown): val is Record<any, any> =>
   val !== null && typeof val === 'object'

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -1,4 +1,4 @@
-import { isArray, isString, isObject, hyphenate } from './'
+import { isArray, isString, isObject, hyphenate, isNumber } from './'
 import { isNoUnitNumericStyleProp } from './domAttrConfig'
 
 export type NormalizedStyle = Record<string, string | number>
@@ -53,7 +53,7 @@ export function stringifyStyle(
     const normalizedKey = key.startsWith(`--`) ? key : hyphenate(key)
     if (
       isString(value) ||
-      (typeof value === 'number' && isNoUnitNumericStyleProp(normalizedKey))
+      (isNumber(value) && isNoUnitNumericStyleProp(normalizedKey))
     ) {
       // only render valid values
       ret += `${normalizedKey}:${value};`


### PR DESCRIPTION
In code, there are many places and common to judge the types number and Boolean, so these two methods are added At the same time, in other types of judgment, some use the methods in shared, while others directly use typeof, such as judging string or function. It is suggested to unify them

The change points are as follows:
1. add isNumber and isBoolean shared method
2. the place to judge the variable type in the code is replaced