### PR TITLE
fix(compiler-core): fix directive wrong on DEV_ROOT_FRAGMENT

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -215,7 +215,15 @@ export function renderComponentRoot(
           `The directives will not function as intended.`
       )
     }
-    root.dirs = root.dirs ? root.dirs.concat(vnode.dirs) : vnode.dirs
+    if (
+      __DEV__ &&
+      result.patchFlag > 0 &&
+      result.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
+    ) {
+      root.dirs = vnode.dirs
+    } else {
+      root.dirs = root.dirs ? root.dirs.concat(vnode.dirs) : vnode.dirs
+    }
   }
   // inherit transition data
   if (vnode.transition) {


### PR DESCRIPTION
#5523    https://github.com/vuejs/core/commit/2bab63968355995a4026cf5cd1ccad7c79e8d89c

directive is compiled on fragment（dev_root_fragment）, ChildRoot should get directive  by instance vnode