### PR TITLE
fix(runtime-core): export ComponentProvideOptions

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -217,6 +217,7 @@ export {
   ComponentOptionsWithArrayProps,
   ComponentCustomOptions,
   ComponentOptionsBase,
+  ComponentProvideOptions,
   RenderFunction,
   MethodOptions,
   ComputedOptions,


### PR DESCRIPTION
The new type introduced in 98b821d94a0a0fb4d7701809da6bec331a47e6e5 is not publicly available

This is an issue for test-utils, as `mount` currently needs the same types as `DefineComponent` 

This commit exports the type `ComponentProvideOptions`, allowing to update the signature of `mount` (see https://github.com/vuejs/test-utils/pull/1510)