### PR TITLE
fix(reactivity): ensure get the latest value when reading the compute

### DIFF
--- a/packages/reactivity/__tests__/deferredComputed.spec.ts
+++ b/packages/reactivity/__tests__/deferredComputed.spec.ts
@@ -166,6 +166,32 @@ describe('deferred computed', () => {
     expect(effectSpy).toHaveBeenCalledTimes(2)
   })
 
+  test('sync access to computed property should get the latest value', () => {
+    const bSpy = jest.fn()
+    const c1Spy = jest.fn()
+    const c2Spy = jest.fn()
+
+    const a = ref(0)
+    const b = deferredComputed(() => {
+      bSpy()
+      return a.value
+    })
+    const c1 = deferredComputed(() => {
+      c1Spy()
+      return b.value
+    })
+    const c2 = computed(() => {
+      c2Spy()
+      return b.value
+    })
+    // emit computed getter
+    c1.value;c2.value;
+    a.value = 2
+    // sync access
+    expect(c1.value).toEqual(2)
+    expect(c2.value).toEqual(2)
+  })
+
   test('should not compute if deactivated before scheduler is called', async () => {
     const c1Spy = jest.fn()
     const src = ref(0)

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -59,19 +59,15 @@ export class ComputedRefImpl<T> {
     this[ReactiveFlags.IS_READONLY] = isReadonly
   }
 
-  private _get() {
-    if (this._dirty || !this._cacheable) {
-      this._dirty = false
-      return (this._value = this.effect.run()!)
-    }
-    return this._value
-  }
-
   get value() {
     // the computed ref may get wrapped by other proxies e.g. readonly() #3376
     const self = toRaw(this)
     trackRefValue(self)
-    return self._get()
+    if (self._dirty || !self._cacheable) {
+      self._dirty = false
+      self._value = self.effect.run()!
+    }
+    return self._value
   }
 
   set value(newValue: T) {

--- a/packages/reactivity/src/deferredComputed.ts
+++ b/packages/reactivity/src/deferredComputed.ts
@@ -58,7 +58,7 @@ class DeferredComputedRefImpl<T> {
         // value invalidation in case of sync access; normal effects are
         // deferred to be triggered in scheduler.
         for (const e of this.dep) {
-          if (e.computed instanceof DeferredComputedRefImpl) {
+          if (e.computed) {
             e.scheduler!(true /* computedTrigger */)
           }
         }


### PR DESCRIPTION
Example: https://sfc.vuejs.org/#eNp9UctuwjAQ/JWVLwQp2CWcmgZE1d/wJSQLpI0fsje0Fcq/1yYBpaD2Yu2OZ2fs2TN7tZafOmQ5K3zlGkvgkTq7kbpR1jiCMzjcp1DjHp3D+s0o2xHWKVRjBT3snVEwCzLCYVlRc2roeya11JXRnqCEdRRJnuZXZBeQe8UkmcN6AyU/lW2HN2q1/Ju7u+dmgXt91yNnOZQvVTYUUo9mYSobNEyLvDWH5MoN3xzJcxAC8MtiRWA6ChY5ZHFM6kIM0YXQQkOobFsShg6gOC43hQhHZE1uWMqGfBeqtPzdGx02cI4TcrzwkuVwQSIWso29ZEci63MhOm0/Djz8VWwvuXeaGoWL2qjtimd89SzqxtMU5+jVYufMp0cXHCVLB/FRfrK6/51utN9GN/jBJ9r0Uves/wF/L9T/