### PR TITLE
chore: suggest using npm to run scripts

### DIFF
--- a/packages/reactivity/README.md
+++ b/packages/reactivity/README.md
@@ -4,7 +4,7 @@
 
 This package is inlined into Global & Browser ESM builds of user-facing renderers (e.g. `@vue/runtime-dom`), but also published as a package that can be used standalone. The standalone build should not be used alongside a pre-bundled build of a user-facing renderer, as they will have different internal storage for reactivity connections. A user-facing renderer should re-export all APIs from this package.
 
-For full exposed APIs, see `src/index.ts`. You can also run `yarn build reactivity --types` from repo root, which will generate an API report at `temp/reactivity.api.md`.
+For full exposed APIs, see `src/index.ts`. You can also run `npm run build reactivity -- --types` from repo root, which will generate an API report at `temp/reactivity.api.md`.
 
 ## Credits
 

--- a/packages/runtime-core/README.md
+++ b/packages/runtime-core/README.md
@@ -2,7 +2,7 @@
 
 > This package is published only for typing and building custom renderers. It is NOT meant to be used in applications.
 
-For full exposed APIs, see `src/index.ts`. You can also run `yarn build runtime-core --types` from repo root, which will generate an API report at `temp/runtime-core.api.md`.
+For full exposed APIs, see `src/index.ts`. You can also run `npm run build runtime-core -- --types` from repo root, which will generate an API report at `temp/runtime-core.api.md`.
 
 ## Building a Custom Renderer
 


### PR DESCRIPTION
#4766 migrated to pnpm, but there are some documents still referring Yarn.

This pull request changes them to suggest using npm instead, to align with [.github/contributing.md](https://github.com/vuejs/core/blob/8772a01a9280b1591e781e20741d32e2f9a836c8/.github/contributing.md?plain=1#L64).