### PR TITLE
Improve the performance of `performance`.

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -25,7 +25,7 @@ const [_getNow, skipTimestampCheck] = /*#__PURE__*/ (() => {
       // if the low-res timestamp which is bigger than the event timestamp
       // (which is evaluated AFTER) it means the event is using a hi-res timestamp,
       // and we need to use the hi-res version for event listeners as well.
-      _getNow = () => performance.now()
+      _getNow = performance.now.bind(performance)
     }
     // #3485: Firefox <= 53 has incorrect Event.timeStamp implementation
     // and does not fire microtasks in between event propagation, so safe to exclude.


### PR DESCRIPTION
```js
function test(f) {
    console.time()
    let i = 0
    while (i++ < 1e6) {
        f()
    }
    console.timeEnd()
}
test(performance.now.bind(performance))
test(()=>performance.now())

// VM2470:7 default: 120.751220703125 ms
// VM2470:7 default: 453.26416015625 ms```