### PR TITLE
fix: "props" and "emits" has been merged.

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -969,8 +969,12 @@ export function resolveMergedOptions(
   if (isObject(base)) {
     cache.set(base, resolved)
   }
-  resolved.props = instance.propsOptions[0]
-  resolved.emits = instance.emitsOptions
+  if(instance.propsOptions[0]){
+    resolved.props = instance.propsOptions[0]
+  }
+  if(instance.emitsOptions){
+    resolved.emits = instance.emitsOptions
+  }
   return resolved
 }
 

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -969,6 +969,8 @@ export function resolveMergedOptions(
   if (isObject(base)) {
     cache.set(base, resolved)
   }
+  resolved.props = instance.propsOptions[0]
+  resolved.emits = instance.emits
   return resolved
 }
 
@@ -1000,6 +1002,8 @@ export function mergeOptions(
           `"expose" option is ignored when declared in mixins or extends. ` +
             `It should only be declared in the base component itself.`
         )
+    } else if (key === "props" || key === "emits") {
+      continue
     } else {
       const strat = internalOptionMergeStrats[key] || (strats && strats[key])
       to[key] = strat ? strat(to[key], from[key]) : from[key]
@@ -1010,8 +1014,6 @@ export function mergeOptions(
 
 export const internalOptionMergeStrats: Record<string, Function> = {
   data: mergeDataFn,
-  props: mergeObjectOptions, // TODO
-  emits: mergeObjectOptions, // TODO
   // objects
   methods: mergeObjectOptions,
   computed: mergeObjectOptions,

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -970,7 +970,7 @@ export function resolveMergedOptions(
     cache.set(base, resolved)
   }
   resolved.props = instance.propsOptions[0]
-  resolved.emits = instance.emits
+  resolved.emits = instance.emitsOptions
   return resolved
 }
 

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -970,10 +970,10 @@ export function resolveMergedOptions(
     cache.set(base, resolved)
   }
   if(instance.propsOptions[0]){
-    resolved.props = instance.propsOptions[0]
+    resolved.props = extend(Object.create(null), instance.propsOptions[0])
   }
   if(instance.emitsOptions){
-    resolved.emits = instance.emitsOptions
+    resolved.emits = extend(Object.create(null), instance.emitsOptions)
   }
   return resolved
 }


### PR DESCRIPTION
The "props" and "emits" attributes have been merged when creating component instances, so there is no need to merge them here. It's OK to directly reference the previously merged values.
If I declare "emits" and "mixins" at the same time and then access the "emits" attribute through "this. $options" in "setup", the accessed "emits" attribute will not be merged.
```vue
<script>
import { h } from "vue";
export default {
  setup() {
    return function () {
      console.log(this.$options);
      return h("div", null, 123);
    };
  },
  emits: ["he"],
  mixins: [
    {
      emits: ["hello"],
    },
  ],
};
</script>
```
- before updating
![%$1Z (DLE@WHPU)IJU2`~CG](https://user-images.githubusercontent.com/79794654/197403978-f9bb4c17-fe58-4455-8313-8b85db951e98.png)
- after updating the attributes of "emits" is right
![@ ZCL6IG)IJ)A A%~YBL8EH](https://user-images.githubusercontent.com/79794654/197404006-13287c6b-369e-48ea-86cc-f458c2d2db98.png)

