### PR TITLE
fix(runtime-core): avoid multiple component instance option sharing #6075

### DIFF
--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -530,7 +530,7 @@ function installCompatMount(
           }
         }
         instance.render = null
-        ;(component as ComponentOptions).template = container.innerHTML
+        ;(component as ComponentOptions).template = (instance.type as ComponentOptions).template = container.innerHTML
         finishComponentSetup(instance, false, true /* skip options */)
       }
 

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -472,7 +472,7 @@ export function createComponentInstance(
   const instance: ComponentInternalInstance = {
     uid: uid++,
     vnode,
-    type,
+    type: isObject(type) ? {...type} : type,
     parent,
     appContext,
     root: null!, // to be immediately set

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -570,21 +570,9 @@ export function applyOptions(instance: ComponentInternalInstance) {
     inject: injectOptions,
     // lifecycle
     created,
-    beforeMount,
-    mounted,
-    beforeUpdate,
-    updated,
-    activated,
-    deactivated,
     beforeDestroy,
-    beforeUnmount,
     destroyed,
-    unmounted,
     render,
-    renderTracked,
-    renderTriggered,
-    errorCaptured,
-    serverPrefetch,
     // public API
     expose,
     inheritAttrs,
@@ -757,18 +745,18 @@ export function applyOptions(instance: ComponentInternalInstance) {
     }
   }
 
-  registerLifecycleHook(onBeforeMount, beforeMount)
-  registerLifecycleHook(onMounted, mounted)
-  registerLifecycleHook(onBeforeUpdate, beforeUpdate)
-  registerLifecycleHook(onUpdated, updated)
-  registerLifecycleHook(onActivated, activated)
-  registerLifecycleHook(onDeactivated, deactivated)
-  registerLifecycleHook(onErrorCaptured, errorCaptured)
-  registerLifecycleHook(onRenderTracked, renderTracked)
-  registerLifecycleHook(onRenderTriggered, renderTriggered)
-  registerLifecycleHook(onBeforeUnmount, beforeUnmount)
-  registerLifecycleHook(onUnmounted, unmounted)
-  registerLifecycleHook(onServerPrefetch, serverPrefetch)
+  registerLifecycleHook(onBeforeMount, options.beforeMount)
+  registerLifecycleHook(onMounted, options.mounted)
+  registerLifecycleHook(onBeforeUpdate, options.beforeUpdate)
+  registerLifecycleHook(onUpdated, options.updated)
+  registerLifecycleHook(onActivated, options.activated)
+  registerLifecycleHook(onDeactivated, options.deactivated)
+  registerLifecycleHook(onErrorCaptured, options.errorCaptured)
+  registerLifecycleHook(onRenderTracked, options.renderTracked)
+  registerLifecycleHook(onRenderTriggered, options.renderTriggered)
+  registerLifecycleHook(onBeforeUnmount, options.beforeUnmount)
+  registerLifecycleHook(onUnmounted, options.unmounted)
+  registerLifecycleHook(onServerPrefetch, options.serverPrefetch)
 
   if (__COMPAT__) {
     if (

--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -110,7 +110,7 @@ function reload(id: string, newComp: HMRComponent) {
   const instances = [...record.instances]
 
   for (const instance of instances) {
-    const oldComp = normalizeClassComponent(instance.type as HMRComponent)
+    const oldComp = normalizeClassComponent(instance.vnode.type as HMRComponent)
 
     if (!hmrDirtyComponents.has(oldComp)) {
       // 1. Update existing comp definition to match new one


### PR DESCRIPTION
Fix https://github.com/vuejs/core/issues/6075

Avoid components that reference the same option and cause hook behaviors to interfere with each other. Fixed the issue and added test cases for this.

![image](https://user-images.githubusercontent.com/3411696/191436184-a60e16d2-f08a-46fa-b0e9-1a1683d7065c.png)
