### PR TITLE
fix(compiler-sfc): escape non-word characters of css var

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
@@ -75,9 +75,9 @@ export default {
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-foo\\": (_unref(foo)),
-  \\"xxxxxxxx-foo____px_\\": (_unref(foo) + 'px'),
-  \\"xxxxxxxx-_a___b____2____px_\\": ((_unref(a) + _unref(b)) / 2 + 'px'),
-  \\"xxxxxxxx-__a___b______2___a_\\": (((_unref(a) + _unref(b))) / (2 * _unref(a)))
+  \\"xxxxxxxx-foo\\\\ \\\\+\\\\ \\\\'px\\\\'\\": (_unref(foo) + 'px'),
+  \\"xxxxxxxx-\\\\(a\\\\ \\\\+\\\\ b\\\\)\\\\ \\\\/\\\\ 2\\\\ \\\\+\\\\ \\\\'px\\\\'\\": ((_unref(a) + _unref(b)) / 2 + 'px'),
+  \\"xxxxxxxx-\\\\(\\\\(a\\\\ \\\\+\\\\ b\\\\)\\\\)\\\\ \\\\/\\\\ \\\\(2\\\\ \\\\*\\\\ a\\\\)\\": (((_unref(a) + _unref(b))) / (2 * _unref(a)))
 }))
 
         let a = 100
@@ -133,7 +133,7 @@ import { useCssVars as _useCssVars } from 'vue'
 const __injectCSSVars__ = () => {
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-color\\": (_ctx.color),
-  \\"xxxxxxxx-font_size\\": (_ctx.font.size)
+  \\"xxxxxxxx-font\\\\.size\\": (_ctx.font.size)
 }))}
 const __setup__ = __default__.setup
 __default__.setup = __setup__

--- a/packages/compiler-sfc/__tests__/cssVars.spec.ts
+++ b/packages/compiler-sfc/__tests__/cssVars.spec.ts
@@ -12,7 +12,7 @@ describe('CSS vars injection', () => {
     )
     expect(content).toMatch(`_useCssVars(_ctx => ({
   "${mockId}-color": (_ctx.color),
-  "${mockId}-font_size": (_ctx.font.size)
+  "${mockId}-font\\.size": (_ctx.font.size)
 })`)
     assertCode(content)
   })
@@ -86,7 +86,24 @@ describe('CSS vars injection', () => {
     expect(code).toMatchInlineSnapshot(`
       ".foo {
               color: var(--test-color);
-              font-size: var(--test-font_size);
+              font-size: var(--test-font\\\\.size);
+      }"
+    `)
+
+    // #6803
+    expect(
+      compileStyle({
+        source: `.foo {
+        color: v-bind(蓝色);
+        font-size: v-bind(字体);
+      }`,
+        filename: 'test.css',
+        id: 'data-v-test'
+      }).code
+    ).toMatchInlineSnapshot(`
+      ".foo {
+              color: var(--test-\\\\蓝\\\\色);
+              font-size: var(--test-\\\\字\\\\体);
       }"
     `)
   })
@@ -225,10 +242,10 @@ describe('CSS vars injection', () => {
       )
       expect(content).toMatch(`_useCssVars(_ctx => ({
   "${mockId}-foo": (_unref(foo)),
-  "${mockId}-foo____px_": (_unref(foo) + 'px'),
-  "${mockId}-_a___b____2____px_": ((_unref(a) + _unref(b)) / 2 + 'px'),
-  "${mockId}-__a___b______2___a_": (((_unref(a) + _unref(b))) / (2 * _unref(a)))
-})`)
+  "${mockId}-foo\\ \\+\\ \\'px\\'": (_unref(foo) + 'px'),
+  "${mockId}-\\(a\\ \\+\\ b\\)\\ \\/\\ 2\\ \\+\\ \\'px\\'": ((_unref(a) + _unref(b)) / 2 + 'px'),
+  "${mockId}-\\(\\(a\\ \\+\\ b\\)\\)\\ \\/\\ \\(2\\ \\*\\ a\\)": (((_unref(a) + _unref(b))) / (2 * _unref(a)))
+}))`)
       assertCode(content)
     })
 

--- a/packages/compiler-sfc/__tests__/cssVars.spec.ts
+++ b/packages/compiler-sfc/__tests__/cssVars.spec.ts
@@ -79,6 +79,10 @@ describe('CSS vars injection', () => {
       source: `.foo {
         color: v-bind(color);
         font-size: v-bind('font.size');
+
+        font-weight: v-bind(_φ);
+        font-size: v-bind(1-字号);
+        font-family: v-bind(フォント);
       }`,
       filename: 'test.css',
       id: 'data-v-test'
@@ -87,23 +91,10 @@ describe('CSS vars injection', () => {
       ".foo {
               color: var(--test-color);
               font-size: var(--test-font\\\\.size);
-      }"
-    `)
 
-    // #6803
-    expect(
-      compileStyle({
-        source: `.foo {
-        color: v-bind(蓝色);
-        font-size: v-bind(字体);
-      }`,
-        filename: 'test.css',
-        id: 'data-v-test'
-      }).code
-    ).toMatchInlineSnapshot(`
-      ".foo {
-              color: var(--test-\\\\蓝\\\\色);
-              font-size: var(--test-\\\\字\\\\体);
+              font-weight: var(--test-_φ);
+              font-size: var(--test-1-字号);
+              font-family: var(--test-フォント);
       }"
     `)
   })

--- a/packages/compiler-sfc/src/cssVars.ts
+++ b/packages/compiler-sfc/src/cssVars.ts
@@ -31,7 +31,10 @@ function genVarName(id: string, raw: string, isProd: boolean): string {
     return hash(id + raw)
   } else {
     // escape ASCII Punctuation & Symbols
-    return `${id}-${raw.replace(/[ !"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, s => `\\${s}`)}`
+    return `${id}-${raw.replace(
+      /[ !"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g,
+      s => `\\${s}`
+    )}`
   }
 }
 

--- a/packages/compiler-sfc/src/cssVars.ts
+++ b/packages/compiler-sfc/src/cssVars.ts
@@ -30,7 +30,7 @@ function genVarName(id: string, raw: string, isProd: boolean): string {
   if (isProd) {
     return hash(id + raw)
   } else {
-    return `${id}-${raw.replace(/([^\w-])/g, '_')}`
+    return `${id}-${raw.replace(/([^\w-])/g, s => `\\${s}`)}`
   }
 }
 

--- a/packages/compiler-sfc/src/cssVars.ts
+++ b/packages/compiler-sfc/src/cssVars.ts
@@ -30,7 +30,8 @@ function genVarName(id: string, raw: string, isProd: boolean): string {
   if (isProd) {
     return hash(id + raw)
   } else {
-    return `${id}-${raw.replace(/([^\w-])/g, s => `\\${s}`)}`
+    // escape ASCII Punctuation & Symbols
+    return `${id}-${raw.replace(/[ !"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, s => `\\${s}`)}`
   }
 }
 


### PR DESCRIPTION
This bug will affect dev mode only.

closes #6803


---

ATM, #6815 hasn't been merged. So reproduction cannot reproduce on SFC playground.

Reproduction:
```vue
<script setup>
import { ref } from 'vue'

const 蓝色 = ref('blue')
const 字体 = ref(800)
</script>

<template>
  <div class="text">
    hello
  </div>
</template>

<style>
  .text {
    color: v-bind(蓝色);
    font-weight: v-bind(字体);
  }
</style>
````