### PR TITLE
types(runtime-dom): add missing `img` attr `loading`

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -457,6 +457,7 @@ export interface ImgHTMLAttributes extends HTMLAttributes {
   srcset?: string
   usemap?: string
   width?: Numberish
+  loading?: 'lazy' | 'eager'
 }
 
 export interface InsHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLImageElement/loading

close https://github.com/vuejs/core/issues/3691