### PR TITLE
types(defineComponent): fix `defineComponent` inference to `Component`

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -42,7 +42,7 @@ export type DefineComponent<
   E extends EmitsOptions = {},
   EE extends string = string,
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
-  RawOptions extends {} = {},
+  RawOptions extends Record<string, any> = {},
   PP = PublicProps,
   Props = Readonly<
     PropsOrPropOptions extends ComponentPropsOptions
@@ -111,7 +111,18 @@ export function defineComponent<
   E extends EmitsOptions = EmitsOptions,
   EE extends string = string,
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
-  Options extends {} = {}
+  Options extends ComponentOptionsWithoutProps<
+    Props,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    Provide
+  > = {}
 >(
   options: Options &
     ComponentOptionsWithoutProps<
@@ -154,7 +165,29 @@ export function defineComponent<
   E extends EmitsOptions = Record<string, any>,
   EE extends string = string,
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
-  Options extends {} = {}
+  Options extends ComponentOptionsWithArrayProps<
+    PropNames,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    Provide
+  > = ComponentOptionsWithArrayProps<
+    PropNames,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    Provide
+  >
 >(
   options: Options &
     ComponentOptionsWithArrayProps<
@@ -198,7 +231,29 @@ export function defineComponent<
   E extends EmitsOptions = Record<string, any>,
   EE extends string = string,
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
-  Options extends {} = {}
+  Options extends ComponentOptionsWithObjectProps<
+    PropsOptions,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    Provide
+  > = ComponentOptionsWithObjectProps<
+    PropsOptions,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    Provide
+  >
 >(
   options: Options &
     ComponentOptionsWithObjectProps<

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -1,5 +1,6 @@
 import {
   describe,
+  test,
   Component,
   defineComponent,
   PropType,
@@ -1045,7 +1046,7 @@ describe('emits', () => {
 })
 
 describe('componentOptions setup should be `SetupContext`', () => {
-  expect<ComponentOptions['setup']>(
+  expectType<ComponentOptions['setup']>(
     {} as (props: Record<string, any>, ctx: SetupContext) => any
   )
 })
@@ -1139,6 +1140,20 @@ describe('async setup', () => {
 
   // setup context properties should be mutable
   vm.a = 2
+})
+
+// #5948
+describe('DefineComponent should infer correct types when assigning to Component', () => {
+  let component: Component
+  component = defineComponent({
+    setup(_, { attrs, slots }) {
+      // @ts-expect-error should not be any
+      expectType<[]>(attrs)
+      // @ts-expect-error should not be any
+      expectType<[]>(slots)
+    }
+  })
+  expectType<Component>(component)
 })
 
 // check if defineComponent can be exported

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -4,6 +4,7 @@
 export * from '@vue/runtime-dom'
 
 export function describe(_name: string, _fn: () => void): void
+export function test(_name: string, _fn: () => any): void
 
 export function expectType<T>(value: T): void
 export function expectError<T>(value: T): void
@@ -15,4 +16,4 @@ export type IsUnion<T, U extends T = T> = (
   ? false
   : true
 
-export type IsAny<T> = 0 extends (1 & T) ? true : false
+export type IsAny<T> = 0 extends 1 & T ? true : false


### PR DESCRIPTION
fix https://github.com/vuejs/core/issues/5948

link https://github.com/vuejs/test-utils/pull/1510

