### PR TITLE
refactor(reactivity): the newTracked function code means the opposite

### DIFF
--- a/packages/reactivity/src/dep.ts
+++ b/packages/reactivity/src/dep.ts
@@ -27,7 +27,7 @@ export const createDep = (effects?: ReactiveEffect[]): Dep => {
 
 export const wasTracked = (dep: Dep): boolean => (dep.w & trackOpBit) > 0
 
-export const newTracked = (dep: Dep): boolean => (dep.n & trackOpBit) > 0
+export const newTracked = (dep: Dep): boolean => (dep.n & trackOpBit) <= 0
 
 export const initDepMarkers = ({ deps }: ReactiveEffect) => {
   if (deps.length) {
@@ -43,7 +43,7 @@ export const finalizeDepMarkers = (effect: ReactiveEffect) => {
     let ptr = 0
     for (let i = 0; i < deps.length; i++) {
       const dep = deps[i]
-      if (wasTracked(dep) && !newTracked(dep)) {
+      if (wasTracked(dep) && newTracked(dep)) {
         dep.delete(effect)
       } else {
         deps[ptr++] = dep

--- a/packages/reactivity/src/dep.ts
+++ b/packages/reactivity/src/dep.ts
@@ -27,7 +27,7 @@ export const createDep = (effects?: ReactiveEffect[]): Dep => {
 
 export const wasTracked = (dep: Dep): boolean => (dep.w & trackOpBit) > 0
 
-export const newTracked = (dep: Dep): boolean => (dep.n & trackOpBit) <= 0
+export const newTracked = (dep: Dep): boolean => !((dep.n & trackOpBit) > 0)
 
 export const initDepMarkers = ({ deps }: ReactiveEffect) => {
   if (deps.length) {

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -235,7 +235,7 @@ export function trackEffects(
 ) {
   let shouldTrack = false
   if (effectTrackDepth <= maxMarkerBits) {
-    if (!newTracked(dep)) {
+    if (newTracked(dep)) {
       dep.n |= trackOpBit // set newly tracked
       shouldTrack = !wasTracked(dep)
     }


### PR DESCRIPTION
There are two places in the source code where the newTracked function is used, which made it a little difficult for me to understand the source code.

The code snippet is as follows：
```ts
// trackEffects function
let shouldTrack = false
  if (effectTrackDepth <= maxMarkerBits) {
    if (!newTracked(dep)) {
      dep.n |= trackOpBit // set newly tracked
      shouldTrack = !wasTracked(dep)
    }
  } else {
    // Full cleanup mode.
    shouldTrack = !dep.has(activeEffect!)
  }
```
```ts
// finalizeDepMarkers function
export const finalizeDepMarkers = (effect: ReactiveEffect) => {
  const { deps } = effect
  if (deps.length) {
    let ptr = 0
    for (let i = 0; i < deps.length; i++) {
      const dep = deps[i]
      if (wasTracked(dep) && !newTracked(dep)) {
        dep.delete(effect)
      } else {
        deps[ptr++] = dep
      }
      // clear bits
      dep.w &= ~trackOpBit
      dep.n &= ~trackOpBit
    }
    deps.length = ptr
  }
}
```

The meaning of the newTracked function at this point seems to be oldTracked. Perhaps we could modify the code to remove the unnecessary `!`