### PR TITLE
fix(compiler-sfc): resolveTemplateUsageCheck skip slot

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -722,7 +722,8 @@ return { props, a, emit }
 
 exports[`SFC compile <script setup> dev mode import usage check TS annotations 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
-import { Foo, Bar, Baz } from './x'
+import { h } from 'vue'
+        import { Foo, Bar, Baz, Qux } from './x'
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
@@ -730,8 +731,9 @@ export default /*#__PURE__*/_defineComponent({
 
         const a = 1
         function b() {}
+        const comp = () => h('div', 'test');
         
-return { a, b, Baz }
+return { a, b, comp, Baz }
 }
 
 })"

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -446,17 +446,22 @@ defineExpose({ foo: 123 })
     test('TS annotations', () => {
       const { content } = compile(`
         <script setup lang="ts">
-        import { Foo, Bar, Baz } from './x'
+        import { h } from 'vue'
+        import { Foo, Bar, Baz, Qux } from './x'
         const a = 1
         function b() {}
+        const comp = () => h('div', 'test');
         </script>
         <template>
-          {{ a as Foo }}
+          <component :is="comp">
+            <template #default="{ data }: Qux<string>"></template>
+          </component>
+          {{ a as  Foo }}
           {{ b<Bar>() }}
           {{ Baz }}
         </template>
         `)
-      expect(content).toMatch(`return { a, b, Baz }`)
+      expect(content).toMatch(`return { a, b, comp, Baz }`)
       assertCode(content)
     })
   })

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -2101,7 +2101,7 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
               if (!isBuiltInDir(prop.name)) {
                 code += `,v${capitalize(camelize(prop.name))}`
               }
-              if (prop.exp) {
+              if (prop.exp && prop.name !== 'slot') {
                 code += `,${processExp(
                   (prop.exp as SimpleExpressionNode).content
                 )}`
@@ -2123,7 +2123,7 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
 }
 
 function processExp(exp: string) {
-  if (/ as \w|<.*>/.test(exp)) {
+  if (/ as\s+\w|<.*>/.test(exp)) {
     let ret = ''
     // has potential type cast or generic arguments that uses types
     const ast = parseExpression(exp, { plugins: ['typescript'] })


### PR DESCRIPTION
close #5959
Slot node doesn't use the variable from the script, please let me know if I'm missing.
```vue
<component>
  <template #default></template>
</component>
```
```vue
<component>
  <template #default="{ data }: Type"></template>
</component>
```