### PR TITLE
fix(compiler-sfc): type-only defineProps does not recognize Promise (fix #5941)

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1810,6 +1810,7 @@ function inferRuntimeType(
           case 'WeakSet':
           case 'WeakMap':
           case 'Date':
+          case 'Promise':
             return [node.typeName.name]
           case 'Record':
           case 'Partial':


### PR DESCRIPTION
Add 'Promise' to inferRuntimeType() to recognize type-only defineProps Promise declaration.
