### PR TITLE
fix(compiler-core): KeepAlive should ignore comments

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compiler: element transform <KeepAlive> multiple children should ignore comments 1`] = `
+"const { createCommentVNode: _createCommentVNode, resolveDynamicComponent: _resolveDynamicComponent, openBlock: _openBlock, createBlock: _createBlock, KeepAlive: _KeepAlive } = Vue
+
+return function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_KeepAlive, null, [
+    (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.activeComponent)))
+  ], 1024 /* DYNAMIC_SLOTS */))
+}"
+`;

--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -1224,4 +1224,55 @@ describe('compiler: element transform', () => {
       isBlock: false
     })
   })
+
+  describe('<KeepAlive> multiple children', () => {
+
+    function checkWarning(
+      template: string,
+      shouldWarn: boolean,
+      message = '<KeepAlive> expects exactly one child component.'
+    ) {
+      const spy = jest.fn()
+
+      parseWithBind(template.trim(), {
+        onError: err => {
+          spy(err.message)
+        }
+      })
+
+      if (shouldWarn) expect(spy).toHaveBeenCalledWith(message)
+      else expect(spy).not.toHaveBeenCalled()
+    }
+
+    test('does not warn if has one children', () => {
+      checkWarning(
+        `<KeepAlive>
+           <component :is="activeComponent"/>
+         </KeepAlive>`,
+        false
+      )
+    })
+
+    test('warn if has multiple children', () => {
+      checkWarning(
+        `<KeepAlive>
+          <component :is="activeComponent"/>
+          <component :is="activeComponent2"/>
+         </KeepAlive>`,
+        true
+      )
+    })
+
+    test('should ignore comments', () => {
+      expect(baseCompile(
+        `<KeepAlive>
+          <!--this should be ignored -->
+          <component :is="activeComponent"/>
+          <!--this should be ignored -->
+          </KeepAlive>`,
+          {prefixIdentifiers: true}
+      ).code).toMatchSnapshot()
+    })
+  })
+  
 })

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -19,7 +19,8 @@ import {
   TemplateTextChildNode,
   DirectiveArguments,
   createVNodeCall,
-  ConstantTypes
+  ConstantTypes,
+  PlainElementNode
 } from '../ast'
 import {
   PatchFlags,
@@ -156,7 +157,8 @@ export const transformElement: NodeTransform = (node, context) => {
         shouldUseBlock = true
         // 2. Force keep-alive to always be updated, since it uses raw children.
         patchFlag |= PatchFlags.DYNAMIC_SLOTS
-        if (__DEV__ && node.children.length > 1) {
+        // warn if <KeepAlive> has multiple children
+        if (__DEV__ && hasMultipleChildren(node)) {
           context.onError(
             createCompilerError(ErrorCodes.X_KEEP_ALIVE_INVALID_CHILDREN, {
               start: node.children[0].loc.start,
@@ -927,3 +929,12 @@ function stringifyDynamicPropNames(props: string[]): string {
 function isComponentTag(tag: string) {
   return tag === 'component' || tag === 'Component'
 }
+
+function hasMultipleChildren(node: ComponentNode | PlainElementNode): boolean {
+  // filter out potential comment nodes.
+  const children = (node.children = node.children.filter(
+    c => c.type !== NodeTypes.COMMENT 
+  ))
+
+  return children.length !== 1
+} 


### PR DESCRIPTION
KeepAlive does not ignore comments and the compiler throws an error when a component and a comment are wrapped with KeepAlive, which is obviously a bug.

error reproduction :
[sfc.vuejs.org](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdD5cbmltcG9ydCBDb21wQSBmcm9tICcuL0NvbXBBLnZ1ZSdcbmltcG9ydCBDb21wQiBmcm9tICcuL0NvbXBCLnZ1ZSdcbiAgXG5leHBvcnQgZGVmYXVsdCB7XG4gIGNvbXBvbmVudHM6IHsgQ29tcEEsIENvbXBCIH0sXG4gIGRhdGEoKSB7XG4gICAgcmV0dXJuIHtcbiAgICAgIGN1cnJlbnQ6ICdDb21wQSdcbiAgICB9XG4gIH1cbn1cbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxkaXYgY2xhc3M9XCJkZW1vXCI+XG4gICAgPGxhYmVsPjxpbnB1dCB0eXBlPVwicmFkaW9cIiB2LW1vZGVsPVwiY3VycmVudFwiIHZhbHVlPVwiQ29tcEFcIiAvPiBBPC9sYWJlbD5cbiAgICA8bGFiZWw+PGlucHV0IHR5cGU9XCJyYWRpb1wiIHYtbW9kZWw9XCJjdXJyZW50XCIgdmFsdWU9XCJDb21wQlwiIC8+IEI8L2xhYmVsPlxuICAgIDxLZWVwQWxpdmU+XG4gICAgICA8IS0tIHRoaXMgc2hvdWxkIGJlIGlnbm9yZWQgLCBkZWxldGUgdGhpcyBjb21tZW50IGFuZCBpdCB3b3JrcyAtLT5cbiAgICAgIDxjb21wb25lbnQgOmlzPVwiY3VycmVudFwiPjwvY29tcG9uZW50PlxuICAgIDwvS2VlcEFsaXZlPlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+XG4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59IiwiQ29tcEEudnVlIjoiPHNjcmlwdD5cbmV4cG9ydCBkZWZhdWx0IHtcbiAgZGF0YSgpIHtcbiAgICByZXR1cm4ge1xuICAgICAgY291bnQ6IDBcbiAgICB9XG4gIH1cbn1cbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxwPkN1cnJlbnQgY29tcG9uZW50OiBBPC9wPlxuICA8c3Bhbj5jb3VudDoge3sgY291bnQgfX08L3NwYW4+XG4gIDxidXR0b24gQGNsaWNrPVwiY291bnQrK1wiPis8L2J1dHRvbj5cbjwvdGVtcGxhdGU+XG4iLCJDb21wQi52dWUiOiI8c2NyaXB0PlxuZXhwb3J0IGRlZmF1bHQge1xuICBkYXRhKCkge1xuICAgIHJldHVybiB7XG4gICAgICBtc2c6ICcnXG4gICAgfVxuICB9XG59XG48L3NjcmlwdD5cblxuXG48dGVtcGxhdGU+XG4gIDxwPkN1cnJlbnQgY29tcG9uZW50OiBCPC9wPlxuICA8c3Bhbj5NZXNzYWdlIGlzOiB7eyBtc2cgfX08L3NwYW4+XG4gIDxpbnB1dCB2LW1vZGVsPVwibXNnXCI+XG48L3RlbXBsYXRlPlxuIn0=)

thanks.