### PR TITLE
fix(sfc-playground): hide versions when click iframe & set color-scheme to dark

### DIFF
--- a/packages/sfc-playground/src/App.vue
+++ b/packages/sfc-playground/src/App.vue
@@ -82,6 +82,10 @@ function toggleSSR() {
 </template>
 
 <style>
+.dark {
+  color-scheme: dark;
+}
+
 body {
   font-size: 13px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,

--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -54,6 +54,11 @@ onMounted(async () => {
   window.addEventListener('click', () => {
     expanded.value = false
   })
+  window.addEventListener('blur', () => {
+    if (document.activeElement?.tagName === 'IFRAME') {
+      expanded.value = false
+    }
+  });
 })
 
 async function fetchVersions(): Promise<string[]> {


### PR DESCRIPTION
Version list should also be hidden when clicking on the preview panel.