### PR TITLE
fix(devtools): check _buffer existance

### DIFF
--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -28,7 +28,7 @@ interface DevtoolsHook {
   once: (event: string, handler: Function) => void
   off: (event: string, handler: Function) => void
   appRecords: AppRecord[]
-  _buffer: any[][]
+  _buffer?: any[][]
 }
 
 export let devtools: DevtoolsHook
@@ -109,7 +109,7 @@ const _devtoolsComponentRemoved = /*#__PURE__*/ createDevtoolsComponentHook(
 export const devtoolsComponentRemoved = (
   component: ComponentInternalInstance
 ) => {
-  if (devtools && devtools._buffer.length) {
+  if (devtools && Array.isArray(devtools._buffer) && devtools._buffer.length) {
     let wasBuffered = false
     devtools._buffer = devtools._buffer.filter(item => {
       if (item.some(arg => arg === component)) {


### PR DESCRIPTION
At the moment the [Playground SFC is broken](https://sfc.vuejs.org/#eNqFU8tu4zAM/BVCF6dAYt0NZ3f7B4vtVRfXph13ZUnQw20R5N9LS0rjNH0gCGySQ2o0HB/ZvTHlHJBVrHatHY0Hhz6YX0IBjJPR1sMR3KGRUj//w34Lxup57BBO0Fs9QUHNxQr8t7Go/MOranO95JfUctIt+N7domMuw+nnW62cB6uDR9iv+GxW8LsFmOltiogttqmHSgDLvw+q9aNW4PUwSNzcwXFJQ4KVcyPDcsBVtN+vb/X7inW1Ki2DTkLVPAlJElLgcTKy8RgFrR+D93T4n1aO7f+9YImFYLEKmVRE8gSNQyg82AypH4IzqFwaGDOtJjUVkYBqdDQ0khcM+LmFr3pq/s6IbVnaw25qTPnktCIXRDlELjjBqrNAgtE2lliwg/fGVZy7Pq7oyZXaDpzeShuUHycs0U27R6ufHVoaLNh2NYNTcka7I9k6tGi/m/kBejM3S36iq1y77FM/n42kJZZSD5si9UDcq9RNN6qhIKt8t8FunLOsq+a0sVS6FviDmy+04hB8iZ9Bh30TJH1oeaWR8cWaZE5KWAVHuuoSxscPTrvhGTl8RfT0BlwaY30=) when devtools are installed. I noticed `_buffer` is not always present so I adapted the type but maybe this isn't the right fix
cc @Akryum 