### PR TITLE
chore: PLEASE consider support console in template.

### DIFF
--- a/packages/shared/src/globalsWhitelist.ts
+++ b/packages/shared/src/globalsWhitelist.ts
@@ -3,6 +3,6 @@ import { makeMap } from './makeMap'
 const GLOBALS_WHITE_LISTED =
   'Infinity,undefined,NaN,isFinite,isNaN,parseFloat,parseInt,decodeURI,' +
   'decodeURIComponent,encodeURI,encodeURIComponent,Math,Number,Date,Array,' +
-  'Object,Boolean,String,RegExp,Map,Set,JSON,Intl,BigInt'
+  'Object,Boolean,String,RegExp,Map,Set,JSON,Intl,BigInt,console'
 
 export const isGloballyWhitelisted = /*#__PURE__*/ makeMap(GLOBALS_WHITE_LISTED)


### PR DESCRIPTION
many many times, I have to add this code at every vue project,  for log something at template
It's pretty boring and disgusting.
`app.config.globalProperties.console = 'console'` or `const console = window.console`

I don't think this is a very rare sense, that use log at template
I'm curious to know why this feature is not turned on
What harm could it do, THANKS

more https://github.com/vuejs/core/pull/3450#issue-835751911
