### PR TITLE
fix(shared): parse multi-line inline style

### DIFF
--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -1,4 +1,4 @@
-import { normalizeClass } from '../src'
+import { normalizeClass, parseStringStyle } from '../src'
 
 describe('normalizeClass', () => {
   test('handles string correctly', () => {
@@ -15,5 +15,32 @@ describe('normalizeClass', () => {
     expect(normalizeClass({ foo: true, bar: false, baz: true })).toEqual(
       'foo baz'
     )
+  })
+
+  // #6777
+  test('parse multi-line inline style', () => {
+    expect(
+      parseStringStyle(`border: 1px solid transparent;
+    background: linear-gradient(white, white) padding-box,
+      repeating-linear-gradient(
+        -45deg,
+        #ccc 0,
+        #ccc 0.5em,
+        white 0,
+        white 0.75em
+      );`)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "background": "linear-gradient(white, white) padding-box,
+            repeating-linear-gradient(
+              -45deg,
+              #ccc 0,
+              #ccc 0.5em,
+              white 0,
+              white 0.75em
+            )",
+        "border": "1px solid transparent",
+      }
+    `)
   })
 })

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -28,7 +28,7 @@ export function normalizeStyle(
 }
 
 const listDelimiterRE = /;(?![^(]*\))/g
-const propertyDelimiterRE = /:(.+)/
+const propertyDelimiterRE = /:(.+)/s
 
 export function parseStringStyle(cssText: string): NormalizedStyle {
   const ret: NormalizedStyle = {}

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -28,7 +28,7 @@ export function normalizeStyle(
 }
 
 const listDelimiterRE = /;(?![^(]*\))/g
-const propertyDelimiterRE = /:(.+)/s
+const propertyDelimiterRE = /:([^]+)/
 
 export function parseStringStyle(cssText: string): NormalizedStyle {
   const ret: NormalizedStyle = {}


### PR DESCRIPTION
[Not Fixed Demo](https://vue-next-template-explorer.netlify.app/#eyJzcmMiOiI8ZGl2IHN0eWxlPVwiXG4gICAgICBib3JkZXI6IDFweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgICAgIGJhY2tncm91bmQ6IGxpbmVhci1ncmFkaWVudCh3aGl0ZSwgd2hpdGUpIHBhZGRpbmctYm94LFxuICAgICAgICByZXBlYXRpbmctbGluZWFyLWdyYWRpZW50KFxuICAgICAgICAgIC00NWRlZyxcbiAgICAgICAgICAjY2NjIDAsXG4gICAgICAgICAgI2NjYyAwLjVlbSxcbiAgICAgICAgICB3aGl0ZSAwLFxuICAgICAgICAgIHdoaXRlIDAuNzVlbVxuICAgICAgICApO1xuICAgIFwiPlxuPC9kaXY+Iiwic3NyIjpmYWxzZSwib3B0aW9ucyI6eyJpbmxpbmUiOnRydWV9fQ==)

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/6481596/193019849-f376ccaf-6fbb-475c-a578-e6552586f467.png">

---

[Fixed Demo](https://deploy-preview-6777--vue-sfc-playground.netlify.app/#eNqlkUFOwzAQRa8yMhsq1Q5IlEihIHEPb9x4mhoS2xq7aaOqd8cOoYXADm8sv/njr/lzYq/ei36PrGLriJ1vVcQXaQHW2vQQ4tDis2QZ5LNxpJEquPdHCK41GiIpG7witPHpolL1e0Nub3UFrbGoiDektEma28PORFzCeC3AK62NbfjGHZdf3QCEHlXMfN591QDwh5XG5lsbwE1d13D3BxIr7H7g0X8mnZgok/jKF9NYkqVY1kVKZbwvWbElM513FHmnvHgLzqYoT7lHToUgWQUjySxlnd+S7WL0oSoKjb51A/eEvcEDfyzLkvOk4mFb8+QxfEYpLMbWbAehvC9SWdDeRtOhwNDxDblDQEr2kk0zjU5Fgj0ST+tJe0P6v/Psw1/u2fws7ZmdPwD31MD3)