### PR TITLE
fix(runtime-dom): Fixed a runtime error when the element node's style…

### DIFF
--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -6,7 +6,12 @@ describe(`runtime-dom: style patching`, () => {
     patchProp(el, 'style', {}, 'color:red')
     expect(el.style.cssText.replace(/\s/g, '')).toBe('color:red;')
   })
-
+  // #5106
+  it('Array', () => {
+    const el = document.createElement('div')
+    patchProp(el, 'style', {}, [{color:'red'}])
+    expect(el.style.cssText.replace(/\s/g, '')).toBe('color:red;')
+  })
   // #1309
   it('should not patch same string style', () => {
     const el = document.createElement('div')

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -7,8 +7,15 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   const style = (el as HTMLElement).style
   const isCssString = isString(next)
   if (next && !isCssString) {
-    for (const key in next) {
-      setStyle(style, key, next[key])
+    // #5106
+    if(Array.isArray(next)){
+      next.forEach(val=>{
+        patchStyle(el,prev,val)
+      })
+    }else{
+      for (const key in next) {
+        setStyle(style, key, next[key])
+      }
     }
     if (prev && !isString(prev)) {
       for (const key in prev) {


### PR DESCRIPTION
… binding array was not compiled as 'createStaticVNode'. (fix #5107)