### PR TITLE
fix(compiler-core): keep whitespaces with newline between interpolation and comment

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -1980,6 +1980,17 @@ foo
       expect(ast.children[2].type).toBe(NodeTypes.INTERPOLATION)
     })
 
+    it('should NOT remove whitespaces w/ newline between interpolation and comment', () => {
+      const ast = parse(`<!-- foo --> \n {{msg}}`)
+      expect(ast.children.length).toBe(3)
+      expect(ast.children[0].type).toBe(NodeTypes.COMMENT)
+      expect(ast.children[1]).toMatchObject({
+        type: NodeTypes.TEXT,
+        content: ' '
+      })
+      expect(ast.children[2].type).toBe(NodeTypes.INTERPOLATION)
+    })
+    
     it('should NOT remove whitespaces w/o newline between elements', () => {
       const ast = parse(`<div/> <div/> <div/>`)
       expect(ast.children.length).toBe(5)

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -264,14 +264,19 @@ function parseChildren(
             const next = nodes[i + 1]
             // Remove if:
             // - the whitespace is the first or last node, or:
-            // - (condense mode) the whitespace is adjacent to a comment, or:
+            // - (condense mode) the whitespace is between twos comments, or:
+            // - (condense mode) the whitespace is between comment and element, or:
             // - (condense mode) the whitespace is between two elements AND contains newline
             if (
               !prev ||
               !next ||
               (shouldCondense &&
-                (prev.type === NodeTypes.COMMENT ||
-                  next.type === NodeTypes.COMMENT ||
+                ((prev.type === NodeTypes.COMMENT &&
+                  next.type === NodeTypes.COMMENT) ||
+                  (prev.type === NodeTypes.COMMENT && 
+                  next.type === NodeTypes.ELEMENT) ||
+                  (prev.type === NodeTypes.ELEMENT &&
+                  next.type === NodeTypes.COMMENT) ||
                   (prev.type === NodeTypes.ELEMENT &&
                     next.type === NodeTypes.ELEMENT &&
                     /[\r\n]/.test(node.content))))


### PR DESCRIPTION
Fix #6352

track 1c0a2c6

[playground](https://deploy-preview-6828--vue-sfc-playground.netlify.app/#eNqtU8uO2zAM/BWuLmmBlY30UCwCb4DeeumtQC+6KBaduLAeEOmkgeF/L23nAXRb9LE9WeRQnBlaHNSHlIpjj2qjKqpzmxgIuU9bE1qfYmYYIGMDIzQ5elhJ6coEE+oYiMHTHp4n/M3qI3ZdhC8xd+5h9daEqlzaSSMJGH3qLKNEABUlG7ZNjFIznQS/fAF2Ns93rzFUD1rD5wPCDrt4Eq7gMBNYAqOqw3r7CYnsHjdVKQEsKk6zCqNA64XQtUeoO0v0bNQ+RmfUnDf8osOSHobZ2jhKMN0vpcECTdHfKPoDQTt71SPAz/TcKFuCOnqPgaG2PSEBiwyZVT2J4RNimDOHNdjg5iPjNwaOAotQH4/orhoAbi5f6XEh+YW7PtimwZrRrX/ncmrzWilRTOf/Jejl2F2UoYd4mf+/jP9RzvfLMy79iS239f3X3G38OJCqvO2SelTLjmpvU/GVYpAtHuayC0BGbWDOTDnZ3Sk26sCcaFOWDlMXzzplPLZ40u+f3j1pLVWamloLx3mfYx9cEZC7tjkXNqVS4CL3gVuPBZLXuxxPhFnojZqI5DGNavwO4EZqDw==)