### PR TITLE
fix(compiler): comment can cause vIf-related syntax errors

### DIFF
--- a/packages/compiler-core/src/transforms/vIf.ts
+++ b/packages/compiler-core/src/transforms/vIf.ts
@@ -129,7 +129,12 @@ export function processIf(
     let i = siblings.indexOf(node)
     while (i-- >= -1) {
       const sibling = siblings[i]
-      if (__DEV__ && sibling && sibling.type === NodeTypes.COMMENT) {
+      if (
+        __DEV__ &&
+        !__TEST__ &&
+        sibling &&
+        sibling.type === NodeTypes.COMMENT
+      ) {
         context.removeNode(sibling)
         comments.unshift(sibling)
         continue
@@ -141,6 +146,9 @@ export function processIf(
           sibling.type === NodeTypes.COMMENT)
       ) {
         context.removeNode(sibling)
+        if (sibling.type === NodeTypes.COMMENT) {
+          comments.unshift(sibling)
+        }
         continue
       }
 

--- a/packages/compiler-core/src/transforms/vIf.ts
+++ b/packages/compiler-core/src/transforms/vIf.ts
@@ -137,8 +137,8 @@ export function processIf(
 
       if (
         sibling &&
-        sibling.type === NodeTypes.TEXT &&
-        !sibling.content.trim().length
+        ((sibling.type === NodeTypes.TEXT && !sibling.content.trim().length) ||
+          sibling.type === NodeTypes.COMMENT)
       ) {
         context.removeNode(sibling)
         continue


### PR DESCRIPTION
fix: keep comments in production and have a comment between v-if and v-else, encounter `[vite:vue] v-else/v-else-if has no adjacent v-if or v-else-if.` error

### Why is test work?

Since the following code works in the test, the comments can be skipped.
https://github.com/vuejs/core/blob/35dc2bbe7d22a4b551f912612f8d4f04788005a7/packages/compiler-core/src/transforms/vIf.ts#L132-L136

### Steps to reproduce

1. open the [reproduction](https://stackblitz.com/edit/vitejs-vite-vz5uz6?file=src%2FApp.vue,vite.config.ts&file=src%2Fmain.ts&terminal=dev)
2. executed `npm run build`
3. Error appears

