### PR TITLE
fix(runtime-core): support extends template for runtime compiler

### DIFF
--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -12,6 +12,7 @@ import {
   createApp,
   computed
 } from '@vue/runtime-test'
+import { render as domRender } from 'vue'
 
 describe('api: options', () => {
   test('data', async () => {
@@ -1034,6 +1035,19 @@ describe('api: options', () => {
 
     expect(renderToString(h(Comp))).toBe('base,base')
   })
+
+  test('extends template', () => {
+    const Comp = {
+      extends: {
+        template: `<h1>Foo</h1>`
+      }
+    }
+
+    const root = document.createElement('div') as any
+    domRender(h(Comp), root)
+    expect(root.innerHTML).toBe(`<h1>Foo</h1>`)
+  })
+
 
   test('options defined in component have higher priority', async () => {
     const Mixin = {

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -35,7 +35,8 @@ import {
   applyOptions,
   ComponentOptions,
   ComputedOptions,
-  MethodOptions
+  MethodOptions,
+  resolveMergedOptions
 } from './componentOptions'
 import {
   EmitsOptions,
@@ -788,7 +789,8 @@ export function finishComponentSetup(
         (__COMPAT__ &&
           instance.vnode.props &&
           instance.vnode.props['inline-template']) ||
-        Component.template || (instance.ctx.$options as any).template
+        Component.template ||
+        resolveMergedOptions(instance).template
       if (template) {
         if (__DEV__) {
           startMeasure(instance, `compile`)

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -788,7 +788,7 @@ export function finishComponentSetup(
         (__COMPAT__ &&
           instance.vnode.props &&
           instance.vnode.props['inline-template']) ||
-        Component.template
+        Component.template || instance.ctx.$options.template
       if (template) {
         if (__DEV__) {
           startMeasure(instance, `compile`)

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -788,7 +788,7 @@ export function finishComponentSetup(
         (__COMPAT__ &&
           instance.vnode.props &&
           instance.vnode.props['inline-template']) ||
-        Component.template || instance.ctx.$options.template
+        Component.template || (instance.ctx.$options as any).template
       if (template) {
         if (__DEV__) {
           startMeasure(instance, `compile`)


### PR DESCRIPTION
**this behavior supported in vue2.**
close #6249 