### PR TITLE
fix(types): improve class and style attributes types

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -236,7 +236,7 @@ interface AriaAttributes {
 
 // Vue's style and class normalization supports nested arrays
 export type StyleValue = string | CSSProperties | Array<StyleValue>
-export type ClassValue = string | Record<string, unknown> | Array<ClassValue>
+export type ClassValue = unknown | Record<string, unknown> | Array<ClassValue>
 
 export interface HTMLAttributes extends AriaAttributes, EventHandlers<Events> {
   innerHTML?: string

--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -234,13 +234,14 @@ interface AriaAttributes {
   'aria-valuetext'?: string
 }
 
-// Vue's style normalization supports nested arrays
+// Vue's style and class normalization supports nested arrays
 export type StyleValue = string | CSSProperties | Array<StyleValue>
+export type ClassValue = string | Record<string, unknown> | Array<ClassValue>
 
 export interface HTMLAttributes extends AriaAttributes, EventHandlers<Events> {
   innerHTML?: string
 
-  class?: any
+  class?: ClassValue
   style?: StyleValue
 
   // Standard HTML Attributes
@@ -734,8 +735,8 @@ export interface SVGAttributes extends AriaAttributes, EventHandlers<Events> {
    * SVG Styling Attributes
    * @see https://www.w3.org/TR/SVG/styling.html#ElementSpecificStyling
    */
-  class?: any
-  style?: string | CSSProperties
+  class?: ClassValue
+  style?: StyleValue
 
   color?: string
   height?: Numberish

--- a/test-dts/tsx.test-d.tsx
+++ b/test-dts/tsx.test-d.tsx
@@ -23,6 +23,11 @@ expectType<JSX.Element>(
   <div style={[{ color: 'red' }, [{ fontSize: '1em' }]]} />
 )
 
+// allow array, object classes and nested classes
+expectType<JSX.Element>(<div class="" />)
+expectType<JSX.Element>(<div class={[undefined && '', { 'foo': true }, '']} />)
+expectType<JSX.Element>(<div class={{ 'foo': true, 'bar': undefined }} />)
+
 // @ts-expect-error unknown prop
 expectError(<div foo="bar" />)
 


### PR DESCRIPTION
Based on [normalizeClass](https://github.com/vuejs/core/blob/769e5555f9d9004ce541613341652db859881570/packages/shared/src/normalizeProp.ts#L65), user can pass only this types to `class` attribute

Also reused already created `StyleValue` for SVG Style because it supports Array values