### PR TITLE
types(reactive): remove unnecessary type assertion

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -252,4 +252,4 @@ export const toReactive = <T extends unknown>(value: T): T =>
   isObject(value) ? reactive(value) : value
 
 export const toReadonly = <T extends unknown>(value: T): T =>
-  isObject(value) ? readonly(value as Record<any, any>) : value
+  isObject(value) ? readonly(value) : value


### PR DESCRIPTION
Remove unnecessary types in `toReadonly` function to be consistent with `toReactive` function.

Details:

```ts
export const toReadonly = <T extends unknown>(value: T): T =>
  isObject(value) ? readonly(value as Record<any, any>) : value
```

when `isObject(value)` is true, the type of `value` is `Record<any, any>`, so no longer need `as Record<any, any>`