### PR TITLE
fix(ssr): forward helpers provided by CSS `v-bind`

### DIFF
--- a/packages/compiler-ssr/__tests__/ssrInjectCssVars.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrInjectCssVars.spec.ts
@@ -129,6 +129,7 @@ describe('ssr: inject <style vars>', () => {
     expect(result.ast.helpers).toMatchInlineSnapshot(`
       Array [
         Symbol(mergeProps),
+        Symbol(unref),
       ]
     `)
   })

--- a/packages/compiler-ssr/__tests__/ssrInjectCssVars.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrInjectCssVars.spec.ts
@@ -1,3 +1,4 @@
+import { BindingTypes } from '@vue/compiler-dom'
 import { compile } from '../src'
 
 describe('ssr: inject <style vars>', () => {
@@ -109,6 +110,26 @@ describe('ssr: inject <style vars>', () => {
           _: 1 /* STABLE */
         })
       }"
+    `)
+  })
+
+  test('inject helpers', () => {
+    const result = compile(`<div/>`, {
+      inline: true,
+      bindingMetadata: { dynamic: BindingTypes.SETUP_MAYBE_REF },
+      ssrCssVars: '{ "--hash": (dynamic) }'
+    })
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "(_ctx, _push, _parent, _attrs) => {
+        const _cssVars = { style: { \\"--hash\\": (_unref(dynamic)) }}
+        _push(\`<div\${_ssrRenderAttrs(_mergeProps(_attrs, _cssVars))}></div>\`)
+      }"
+    `)
+    expect(result.ast.helpers).toMatchInlineSnapshot(`
+      Array [
+        Symbol(mergeProps),
+      ]
     `)
   })
 })

--- a/packages/compiler-ssr/src/ssrCodegenTransform.ts
+++ b/packages/compiler-ssr/src/ssrCodegenTransform.ts
@@ -40,12 +40,16 @@ export function ssrCodegenTransform(ast: RootNode, options: CompilerOptions) {
   // we do this instead of inlining the expression to ensure the vars are
   // only resolved once per render
   if (options.ssrCssVars) {
+    const cssContext = createTransformContext(createRoot([]), options)
     const varsExp = processExpression(
       createSimpleExpression(options.ssrCssVars, false),
-      createTransformContext(createRoot([]), options)
+      cssContext
     )
     context.body.push(
       createCompoundExpression([`const _cssVars = { style: `, varsExp, `}`])
+    )
+    Array.from(cssContext.helpers.keys()).forEach(helper =>
+      ast.helpers.push(helper)
     )
   }
 


### PR DESCRIPTION
During SSR build, the `_unref` helper provided by injecting CSS binding is not forwarded to the main ast. Causing `_unref is not defined` error on SSR.

fix #6201
fix https://github.com/nuxt/framework/issues/6567

close #6218 as an alternative

Reproduction with Vite: https://stackblitz.com/edit/vitejs-vite-ukhxfu?file=README.md&terminal=run