### PR TITLE
feat(reactivity): export RawSymbol

### DIFF
--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -17,6 +17,7 @@ export {
   RefUnwrapBailTypes,
   CustomRefFactory
 } from './ref'
+export type { RawSymbol } from './ref'
 export {
   reactive,
   readonly,


### PR DESCRIPTION
fix
```
Exported variable 'ElImage' has or is using name 'RawSymbol' from external module "/home/runner/work/element-plus/element-plus/node_modules/@vue/reactivity/dist/reactivity" but cannot be named.
```

https://github.com/element-plus/element-plus/runs/6622711615?check_suite_focus=true