### PR TITLE
refactor(reactivity): remove unnecessary properties and condition

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -336,19 +336,19 @@ export function trigger(
       }
     }
     if (__DEV__) {
-      triggerEffects(createDep(effects), eventInfo)
+      triggerEffects(new Set(effects), eventInfo)
     } else {
-      triggerEffects(createDep(effects))
+      triggerEffects(new Set(effects))
     }
   }
 }
 
 export function triggerEffects(
-  dep: Dep | ReactiveEffect[],
+  dep: Dep | Set<ReactiveEffect>,
   debuggerEventExtraInfo?: DebuggerEventExtraInfo
 ) {
   // spread into array for stabilization
-  const effects = isArray(dep) ? dep : [...dep]
+  const effects = [...dep]
   for (const effect of effects) {
     if (effect.computed) {
       triggerEffect(effect, debuggerEventExtraInfo)


### PR DESCRIPTION
type of the first parameter of `triggerEffects` is always `Set`, so remove `isArray`, and the parameter will be spread, the `createDep` that adds `wasTracked` and `newTracked` is unnecessary.