### PR TITLE
fix(compiler-sfc): add semicolon after `defineProps` statement

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -640,7 +640,7 @@ export default {
   setup(__props, { expose }) {
   expose();
 
-const props = __props
+const props = __props;
 
     
     
@@ -658,7 +658,7 @@ export default {
   setup(__props, { expose }) {
   expose();
 
-const props = __props
+const props = __props;
 
     
 return { props, x }
@@ -675,7 +675,7 @@ exports[`SFC compile <script setup> defineProps() 1`] = `
   setup(__props, { expose }) {
   expose();
 
-const props = __props
+const props = __props;
 
 
 const bar = 1
@@ -693,7 +693,7 @@ exports[`SFC compile <script setup> defineProps/defineEmits in multi-variable de
   setup(__props, { expose, emit }) {
   expose();
 
-const props = __props
+const props = __props;
 
     
     
@@ -710,7 +710,7 @@ exports[`SFC compile <script setup> defineProps/defineEmits in multi-variable de
   setup(__props, { expose, emit }) {
   expose();
 
-const props = __props
+const props = __props;
 
     const a = 1;
     
@@ -1611,7 +1611,7 @@ export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose, emit }) {
   expose();
 
-const props = __props
+const props = __props;
 
 
 
@@ -1705,7 +1705,7 @@ const props = __props as {
         foo?: string
         bar?: number
         baz: boolean
-      }
+      };
 
       
       
@@ -1728,7 +1728,7 @@ export default /*#__PURE__*/_defineComponent({
   setup(__props: any, { expose }) {
   expose();
 
-const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number }
+const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number };
 
       
       

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScriptPropsTransform.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScriptPropsTransform.spec.ts.snap
@@ -160,7 +160,7 @@ export default {
   props: ['foo', 'bar', 'baz'],
   setup(__props) {
 
-const rest = _createPropsRestProxy(__props, [\\"foo\\",\\"bar\\"])
+const rest = _createPropsRestProxy(__props, [\\"foo\\",\\"bar\\"]);
 
       
       

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1411,7 +1411,7 @@ export function compileScript(
       startOffset,
       `\nconst ${propsIdentifier} = __props${
         propsTypeDecl ? ` as ${genSetupPropsType(propsTypeDecl)}` : ``
-      }\n`
+      };\n`
     )
   }
   if (propsDestructureRestId) {
@@ -1419,7 +1419,7 @@ export function compileScript(
       startOffset,
       `\nconst ${propsDestructureRestId} = ${helper(
         `createPropsRestProxy`
-      )}(__props, ${JSON.stringify(Object.keys(propsDestructuredBindings))})\n`
+      )}(__props, ${JSON.stringify(Object.keys(propsDestructuredBindings))});\n`
     )
   }
   // inject temp variables for async context preservation


### PR DESCRIPTION
closes #6428

related #6303, #6430