### PR TITLE
fix(runtime-core): ensure functional component's context parameter is not null. (fix: #6580 )

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -131,6 +131,22 @@ describe('component props', () => {
     expect(props).toBe(attrs)
   })
 
+  test('functional with default props declaration', () => {
+    let props: any
+    let attrs: any
+
+    const Comp: FunctionalComponent = (_props = {}, { attrs: _attrs }) => {
+      props = _props
+      attrs = _attrs
+    }
+    
+    const root = nodeOps.createElement('div')
+
+    render(h(Comp), root)
+    expect(props).toEqual({})
+    expect(attrs).toEqual({})
+
+  })
   test('boolean casting', () => {
     let proxy: any
     const Comp = {

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -93,21 +93,19 @@ export function renderComponentRoot(
         markAttrsAccessed()
       }
       result = normalizeVNode(
-        render.length > 1
-          ? render(
-              props,
-              __DEV__
-                ? {
-                    get attrs() {
-                      markAttrsAccessed()
-                      return attrs
-                    },
-                    slots,
-                    emit
-                  }
-                : { attrs, slots, emit }
-            )
-          : render(props, null as any /* we know it doesn't need it */)
+        render(
+          props,
+          __DEV__
+            ? {
+                get attrs() {
+                  markAttrsAccessed()
+                  return attrs
+                },
+                slots,
+                emit
+              }
+            : { attrs, slots, emit }
+        )
       )
       fallthroughAttrs = Component.props
         ? attrs


### PR DESCRIPTION
fix #6580