### PR TITLE
fix(compile-sfc): Support define Error as prop type

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -232,6 +232,7 @@ export default /*#__PURE__*/_defineComponent({
     alias: { type: Array, required: true },
     method: { type: Function, required: true },
     symbol: { type: Symbol, required: true },
+    error: { type: Error, required: true },
     extract: { type: Number, required: true },
     exclude: { type: [Number, Boolean], required: true },
     uppercase: { type: String, required: true },

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -97,6 +97,7 @@ const props = defineProps({ foo: String })
       alias: Alias
       method(): void
       symbol: symbol
+      error: Error
       extract: Extract<1 | 2 | boolean, 2>
       exclude: Exclude<1 | 2 | boolean, 2>
       uppercase: Uppercase<'foo'>
@@ -143,6 +144,7 @@ const props = defineProps({ foo: String })
     expect(content).toMatch(`alias: { type: Array, required: true }`)
     expect(content).toMatch(`method: { type: Function, required: true }`)
     expect(content).toMatch(`symbol: { type: Symbol, required: true }`)
+    expect(content).toMatch(`error: { type: Error, required: true }`)
     expect(content).toMatch(
       `objectOrFn: { type: [Function, Object], required: true },`
     )
@@ -198,6 +200,7 @@ const props = defineProps({ foo: String })
       alias: BindingTypes.PROPS,
       method: BindingTypes.PROPS,
       symbol: BindingTypes.PROPS,
+      error: BindingTypes.PROPS,
       objectOrFn: BindingTypes.PROPS,
       extract: BindingTypes.PROPS,
       exclude: BindingTypes.PROPS,

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1391,6 +1391,7 @@ export function inferRuntimeType(
             case 'WeakMap':
             case 'Date':
             case 'Promise':
+            case 'Error':
               return [node.typeName.name]
 
             // TS built-in utility types


### PR DESCRIPTION
[reproduction](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cCBsYW5nPVwidHNcIj5cbmltcG9ydCBDb21wIGZyb20gJy4vQ29tcC52dWUnO1xuY29uc3QgZXJyID0gbmV3IEVycm9yKCdoZWxsbycpO1xuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPENvbXAgOm1zZz1cImVyclwiIC8+XG48L3RlbXBsYXRlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiXG4gIH1cbn0iLCJDb21wLnZ1ZSI6IjxzY3JpcHQgc2V0dXAgbGFuZz1cInRzXCI+XG5kZWZpbmVQcm9wczx7XG4gIG1zZzogc3RyaW5nIHwgRXJyb3Jcbn0+KCk7XG48L3NjcmlwdD5cbjx0ZW1wbGF0ZT5cbnt7bXNnfX1cbjwvdGVtcGxhdGU+In0=)

Obviously this list of types doesn't currently cover all Web APIs, and I also don't think "find one, add one" is a good way.