### PR TITLE
fix(runtime-core): only set cache for object keys

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -226,7 +226,9 @@ export function normalizeEmitsOptions(
   }
 
   if (!raw && !hasExtends) {
-    cache.set(comp, null)
+    if (comp && typeof comp === 'object') {
+      cache.set(comp, null)
+    }
     return null
   }
 
@@ -236,7 +238,9 @@ export function normalizeEmitsOptions(
     extend(normalized, raw)
   }
 
-  cache.set(comp, normalized)
+  if (comp && typeof comp === 'object') {
+    cache.set(comp, normalized)
+  }
   return normalized
 }
 

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -7,6 +7,7 @@ import {
   hyphenate,
   isArray,
   isFunction,
+  isObject,
   isOn,
   toNumber,
   UnionToIntersection
@@ -226,7 +227,7 @@ export function normalizeEmitsOptions(
   }
 
   if (!raw && !hasExtends) {
-    if (comp && typeof comp === 'object') {
+    if (isObject(comp)) {
       cache.set(comp, null)
     }
     return null
@@ -238,7 +239,7 @@ export function normalizeEmitsOptions(
     extend(normalized, raw)
   }
 
-  if (comp && typeof comp === 'object') {
+  if (isObject(comp)) {
     cache.set(comp, normalized)
   }
   return normalized

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -966,8 +966,9 @@ export function resolveMergedOptions(
     }
     mergeOptions(resolved, base, optionMergeStrategies)
   }
-
-  cache.set(base, resolved)
+  if (base && typeof base === 'object') {
+    cache.set(base, resolved)
+  }
   return resolved
 }
 

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -966,7 +966,7 @@ export function resolveMergedOptions(
     }
     mergeOptions(resolved, base, optionMergeStrategies)
   }
-  if (base && typeof base === 'object') {
+  if (isObject(base)) {
     cache.set(base, resolved)
   }
   return resolved

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -494,7 +494,7 @@ export function normalizePropsOptions(
   }
 
   if (!raw && !hasExtends) {
-    if (comp && typeof comp === 'object') {
+    if (isObject(comp)) {
       cache.set(comp, EMPTY_ARR as any)
     }
     return EMPTY_ARR as any
@@ -536,7 +536,7 @@ export function normalizePropsOptions(
   }
 
   const res: NormalizedPropsOptions = [normalized, needCastKeys]
-  if (comp && typeof comp === 'object') {
+  if (isObject(comp)) {
     cache.set(comp, res)
   }
   return res

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -494,7 +494,9 @@ export function normalizePropsOptions(
   }
 
   if (!raw && !hasExtends) {
-    cache.set(comp, EMPTY_ARR as any)
+    if (comp && typeof comp === 'object') {
+      cache.set(comp, EMPTY_ARR as any)
+    }
     return EMPTY_ARR as any
   }
 
@@ -534,7 +536,9 @@ export function normalizePropsOptions(
   }
 
   const res: NormalizedPropsOptions = [normalized, needCastKeys]
-  cache.set(comp, res)
+  if (comp && typeof comp === 'object') {
+    cache.set(comp, res)
+  }
   return res
 }
 


### PR DESCRIPTION
## Background

On SSR if an unregistered component is used we have a hard crash as we try to cache the details about this component, but it's a string (not a resolved object) and can't be used as a cache key to the WeakMap that's we're using.

It's true this is wrong usage, and there is a helpful warning:

```bash
[Vue warn]: Failed to resolve component: SomeThing
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement.
```

But there is also a fatal and hard error that occurs:

**Fatal error**:
```bash
Error: WeakMap key must be an object, got comp
    at _evaluate (https://node-2lafe5-dfi279td.w-corp.staticblitz.com/blitz.bff91798029e1af88e01551d056a592b2882b9ac.js:15:286611)
    at <anonymous> (<anonymous>)
```

### Code

```js
import { createSSRApp } from 'vue';
import { renderToString } from 'vue/server-renderer';

const app = createSSRApp({
  template: `<SomeThing />`,
});

console.log(await renderToString(app));
```

https://stackblitz.com/edit/node-2lafe5?file=index.mjs
