### PR TITLE
fix(runtime-core): comments before single root element breaking Transition

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2203,22 +2203,6 @@ function baseCreateRenderer(
     } else {
       performRemove()
     }
-
-    // if (
-    //   vnode.shapeFlag & ShapeFlags.ELEMENT &&
-    //   transition &&
-    //   !transition.persisted
-    // ) {
-    //   const { leave, delayLeave } = transition
-    //   const performLeave = () => leave(el!, performRemove)
-    //   if (delayLeave) {
-    //     delayLeave(vnode.el!, performRemove, performLeave)
-    //   } else {
-    //     performLeave()
-    //   }
-    // } else {
-    //   performRemove()
-    // }
   }
 
   const removeFragment = (cur: RendererNode, end: RendererNode) => {


### PR DESCRIPTION
fix #6080.

<details>
<summary>The testing html</summary>

```html
<script src="../../dist/vue.global.js"></script>

<script type="text/x-template" id="home">
  <div class="home">
    Home
  </div>
</script>
<script type="text/x-template" id="about">
  <!-- Breaking Comment -->
  <div class="about">
    About
  </div>
</script>
<script>
const Home = {
  template: '#home'
}
const About = {
  template: '#about'
}
</script>

<!-- app -->
<div id="app">
  <button @click="isHome = !isHome">
    Toggle
  </button>
  <transition name="fade" mode="out-in">
  <!-- <transition name="fade" mode="in-out"> -->
  <!-- <transition name="fade"> -->
    <home v-if="isHome"></home>
    <about v-else></about>
  </transition>
</div>

<script>
Vue.createApp({
  components: { Home, About },
  data: () => ({
    isHome: true
  })
}).mount('#app')
</script>

<style>
.fade-enter-active {
  animation: fade-in 600ms;
}

.fade-leave-active {
  animation: fade-out 600ms;
}

@keyframes fade-in {
  0% {
    opacity: 0%;
  }

  100% {
    opacity: 100%;
  }
}

@keyframes fade-out {
  0% {
    opacity: 100%;
  }

  100% {
    opacity: 0%;
  }
}
</style>

```
</details>