### PR TITLE
fix(sfc-playground): persist light mode

### DIFF
--- a/packages/sfc-playground/index.html
+++ b/packages/sfc-playground/index.html
@@ -9,10 +9,10 @@
     <script>
       // process shim for old versions of @vue/compiler-sfc dependency
       window.process = { env: {} }
-      const saved = localStorage.getItem('vue-sfc-playground-prefer-dark')
+      const savedPreferDark = localStorage.getItem('vue-sfc-playground-prefer-dark')
       if (
-        saved !== 'false' ||
-        window.matchMedia('(prefers-color-scheme: dark)').matches
+        savedPreferDark === 'true' ||
+        (!savedPreferDark && window.matchMedia('(prefers-color-scheme: dark)').matches)
       ) {
         document.documentElement.classList.add('dark')
       }


### PR DESCRIPTION
The current logic of setting dark mode actually doesn't persist the light mode when the user explicitly chooses it. This can be confirmed by clicking the moon icon in the dark mode and refreshing the page — the page will still be in dark mode if the OS uses it.