### PR TITLE
feat(runtime-core): return result of handlers in `emit`

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -160,8 +160,9 @@ export function emit(
     handler = props[(handlerName = toHandlerKey(hyphenate(event)))]
   }
 
+  let result
   if (handler) {
-    callWithAsyncErrorHandling(
+    result = callWithAsyncErrorHandling(
       handler,
       instance,
       ErrorCodes.COMPONENT_EVENT_HANDLER,
@@ -177,7 +178,7 @@ export function emit(
       return
     }
     instance.emitted[handlerName] = true
-    callWithAsyncErrorHandling(
+    result = callWithAsyncErrorHandling(
       onceHandler,
       instance,
       ErrorCodes.COMPONENT_EVENT_HANDLER,
@@ -189,6 +190,8 @@ export function emit(
     compatModelEmit(instance, event, args)
     return compatInstanceEmit(instance, event, args)
   }
+  
+  return result
 }
 
 export function normalizeEmitsOptions(


### PR DESCRIPTION
It would be great if `emit` could return the result of the handlers. A typical example could be to show a loading indicator while asynchronous event handlers are running:
```ts
const loading = ref(false)

const handleClick = async () => {
  loading.value = true
  await emit('click')
  loading.value = false
}
```

This is just a basic example that does not consider errors or multiple clicks but it gives an idea what would be possible. The same could already be implemented with props but it duplicates the handling.

If you think this is a good idea, I can extend the PR with corresponding tests.