### PR TITLE
fix(runtime-core): ensure props definition objects are not mutated during props normalization (close: #6915)

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -595,4 +595,23 @@ describe('component props', () => {
       JSON.stringify(attrs) + Object.keys(attrs)
     )
   })
+
+  // #691ef
+  test('should not mutate original props long-form definition object', () => {
+    const props = {
+      msg: {
+        type: String
+      }
+    }
+    const Comp = defineComponent({
+      props,
+      render() {}
+    })
+
+    const root = nodeOps.createElement('div')
+
+    render(h(Comp, { msg: 'test' }), root)
+
+    expect(Object.keys(props.msg).length).toBe(1)
+  })
 })

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -522,7 +522,7 @@ export function normalizePropsOptions(
       if (validatePropName(normalizedKey)) {
         const opt = raw[key]
         const prop: NormalizedProp = (normalized[normalizedKey] =
-          isArray(opt) || isFunction(opt) ? { type: opt } : opt)
+          isArray(opt) || isFunction(opt) ? { type: opt } : { ...opt })
         if (prop) {
           const booleanIndex = getTypeIndex(Boolean, prop.type)
           const stringIndex = getTypeIndex(String, prop.type)


### PR DESCRIPTION
During Props normalization, we add a couple of flags to the definition object for internal purposes, so this:
```js
{
  type: String
}
```

becomes this:

```js
{
  type: String,
  0: true,
  1: false
}
```
The problem is that we do this to the original object provided by the developer  in the component's options. This can lead to issues when the developer re-uses these objects in different places.

This PR makes a shallow copy of that object before adding those flags, so the original definition stays untouched.

close: #6915