### PR TITLE
feat(ignoreSideEffectTags): support style in svg

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/ignoreSideEffectTags.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/ignoreSideEffectTags.spec.ts
@@ -39,6 +39,20 @@ describe('compiler: ignore side effect tags', () => {
     expect(err).toBeUndefined()
   })
 
+  it('should ignore style in svg(defs)', () => {
+    let err: CompilerError | undefined
+    const { code } = compile(
+      `<svg><g/><defs><style>h1 { color: red }</style></defs></svg>`,
+      {
+        onError(e) {
+          err = e
+        }
+      }
+    )
+    expect(code).toMatch('style')
+    expect(err).toBeUndefined()
+  })
+
   it('should ignore style not in svg', () => {
     let err: CompilerError | undefined
     const { code } = compile(`<div><style>h1 { color: red }</style></div>`, {

--- a/packages/compiler-dom/__tests__/transforms/ignoreSideEffectTags.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/ignoreSideEffectTags.spec.ts
@@ -24,4 +24,30 @@ describe('compiler: ignore side effect tags', () => {
     expect(err).toBeDefined()
     expect(err!.message).toMatch(`Tags with side effect`)
   })
+
+  it('should not ignore style in svg', () => {
+    let err: CompilerError | undefined
+    const { code } = compile(
+      `<svg><g/><style>h1 { color: red }</style></svg>`,
+      {
+        onError(e) {
+          err = e
+        }
+      }
+    )
+    expect(code).toMatch('style')
+    expect(err).toBeUndefined()
+  })
+
+  it('should ignore style not in svg', () => {
+    let err: CompilerError | undefined
+    const { code } = compile(`<div><style>h1 { color: red }</style></div>`, {
+      onError(e) {
+        err = e
+      }
+    })
+    expect(code).not.toMatch('style')
+    expect(err).toBeDefined()
+    expect(err!.message).toMatch(`Tags with side effect`)
+  })
 })

--- a/packages/compiler-dom/src/transforms/ignoreSideEffectTags.ts
+++ b/packages/compiler-dom/src/transforms/ignoreSideEffectTags.ts
@@ -3,7 +3,8 @@ import { DOMErrorCodes, createDOMCompilerError } from '../errors'
 
 export const ignoreSideEffectTags: NodeTransform = (node, context) => {
   const inSvg = context.parent
-    ? context.parent.type === NodeTypes.ELEMENT && context.parent.tag === 'svg'
+    ? context.parent.type === NodeTypes.ELEMENT &&
+      (context.parent.tag === 'svg' || context.parent.tag === 'defs')
     : false
   if (
     node.type === NodeTypes.ELEMENT &&

--- a/packages/compiler-dom/src/transforms/ignoreSideEffectTags.ts
+++ b/packages/compiler-dom/src/transforms/ignoreSideEffectTags.ts
@@ -2,10 +2,13 @@ import { NodeTransform, NodeTypes, ElementTypes } from '@vue/compiler-core'
 import { DOMErrorCodes, createDOMCompilerError } from '../errors'
 
 export const ignoreSideEffectTags: NodeTransform = (node, context) => {
+  const inSvg = context.parent
+    ? context.parent.type === NodeTypes.ELEMENT && context.parent.tag === 'svg'
+    : false
   if (
     node.type === NodeTypes.ELEMENT &&
     node.tagType === ElementTypes.ELEMENT &&
-    (node.tag === 'script' || node.tag === 'style')
+    (node.tag === 'script' || (node.tag === 'style' && !inSvg))
   ) {
     context.onError(
       createDOMCompilerError(DOMErrorCodes.X_IGNORED_SIDE_EFFECT_TAG, node.loc)


### PR DESCRIPTION
style should not be removed from context if it's in svg.
https://www.w3.org/TR/SVG2/styling.html