### PR TITLE
chore: add no-debugger eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     sourceType: 'module'
   },
   rules: {
+    'no-debugger': 'error',
     'no-unused-vars': [
       'error',
       // we are only using this rule to check for unused arguments since TS

--- a/packages/compiler-dom/src/index.ts
+++ b/packages/compiler-dom/src/index.ts
@@ -29,7 +29,7 @@ export const DOMNodeTransforms: NodeTransform[] = [
 ]
 
 export const DOMDirectiveTransforms: Record<string, DirectiveTransform> = {
-cloak: noopDirectiveTransform,
+  cloak: noopDirectiveTransform,
   html: transformVHtml,
   text: transformVText,
   model: transformModel, // override compiler-core

--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -257,7 +257,6 @@ describe('component: proxy', () => {
     expect(instanceProxy.isDisplayed).toBe(true)
   })
 
- 
   test('allow jest spying on proxy methods with Object.defineProperty', () => {
     // #5417
     let instanceProxy: any
@@ -425,7 +424,6 @@ describe('component: proxy', () => {
     })
     expect(instanceProxy.fromProp).toBe(false)
   })
-
 
   // #864
   test('should not warn declared but absent props', () => {

--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -443,10 +443,8 @@ describe('api: template refs', () => {
     expect(mapRefs()).toMatchObject(['2', '3', '4'])
   })
 
-   
-
   test('named ref in v-for', async () => {
-    const show = ref(true);
+    const show = ref(true)
     const list = reactive([1, 2, 3])
     const listRefs = ref([])
     const mapRefs = () => listRefs.value.map(n => serializeInner(n))
@@ -495,6 +493,4 @@ describe('api: template refs', () => {
     await nextTick()
     expect(mapRefs()).toMatchObject(['2', '3', '4'])
   })
-
-
 })

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -135,8 +135,8 @@ const enum BooleanFlags {
 
 // extract props which defined with default from prop options
 export type ExtractDefaultPropTypes<O> = O extends object
-  // use `keyof Pick<O, DefaultKeys<O>>` instead of `DefaultKeys<O>` to support IDE features
-  ? { [K in keyof Pick<O, DefaultKeys<O>>]: InferPropType<O[K]> }
+  ? // use `keyof Pick<O, DefaultKeys<O>>` instead of `DefaultKeys<O>` to support IDE features
+    { [K in keyof Pick<O, DefaultKeys<O>>]: InferPropType<O[K]> }
   : {}
 
 type NormalizedProp =
@@ -226,7 +226,7 @@ export function updateProps(
       for (let i = 0; i < propsToUpdate.length; i++) {
         let key = propsToUpdate[i]
         // skip if the prop key is a declared emit event listener
-        if (isEmitListener(instance.emitsOptions, key)){
+        if (isEmitListener(instance.emitsOptions, key)) {
           continue
         }
         // PROPS flag guarantees rawProps to be non-null

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -113,7 +113,7 @@ export function createHydrationFunctions(
           nextNode = onMismatch()
         } else {
           if ((node as Text).data !== vnode.children) {
-            hasMismatch = true;
+            hasMismatch = true
             __DEV__ &&
               warn(
                 `Hydration text mismatch:` +
@@ -351,7 +351,7 @@ export function createHydrationFunctions(
         )
         let hasWarned = false
         while (next) {
-          hasMismatch = true;
+          hasMismatch = true
           if (__DEV__ && !hasWarned) {
             warn(
               `Hydration children mismatch in <${vnode.type as string}>: ` +
@@ -366,7 +366,7 @@ export function createHydrationFunctions(
         }
       } else if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
         if (el.textContent !== vnode.children) {
-          hasMismatch = true;
+          hasMismatch = true
           __DEV__ &&
             warn(
               `Hydration text content mismatch in <${
@@ -411,7 +411,7 @@ export function createHydrationFunctions(
       } else if (vnode.type === Text && !vnode.children) {
         continue
       } else {
-        hasMismatch = true;
+        hasMismatch = true
         if (__DEV__ && !hasWarned) {
           warn(
             `Hydration children mismatch in <${container.tagName.toLowerCase()}>: ` +
@@ -465,7 +465,7 @@ export function createHydrationFunctions(
     } else {
       // fragment didn't hydrate successfully, since we didn't get a end anchor
       // back. This should have led to node/children mismatch warnings.
-      hasMismatch = true;
+      hasMismatch = true
       // since the anchor is missing, we need to create one and insert it
       insert((vnode.anchor = createComment(`]`)), container, next)
       return next
@@ -480,7 +480,7 @@ export function createHydrationFunctions(
     slotScopeIds: string[] | null,
     isFragment: boolean
   ): Node | null => {
-    hasMismatch = true;
+    hasMismatch = true
     __DEV__ &&
       warn(
         `Hydration node mismatch:\n- Client vnode:`,

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -113,7 +113,7 @@ export function createHydrationFunctions(
           nextNode = onMismatch()
         } else {
           if ((node as Text).data !== vnode.children) {
-            hasMismatch = true; debugger
+            hasMismatch = true;
             __DEV__ &&
               warn(
                 `Hydration text mismatch:` +
@@ -351,7 +351,7 @@ export function createHydrationFunctions(
         )
         let hasWarned = false
         while (next) {
-          hasMismatch = true; debugger
+          hasMismatch = true;
           if (__DEV__ && !hasWarned) {
             warn(
               `Hydration children mismatch in <${vnode.type as string}>: ` +
@@ -366,7 +366,7 @@ export function createHydrationFunctions(
         }
       } else if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
         if (el.textContent !== vnode.children) {
-          hasMismatch = true; debugger
+          hasMismatch = true;
           __DEV__ &&
             warn(
               `Hydration text content mismatch in <${
@@ -411,7 +411,7 @@ export function createHydrationFunctions(
       } else if (vnode.type === Text && !vnode.children) {
         continue
       } else {
-        hasMismatch = true; debugger
+        hasMismatch = true;
         if (__DEV__ && !hasWarned) {
           warn(
             `Hydration children mismatch in <${container.tagName.toLowerCase()}>: ` +
@@ -465,7 +465,7 @@ export function createHydrationFunctions(
     } else {
       // fragment didn't hydrate successfully, since we didn't get a end anchor
       // back. This should have led to node/children mismatch warnings.
-      hasMismatch = true; debugger
+      hasMismatch = true;
       // since the anchor is missing, we need to create one and insert it
       insert((vnode.anchor = createComment(`]`)), container, next)
       return next
@@ -480,7 +480,7 @@ export function createHydrationFunctions(
     slotScopeIds: string[] | null,
     isFragment: boolean
   ): Node | null => {
-    hasMismatch = true; debugger
+    hasMismatch = true;
     __DEV__ &&
       warn(
         `Hydration node mismatch:\n- Client vnode:`,

--- a/packages/runtime-dom/__tests__/createApp.spec.ts
+++ b/packages/runtime-dom/__tests__/createApp.spec.ts
@@ -15,8 +15,7 @@ describe('createApp for dom', () => {
 
   // #4398
   test('should not mutate original root component options object', () => {
-    
-    const originalObj =  {
+    const originalObj = {
       data() {
         return {
           counter: 0
@@ -28,17 +27,16 @@ describe('createApp for dom', () => {
       expect(msg).toMatch(`Component is missing template or render function`)
     })
 
-    const Root = { ...originalObj}
-    
+    const Root = { ...originalObj }
+
     const app = createApp(Root)
     app.config.warnHandler = handler
-    app.mount(document.createElement('div')) 
- 
-    // ensure mount is based on a copy of Root object rather than Root object itself 
+    app.mount(document.createElement('div'))
+
+    // ensure mount is based on a copy of Root object rather than Root object itself
     expect(app._component).not.toBe(Root)
-    
+
     // ensure no mutation happened to Root object
     expect(originalObj).toMatchObject(Root)
-    
   })
 })

--- a/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
@@ -12,7 +12,9 @@ import {
 } from '@vue/shared'
 
 // leading comma for empty string ""
-const shouldIgnoreProp = makeMap(`,key,ref,innerHTML,textContent,ref_key,ref_for`)
+const shouldIgnoreProp = makeMap(
+  `,key,ref,innerHTML,textContent,ref_key,ref_for`
+)
 
 export function ssrRenderAttrs(
   props: Record<string, unknown>,

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -7,7 +7,6 @@ export type UnionToIntersection<U> = (
 // make keys required but keep undefined values
 export type LooseRequired<T> = { [P in string & keyof T]: T[P] }
 
-
 // If the the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
-export type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N
+export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N


### PR DESCRIPTION
@yyx990803 Some `debugger` instructions slipped through commit 9309b044bd4f9d0a34e0d702ed4690a529443a41

This removes them, and adds a lint rule to fail the build if a debugger instruction is added