### PR TITLE
fix(compiler-sfc): dynamic import type annotation

### DIFF
--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -44,14 +44,8 @@ export interface SFCScriptBlock extends SFCBlock {
   setup?: string | boolean
   bindings?: BindingMetadata
   imports?: Record<string, ImportBinding>
-  /**
-   * import('\@babel/types').Statement
-   */
-  scriptAst?: any[]
-  /**
-   * import('\@babel/types').Statement
-   */
-  scriptSetupAst?: any[]
+  scriptAst?: import('@babel/types').Statement[]
+  scriptSetupAst?: import('@babel/types').Statement[]
 }
 
 export interface SFCStyleBlock extends SFCBlock {


### PR DESCRIPTION
- the correct type is  `Statement[]`, instead of `Statement`.
- comment of type annotation is useless for dts file. So I change it to dynamic import.