### PR TITLE
build: support dev source map

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -11,6 +11,7 @@ const args = require('minimist')(process.argv.slice(2))
 const target = args._[0] || 'vue'
 const format = args.f || 'global'
 const inlineDeps = args.i || args.inline
+const sourceMap = args.s || args.sourcemap || false
 const pkg = require(resolve(__dirname, `../packages/${target}/package.json`))
 
 // resolve output
@@ -73,7 +74,7 @@ build({
   outfile,
   bundle: true,
   external,
-  sourcemap: true,
+  sourcemap: sourceMap ? true : false,
   format: outputFormat,
   globalName: pkg.buildOptions?.name,
   platform: format === 'cjs' ? 'node' : 'browser',


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3411696/172570787-493597a1-1c8e-4bfd-bdc3-35a9b6003944.png)

It is found that when developing and debugging Vue locally, the `sourcemap` mode is enabled by default and cannot be closed. This does not match what the documentation describes. So `sourcemap` support in development mode has been improved for this purpose.
