### PR TITLE
fix(runtime-core): Lifecycle hooks should support callbacks shared by reference (fix #6686)

### DIFF
--- a/packages/runtime-core/__tests__/apiLifecycle.spec.ts
+++ b/packages/runtime-core/__tests__/apiLifecycle.spec.ts
@@ -378,4 +378,27 @@ describe('api: lifecycle hooks', () => {
       newValue: 3
     })
   })
+
+  it('runs shared hook fn for each instance', async () => {
+    const fn = jest.fn()
+    const toggle = ref(true)
+    const Comp = {
+      setup() {
+        return () => (toggle.value ? [h(Child), h(Child)] : null)
+      }
+    }
+    const Child = {
+      setup() {
+        onMounted(fn)
+        onBeforeUnmount(fn)
+        return () => h('div')
+      }
+    }
+
+    render(h(Comp), nodeOps.createElement('div'))
+    expect(fn).toHaveBeenCalledTimes(2)
+    toggle.value = false
+    await nextTick()
+    expect(fn).toHaveBeenCalledTimes(4)
+  })
 })

--- a/packages/runtime-core/src/apiLifecycle.ts
+++ b/packages/runtime-core/src/apiLifecycle.ts
@@ -68,7 +68,7 @@ export const createHook =
   (hook: T, target: ComponentInternalInstance | null = currentInstance) =>
     // post-create lifecycle registrations are noops during SSR (except for serverPrefetch)
     (!isInSSRComponentSetup || lifecycle === LifecycleHooks.SERVER_PREFETCH) &&
-    injectHook(lifecycle, hook, target)
+    injectHook(lifecycle, (...args: unknown[]) => hook(...args), target)
 
 export const onBeforeMount = createHook(LifecycleHooks.BEFORE_MOUNT)
 export const onMounted = createHook(LifecycleHooks.MOUNTED)


### PR DESCRIPTION
the current deduping implementation of `injectHook` relies on lifecycle callbacks always being created within setup.

When using i.e. an imported function directly as a hook callback, it will not reliably be run for each instance of a component.

This PR wraps each received callback in another arrow function in in order to ensure that each component instance has its own distinct copy of the callback.