### PR TITLE
fix(runtime-core): TypeError: oldBindings[i] is undefined

### DIFF
--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -126,7 +126,7 @@ export function invokeDirectiveHook(
   const oldBindings = prevVNode && prevVNode.dirs!
   for (let i = 0; i < bindings.length; i++) {
     const binding = bindings[i]
-    if (oldBindings) {
+    if (oldBindings && oldBindings[i]) {
       binding.oldValue = oldBindings[i].value
     }
     let hook = binding.dir[name] as DirectiveHook | DirectiveHook[] | undefined


### PR DESCRIPTION
Related issues:

- https://github.com/vuejs/core/issues/6658
- https://github.com/vuejs/core/issues/6573
- https://github.com/vuejs/core/pull/4443
- https://github.com/vuetifyjs/vuetify/issues/15779
- https://github.com/vuetifyjs/vuetify/issues/15755
- https://github.com/vuetifyjs/vuetify/issues/15724