### PR TITLE
fix(runtime-dom): avoid transform affect flip animation #6105

### DIFF
--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -27,8 +27,13 @@ import {
 } from '@vue/runtime-core'
 import { extend } from '@vue/shared'
 
-const positionMap = new WeakMap<VNode, DOMRect>()
-const newPositionMap = new WeakMap<VNode, DOMRect>()
+interface Position {
+  top: number
+  left: number
+}
+
+const positionMap = new WeakMap<VNode, Position>()
+const newPositionMap = new WeakMap<VNode, Position>()
 
 export type TransitionGroupProps = Omit<TransitionProps, 'mode'> & {
   tag?: string
@@ -132,7 +137,7 @@ const TransitionGroupImpl: ComponentOptions = {
             child,
             resolveTransitionHooks(child, cssTransitionProps, state, instance)
           )
-          positionMap.set(child, (child.el as Element).getBoundingClientRect())
+          positionMap.set(child, { left: (child.el as HTMLElement).offsetLeft, top: (child.el as HTMLElement).offsetTop })
         }
       }
 
@@ -171,7 +176,7 @@ function callPendingCbs(c: VNode) {
 }
 
 function recordPosition(c: VNode) {
-  newPositionMap.set(c, (c.el as Element).getBoundingClientRect())
+  newPositionMap.set(c, { left: (c.el as HTMLElement).offsetLeft, top: (c.el as HTMLElement).offsetTop })
 }
 
 function applyTranslation(c: VNode): VNode | undefined {


### PR DESCRIPTION
Fix #6105
use offsetLeft and offsetTop replace Element.getBoundingClientRect