### PR TITLE
fix(hmr): fix vite hmr error

### DIFF
--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -184,6 +184,7 @@ function tryWrap(fn: (id: string, arg: any) => any): Function {
     try {
       return fn(id, arg)
     } catch (e: any) {
+      hmrDirtyComponents.clear()
       console.error(e)
       console.warn(
         `[HMR] Something went wrong during Vue component hot-reload. ` +


### PR DESCRIPTION
Fix the problem that hmr does not take effect after re-rendering with runtime errors。
use `vite`.
![image](https://user-images.githubusercontent.com/34960995/197960197-f0adbcaa-aa60-4dc5-8ef6-79e60088c151.png)
and dispatch a runtime error.
![image](https://user-images.githubusercontent.com/34960995/197960345-1c51d958-657d-4374-85e7-34decabda573.png)
![image](https://user-images.githubusercontent.com/34960995/197960420-9fad46f8-f19a-4788-bdb7-f8a3e3cdf34a.png)
then fix the error but hmr not re-render the correct component.
![image](https://user-images.githubusercontent.com/34960995/197960984-1ad6c5da-5312-4845-9ceb-2603800b7388.png)

![image](https://user-images.githubusercontent.com/34960995/197960768-a40d086a-d35b-42d0-98f6-ea755196ac7e.png)
The reason is that `hmrDirtyComponents` is not cleaned up due to an error when running
