### PR TITLE
fix(Suspense): switch suspense cause error in the Keepalive (fix: #6416)

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -775,7 +775,8 @@ export function queueEffectWithSuspense(
 function setActiveBranch(suspense: SuspenseBoundary, branch: VNode) {
   suspense.activeBranch = branch
   const { vnode, parentComponent } = suspense
-  const el = (vnode.el = branch.el)
+  const el = branch.el
+  if (el) vnode.el = el
   // in case suspense is the root node of a component,
   // recursively update the HOC el
   if (parentComponent && parentComponent.subTree === vnode) {

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -321,7 +321,7 @@ function patchSuspense(
       triggerEvent(n2, 'onPending')
       // mount pending branch in off-dom container
       suspense.pendingBranch = newBranch
-      suspense.pendingId++
+      if (suspense.pendingId > 0) suspense.pendingId--
       patch(
         null,
         newBranch,

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -42,7 +42,7 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
     el.textContent = text
   },
 
-  parentNode: node => node.parentNode as Element | null,
+  parentNode: node => (node ? node.parentNode : null) as Element | null,
 
   nextSibling: node => node.nextSibling,
 

--- a/packages/runtime-test/src/nodeOps.ts
+++ b/packages/runtime-test/src/nodeOps.ts
@@ -212,7 +212,7 @@ function setElementText(el: TestElement, text: string) {
 }
 
 function parentNode(node: TestNode): TestElement | null {
-  return node.parentNode
+  return node ? node.parentNode : null
 }
 
 function nextSibling(node: TestNode): TestNode | null {


### PR DESCRIPTION
Fixes [#6416 ](https://github.com/vuejs/core/issues/6416) 
I wrote a test case to replicate the bug in Suspense.spec.ts。

This bug occurs for two reasons

1. One is pendingId , pendingId controls whether to render pendingBranch or not .so we need to reduce pendingId sometimes.
2. In Function setActiveBranch, sometimes,branch.el is null,it overlay suspense.vnode.el, cause suspense.vnode.el missing.Finally,it will cause parent misiing in Function parentNode
3. but this bug still alive in some case...
```javascript
function setActiveBranch(suspense: SuspenseBoundary, branch: VNode) {
  suspense.activeBranch = branch
  const { vnode, parentComponent } = suspense
  const el = (vnode.el = branch.el) //sometime,branch.el is null
  if (parentComponent && parentComponent.subTree === vnode) {
  //...
  }
}
```
Here's a video demo of the fix: https://www.bilibili.com/video/BV1Cd4y1R7bU/
and SFC Playground demo of this fix:[my demo](https://deploy-preview-6467--vue-sfc-playground.netlify.app/#eNrdVMtu00AU/ZXBLOpIHTuPqkjBiajYskBql95M7OtmqD0ezYyTRpUlkCohAQsWIAESS6TuCgtY0AU/Q9PyF4xfietGpFJXdJXMvee+zj3XR8YO59YkAaNvOAoiHhIFQ5ch5Ph0gqg/cI3dRHJgEvZAKtfIndo97gwvf3388/LNxbuT+ecv8++vL0/fn786mT9/cXF2/Pvsh2NrSAkeJUrFDD3yQuod6JRySpU33o2Z2W7plDJmHccuQOtDOmVI9+Yh3TKk1wy5hzEqxjj/+m3+4XSU7F98Os7m+fkWYVzBDgA4JiGdFNzkNlnSsrBomxdHPGbAFOpTqTvwEiH0Sxd37IWvHlBRju4HJAxHxDuoeYslDJ/ExKdsH/szRiLq4UUiaVmWY2eQWkb7yhYLU6NVx27MUyW5EuxIT1BedEt1RaHQURHvQ0AZ7MgZ8x5XvWzWXVetKQpEHKENrbKNh7Vs2dZLl2Vnj0yHTUS3juiuQvTqiN4CkYHgMAfppkgS5r/15sxqHKKI2aqGQ0iASgRbvlG5xX7WY2VMiz9pOXcEahz7sr8IWmqPMh8OW8tsiAaFbTBot9SYSqvMP6jnr8M612DdVbDuNViv2W2+jpamR2ui2K6xaRRU4ohw65kO0l+CvFm3dEjX6FdkuIamN3u7xlgpLvu27QMP4xnmAiYUpnh7a/sBxhqFZeBhraXZvogT5lsMVEiDmUU4t7XbEglTNAILZIRHIp5KELq8a5SE5pVsbZyAwHoeHwSI21duJLxWPSfIZammpVLkyi9jeUnVxv51QOj2F5RpMlh5SjdTOCJZJSS1sLlZlyIiU0IVYjBFT3ViKsE0Bcg4nEALDYa1G8iGBbWnNxYnytTn0vRmPeaBZqavpTXdRFvtdrtuTFvl/9V6rA59DfH5DfyvxK8jIP+OrSEgv+47SED6F7sM2o4=)

