### PR TITLE
types(reactivity-transform): fix converting arrays to ref

### DIFF
--- a/packages/vue/macros.d.ts
+++ b/packages/vue/macros.d.ts
@@ -64,7 +64,7 @@ export declare function $$<T>(
   value: WritableComputedRefValue<T>
 ): WritableComputedRef<T>
 
-type ToRawRefs<T extends object> = {
+type ToRawRefs<T extends object> = T extends Array<any> ? Ref<T> : {
   [K in keyof T]: T[K] extends RefValue<infer V>
     ? Ref<V>
     : T[K] extends ComputedRefValue<infer V>


### PR DESCRIPTION
When using `$$` on arrays, the resulting type should be `Ref<T[]>` instead of `Ref<T>[]`. This PR adds an extra check to prevent converting every element inside the array to Ref.

Example:
```
const object = { msg: ["test"] };
toRef(object, "msg"); // correct, the resulting type is Ref<string[]>
```
```
const msg = ["test"];
$$(msg);  // incorrect, the resulting type is Ref<string>[]
```