### PR TITLE
feat(compiler-sfc): supports reference a variable in `withDefaults`

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1782,6 +1782,33 @@ return { props, get defaults() { return defaults } }
 })"
 `;
 
+exports[`SFC compile <script setup> > with TypeScript > withDefaults (reference) 1`] = `
+"import { mergeDefaults as _mergeDefaults, defineComponent as _defineComponent } from 'vue'
+import { defaults } from './foo'
+      
+export default /*#__PURE__*/_defineComponent({
+  props: _mergeDefaults({
+    foo: { type: String, required: false },
+    bar: { type: Number, required: false },
+    baz: { type: Boolean, required: true }
+  }, defaults),
+  setup(__props: any, { expose }) {
+  expose();
+
+const props = __props as {
+        foo?: string
+        bar?: number
+        baz: boolean
+      };
+
+      
+      
+return { props, get defaults() { return defaults } }
+}
+
+})"
+`;
+
 exports[`SFC compile <script setup> > with TypeScript > withDefaults (static) + normal script 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1190,6 +1190,29 @@ const emit = defineEmits(['a', 'b'])
       )
     })
 
+    test('withDefaults (reference)', () => {
+      const { content } = compile(`
+      <script setup lang="ts">
+      import { defaults } from './foo'
+      const props = withDefaults(defineProps<{
+        foo?: string
+        bar?: number
+        baz: boolean
+      }>(), defaults)
+      </script>
+      `)
+      assertCode(content)
+      expect(content).toMatch(`import { mergeDefaults as _mergeDefaults`)
+      expect(content).toMatch(
+        `
+  _mergeDefaults({
+    foo: { type: String, required: false },
+    bar: { type: Number, required: false },
+    baz: { type: Boolean, required: true }
+  }, defaults)`.trim()
+      )
+    })
+
     // #7111
     test('withDefaults (dynamic) w/ production mode', () => {
       const { content } = compile(

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -290,7 +290,7 @@ export function compileScript(
   let hasDefaultExportName = false
   let hasDefaultExportRender = false
   let propsRuntimeDecl: Node | undefined
-  let propsRuntimeDefaults: ObjectExpression | undefined
+  let propsRuntimeDefaults: Node | undefined
   let propsDestructureDecl: Node | undefined
   let propsDestructureRestId: string | undefined
   let propsTypeDecl: PropsDeclType | undefined
@@ -528,16 +528,14 @@ export function compileScript(
           node.callee
         )
       }
-      propsRuntimeDefaults = node.arguments[1] as ObjectExpression
-      if (
-        !propsRuntimeDefaults ||
-        propsRuntimeDefaults.type !== 'ObjectExpression'
-      ) {
+      propsRuntimeDefaults = node.arguments[1]
+      if (!propsRuntimeDefaults) {
         error(
-          `The 2nd argument of ${WITH_DEFAULTS} must be an object literal.`,
+          `The 2nd argument of ${WITH_DEFAULTS} is required.`,
           propsRuntimeDefaults || node
         )
       }
+      checkInvalidScopeReference(propsRuntimeDefaults, WITH_DEFAULTS)
     } else {
       error(
         `${WITH_DEFAULTS}' first argument must be a ${DEFINE_PROPS} call.`,

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -809,7 +809,9 @@ export function compileScript(
         if (destructured) {
           defaultString = `default: ${destructured}`
         } else if (hasStaticDefaults) {
-          const prop = propsRuntimeDefaults!.properties.find(node => {
+          const prop = (
+            propsRuntimeDefaults as ObjectExpression
+          ).properties.find(node => {
             if (node.type === 'SpreadElement') return false
             return resolveObjectKey(node.key, node.computed) === key
           }) as ObjectProperty | ObjectMethod
@@ -897,7 +899,7 @@ export function compileScript(
           m.key.type === 'Identifier'
         ) {
           if (
-            propsRuntimeDefaults!.properties.some(p => {
+            (propsRuntimeDefaults as ObjectExpression).properties.some(p => {
               if (p.type === 'SpreadElement') return false
               return (
                 resolveObjectKey(p.key, p.computed) ===


### PR DESCRIPTION
- Support
```ts
import defaults from './some'
withDefaults(defineProps<{ foo: string }>(), defaults)
```

---


Existing plugin: https://github.com/Zolyn/vite-plugin-vue-with-defaults-imports
Inspired by @Zolyn