### PR TITLE
Add custom named slots into customElements/WebComponents

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -191,8 +191,40 @@ export class VueElement extends BaseClass {
             `defined as hydratable. Use \`defineSSRCustomElement\`.`
         )
       }
-      this.attachShadow({ mode: 'open' })
+      this.attachShadow({ mode: 'open' });
+      
+      nextTick(() => {
+        if (this.shadowRoot?.children) {
+          this.customNamedSlots(this.shadowRoot?.children);
+        }
+      });
     }
+  }
+  
+  private customNamedSlots(shadowRootChildren: HTMLCollection) {
+    const getAllTemplates: NodeListOf<HTMLTemplateElement> =
+      this.querySelectorAll('template');
+
+    getAllTemplates.forEach((template: HTMLTemplateElement) => {
+      for (let i = 0; i < template.attributes.length; i++) {
+        Array.from(shadowRootChildren).forEach((el: Element) => {
+          const getElToInject: Element | null = el.querySelector(
+            `[data-provide-${template.attributes[i].name}]`
+          );
+
+          if (getElToInject) {
+            let contentWrapper: HTMLSpanElement =
+              document.createElement('span');
+            contentWrapper.setAttribute(
+              `data-injected-${template.attributes[i].name}`,
+              ''
+            );
+            contentWrapper.append(template.content);
+            getElToInject.appendChild(contentWrapper);
+          }
+        });
+      }
+    });
   }
 
   attributeChangedCallback(name: string, _oldValue: string, newValue: string) {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -224,6 +224,8 @@ export class VueElement extends BaseClass {
           }
         });
       }
+      
+      this.removeChild(template);
     });
   }
 


### PR DESCRIPTION
I added named slots, which are append into shadowRoot. We needed to add slots to the web-component as it does in vue. After the changes have been made, we can add a template with the name and content. A slot inside the component will be rendered.

Example of use

index.html
![image](https://user-images.githubusercontent.com/21343496/181234168-bd0e5e51-8fa0-4193-bb7d-1cac0a7abe77.png)

In the web-component, add 'template' with the attribute by which it will be recognized - e.g. **ce-right-slot-header**

In the component.vue, add an attribute starting with 'data-provide' plus the name we provided in the template, that is: **data-provide-ce-right-slot-header**

![image](https://user-images.githubusercontent.com/21343496/181234443-c1d4aeaf-677d-498c-991c-e55e8e914cb5.png)


On this basis, the web-component will be rendered and the value from template will be embedded in it. We can use a few slots in web-component.

The result of this is:
![image](https://user-images.githubusercontent.com/21343496/181235141-77977dae-4d8b-4299-9251-ed5b4456167f.png)
![image](https://user-images.githubusercontent.com/21343496/181234874-5e749476-7298-4269-aadf-3fbfcb89503d.png)
