### PR TITLE
fix(ssr): reset current instance after rendering error on SSR.(fix #6110)

### DIFF
--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -20,7 +20,8 @@ import {
   resolveDynamicComponent,
   renderSlot,
   onErrorCaptured,
-  onServerPrefetch
+  onServerPrefetch,
+  getCurrentInstance
 } from 'vue'
 import { escapeHtml } from '@vue/shared'
 import { renderToString } from '../src/renderToString'
@@ -780,6 +781,23 @@ function testRender(type: string, render: typeof renderToString) {
           `Template compilation error: Unexpected EOF in tag.`
         ).toHaveBeenWarned()
         expect(`Element is missing end tag`).toHaveBeenWarned()
+      })
+
+      // #6110
+      test('reset current instance after rendering error', async () => {
+        const prev = getCurrentInstance()
+        expect(prev).toBe(null)
+        try {
+          await render(
+            createApp({
+              data() {
+                return { msg: null }
+              },
+              template: `<div>{{ msg.text }}</div>`
+            })
+          )
+        } catch {}
+        expect(getCurrentInstance()).toBe(prev)
       })
     })
 

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -174,18 +174,21 @@ function renderComponentSubTree(
 
       // set current rendering instance for asset resolution
       const prev = setCurrentRenderingInstance(instance)
-      ssrRender(
-        instance.proxy,
-        push,
-        instance,
-        attrs,
-        // compiler-optimized bindings
-        instance.props,
-        instance.setupState,
-        instance.data,
-        instance.ctx
-      )
-      setCurrentRenderingInstance(prev)
+      try {
+        ssrRender(
+          instance.proxy,
+          push,
+          instance,
+          attrs,
+          // compiler-optimized bindings
+          instance.props,
+          instance.setupState,
+          instance.data,
+          instance.ctx
+        )
+      } finally {
+        setCurrentRenderingInstance(prev)
+      }
     } else if (instance.render && instance.render !== NOOP) {
       renderVNode(
         push,


### PR DESCRIPTION
ensure the current instance is not affected by rendering error.
close #6110 