### PR TITLE
ci: correct filter unit tests in windows system

### DIFF
--- a/scripts/filter-unit.js
+++ b/scripts/filter-unit.js
@@ -1,9 +1,10 @@
+const path = require('path')
 const { e2eTests } = require('./filter-e2e')
 
 module.exports = list => {
   return {
     filtered: list
-      .filter(t => !e2eTests.some(tt => t.includes(tt)))
+      .filter(t => !e2eTests.some(tt => t.includes(path.normalize(tt))))
       .map(test => ({ test }))
   }
 }


### PR DESCRIPTION
fix: Both unit tests and e2e tests run when running `test-unit` script in windows 10 system.