### PR TITLE
fix: stricter type condition for `EventHandlers`

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1301,7 +1301,7 @@ export interface Events {
 }
 
 type EventHandlers<E> = {
-  [K in keyof E]?: E[K] extends Function ? E[K] : (payload: E[K]) => void
+  [K in keyof E]?: E[K] extends (...args: any) => any ? E[K] : (payload: E[K]) => void
 }
 
 // use namespace import to avoid collision with generated types which use


### PR DESCRIPTION
Issue: https://github.com/johnsoncodehk/volar/issues/1985

With `@types/node` version >= 18.8.1, `MouseEvent extends Function` is true, but with version <= 18.8.0 `MouseEvent extends Function` is false.

Close #6899