### PR TITLE
fix(compiler-core): let `v-on` matchs more arrow functions

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -590,58 +590,26 @@ describe('compiler: transform v-on', () => {
     })
 
     test('inline async arrow function expression handler', () => {
-      const inputs = [
+      const { root, node } = parseWithVOn(
         `<div v-on:click="async () => await foo()" />`,
-        `<Comp v-on:click="(async now => msg = now)" />`,
-        `<Comp v-on:click="(now => msg = now)" />`,
-        `<Comp v-on:click="async now => msg = now" />`
-      ]
-      const outputs = [
         {
-          type: NodeTypes.JS_CACHE_EXPRESSION,
-          index: 0,
-          value: {
-            type: NodeTypes.COMPOUND_EXPRESSION,
-            children: [`async () => await `, { content: `_ctx.foo` }, `()`]
-          }
-        },
-        {
-          type: NodeTypes.JS_CACHE_EXPRESSION,
-          index: 0,
-          value: {
-            type: NodeTypes.COMPOUND_EXPRESSION,
-            children: [`(async `, { content: `now` }, ` => `, { content: `_ctx.msg` }, ` = `, { content: `now` }, `)`]
-          }
-        },
-        {
-          type: NodeTypes.JS_CACHE_EXPRESSION,
-          index: 0,
-          value: {
-            type: NodeTypes.COMPOUND_EXPRESSION,
-            children: [`(`, { content: `now` }, ` => `, { content: `_ctx.msg` }, ` = `, { content: `now` }, `)`]
-          }
-        },
-        {
-          type: NodeTypes.JS_CACHE_EXPRESSION,
-          index: 0,
-          value: {
-            type: NodeTypes.COMPOUND_EXPRESSION,
-            children: [`async `, { content: `now` }, ` => `, { content: `_ctx.msg` }, ` = `, { content: `now` }]
-          }
-        }
-      ]
-
-      inputs.forEach((input, index) => {
-        const { root, node } = parseWithVOn(input, {
           prefixIdentifiers: true,
           cacheHandlers: true
-        })
-        expect(root.cached).toBe(1)
-        const vnodeCall = node.codegenNode as VNodeCall
-        // should not treat cached handler as dynamicProp, so no flags
-        expect(vnodeCall.patchFlag).toBeUndefined()
-        expect((vnodeCall.props as ObjectExpression).properties[0].value)
-          .toMatchObject(outputs[index])
+        }
+      )
+      expect(root.cached).toBe(1)
+      const vnodeCall = node.codegenNode as VNodeCall
+      // should not treat cached handler as dynamicProp, so no flags
+      expect(vnodeCall.patchFlag).toBeUndefined()
+      expect(
+        (vnodeCall.props as ObjectExpression).properties[0].value
+      ).toMatchObject({
+        type: NodeTypes.JS_CACHE_EXPRESSION,
+        index: 0,
+        value: {
+          type: NodeTypes.COMPOUND_EXPRESSION,
+          children: [`async () => await `, { content: `_ctx.foo` }, `()`]
+        }
       })
     })
 

--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -666,5 +666,52 @@ describe('compiler: transform v-on', () => {
         }
       })
     })
+
+    test('inline arrow function with valid format handler', () => {
+      const inputs = [
+        `<div v-on:click="(async now => msg = now)" />`,
+        `<div v-on:click="(now => msg = now)" />`,
+        `<div v-on:click="async now => msg = now" />`
+      ]
+      const outputs = [
+        {
+          type: NodeTypes.JS_CACHE_EXPRESSION,
+          index: 0,
+          value: {
+            type: NodeTypes.COMPOUND_EXPRESSION,
+            children: [`(async `, { content: `now` }, ` => `, { content: `_ctx.msg` }, ` = `, { content: `now` }, `)`]
+          }
+        },
+        {
+          type: NodeTypes.JS_CACHE_EXPRESSION,
+          index: 0,
+          value: {
+            type: NodeTypes.COMPOUND_EXPRESSION,
+            children: [`(`, { content: `now` }, ` => `, { content: `_ctx.msg` }, ` = `, { content: `now` }, `)`]
+          }
+        },
+        {
+          type: NodeTypes.JS_CACHE_EXPRESSION,
+          index: 0,
+          value: {
+            type: NodeTypes.COMPOUND_EXPRESSION,
+            children: [`async `, { content: `now` }, ` => `, { content: `_ctx.msg` }, ` = `, { content: `now` }]
+          }
+        }
+      ]
+
+      inputs.forEach((input, index) => {
+        const { root, node } = parseWithVOn(input, {
+          prefixIdentifiers: true,
+          cacheHandlers: true
+        })
+        expect(root.cached).toBe(1)
+        const vnodeCall = node.codegenNode as VNodeCall
+        // should not treat cached handler as dynamicProp, so no flags
+        expect(vnodeCall.patchFlag).toBeUndefined()
+        expect((vnodeCall.props as ObjectExpression).properties[0].value)
+          .toMatchObject(outputs[index])
+      })
+    })
   })
 })

--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -13,11 +13,11 @@ import { camelize, toHandlerKey } from '@vue/shared'
 import { createCompilerError, ErrorCodes } from '../errors'
 import { processExpression } from './transformExpression'
 import { validateBrowserExpression } from '../validateExpression'
-import { hasScopeRef, isMemberExpression } from '../utils'
+import { hasScopeRef, isMemberExpression, trimArrowFunctionWrapParens } from '../utils'
 import { TO_HANDLER_KEY } from '../runtimeHelpers'
 
 const fnExpRE =
-  /^\s*([\w$_]+|(async\s*)?\([^)]*?\))\s*=>|^\s*(async\s+)?function(?:\s+[\w$]+)?\s*\(/
+  /^\s*([\w$_]+|(async\s*)?(\([^)]*?\)|[\w$_]+))\s*=>|^\s*(async\s+)?function(?:\s+[\w$]+)?\s*\(/
 
 export interface VOnDirectiveNode extends DirectiveNode {
   // v-on without arg is handled directly in ./transformElements.ts due to it affecting
@@ -78,7 +78,7 @@ export const transformOn: DirectiveTransform = (
   let shouldCache: boolean = context.cacheHandlers && !exp && !context.inVOnce
   if (exp) {
     const isMemberExp = isMemberExpression(exp.content, context)
-    const isInlineStatement = !(isMemberExp || fnExpRE.test(exp.content))
+    const isInlineStatement = !(isMemberExp || fnExpRE.test(trimArrowFunctionWrapParens(exp.content)))
     const hasMultipleStatements = exp.content.includes(`;`)
 
     // process the expression since it's been skipped

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -537,3 +537,10 @@ export function makeBlock(
     helper(getVNodeBlockHelper(inSSR, node.isComponent))
   }
 }
+
+export function trimArrowFunctionWrapParens(content: string): string {
+  content = content.trim()
+  return !/^\([^)]*?\)\s*=>/.test(content) && content.startsWith('(') && content.endsWith(')')
+    ? trimArrowFunctionWrapParens(content.replace(/^\(|\)$/g, ''))
+    : content
+}


### PR DESCRIPTION
Check this [situation](https://sfc.vuejs.org/#eNp9U+1q4zAQfJVFHMSB2OKuPw58islx17fQjyb2OnUbfSDJKcXo3buy0+AmTf55Z5YZ7ex6YH+tLY49spIJX7vOBvAYeltJ3SlrXIABHLYQoXVGwYJaF2fqn1H2hBc8FUmJaKlro32Attewhq1/1zVo8wbrCpTfE0TFZ88EkEX29GOA8G7RtJBddi8h/pnR30t+bUrm8WkpteDTYDQSFQGVPWwDUgUgnn9WwzAqxCg4VSM6zrXZY8hJdS3Z9XMkq65BMWZwQ+LGk5PQDeqe3I1MWfU9cZZKaZwTYCs2LTJXW1u8eKPpCobkJ0+El6yEEUkYLTfVkj2HYH3Jea/t676ojeIb4rjrdegU5o1Rm4fiV/HwmzedD3O8QK/ynTNvHh05SraaiXMCj+hyh7pBh+6u2UXvF8ML7so0eUapIwXwebWz+z9s9Z4iTsOf/4XpVlF1wVOiDbadxsdUiQEyLGFxWs1iBccSdK926JYlHE3XQKyye1cog9j1IRgNm/rQ1a9kPfpkM83/1FrQZ7ZMBzNFJvzBBODTffBJohI7l5D5kuMHXJdOOQ==) in Vue3.2.37.

```
<Comp @get-now="(now => msg = now)">(now => msg = now)</Comp>
<Comp @get-now="(async now => msg = now)">(async now => msg = now)</Comp>
<Comp @get-now="async now => msg = now">async now => msg = now</Comp>
```

These 3 funs are actually a `function` type which should update the `msg` normally but not.

And then I try this PR firstly(just a trial).I have already tested pass though `dev-sfc` script.

Appreciate for any correction(humbly).