### PR TITLE
chore(compiler-sfc): more specific tips for :deep

### DIFF
--- a/packages/compiler-sfc/src/stylePluginScoped.ts
+++ b/packages/compiler-sfc/src/stylePluginScoped.ts
@@ -130,7 +130,7 @@ function rewriteSelector(
           // DEPRECATED usage
           // .foo ::v-deep .bar -> .foo[xxxxxxx] .bar
           warn(
-            `::v-deep usage as a combinator has ` +
+            `:deep and ::v-deep usage as a combinator has ` +
               `been deprecated. Use :deep(<inner-selector>) instead.`
           )
           const prev = selector.at(selector.index(n) - 1)


### PR DESCRIPTION
:deep and ::v-deep will have alarm prompts, so add complete alarm prompts to avoid misunderstandings