### PR TITLE
Adding more robust check to see if window and document are both defined so that Vue works in Deno Deploy

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -16,7 +16,7 @@ type EventValue = Function | Function[]
 const [_getNow, skipTimestampCheck] = /*#__PURE__*/ (() => {
   let _getNow = Date.now
   let skipTimestampCheck = false
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     // Determine what event timestamp the browser is using. Annoyingly, the
     // timestamp can either be hi-res (relative to page load) or low-res
     // (relative to UNIX epoch), so in order to compare time we have to use the


### PR DESCRIPTION
When trying to run Astro with Vue inside of Deno, I was running into errors. `window` is defined in the Deno runtime but `document` is not. So it would fail when trying to run my project. 

See this issue for reference https://github.com/withastro/astro/issues/3440