### PR TITLE
fix(compiler-sfc): syntax error when v-on contains objects

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -474,6 +474,18 @@ defineExpose({ foo: 123 })
       </tempalte>
       `)
     })
+
+    test('v-on contain object', () => {
+      // should not error
+      compile(`
+      <script setup lang="ts">
+        import { foo } from './foo'
+      </script>
+      <template>
+        <div v-on="{ foo }"></div>
+      </tempalte>
+      `)
+    })
   })
 
   describe('inlineTemplate mode', () => {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -2135,7 +2135,11 @@ function processExp(exp: string, dir?: string): string {
     if (dir === 'slot') {
       exp = `(${exp})=>{}`
     } else if (dir === 'on') {
-      exp = `()=>{${exp}}`
+      if (/^\{.*\}$/.test(exp.trim())) {
+        exp = `()=>(${exp})`
+      } else {
+        exp = `()=>{${exp}}`
+      }
     } else if (dir === 'for') {
       const inMatch = exp.match(forAliasRE)
       if (inMatch) {


### PR DESCRIPTION
fix: #6674

If this is merged I will sync the code to vuejs/vue