### PR TITLE
fix(runtime-dom): ensure customElement handles empty props correctly. (fix #6361,#6895)

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -210,6 +210,20 @@ describe('defineCustomElement', () => {
       customElements.define('my-el-upgrade', E)
       expect(el.shadowRoot.innerHTML).toBe(`foo: hello`)
     })
+
+    // https://github.com/vuejs/core/issues/6163
+    test('handle components with no props', async () => {
+      const E = defineCustomElement({
+        render() {
+          return h('div', 'foo')
+        }
+      })
+      customElements.define('my-element-noprops', E)
+      const el = document.createElement('my-element-noprops')
+      container.appendChild(el)
+      await nextTick()
+      expect(el.shadowRoot!.innerHTML).toMatchInlineSnapshot('"<div>foo</div>"')
+    })
   })
 
   describe('emits', () => {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -215,7 +215,7 @@ export class VueElement extends BaseClass {
     }).observe(this, { attributes: true })
 
     const resolve = (def: InnerComponentDef) => {
-      const { props, styles } = def
+      const { props = {}, styles } = def
       const hasOptions = !isArray(props)
       const rawKeys = props ? (hasOptions ? Object.keys(props) : props) : []
 


### PR DESCRIPTION
If a component wrapped with `defineCustomElement()` did not hae any props defined, and was passed any custom attribute (such as, in #6361, a data-v attribute), it would throw an error.

closes #6163, close #6895