### PR TITLE
[@vue/compat] Prevent local asset registration from affecting other local apps (fix #5699)

### DIFF
--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -380,21 +380,12 @@ function installLegacyAPIs(app: App) {
 }
 
 function applySingletonAppMutations(app: App) {
-  // create asset registry proxies which lookup from singleton and fallback to local registry
-  (['mixins', 'components', 'directives', 'filters'] as const).forEach(key => {
+  // copy over asset registries and deopt flag
+  app._context.mixins = [...singletonApp._context.mixins]
+  ;['components', 'directives', 'filters'].forEach(key => {
     // @ts-ignore
-    app._context[key] = new Proxy(app._context[key]!, {
-      get(target, prop) {
-        if (prop in singletonApp._context[key]!) {
-          // @ts-ignore
-          return singletonApp._context[key][prop];
-        }
-        return Reflect.get(target, prop);
-      }
-    })
+    app._context[key] = Object.create(singletonApp._context[key])
   })
-  // @ts-ignore
-  app._context.deopt = singletonApp._context.deopt
 
   // copy over global config mutations
   isCopyingConfig = true

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -383,7 +383,7 @@ function applySingletonAppMutations(app: App) {
   // copy over asset registries and deopt flag
   ;['mixins', 'components', 'directives', 'filters', 'deopt'].forEach(key => {
     // @ts-ignore
-    app._context[key] = singletonApp._context[key]
+    app._context[key] = { ...singletonApp._context[key] }
   })
 
   // copy over global config mutations

--- a/packages/vue-compat/__tests__/global.spec.ts
+++ b/packages/vue-compat/__tests__/global.spec.ts
@@ -449,6 +449,16 @@ test('global asset registration should affect apps created via createApp', () =>
   delete singletonApp._context.components.foo
 })
 
+test('post-facto global asset registration should affect apps created via createApp', () => {
+  const app = createApp({
+    template: '<foo/>'
+  })
+  Vue.component('foo', { template: 'foo' })
+  const vm = app.mount(document.createElement('div')) as any;
+  expect(vm.$el.textContent).toBe('foo')
+  delete singletonApp._context.components.foo
+})
+
 test('local asset registration should not affect other local apps', () => {
   const app1 = createApp({});
   const app2 = createApp({});

--- a/packages/vue-compat/__tests__/global.spec.ts
+++ b/packages/vue-compat/__tests__/global.spec.ts
@@ -448,3 +448,15 @@ test('global asset registration should affect apps created via createApp', () =>
   expect(vm.$el.textContent).toBe('foo')
   delete singletonApp._context.components.foo
 })
+
+test('local asset registration should not affect other local apps', () => {
+  const app1 = createApp({});
+  const app2 = createApp({});
+
+  app1.component('foo', {});
+  app2.component('foo', {});
+
+  expect(
+    `Component "foo" has already been registered in target app`
+  ).not.toHaveBeenWarned()
+})


### PR DESCRIPTION
Closes #5699. Because `applySingletonAppMutations` copies the reference of the singleton context instead of a copy of it, all local asset registration into any local app modifies all other local apps both post-facto and globally. My initial take at solving this was to simply create a shallow copy of the singleton app context instead of copying the reference, but then I realized the existing implementation allows for code like the following to work:

```
const app = createApp({ template: '<foo />' });
Vue.component('foo', /* some impl */);
app.mount(...); // resolves 'foo' from the global registry even though it was created after the fact
```

I'm not sure if this is behavior we wanted or meant to have, but in the interest of not breaking anything, I added a test for both the original issue and this one, and fixed both by using a proxy setup which first attempts to resolve components from the `singletonApp` registry, and if that doesn't work it instead resolves them from the local one. This implementation passes all tests. (If we're not interested in preserving the old behavior of allowing post-facto global registrations to affect local apps, then we can strip off the latter two commits and use the much simpler shallow copy implementation). 