### PR TITLE
fix(transition): get root el of DEV_FRAGMENT_ROOT

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -354,6 +354,8 @@ export {
   normalizeStyle,
 } from '@vue/shared'
 
+export { filterSingleRoot } from './componentRenderUtils'
+
 // For test-utils
 export { transformVNodeArgs } from './vnode'
 


### PR DESCRIPTION
fix #6745

<br>
___

an alternative to re-assigning `el` would be something like 

```js
prevChildren = prevChildren.map((child) => {
  if (DEV_ROOT_FRAGMENT) {
    const clone = cloneVNode(child)
    clone.el = elementRoot.el
    return clone
  }
  return child
})
```

but I don't think the cloning is actually necessary here. Not sure though.