### PR TITLE
feat(types): add slots types for built-in components

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -279,6 +279,9 @@ if (__COMPAT__) {
 export const BaseTransition = BaseTransitionImpl as any as {
   new (): {
     $props: BaseTransitionProps<any>
+    $slots: {
+      default(): VNode[]
+    }
   }
 }
 

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -342,6 +342,9 @@ export const KeepAlive = KeepAliveImpl as any as {
   __isKeepAlive: true
   new (): {
     $props: VNodeProps & KeepAliveProps
+    $slots: {
+      default(): VNode[]
+    }
   }
 }
 

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -91,7 +91,13 @@ export const SuspenseImpl = {
 // Force-casted public typing for h and TSX props inference
 export const Suspense = (__FEATURE_SUSPENSE__ ? SuspenseImpl : null) as any as {
   __isSuspense: true
-  new (): { $props: VNodeProps & SuspenseProps }
+  new (): {
+    $props: VNodeProps & SuspenseProps
+    $slots: {
+      default(): VNode[]
+      fallback(): VNode[]
+    }
+  }
 }
 
 function triggerEvent(

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -390,5 +390,10 @@ function hydrateTeleport(
 // Force-casted public typing for h and TSX props inference
 export const Teleport = TeleportImpl as any as {
   __isTeleport: true
-  new (): { $props: VNodeProps & TeleportProps }
+  new(): {
+    $props: VNodeProps & TeleportProps
+    $slots: {
+      default(): VNode[]
+    }
+  }
 }


### PR DESCRIPTION
This PR make built-in components slots navigable. Look to document (https://vuejs.org/guide/built-ins/suspense.html) these slots seems do not have binding variables so there just keep it empty.

<img width="779" alt="螢幕截圖 2022-06-16 13 17 38" src="https://user-images.githubusercontent.com/16279759/173996753-b1bd506e-91f6-436e-ad6f-d5261aa3e689.png">