### PR TITLE
fix(ssr): avoid ast.helpers duplication

### DIFF
--- a/packages/compiler-ssr/src/ssrCodegenTransform.ts
+++ b/packages/compiler-ssr/src/ssrCodegenTransform.ts
@@ -48,9 +48,10 @@ export function ssrCodegenTransform(ast: RootNode, options: CompilerOptions) {
     context.body.push(
       createCompoundExpression([`const _cssVars = { style: `, varsExp, `}`])
     )
-    Array.from(cssContext.helpers.keys()).forEach(helper =>
-      ast.helpers.push(helper)
-    )
+    Array.from(cssContext.helpers.keys()).forEach(helper => {
+      if (!ast.helpers.includes(helper))
+        ast.helpers.push(helper)
+    })
   }
 
   const isFragment =


### PR DESCRIPTION
Fix https://github.com/nuxt/framework/issues/7343

It was introduced in https://github.com/vuejs/core/pull/6489

Out of scope of this PR, but should we consider doing some unique normalization for it to reduce maintenance burden, or even directly change it to `Set`?