### PR TITLE
fix(types): directives without arguments but with modifiers

### DIFF
--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -74,7 +74,7 @@ export type DirectiveArguments = Array<
   | [Directive]
   | [Directive, any]
   | [Directive, any, string]
-  | [Directive, any, string, DirectiveModifiers]
+  | [Directive, any, string | undefined, DirectiveModifiers]
 >
 
 /**


### PR DESCRIPTION
fix #6427
```vue
<input v-model.trim="msg" />

/**
 * after compilation
 * 
 * [
 *    vModelText,
 *    msg.value,
 *    void 0,
 *    { trim: true }
 * ]
 */
```
error :
```bash
TS2322: Type '[ModelDirective<HTMLInputElement | HTMLTextAreaElement>, any, undefined, { trim: true; }]' is not assignable to type '[Directive<any, any>] | [Directive<any, any>, any] | [Directive<any, any>, any, string] | [Directive<any, any>, any, string, DirectiveModifiers]'.
  Type '[ModelDirective<HTMLInputElement | HTMLTextAreaElement>, any, undefined, { trim: true; }]' is not assignable to type '[Directive<any, any>, any, string, DirectiveModifiers]'.
    Type at position 2 in source is not compatible with type at position 2 in target.
      Type 'undefined' is not assignable to type 'string'.
```