### PR TITLE
fix(reactivity):  effect return ReactiveEffectRunner<T>

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -170,7 +170,7 @@ export interface ReactiveEffectRunner<T = any> {
 export function effect<T = any>(
   fn: () => T,
   options?: ReactiveEffectOptions
-): ReactiveEffectRunner {
+): ReactiveEffectRunner<T> {
   if ((fn as ReactiveEffectRunner).effect) {
     fn = (fn as ReactiveEffectRunner).effect.fn
   }
@@ -183,7 +183,7 @@ export function effect<T = any>(
   if (!options || !options.lazy) {
     _effect.run()
   }
-  const runner = _effect.run.bind(_effect) as ReactiveEffectRunner
+  const runner = _effect.run.bind(_effect) as ReactiveEffectRunner<T>
   runner.effect = _effect
   return runner
 }


### PR DESCRIPTION
`effect` lost the generic T, it should return `ReactiveEffectRunner<T>`