### PR TITLE
fix(computed): invalidate cache on setter (#6130)

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,6 +1,6 @@
 import { DebuggerOptions, ReactiveEffect } from './effect'
 import { Ref, trackRefValue, triggerRefValue } from './ref'
-import { isFunction, NOOP } from '@vue/shared'
+import { hasChanged, isFunction, NOOP } from '@vue/shared'
 import { ReactiveFlags, toRaw } from './reactive'
 import { Dep } from './dep'
 
@@ -64,7 +64,12 @@ export class ComputedRefImpl<T> {
   }
 
   set value(newValue: T) {
+    const self = toRaw(this)
+    self._dirty = self._dirty || hasChanged(newValue, self._value)
     this._setter(newValue)
+    if (self._dirty) {
+      triggerRefValue(this)
+    }
   }
 }
 


### PR DESCRIPTION
If assigning a new value to a computed ref via its available setter,
the internal cache is invalidated and all depending reactive effects
are notified.

Previously, setting a new value was silently ignored and the cache not
invalidated. Reading the value returned the old (cached) one
instead of the real current value.

fix #6130
