### PR TITLE
fix(sfc-compiler): fix duplicated declarations of macros

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -720,6 +720,23 @@ return { props, a, emit }
 }"
 `;
 
+exports[`SFC compile <script setup> defineProps/defineEmits in multi-variable declaration fix #6757  1`] = `
+"export default {
+  props: ['item'],
+  emits: ['a'],
+  setup(__props, { expose, emit }) {
+  expose();
+
+const props = __props
+
+    const a = 1;
+    
+return { a, props, emit }
+}
+
+}"
+`;
+
 exports[`SFC compile <script setup> dev mode import usage check TS annotations 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 import { Foo, Bar, Baz, Qux, Fred } from './x'

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -141,6 +141,21 @@ const myEmit = defineEmits(['foo', 'bar'])
     expect(content).toMatch(`emits: ['a'],`)
   })
 
+  // #6757
+  test('defineProps/defineEmits in multi-variable declaration fix #6757 ', () => {
+    const { content } = compile(`
+    <script setup>
+    const a = 1,
+          props = defineProps(['item']),
+          emit = defineEmits(['a']);
+    </script>
+  `)
+    assertCode(content)
+    expect(content).toMatch(`const a = 1;`) // test correct removal
+    expect(content).toMatch(`props: ['item'],`)
+    expect(content).toMatch(`emits: ['a'],`)
+  })
+
   test('defineProps/defineEmits in multi-variable declaration (full removal)', () => {
     const { content } = compile(`
     <script setup>

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1105,11 +1105,11 @@ export function compileScript(
             } else {
               let start = decl.start! + startOffset
               let end = decl.end! + startOffset
-              if (i < total - 1) {
-                // not the last one, locate the start of the next
+              if (i === 0) {
+                // first one, locate the start of the next
                 end = node.declarations[i + 1].start! + startOffset
               } else {
-                // last one, locate the end of the prev
+                // not first one, locate the end of the prev
                 start = node.declarations[i - 1].end! + startOffset
               }
               s.remove(start, end)


### PR DESCRIPTION
fix #6757 

[preview](https://deploy-preview-6778--vue-sfc-playground.netlify.app/#eNptUE1PwzAM/StWLu0k0t4YKtskhDhwgjvh0GXuyGg+lLgbVdX/jrtB2QGf8vye/Zw3iIcQimOHohKrpKMJBAmpCxvljA0+EgywR3rsYkRHzy5R7TTCCE30FjKezJRTTntmWKrpi7n1PyP54kY5OFeIPiQW7bAxDl8nlA+/JIAhtBVcNQCoD1jBy/aAmuY1U/GKumupgnwB6w3kw/hnAzDO76s2WkOz+RODlL9lujX6M3tf3Cu3Ki85cAIM+JbQ1oSMACZybogbcUlI2joUh+QdZ3i+Wv0QSYn5H0pwVBNW4oMopKosdxha38sQ8WjwJG+XyzspWSVToyV79PvoO7crHFJrmr6oQyiZLmLnyFgsMFm5jf6UMLK9EpPRqNwoxm9RoZkP)