### PR TITLE
fix(reactivity): enable trigger when use str to set length of arr

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -922,19 +922,19 @@ describe('reactivity/effect', () => {
     expect(fnSpy2).toHaveBeenCalledTimes(1)
   })
 
-  it('should be triggered when set length with string',()=>{
-    let ret1='idle'
-    let ret2='idle'
-    const arr1=reactive(new Array(11).fill(0))
-    const arr2=reactive(new Array(11).fill(0))
-    effect(()=>{
-        ret1=arr1[10]===undefined?'arr[10] is set to empty':'idle'
+  it('should be triggered when set length with string', () => {
+    let ret1 = 'idle'
+    let ret2 = 'idle'
+    const arr1 = reactive(new Array(11).fill(0))
+    const arr2 = reactive(new Array(11).fill(0))
+    effect(() => {
+      ret1 = arr1[10] === undefined ? 'arr[10] is set to empty' : 'idle'
     })
-    effect(()=>{
-        ret2=arr2[10]===undefined?'arr[10] is set to empty':'idle'
+    effect(() => {
+      ret2 = arr2[10] === undefined ? 'arr[10] is set to empty' : 'idle'
     })
-    arr1.length=2
-    arr2.length='2' as any
+    arr1.length = 2
+    arr2.length = '2' as any
     expect(ret1).toBe(ret2)
   })
 

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -922,6 +922,22 @@ describe('reactivity/effect', () => {
     expect(fnSpy2).toHaveBeenCalledTimes(1)
   })
 
+  it('should be triggered when set length with string',()=>{
+    let ret1='idle'
+    let ret2='idle'
+    const arr1=reactive(new Array(11).fill(0))
+    const arr2=reactive(new Array(11).fill(0))
+    effect(()=>{
+        ret1=arr1[10]===undefined?'arr[10] is set to empty':'idle'
+    })
+    effect(()=>{
+        ret2=arr2[10]===undefined?'arr[10] is set to empty':'idle'
+    })
+    arr1.length=2
+    arr2.length='2' as any
+    expect(ret1).toBe(ret2)
+  })
+
   describe('readonly + reactive for Map', () => {
     test('should work with readonly(reactive(Map))', () => {
       const m = reactive(new Map())

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -1,5 +1,5 @@
 import { TrackOpTypes, TriggerOpTypes } from './operations'
-import { extend, isArray, isIntegerKey, isMap } from '@vue/shared'
+import { extend, isArray, isIntegerKey, isMap, toNumber } from '@vue/shared'
 import { EffectScope, recordEffectScope } from './effectScope'
 import {
   createDep,
@@ -277,7 +277,7 @@ export function trigger(
     deps = [...depsMap.values()]
   } else if (key === 'length' && isArray(target)) {
     depsMap.forEach((dep, key) => {
-      if (key === 'length' || key >= (newValue as number)) {
+      if (key === 'length' || key >= toNumber(newValue)) {
         deps.push(dep)
       }
     })


### PR DESCRIPTION
js allows use string to set length of array. 
The original code uses an implicit conversion that requires newValue to be a number as key's type is string.  If newValue is also a string, string comparison are performed instead of number comparison. The string comparison is lexicographical order, so "10"< "2", causing the length to be set to 2  but watch element at 10 will not be triggered