### PR TITLE
chore: bumpo node engine requirement to node 16.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "engines": {
-    "node": ">=16.5.0"
+    "node": ">=16.11.0"
   },
   "devDependencies": {
     "@babel/types": "^7.12.0",


### PR DESCRIPTION
unit tests fail with a lower version due to:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks