### PR TITLE
chore: use `packageManager` field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 7.0.1
+        uses: pnpm/action-setup@v2
 
       - name: Set node version to 16
         uses: actions/setup-node@v2
@@ -34,9 +32,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 7.0.1
+        uses: pnpm/action-setup@v2
 
       - name: Set node version to 16
         uses: actions/setup-node@v2
@@ -55,9 +51,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 7.0.1
+        uses: pnpm/action-setup@v2
 
       - name: Set node version to 16
         uses: actions/setup-node@v2
@@ -81,9 +75,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 7.0.1
+        uses: pnpm/action-setup@v2
 
       - name: Set node version to 16
         uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "version": "3.2.33",
+  "packageManager": "pnpm@7.1.0",
   "scripts": {
     "dev": "node scripts/dev.js",
     "build": "node scripts/build.js",


### PR DESCRIPTION
This allows users who enabled https://github.com/nodejs/corepack to pick the right version automatically. `pnpm/action-setup` also reads the field so we can have a single source of truth and avoid duplication.