### PR TITLE
modify the key type of targetMap to object

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -2,11 +2,15 @@
 import fs from 'node:fs'
 import chalk from 'chalk'
 import { createRequire } from 'node:module'
+import { resolve } from 'path'
 
 const require = createRequire(import.meta.url)
 
 export const targets = fs.readdirSync('packages').filter(f => {
-  if (!fs.statSync(`packages/${f}`).isDirectory()) {
+  if (
+    !fs.statSync(`packages/${f}`).isDirectory() ||
+    !fs.existsSync(resolve(resolve(), `./packages/${f}/package.json`))
+  ) {
     return false
   }
   const pkg = require(`../packages/${f}/package.json`)


### PR DESCRIPTION
在某些场景下，如一个分支到另一个分支在packages会出现残留的文件夹，会导致打包失败