### PR TITLE
fix(runtime-dom): use KeepAlive and CustomElement at same time(#6934)

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -179,7 +179,11 @@ export class VueElement extends BaseClass {
   connectedCallback() {
     this._connected = true
     if (!this._instance) {
-      this._resolveDef()
+      if (this._resolved) {
+        this._update()
+      } else {
+        this._resolveDef()
+      }
     }
   }
 
@@ -197,14 +201,6 @@ export class VueElement extends BaseClass {
    * resolve inner component definition (handle possible async component)
    */
   private _resolveDef() {
-    if (this._resolved) {
-      //#6934 if you use Both of KeepAlive and CustemElement,
-      //CustemElement will not recreate,so the property of 
-      //"_resolved" would be "true",it means that should update it
-      this._applyStyles(this._def.styles)
-      this._update()
-      return
-    }
     this._resolved = true
 
     // set initial attrs

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -198,6 +198,13 @@ export class VueElement extends BaseClass {
    */
   private _resolveDef() {
     if (this._resolved) {
+      //#6934 if you use Both of KeepAlive and CustemElement,
+      //CustemElement will not recreate,so the property of 
+      //"_resolved" would be "true",it means that should update it
+      if (this._resolved) {
+        this._applyStyles(this._def.styles)
+        this._update()
+      }
       return
     }
     this._resolved = true

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -201,10 +201,8 @@ export class VueElement extends BaseClass {
       //#6934 if you use Both of KeepAlive and CustemElement,
       //CustemElement will not recreate,so the property of 
       //"_resolved" would be "true",it means that should update it
-      if (this._resolved) {
-        this._applyStyles(this._def.styles)
-        this._update()
-      }
+      this._applyStyles(this._def.styles)
+      this._update()
       return
     }
     this._resolved = true


### PR DESCRIPTION
if you use KeepAlive and CustomElement.CustomElement will not recreate.so the property of "_resolved" would be "true",it means that should update it
- fix #6934 