### PR TITLE
fix(runtime-core): `in` operator returning `false` for built-in instance properties in `exposeProxy` (fix #6137)

### DIFF
--- a/packages/runtime-core/__tests__/apiExpose.spec.ts
+++ b/packages/runtime-core/__tests__/apiExpose.spec.ts
@@ -203,7 +203,9 @@ describe('api: expose', () => {
         return h('div')
       },
       setup(_, { expose }) {
-        expose()
+        expose({
+          foo: 42
+        })
         return () => h(GrandChild, { ref: grandChildRef })
       }
     })
@@ -218,6 +220,7 @@ describe('api: expose', () => {
     render(h(Parent), root)
     expect('$el' in childRef.value).toBe(true)
     expect(childRef.value.$el.tag).toBe('div')
+    expect('foo' in childRef.value).toBe(true)
     expect('$parent' in grandChildRef.value).toBe(true)
     expect(grandChildRef.value.$parent).toBe(childRef.value)
     expect(grandChildRef.value.$parent.$parent).toBe(grandChildRef.value.$root)

--- a/packages/runtime-core/__tests__/apiExpose.spec.ts
+++ b/packages/runtime-core/__tests__/apiExpose.spec.ts
@@ -216,7 +216,9 @@ describe('api: expose', () => {
     }
     const root = nodeOps.createElement('div')
     render(h(Parent), root)
+    expect('$el' in childRef.value).toBe(true)
     expect(childRef.value.$el.tag).toBe('div')
+    expect('$parent' in grandChildRef.value).toBe(true)
     expect(grandChildRef.value.$parent).toBe(childRef.value)
     expect(grandChildRef.value.$parent.$parent).toBe(grandChildRef.value.$root)
   })

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -942,6 +942,15 @@ export function getExposeProxy(instance: ComponentInternalInstance) {
           } else if (key in publicPropertiesMap) {
             return publicPropertiesMap[key](instance)
           }
+        },
+        has(target, key: string) {
+          if (key in target) {
+            return true
+          } else if (key in publicPropertiesMap) {
+            return true
+          }
+
+          return false
         }
       }))
     )

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -944,13 +944,7 @@ export function getExposeProxy(instance: ComponentInternalInstance) {
           }
         },
         has(target, key: string) {
-          if (key in target) {
-            return true
-          } else if (key in publicPropertiesMap) {
-            return true
-          }
-
-          return false
+          return key in target || key in publicPropertiesMap
         }
       }))
     )


### PR DESCRIPTION
This PR tries to fix #6137.

### Background info

The component `exposeProxy` implements a fallback logic for accessing built-in instance properties but was missing the same logic for the `in` operator in the Proxy's `has()` handler.