### PR TITLE
fix(runtime-core): prevent runtime errors when using suspense

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1501,7 +1501,7 @@ function baseCreateRenderer(
           prevTree,
           nextTree,
           // parent may have changed if it's in a teleport
-          hostParentNode(prevTree.el!)!,
+          prevTree.el! && hostParentNode(prevTree.el!)!,
           // anchor may have changed if it's in a fragment
           getNextHostNode(prevTree),
           instance,
@@ -2314,7 +2314,7 @@ function baseCreateRenderer(
   }
 
   const getNextHostNode: NextFn = vnode => {
-    if (vnode.shapeFlag & ShapeFlags.COMPONENT) {
+    if (vnode.shapeFlag & ShapeFlags.COMPONENT && vnode.component!.subTree) {
       return getNextHostNode(vnode.component!.subTree)
     }
     if (__FEATURE_SUSPENSE__ && vnode.shapeFlag & ShapeFlags.SUSPENSE) {


### PR DESCRIPTION
From https://github.com/vuetifyjs/vuetify/pull/15215 (remove the patch)

![Screenshot_20220608_013935](https://user-images.githubusercontent.com/16421948/173081546-69078d89-56bf-42b6-a9b1-fd9dab7892b4.png)
![Screenshot_20220608_014012](https://user-images.githubusercontent.com/16421948/173081556-3873faac-28a8-48c6-8d85-4a59fc157e6e.png)

I didn't manage to reproduce it anywhere else though: [playground attempt](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cblx0aW1wb3J0IEdyb3VwIGZyb20gJy4vR3JvdXAuanMnXG4gIGltcG9ydCBJdGVtIGZyb20gJy4vSXRlbS52dWUnXG4gIGltcG9ydCBXcmFwcGVkSXRlbSBmcm9tICcuL1dyYXBwZWRJdGVtLnZ1ZSdcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxHcm91cD5cbiAgICA8SXRlbT5PbmU8L0l0ZW0+XG4gICAgPEl0ZW0+VHdvPC9JdGVtPlxuICAgIDxJdGVtPlRocmVlPC9JdGVtPlxuICA8L0dyb3VwPlxuXG4gIDxHcm91cD5cbiAgICA8V3JhcHBlZEl0ZW0+T25lPC9XcmFwcGVkSXRlbT5cbiAgICA8V3JhcHBlZEl0ZW0+VHdvPC9XcmFwcGVkSXRlbT5cbiAgICA8V3JhcHBlZEl0ZW0+VGhyZWU8L1dyYXBwZWRJdGVtPlxuICA8L0dyb3VwPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIixcbiAgICBcInZ1ZS9zZXJ2ZXItcmVuZGVyZXJcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvc2VydmVyLXJlbmRlcmVyLmVzbS1icm93c2VyLmpzXCJcbiAgfVxufSIsIkdyb3VwLmpzIjoiaW1wb3J0IHsgcmVmLCBjb21wdXRlZCwgcHJvdmlkZSwgRnJhZ21lbnQsIFN1c3BlbnNlLCBoIH0gZnJvbSAndnVlJ1xuXG5leHBvcnQgZGVmYXVsdCB7XG4gIHNldHVwIChwcm9wcywgeyBzbG90cyB9KSB7XG4gICAgY29uc3QgaXRlbXMgPSByZWYoW10pXG4gICAgZnVuY3Rpb24gcmVnaXN0ZXIgKGlkKSB7XG4gICAgICBpdGVtcy52YWx1ZS5wdXNoKHsgaWQgfSlcbiAgICB9XG5cbiAgICBwcm92aWRlKCdncm91cCcsIHsgcmVnaXN0ZXIsIGl0ZW1zIH0pXG4gICAgXG4gICAgcmV0dXJuICgpID0+IChcbiAgICAgIGgoJ2RpdicsIHsgY2xhc3M6ICdncm91cCcgfSwgW1xuICAgICAgICBoKFN1c3BlbnNlLCBbXG4gICAgICAgICAgaChGcmFnbWVudCwgc2xvdHMuZGVmYXVsdD8uKCkpXG4gICAgICAgIF0pXG4gICAgICBdKVxuICAgIClcbiAgfVxufVxuIiwiSXRlbS52dWUiOiI8c2NyaXB0PlxuICBpbXBvcnQgeyBpbmplY3QsIG5leHRUaWNrIH0gZnJvbSAndnVlJ1xuICBcbiAgbGV0IF9pZCA9IDBcbiAgZnVuY3Rpb24gZ2V0SWQgKCkge1xuICAgIHJldHVybiBfaWQrK1xuICB9XG4gIFxuICBleHBvcnQgZGVmYXVsdCB7XG4gICAgYXN5bmMgc2V0dXAgKCkge1xuICAgICAgY29uc3QgaWQgPSBnZXRJZCgpXG4gICAgICBjb25zdCBncm91cCA9IGluamVjdCgnZ3JvdXAnKVxuICAgICAgXG4gICAgICBncm91cC5yZWdpc3RlcihpZClcbiAgICAgIGF3YWl0IG5leHRUaWNrKClcbiAgICAgIFxuICAgICAgcmV0dXJuIHsgZ3JvdXAgfVxuICAgIH1cbiAgfVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGRpdiBjbGFzcz1cIml0ZW1cIj5cbiAgICA8c2xvdCAvPlxuICA8L2Rpdj5cbjwvdGVtcGxhdGU+IiwiV3JhcHBlZEl0ZW0udnVlIjoiPHNjcmlwdCBzZXR1cD5cblx0aW1wb3J0IEl0ZW0gZnJvbSAnLi9JdGVtLnZ1ZSdcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxJdGVtPlxuICAgIDxzbG90IC8+XG4gIDwvSXRlbT5cbjwvdGVtcGxhdGU+In0=)

No idea if this patch is correct, but the tests pass and I haven't seen any other errors yet. 