### PR TITLE
feat(compiler-sfc): add option filenameAsComponentName to SFCScriptCompileOptions

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -123,6 +123,12 @@ export interface SFCScriptCompileOptions {
    * options passed to `compiler-dom`.
    */
   templateOptions?: Partial<SFCTemplateCompileOptions>
+  /**
+   * Enable/disable automatically infer component name from filename when using script setup.
+   * https://github.com/vuejs/core/pull/4997
+   * Defaults to true.
+   */
+  filenameAsComponentName?: boolean
 }
 
 export interface ImportBinding {
@@ -153,6 +159,7 @@ export function compileScript(
     !!options.reactivityTransform || !!options.propsDestructureTransform
   const isProd = !!options.isProd
   const genSourceMap = options.sourceMap !== false
+  const filenameAsComponentName = options.filenameAsComponentName !== false
   let refBindings: string[] | undefined
 
   if (!options.id) {
@@ -1465,7 +1472,12 @@ export function compileScript(
 
   // 11. finalize default export
   let runtimeOptions = ``
-  if (!hasDefaultExportName && filename && filename !== DEFAULT_FILENAME) {
+  if (
+    filenameAsComponentName &&
+    !hasDefaultExportName &&
+    filename &&
+    filename !== DEFAULT_FILENAME
+  ) {
     const match = filename.match(/([^/\\]+)\.\w+$/)
     if (match) {
       runtimeOptions += `\n  __name: '${match[1]}',`


### PR DESCRIPTION
For enable/disable #4997.

Also, I think default value should be `false`.
In most cases, we don't need component name.
Component name is only required when using `KeepAlive`.
But, #4997 will generate many identical component names (e.g `Index`).
This is prone to unexpected `KeepAlive`,
And will generate a lot of useless component names.