### PR TITLE
fix(runtime-dom): SVGAttributes style hint type error

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -749,7 +749,7 @@ export interface SVGAttributes extends AriaAttributes, EventHandlers<Events> {
    * @see https://www.w3.org/TR/SVG/styling.html#ElementSpecificStyling
    */
   class?: any
-  style?: string | CSSProperties
+  style?: StyleValue
 
   color?: string
   height?: Numberish


### PR DESCRIPTION
Normally, when we binding `:style` to an array of multiple objects in common HTML elements, ts wouldn't hint a type error. But if we do this in SVG elements, ts would hint a type error. 

_when we binding `:style` in common HTML elements:_

<img width="749" alt="截屏2022-07-21 00 26 05" src="https://user-images.githubusercontent.com/43527124/180046646-8dd8a5cf-b9d9-4a18-aaa2-0cae926cdf20.png">

_when we binding `:style` in SVG elements:_

![截屏2022-07-20 23 20 17](https://user-images.githubusercontent.com/43527124/180046288-1b1b06bf-d1bf-41bb-af4c-e29b6c935f39.png)

SVGAttributes.style type may be `StyleValue`, since vue compiler can parse this correctly.