### PR TITLE
chore: typo

### DIFF
--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -42,7 +42,7 @@ declare module '@vue/repl' {
 
 declare interface String {
   /**
-   * @deprecated Please use String.prototype.slice instead of String.prototype.substring in the repository.
+   * @deprecated Please use String.prototype.slice instead of String.prototype.substr in the repository.
    */
-  substring(start: number, end?: number): string
+  substr(start: number, end?: number): string
 }


### PR DESCRIPTION
The `.substr` is deprecated. But the `.substring` doesn't deprecated. See: 

[String.prototype.substr](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)

[String.prototype.substring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring)
