### PR TITLE
Safer isAsyncWrapper check (fix #4002)

### DIFF
--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -38,7 +38,7 @@ export interface AsyncComponentOptions<T = any> {
 }
 
 export const isAsyncWrapper = (i: ComponentInternalInstance | VNode): boolean =>
-  !!(i.type as ComponentOptions).__asyncLoader
+  i && i.type ? !!(i.type as ComponentOptions).__asyncLoader : false
 
 export function defineAsyncComponent<
   T extends Component = { new (): ComponentPublicInstance }


### PR DESCRIPTION
I've found scenarios when it's recursively onmounting components and face one that has `type` empty so `isAsyncWrapper` breaks the whole app instead of just returning `false`.

Cannot provide a live demo since it's hard to replicate the scenarios where this happens as seen in many reports like:
- https://github.com/vuejs/core/issues/4002
- https://github.com/vuejs/core/issues/5040