### PR TITLE
fix(types): reactive collection type is not as expected (#5954)

### DIFF
--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -334,19 +334,18 @@ function subTransform(
   // traverse
   traverseNode(childRoot, childContext)
   // merge helpers/components/directives into parent context
-  ;(['helpers', 'components', 'directives'] as const).forEach(key => {
-    childContext[key].forEach((value: any, helperKey: any) => {
-      if (key === 'helpers') {
-        const parentCount = parentContext.helpers.get(helperKey)
-        if (parentCount === undefined) {
-          parentContext.helpers.set(helperKey, value)
-        } else {
-          parentContext.helpers.set(helperKey, value + parentCount)
-        }
-      } else {
-        ;(parentContext[key] as any).add(value)
-      }
+  ;(['components', 'directives'] as const).forEach(key => {
+    childContext[key].forEach((value: any) => {
+      ;(parentContext[key] as any).add(value)
     })
+  })
+  childContext['helpers'].forEach((value: any, helperKey: any) => {
+    const parentCount = parentContext.helpers.get(helperKey)
+    if (parentCount === undefined) {
+      parentContext.helpers.set(helperKey, value)
+    } else {
+      parentContext.helpers.set(helperKey, value + parentCount)
+    }
   })
   // imports/hoists are not merged because:
   // - imports are only used for asset urls and should be consistent between

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -1,7 +1,40 @@
-import { toRaw, ReactiveFlags, toReactive, toReadonly } from './reactive'
+import { 
+  toRaw,
+  ReactiveFlags,
+  toReactive,
+  toReadonly,
+  ReactiveObject,
+  IsCollectionReactive,
+  IsCollectionReadonly,
+  ReadonlyObject
+} from './reactive'
 import { track, trigger, ITERATE_KEY, MAP_KEY_ITERATE_KEY } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
 import { capitalize, hasOwn, hasChanged, toRawType, isMap } from '@vue/shared'
+
+type CollectionUnwrapRefs<T extends object, V> = 
+  IsCollectionReactive<T> extends true
+  ? ReactiveObject<V>
+  : IsCollectionReadonly<T> extends true
+  ? ReadonlyObject<T>
+  : V
+
+declare global {
+  interface Map<K, V> {
+    get<T extends ThisType<Map<K, V>>>(this: T, key: K): CollectionUnwrapRefs<T, V> | undefined
+    forEach<T extends ThisType<Map<K, V>>>(this: T, callbackfn: (value: CollectionUnwrapRefs<T, V>, key: CollectionUnwrapRefs<T, K>, map: T) => void, thisArg?: any): void;
+  }
+  interface WeakMap<K, V> {
+    get<T extends ThisType<WeakMap<K, V>>>(this: T, key: K): CollectionUnwrapRefs<T, V> | undefined
+    forEach<T extends ThisType<WeakMap<K, V>>>(this: T, callbackfn: (value: CollectionUnwrapRefs<T, V>, key: CollectionUnwrapRefs<T, K>, map: T) => void, thisArg?: any): void;
+  }
+  interface Set<T> {
+    forEach<TT extends ThisType<Set<T>>>(this: TT, callbackfn: (value1: CollectionUnwrapRefs<TT, T>, value2: CollectionUnwrapRefs<TT, T>, set: TT) => void, thisArg?: any): void;
+  }
+  interface WeakSet<T> {
+    forEach<TT extends ThisType<WeakSet<T>>>(this: TT, callbackfn: (value1: CollectionUnwrapRefs<TT, T>, value2: CollectionUnwrapRefs<TT, T>, set: TT) => void, thisArg?: any): void;
+  }
+}
 
 export type CollectionTypes = IterableCollections | WeakCollections
 

--- a/test-dts/reactivity.test-d.ts
+++ b/test-dts/reactivity.test-d.ts
@@ -60,3 +60,118 @@ describe('shallowReadonly ref unwrap', () => {
   expectType<Ref>(r.count.n)
   r.count.n.value = 123
 })
+
+describe('collection-type', () => {
+  it('primitive type as value', () => {
+    const m = reactive(new Map<string, number>())
+    const s = reactive(new Set<string>())
+    m.set('a', 1)
+    s.add('b')
+
+    expectType<Map<string, number>>(m)
+    expectType<Set<string>>(s)
+    expectType<number>(m.get('a')!)
+    m.forEach((v1, v2, m) => {
+      expectType<number>(v1)
+      expectType<string>(v2)
+      expectType<Map<string, number>>(m)
+    })
+    s.forEach((v1, v2, s) => {
+      expectType<string>(v1)
+      expectType<string>(v2)
+      expectType<Set<string>>(s)
+    })
+  })
+
+  it('composite types as values', () => {
+    const m = reactive(new Map<string, {a: number}>())
+    const s = reactive(new Set<{a: number}>())
+    m.set('a', {a: 1})
+    s.add({a: 1})
+
+    expectType<{a: number}>(m.get('a')!)
+    m.forEach((v1, v2, m) => {
+      expectType<{a: number}>(v1)
+      expectType<string>(v2)
+    })
+    s.forEach((v1, v2, s) => {
+      expectType<{a: number}>(v1)
+      expectType<{a: number}>(v2)
+    })
+  })
+
+  it('composite type as key', () => {
+    const m = reactive(new Map<{a: number}, string>())
+    m.set({a: 1}, 'a')
+    m.forEach((v1, v2, m) => {
+      expectType<string>(v1)
+      expectType<{a: number}>(v2)
+    })
+  })
+
+  it('ref as value', () => {
+    const m = reactive(new Map<string, Ref<number>>())
+    const s = reactive(new Set<Ref<string>>())
+    m.set('a', ref(1))
+    s.add(ref('b'))
+
+    expectType<Map<string, Ref<number>>>(m)
+    expectType<Set<Ref<string>>>(s)
+    expectType<Ref<number>>(m.get('a')!)
+
+    m.forEach((v1, v2, m) => {
+      expectType<Ref<number>>(v1)
+      expectType<string>(v2)
+      expectType<Map<string, Ref<number>>>(m)
+    })
+
+    s.forEach((v1, v2, s) => {
+      expectType<Ref<string>>(v1)
+      expectType<Ref<string>>(v2)
+      expectType<Set<Ref<string>>>(s)
+    })
+  })
+
+  it('when value is an object and ref is used as an object property', () => {
+    const m = reactive(new Map<string, { foo: Ref<number> }>())
+    const s = reactive(new Set<{ foo:Ref<number> }>())
+    m.set('a', {
+      foo: ref(1)
+    })
+    s.add({
+      foo: ref(1)
+    })
+
+
+    expectType<Map<string, { foo: Ref<number> }>>(m)
+    expectType<Set<{ foo:Ref<number> }>>(s)
+    expectType<{foo: number}>(m.get('a')!)
+
+    m.forEach((v1, v2, m) => {
+      expectType<{ foo: number }>(v1)
+      expectType<string>(v2)
+      expectType<Map<string, { foo: Ref<number> }>>(m)
+    })
+
+    s.forEach((v1, v2, s) => {
+      expectType<{foo: number}>(v1)
+      expectType<{foo: number}>(v2)
+      expectType<Set<{foo: Ref<number>}>>(s)
+    })
+  })
+  it('When the key is an object and the responsive data is an object property', () => {
+    const m = reactive(new Map<{ foo: Ref<number> }, string>())
+    const obj = {
+      foo: ref(1)
+    }
+    m.set(obj, 'a')
+
+    expectType<Map<{ foo:Ref<number> }, string>>(m)
+    m.forEach((v1, v2, m) => {
+      expectType<string>(v1)
+      expectType<{foo: number}>(v2)
+      expectType<Map<{ foo: Ref<number> }, string>>(m)
+    })
+
+  })
+})


### PR DESCRIPTION
fix: https://github.com/vuejs/core/issues/5954

When we explicitly declare the type for the argument to the `reactive` function:
```ts
interface WrapRef {
   foo: Ref<number>
}

const obj =  reactive<WrapRef>({
   foo: ref(1)
})

const map = reactive(new Map<string, WrapRef>())
map.set('a', {
   foo: ref(1)
})
```
The types of the `map` and `set` methods at this point are:
```ts
interface Map<K, V>{
   set(key: K, value: V): this;
}
```
I think the type of `map` as `Map<string, WrapRef>` is as expected.

The problem is that when using `map.get` to get a value, the `ref` value will automatically unref.  So it is possible to handle it from the `get` method.