### PR TITLE
fix(runtime-core): modifier `.trim` compatibility (fix #6711)

### DIFF
--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -355,6 +355,38 @@ describe('component: emit', () => {
     expect(fn2).toHaveBeenCalledWith('two')
   })
 
+  // #6711
+  test('.trim modifier only works with string parameters.', () => {
+    const Foo = defineComponent({
+      render() {},
+      created() {
+        this.$emit('update:modelValue', ' one ', { one: 'one' })
+        this.$emit('update:foo', '  two  ', ['two'])
+      }
+    })
+
+    const fn1 = jest.fn()
+    const fn2 = jest.fn()
+
+    const Comp = () =>
+      h(Foo, {
+        modelValue: null,
+        modelModifiers: { trim: true },
+        'onUpdate:modelValue': fn1,
+
+        foo: null,
+        fooModifiers: { trim: true },
+        'onUpdate:foo': fn2
+      })
+
+    render(h(Comp), nodeOps.createElement('div'))
+
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn1).toHaveBeenCalledWith('one', { one: 'one' })
+    expect(fn2).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledWith('two', ['two'])
+  })
+
   test('.trim and .number modifiers should work with v-model on component', () => {
     const Foo = defineComponent({
       render() {},

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -9,6 +9,7 @@ import {
   isFunction,
   isObject,
   isOn,
+  isString,
   toNumber,
   UnionToIntersection
 } from '@vue/shared'
@@ -122,7 +123,18 @@ export function emit(
     }Modifiers`
     const { number, trim } = props[modifiersKey] || EMPTY_OBJ
     if (trim) {
-      args = rawArgs.map(a => a.trim())
+      args = rawArgs.map(a => {
+        if(isString(a)) {
+          return a.trim();
+        } else {
+          if (__DEV__) {
+            warn(
+              `Incompatible type: ${a} is not String.`
+            )
+          }
+          return a;
+        }
+      })
     }
     if (number) {
       args = rawArgs.map(toNumber)

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -123,18 +123,7 @@ export function emit(
     }Modifiers`
     const { number, trim } = props[modifiersKey] || EMPTY_OBJ
     if (trim) {
-      args = rawArgs.map(a => {
-        if(isString(a)) {
-          return a.trim();
-        } else {
-          if (__DEV__) {
-            warn(
-              `Incompatible type: ${a} is not String.`
-            )
-          }
-          return a;
-        }
-      })
+      args = rawArgs.map(a => (isString(a) ? a.trim() : a))
     }
     if (number) {
       args = rawArgs.map(toNumber)


### PR DESCRIPTION
### issue
`v-model.trim`: incompatible `trim()` when emit arg is not string  https://github.com/vuejs/core/issues/6711

### solution

<img width="500" alt="image" src="https://user-images.githubusercontent.com/44194929/191641673-de3457bc-43a4-4961-9ead-a2f85825b6da.png">

If the emit's arg type is string, `a.trim()` is returned like before, if it is not, `a` is directly returned. 