### PR TITLE
fix: ensure tracking is paused when emit() calls handler so it can safely be called in effects (fix #6669)

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -27,6 +27,7 @@ import {
   compatModelEventPrefix,
   compatModelEmit
 } from './compat/componentVModel'
+import { pauseTracking, resetTracking } from '@vue/reactivity'
 
 export type ObjectEmitsOptions = Record<
   string,
@@ -161,12 +162,14 @@ export function emit(
   }
 
   if (handler) {
+    pauseTracking()
     callWithAsyncErrorHandling(
       handler,
       instance,
       ErrorCodes.COMPONENT_EVENT_HANDLER,
       args
     )
+    resetTracking()
   }
 
   const onceHandler = props[handlerName + `Once`]


### PR DESCRIPTION
fix: #6669

If emit() is called in an effect (i.e. the callback of a watchEffect), it will collect any reactive values accessed in that parent handle as dependencies of the current component.

This can lead to a recursive loop crashing the app.
