### PR TITLE
refactor: migrate to gen/trace-mapping

### DIFF
--- a/packages/compiler-core/__tests__/compile.spec.ts
+++ b/packages/compiler-core/__tests__/compile.spec.ts
@@ -1,5 +1,5 @@
 import { baseCompile as compile } from '../src'
-import { SourceMapConsumer, RawSourceMap } from 'source-map'
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
 
 describe('compiler: integration tests', () => {
   const source = `
@@ -54,58 +54,58 @@ describe('compiler: integration tests', () => {
     expect(map!.sources).toEqual([`foo.vue`])
     expect(map!.sourcesContent).toEqual([source])
 
-    const consumer = new SourceMapConsumer(map as RawSourceMap)
+    const consumer = new TraceMap(map!)
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `id`))
+      originalPositionFor(consumer, getPositionInCode(code, `id`))
     ).toMatchObject(getPositionInCode(source, `id`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `"foo"`))
+      originalPositionFor(consumer, getPositionInCode(code, `"foo"`))
     ).toMatchObject(getPositionInCode(source, `"foo"`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `class:`))
+      originalPositionFor(consumer, getPositionInCode(code, `class:`))
     ).toMatchObject(getPositionInCode(source, `class=`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `bar`))
+      originalPositionFor(consumer, getPositionInCode(code, `bar`))
     ).toMatchObject(getPositionInCode(source, `bar`))
 
     // without prefixIdentifiers: true, identifiers inside compound expressions
     // are mapped to closest parent expression.
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `baz`))
+      originalPositionFor(consumer, getPositionInCode(code, `baz`))
     ).toMatchObject(getPositionInCode(source, `bar`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `world`))
+      originalPositionFor(consumer, getPositionInCode(code, `world`))
     ).toMatchObject(getPositionInCode(source, `world`))
 
     // without prefixIdentifiers: true, identifiers inside compound expressions
     // are mapped to closest parent expression.
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `burn()`))
+      originalPositionFor(consumer, getPositionInCode(code, `burn()`))
     ).toMatchObject(getPositionInCode(source, `world`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `ok`))
+      originalPositionFor(consumer, getPositionInCode(code, `ok`))
     ).toMatchObject(getPositionInCode(source, `ok`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `list`))
+      originalPositionFor(consumer, getPositionInCode(code, `list`))
     ).toMatchObject(getPositionInCode(source, `list`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `value`))
+      originalPositionFor(consumer, getPositionInCode(code, `value`))
     ).toMatchObject(getPositionInCode(source, `value`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `index`))
+      originalPositionFor(consumer, getPositionInCode(code, `index`))
     ).toMatchObject(getPositionInCode(source, `index`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `value + index`))
+      originalPositionFor(consumer, getPositionInCode(code, `value + index`))
     ).toMatchObject(getPositionInCode(source, `value + index`))
   })
 
@@ -120,67 +120,67 @@ describe('compiler: integration tests', () => {
     expect(map!.sources).toEqual([`foo.vue`])
     expect(map!.sourcesContent).toEqual([source])
 
-    const consumer = new SourceMapConsumer(map as RawSourceMap)
+    const consumer = new TraceMap(map!)
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `id`))
+      originalPositionFor(consumer, getPositionInCode(code, `id`))
     ).toMatchObject(getPositionInCode(source, `id`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `"foo"`))
+      originalPositionFor(consumer, getPositionInCode(code, `"foo"`))
     ).toMatchObject(getPositionInCode(source, `"foo"`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `class:`))
+      originalPositionFor(consumer, getPositionInCode(code, `class:`))
     ).toMatchObject(getPositionInCode(source, `class=`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `bar`))
+      originalPositionFor(consumer, getPositionInCode(code, `bar`))
     ).toMatchObject(getPositionInCode(source, `bar`))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `_ctx.bar`, `bar`))
+      originalPositionFor(consumer, getPositionInCode(code, `_ctx.bar`, `bar`))
     ).toMatchObject(getPositionInCode(source, `bar`, true))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `baz`))
+      originalPositionFor(consumer, getPositionInCode(code, `baz`))
     ).toMatchObject(getPositionInCode(source, `baz`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `world`, true))
+      originalPositionFor(consumer, getPositionInCode(code, `world`, true))
     ).toMatchObject(getPositionInCode(source, `world`, `world`))
     expect(
-      consumer.originalPositionFor(
+      originalPositionFor(consumer,
         getPositionInCode(code, `_ctx.world`, `world`)
       )
     ).toMatchObject(getPositionInCode(source, `world`, `world`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `burn()`))
+      originalPositionFor(consumer, getPositionInCode(code, `burn()`))
     ).toMatchObject(getPositionInCode(source, `burn()`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `ok`))
+      originalPositionFor(consumer, getPositionInCode(code, `ok`))
     ).toMatchObject(getPositionInCode(source, `ok`))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `_ctx.ok`, `ok`))
+      originalPositionFor(consumer, getPositionInCode(code, `_ctx.ok`, `ok`))
     ).toMatchObject(getPositionInCode(source, `ok`, true))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `list`))
+      originalPositionFor(consumer, getPositionInCode(code, `list`))
     ).toMatchObject(getPositionInCode(source, `list`))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `_ctx.list`, `list`))
+      originalPositionFor(consumer, getPositionInCode(code, `_ctx.list`, `list`))
     ).toMatchObject(getPositionInCode(source, `list`, true))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `value`))
+      originalPositionFor(consumer, getPositionInCode(code, `value`))
     ).toMatchObject(getPositionInCode(source, `value`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `index`))
+      originalPositionFor(consumer, getPositionInCode(code, `index`))
     ).toMatchObject(getPositionInCode(source, `index`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `value + index`))
+      originalPositionFor(consumer, getPositionInCode(code, `value + index`))
     ).toMatchObject(getPositionInCode(source, `value + index`))
   })
 
@@ -195,67 +195,67 @@ describe('compiler: integration tests', () => {
     expect(map!.sources).toEqual([`foo.vue`])
     expect(map!.sourcesContent).toEqual([source])
 
-    const consumer = new SourceMapConsumer(map as RawSourceMap)
+    const consumer = new TraceMap(map!)
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `id`))
+      originalPositionFor(consumer, getPositionInCode(code, `id`))
     ).toMatchObject(getPositionInCode(source, `id`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `"foo"`))
+      originalPositionFor(consumer, getPositionInCode(code, `"foo"`))
     ).toMatchObject(getPositionInCode(source, `"foo"`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `class:`))
+      originalPositionFor(consumer, getPositionInCode(code, `class:`))
     ).toMatchObject(getPositionInCode(source, `class=`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `bar`))
+      originalPositionFor(consumer, getPositionInCode(code, `bar`))
     ).toMatchObject(getPositionInCode(source, `bar`))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `_ctx.bar`, `bar`))
+      originalPositionFor(consumer, getPositionInCode(code, `_ctx.bar`, `bar`))
     ).toMatchObject(getPositionInCode(source, `bar`, true))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `baz`))
+      originalPositionFor(consumer, getPositionInCode(code, `baz`))
     ).toMatchObject(getPositionInCode(source, `baz`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `world`, true))
+      originalPositionFor(consumer, getPositionInCode(code, `world`, true))
     ).toMatchObject(getPositionInCode(source, `world`, `world`))
     expect(
-      consumer.originalPositionFor(
+      originalPositionFor(consumer,
         getPositionInCode(code, `_ctx.world`, `world`)
       )
     ).toMatchObject(getPositionInCode(source, `world`, `world`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `burn()`))
+      originalPositionFor(consumer, getPositionInCode(code, `burn()`))
     ).toMatchObject(getPositionInCode(source, `burn()`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `ok`))
+      originalPositionFor(consumer, getPositionInCode(code, `ok`))
     ).toMatchObject(getPositionInCode(source, `ok`))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `_ctx.ok`, `ok`))
+      originalPositionFor(consumer, getPositionInCode(code, `_ctx.ok`, `ok`))
     ).toMatchObject(getPositionInCode(source, `ok`, true))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `list`))
+      originalPositionFor(consumer, getPositionInCode(code, `list`))
     ).toMatchObject(getPositionInCode(source, `list`))
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `_ctx.list`, `list`))
+      originalPositionFor(consumer, getPositionInCode(code, `_ctx.list`, `list`))
     ).toMatchObject(getPositionInCode(source, `list`, true))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `value`))
+      originalPositionFor(consumer, getPositionInCode(code, `value`))
     ).toMatchObject(getPositionInCode(source, `value`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `index`))
+      originalPositionFor(consumer, getPositionInCode(code, `index`))
     ).toMatchObject(getPositionInCode(source, `index`))
 
     expect(
-      consumer.originalPositionFor(getPositionInCode(code, `value + index`))
+      originalPositionFor(consumer, getPositionInCode(code, `value + index`))
     ).toMatchObject(getPositionInCode(source, `value + index`))
   })
 })

--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -32,12 +32,13 @@
   },
   "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-core#readme",
   "dependencies": {
-    "@vue/shared": "3.2.41",
     "@babel/parser": "^7.16.4",
-    "estree-walker": "^2.0.2",
-    "source-map": "^0.6.1"
+    "@jridgewell/gen-mapping": "^0.3.2",
+    "@vue/shared": "3.2.41",
+    "estree-walker": "^2.0.2"
   },
   "devDependencies": {
-    "@babel/types": "^7.16.0"
+    "@babel/types": "^7.16.0",
+    "@jridgewell/trace-mapping": "^0.3.17"
   }
 }

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileTemplate.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileTemplate.spec.ts.snap
@@ -60,10 +60,12 @@ export function ssrRender(_ctx, _push, _parent, _attrs) {
 
 exports[`source map 1`] = `
 Object {
+  "file": undefined,
   "mappings": ";;;wBACE,oBAA8B;IAAzB,oBAAmB,4BAAbA,WAAM",
   "names": Array [
     "render",
   ],
+  "sourceRoot": undefined,
   "sources": Array [
     "example.vue",
   ],

--- a/packages/compiler-sfc/__tests__/parse.spec.ts
+++ b/packages/compiler-sfc/__tests__/parse.spec.ts
@@ -1,6 +1,6 @@
 import { parse } from '../src'
 import { baseParse, baseCompile } from '@vue/compiler-core'
-import { SourceMapConsumer } from 'source-map'
+import { eachMapping, TraceMap } from '@jridgewell/trace-mapping'
 
 describe('compiler:sfc', () => {
   describe('source map', () => {
@@ -13,9 +13,10 @@ describe('compiler:sfc', () => {
 
       expect(style.map).not.toBeUndefined()
 
-      const consumer = new SourceMapConsumer(style.map!)
-      consumer.eachMapping(mapping => {
-        expect(mapping.originalLine - mapping.generatedLine).toBe(padding)
+      const consumer = new TraceMap(style.map!)
+      eachMapping(consumer, mapping => {
+        expect(mapping.originalLine).not.toBeNull()
+        expect(mapping.originalLine! - mapping.generatedLine).toBe(padding)
       })
     })
 
@@ -28,9 +29,10 @@ describe('compiler:sfc', () => {
 
       expect(script!.map).not.toBeUndefined()
 
-      const consumer = new SourceMapConsumer(script!.map!)
-      consumer.eachMapping(mapping => {
-        expect(mapping.originalLine - mapping.generatedLine).toBe(padding)
+      const consumer = new TraceMap(script!.map!)
+      eachMapping(consumer, mapping => {
+        expect(mapping.originalLine).not.toBeNull()
+        expect(mapping.originalLine! - mapping.generatedLine).toBe(padding)
       })
     })
 
@@ -42,9 +44,10 @@ describe('compiler:sfc', () => {
 
       expect(custom!.map).not.toBeUndefined()
 
-      const consumer = new SourceMapConsumer(custom!.map!)
-      consumer.eachMapping(mapping => {
-        expect(mapping.originalLine - mapping.generatedLine).toBe(padding)
+      const consumer = new TraceMap(custom.map!)
+      eachMapping(consumer, mapping => {
+        expect(mapping.originalLine).not.toBeNull()
+        expect(mapping.originalLine! - mapping.generatedLine).toBe(padding)
       })
     })
   })

--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -33,6 +33,8 @@
   "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-sfc#readme",
   "dependencies": {
     "@babel/parser": "^7.16.4",
+    "@jridgewell/gen-mapping": "^0.3.2",
+    "@jridgewell/trace-mapping": "^0.3.17",
     "@vue/compiler-core": "3.2.41",
     "@vue/compiler-dom": "3.2.41",
     "@vue/compiler-ssr": "3.2.41",
@@ -40,20 +42,19 @@
     "@vue/shared": "3.2.41",
     "estree-walker": "^2.0.2",
     "magic-string": "^0.25.7",
-    "source-map": "^0.6.1",
     "postcss": "^8.1.10"
   },
   "devDependencies": {
-    "@types/estree": "^0.0.48",
+    "@ampproject/remapping": "^2.2.0",
     "@babel/types": "^7.16.0",
+    "@types/estree": "^0.0.48",
     "@types/lru-cache": "^5.1.0",
-    "pug": "^3.0.1",
-    "sass": "^1.26.9",
     "@vue/consolidate": "^0.17.3",
     "hash-sum": "^2.0.0",
     "lru-cache": "^5.1.1",
-    "merge-source-map": "^1.1.0",
     "postcss-modules": "^4.0.0",
-    "postcss-selector-parser": "^6.0.4"
+    "postcss-selector-parser": "^6.0.4",
+    "pug": "^3.0.1",
+    "sass": "^1.26.9"
   }
 }

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -43,7 +43,7 @@ import {
   Expression
 } from '@babel/types'
 import { walk } from 'estree-walker'
-import { RawSourceMap } from 'source-map'
+import { EncodedSourceMap } from '@jridgewell/gen-mapping'
 import {
   CSS_VARS_HELPER,
   genCssVarsCode,
@@ -228,7 +228,7 @@ export function compileScript(
             source: filename,
             hires: true,
             includeContent: true
-          }) as unknown as RawSourceMap
+          }) as EncodedSourceMap
         }
       }
       if (cssVars.length) {
@@ -1564,7 +1564,7 @@ export function compileScript(
           source: filename,
           hires: true,
           includeContent: true
-        }) as unknown as RawSourceMap)
+        }) as EncodedSourceMap)
       : undefined,
     scriptAst: scriptAst?.body,
     scriptSetupAst: scriptSetupAst?.body

--- a/packages/compiler-sfc/src/compileStyle.ts
+++ b/packages/compiler-sfc/src/compileStyle.ts
@@ -13,7 +13,7 @@ import {
   StylePreprocessorResults,
   PreprocessLang
 } from './stylePreprocessors'
-import { RawSourceMap } from 'source-map'
+import { EncodedSourceMap } from '@jridgewell/trace-mapping'
 import { cssVarsPlugin } from './cssVars'
 import postcssModules from 'postcss-modules'
 
@@ -24,7 +24,7 @@ export interface SFCStyleCompileOptions {
   scoped?: boolean
   trim?: boolean
   isProd?: boolean
-  inMap?: RawSourceMap
+  inMap?: EncodedSourceMap
   preprocessLang?: PreprocessLang
   preprocessOptions?: any
   preprocessCustomRequire?: (id: string) => any
@@ -33,7 +33,7 @@ export interface SFCStyleCompileOptions {
   /**
    * @deprecated use `inMap` instead.
    */
-  map?: RawSourceMap
+  map?: EncodedSourceMap
 }
 
 /**
@@ -61,7 +61,7 @@ export interface SFCAsyncStyleCompileOptions extends SFCStyleCompileOptions {
 
 export interface SFCStyleCompileResults {
   code: string
-  map: RawSourceMap | undefined
+  map: EncodedSourceMap | undefined
   rawResult: Result | LazyResult | undefined
   errors: Error[]
   modules?: Record<string, string>
@@ -187,7 +187,8 @@ export function doCompileStyle(
       return result
         .then(result => ({
           code: result.css || '',
-          map: result.map && result.map.toJSON(),
+          map: (result.map &&
+            result.map.toJSON()) as unknown as EncodedSourceMap,
           errors,
           modules: cssModules,
           rawResult: result,
@@ -212,7 +213,7 @@ export function doCompileStyle(
 
   return {
     code: code || ``,
-    map: outMap && outMap.toJSON(),
+    map: (outMap && outMap.toJSON()) as unknown as EncodedSourceMap,
     errors,
     rawResult: result,
     dependencies

--- a/packages/compiler-sfc/src/shims.d.ts
+++ b/packages/compiler-sfc/src/shims.d.ts
@@ -1,3 +1,0 @@
-declare module 'merge-source-map' {
-  export default function merge(oldMap: object, newMap: object): object
-}

--- a/packages/compiler-sfc/src/stylePreprocessors.ts
+++ b/packages/compiler-sfc/src/stylePreprocessors.ts
@@ -1,11 +1,11 @@
-import merge from 'merge-source-map'
-import { RawSourceMap } from 'source-map'
+import merge from '@ampproject/remapping'
+import { EncodedSourceMap } from '@jridgewell/trace-mapping'
 import { SFCStyleCompileOptions } from './compileStyle'
 import { isFunction } from '@vue/shared'
 
 export type StylePreprocessor = (
   source: string,
-  map: RawSourceMap | undefined,
+  map: EncodedSourceMap | undefined,
   options: {
     [key: string]: any
     additionalData?: string | ((source: string, filename: string) => string)

--- a/packages/template-explorer/package.json
+++ b/packages/template-explorer/package.json
@@ -11,7 +11,7 @@
     "enableNonBrowserBranches": true
   },
   "dependencies": {
-    "monaco-editor": "^0.20.0",
-    "source-map": "^0.6.1"
+    "@jridgewell/trace-mapping": "^0.3.17",
+    "monaco-editor": "^0.20.0"
   }
 }

--- a/packages/vue-compat/package.json
+++ b/packages/vue-compat/package.json
@@ -39,8 +39,7 @@
   "homepage": "https://github.com/vuejs/core/tree/main/packages/vue-compat#readme",
   "dependencies": {
     "@babel/parser": "^7.16.4",
-    "estree-walker": "^2.0.2",
-    "source-map": "^0.6.1"
+    "estree-walker": "^2.0.2"
   },
   "peerDependencies": {
     "vue": "3.2.41"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,16 +106,18 @@ importers:
     specifiers:
       '@babel/parser': ^7.16.4
       '@babel/types': ^7.16.0
+      '@jridgewell/gen-mapping': ^0.3.2
+      '@jridgewell/trace-mapping': ^0.3.17
       '@vue/shared': 3.2.41
       estree-walker: ^2.0.2
-      source-map: ^0.6.1
     dependencies:
       '@babel/parser': 7.16.4
+      '@jridgewell/gen-mapping': 0.3.2
       '@vue/shared': link:../shared
       estree-walker: 2.0.2
-      source-map: 0.6.1
     devDependencies:
       '@babel/types': 7.16.0
+      '@jridgewell/trace-mapping': 0.3.17
 
   packages/compiler-dom:
     specifiers:
@@ -127,8 +129,11 @@ importers:
 
   packages/compiler-sfc:
     specifiers:
+      '@ampproject/remapping': ^2.2.0
       '@babel/parser': ^7.16.4
       '@babel/types': ^7.16.0
+      '@jridgewell/gen-mapping': ^0.3.2
+      '@jridgewell/trace-mapping': ^0.3.17
       '@types/estree': ^0.0.48
       '@types/lru-cache': ^5.1.0
       '@vue/compiler-core': 3.2.41
@@ -141,15 +146,15 @@ importers:
       hash-sum: ^2.0.0
       lru-cache: ^5.1.1
       magic-string: ^0.25.7
-      merge-source-map: ^1.1.0
       postcss: ^8.1.10
       postcss-modules: ^4.0.0
       postcss-selector-parser: ^6.0.4
       pug: ^3.0.1
       sass: ^1.26.9
-      source-map: ^0.6.1
     dependencies:
       '@babel/parser': 7.16.4
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
       '@vue/compiler-core': link:../compiler-core
       '@vue/compiler-dom': link:../compiler-dom
       '@vue/compiler-ssr': link:../compiler-ssr
@@ -158,15 +163,14 @@ importers:
       estree-walker: 2.0.2
       magic-string: 0.25.7
       postcss: 8.4.4
-      source-map: 0.6.1
     devDependencies:
+      '@ampproject/remapping': 2.2.0
       '@babel/types': 7.16.0
       '@types/estree': 0.0.48
       '@types/lru-cache': 5.1.1
       '@vue/consolidate': 0.17.3
       hash-sum: 2.0.0
       lru-cache: 5.1.1
-      merge-source-map: 1.1.0
       postcss-modules: 4.2.2_postcss@8.4.4
       postcss-selector-parser: 6.0.7
       pug: 3.0.2
@@ -264,11 +268,11 @@ importers:
 
   packages/template-explorer:
     specifiers:
+      '@jridgewell/trace-mapping': ^0.3.17
       monaco-editor: ^0.20.0
-      source-map: ^0.6.1
     dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
       monaco-editor: 0.20.0
-      source-map: 0.6.1
 
   packages/vue:
     specifiers:
@@ -288,13 +292,19 @@ importers:
     specifiers:
       '@babel/parser': ^7.16.4
       estree-walker: ^2.0.2
-      source-map: ^0.6.1
     dependencies:
       '@babel/parser': 7.16.4
       estree-walker: 2.0.2
-      source-map: 0.6.1
 
 packages:
+
+  /@ampproject/remapping/2.2.0:
+    resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.1.1
+      '@jridgewell/trace-mapping': 0.3.17
+    dev: true
 
   /@babel/code-frame/7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
@@ -905,6 +915,40 @@ packages:
       chalk: 4.1.2
     dev: true
 
+  /@jridgewell/gen-mapping/0.1.1:
+    resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@jridgewell/gen-mapping/0.3.2:
+    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.17
+    dev: false
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+
+  /@jridgewell/set-array/1.1.2:
+    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+
+  /@jridgewell/trace-mapping/0.3.17:
+    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+
   /@microsoft/api-extractor-model/7.16.0:
     resolution: {integrity: sha512-0FOrbNIny8mzBrzQnSIkEjAXk0JMSnPmWYxt3ZDTPVg9S8xIPzB6lfgTg9+Mimu0RKCpGKBpd+v2WcR5vGzyUQ==}
     dependencies:
@@ -1359,7 +1403,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 3.0.9
-      vue: link:packages/vue
+      vue: link:packages\vue
     dev: true
 
   /@vue/consolidate/0.17.3:
@@ -1372,7 +1416,7 @@ packages:
     peerDependencies:
       vue: ^3.2.13
     dependencies:
-      vue: link:packages/vue
+      vue: link:packages\vue
     dev: false
 
   /@zeit/schemas/2.6.0:
@@ -2296,8 +2340,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -5243,12 +5287,6 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /merge-source-map/1.1.0:
-    resolution: {integrity: sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==}
-    dependencies:
-      source-map: 0.6.1
-    dev: true
-
   /merge-stream/2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
@@ -5363,6 +5401,7 @@ packages:
     resolution: {integrity: sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: false
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
@@ -5830,6 +5869,7 @@ packages:
       nanoid: 3.1.30
       picocolors: 1.0.0
       source-map-js: 1.0.1
+    dev: false
 
   /prelude-ls/1.1.2:
     resolution: {integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=}
@@ -6604,6 +6644,7 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map/0.7.3:
     resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -137,7 +137,7 @@ function createConfig(format, output, plugins = []) {
     if (!packageOptions.enableNonBrowserBranches) {
       // normal browser builds - non-browser only imports are tree-shaken,
       // they are only listed here to suppress warnings.
-      external = ['source-map', '@babel/parser', 'estree-walker']
+      external = ['@jridgewell/gen-mapping', '@babel/parser', 'estree-walker']
     }
   } else {
     // Node / esm-bundler builds.


### PR DESCRIPTION
Migrated `source-map@0.6.1` to [`@jridgewell/gen-mapping`](https://github.com/jridgewell/gen-mapping)/[`@jridgewell/trace-mapping`](https://github.com/jridgewell/trace-mapping).

These packages has better memory usage / speed / package install size.

benchmarks: https://github.com/jridgewell/trace-mapping#benchmarks, https://github.com/jridgewell/gen-mapping#benchmarks

[`@jridgewell/source-map`'s package install size is 585kB](https://packagephobia.com/result?p=%40jridgewell%2Fsource-map). (This package depends on `@jridgewell/gen-mapping` and `@jridgewell/trace-mapping`)
[`source-map@0.6.1`'s package install size is 789kB](https://packagephobia.com/result?p=source-map%400.6.1).
