### PR TITLE
fix(types):  readonly-array as an argument to ref/reactive, inconsistency between type and behaviour

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -296,6 +296,8 @@ export type UnwrapRefSimple<T> = T extends
   ? T
   : T extends Array<any>
   ? { [K in keyof T]: UnwrapRefSimple<T[K]> }
+  : T extends ReadonlyArray<any>
+  ? T
   : T extends object & { [ShallowReactiveMarker]?: never }
   ? {
       [P in keyof T]: P extends symbol ? T[P] : UnwrapRef<T[P]>

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -294,10 +294,8 @@ export type UnwrapRefSimple<T> = T extends
   | RefUnwrapBailTypes[keyof RefUnwrapBailTypes]
   | { [RawSymbol]?: true }
   ? T
-  : T extends Array<any>
+  : T extends Array<any> | ReadonlyArray<any>
   ? { [K in keyof T]: UnwrapRefSimple<T[K]> }
-  : T extends ReadonlyArray<any>
-  ? T
   : T extends object & { [ShallowReactiveMarker]?: never }
   ? {
       [P in keyof T]: P extends symbol ? T[P] : UnwrapRef<T[P]>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 importers:
 
@@ -64,7 +64,7 @@ importers:
       '@types/jest': 27.0.3
       '@types/node': 16.11.12
       '@types/puppeteer': 5.4.4
-      '@typescript-eslint/parser': 5.23.0_hxadhbs2xogijvk7vq4t2azzbu
+      '@typescript-eslint/parser': 5.23.0_eslint@7.32.0+typescript@4.7.4
       '@vue/reactivity': link:packages/reactivity
       '@vue/runtime-core': link:packages/runtime-core
       '@vue/runtime-dom': link:packages/runtime-dom
@@ -75,7 +75,7 @@ importers:
       enquirer: 2.3.6
       esbuild: 0.14.35
       eslint: 7.32.0
-      eslint-plugin-jest: 26.1.5_fublp7hbjjjut4jarqgrlzb3ey
+      eslint-plugin-jest: 26.1.5_2d02b7fce14a5349f1208c0d15e43b26
       execa: 4.1.0
       fs-extra: 9.1.0
       jest: 27.4.4
@@ -91,11 +91,11 @@ importers:
       rollup-plugin-node-globals: 1.4.0
       rollup-plugin-polyfill-node: 0.6.2_rollup@2.38.5
       rollup-plugin-terser: 7.0.2_rollup@2.38.5
-      rollup-plugin-typescript2: 0.27.3_svygma56heasd5pd4q5yjh2bo4
+      rollup-plugin-typescript2: 0.27.3_rollup@2.38.5+typescript@4.7.4
       semver: 7.3.5
       serve: 12.0.1
       todomvc-app-css: 2.4.1
-      ts-jest: 27.1.1_3hnzclobtp5be2lqcsbwijsi7u
+      ts-jest: 27.1.1_d9db912dc19bfa1269701483642648fd
       tslib: 2.4.0
       typescript: 4.7.4
       vite: 2.9.8
@@ -1213,7 +1213,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/parser/5.23.0_hxadhbs2xogijvk7vq4t2azzbu:
+  /@typescript-eslint/parser/5.23.0_eslint@7.32.0+typescript@4.7.4:
     resolution: {integrity: sha512-V06cYUkqcGqpFjb8ttVgzNF53tgbB/KoQT/iB++DOIExKmzI9vBJKjZKt/6FuV9c+zrDsvJKbJ2DOCYwX91cbw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1301,7 +1301,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.19.0_hxadhbs2xogijvk7vq4t2azzbu:
+  /@typescript-eslint/utils/5.19.0_eslint@7.32.0+typescript@4.7.4:
     resolution: {integrity: sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2098,8 +2098,6 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /concat-map/0.0.1:
@@ -2427,11 +2425,6 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
@@ -2906,7 +2899,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-plugin-jest/26.1.5_fublp7hbjjjut4jarqgrlzb3ey:
+  /eslint-plugin-jest/26.1.5_2d02b7fce14a5349f1208c0d15e43b26:
     resolution: {integrity: sha512-su89aDuljL9bTjEufTXmKUMSFe2kZUL9bi7+woq+C2ukHZordhtfPm4Vg+tdioHBaKf8v3/FXW9uV0ksqhYGFw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2919,7 +2912,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.19.0_hxadhbs2xogijvk7vq4t2azzbu
+      '@typescript-eslint/utils': 5.19.0_eslint@7.32.0+typescript@4.7.4
       eslint: 7.32.0
       jest: 27.4.4
     transitivePeerDependencies:
@@ -6101,11 +6094,11 @@ packages:
 
   /rollup-plugin-polyfill-node/0.6.2_rollup@2.38.5:
     resolution: {integrity: sha512-gMCVuR0zsKq0jdBn8pSXN1Ejsc458k2QsFFvQdbHoM0Pot5hEnck+pBP/FDwFS6uAi77pD3rDTytsaUStsOMlA==}
-    peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
     dependencies:
       '@rollup/plugin-inject': 4.0.3_rollup@2.38.5
       rollup: 2.38.5
+    transitivePeerDependencies:
+      - rollup
     dev: true
 
   /rollup-plugin-terser/7.0.2_rollup@2.38.5:
@@ -6118,9 +6111,11 @@ packages:
       rollup: 2.38.5
       serialize-javascript: 4.0.0
       terser: 5.10.0
+    transitivePeerDependencies:
+      - acorn
     dev: true
 
-  /rollup-plugin-typescript2/0.27.3_svygma56heasd5pd4q5yjh2bo4:
+  /rollup-plugin-typescript2/0.27.3_rollup@2.38.5+typescript@4.7.4:
     resolution: {integrity: sha512-gmYPIFmALj9D3Ga1ZbTZAKTXq1JKlTQBtj299DXhqYz9cL3g/AQfUvbb2UhH+Nf++cCq941W2Mv7UcrcgLzJJg==}
     peerDependencies:
       rollup: '>=1.26.3'
@@ -6256,8 +6251,6 @@ packages:
       compression: 1.7.3
       serve-handler: 6.1.3
       update-check: 1.5.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /set-immediate-shim/1.0.1:
@@ -6660,6 +6653,8 @@ packages:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
     hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
     peerDependenciesMeta:
       acorn:
         optional: true
@@ -6757,7 +6752,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest/27.1.1_3hnzclobtp5be2lqcsbwijsi7u:
+  /ts-jest/27.1.1_d9db912dc19bfa1269701483642648fd:
     resolution: {integrity: sha512-Ds0VkB+cB+8g2JUmP/GKWndeZcCKrbe6jzolGrVWdqVUFByY/2KDHqxJ7yBSon7hDB1TA4PXxjfZ+JjzJisvgA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -319,3 +319,24 @@ describe('reactive in shallow ref', () => {
 
   expectType<number>(x.value.a.b)
 })
+
+
+
+describe('ref in readonly array', () => {
+  test('as an argument to the ref method', () => {
+    const r = ref([ref(1), 2, ref(3), reactive({a: ref(1)})] as const)
+    expectType<Ref<number>>(r.value[0])
+  })
+  test('as an argument to the reactive method', () => {
+    const r = reactive([ref(1), ref(2), ref(3)])
+    expectType<Ref<number>>(r[0])
+  })
+  test('properties as parameters of the reactive method', () => {
+    const r = reactive({
+      a: [ref(1), 2, ref(3)] as const,
+      b: ref(2)
+    })
+    expectType<Ref<number>>(r.a[0])
+    expectType<number>(r.b)
+  })
+})


### PR DESCRIPTION

When readonly-array is used as a ref/reactive parameter, the result type is inconsistent with the behaviour.

**example:**
```ts
export declare function expectType<T>(value: T): void

const refV = ref([ref(1), 2, ref(3), reactive({a: ref(1)})] as const)  // The same goes for reactive


const first = refV.value[0]

console.log((first as any).value) // 1

expectType<number>(refV.value[0])        // it should be error
expectType<Ref<number>>(refV.value[0])   // it should be right
```
[playground](https://www.typescriptlang.org/play?ssl=15&ssc=63&pln=5&pc=1#code/FASwtgDg9gTgLgAgN4JgUwGYBpVoIYDGcIAbmggL4IYxRgIDkJArmg6JLInAJ4TkoASpkrVa9Jq3bA0AD2jwEAEzQEANnnTVmAOyIgoOhHP5EAKnzQAeMwD4AFCTxrWALgRmAlO5JQQS4GACQwBnRHQMADUEAF5cDHsAbQj7AEZPHAAmHBSAZgzcQmIyeyQ8dxT0ik8AXQQ8EIRgnTDPQKDQxAwQGDDY+MiAOicXNESABhrA5pCoNTRBtSgAc3t7bt7EBvqdHk9h51ZPBAB6E4RUwJNVOAt+Kx1mMAAjNBgHCKGR1gma44QAYDTucQIgQgALKDMNRKBCvYwwWgwGTyG53azCDAPJ6vd4fTBfQ5jSb-YEIUEICFQmFw8gwEDLcFwIA)