### PR TITLE
fix(runtime-dom): using CustemElement After Hmr has an error 

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -34,7 +34,7 @@ const cacheCustomElement = new WeakMap()
 //But the same "customElement" has been
 //registered before update,it could be 
 //trigger an error by DOM.
-if(custemElements){
+if(customElements){
   const hasDefined = new Array()
   const rawDefine = customElements.define
   const wrapperDefine: typeof rawDefine = function(name, ...args){
@@ -44,7 +44,7 @@ if(custemElements){
     hasDefined.push(name)
     return rawDefine.call(customElements, name , ...args)
   }
-  window.customElements.define = wrapperDefine
+  customElements.define = wrapperDefine
 }
 
 // defineCustomElement provides the same type inference as defineComponent

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -27,14 +27,15 @@ import { hydrate, render } from '.'
 export type VueElementConstructor<P = {}> = {
   new (initialProps?: Record<string, any>): VueElement & P
 }
-
+const win = (typeof window !== 'undefined' ? window : null) as Window
 const cacheCustomElement = new WeakMap()
 //HMR: if you use "define" before update.
 //After HMR, "define" will be re-run.
 //But the same "customElement" has been
 //registered before update,it could be 
 //trigger an error by DOM.
-if(customElements){
+if(win){
+  const customElements = win.customElements
   const hasDefined = new Array()
   const rawDefine = customElements.define
   const wrapperDefine: typeof rawDefine = function(name, ...args){

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -34,16 +34,18 @@ const cacheCustomElement = new WeakMap()
 //But the same "customElement" has been
 //registered before update,it could be 
 //trigger an error by DOM.
-const hasDefined = new Array()  
-const rawDefine = window.customElements.define
-const wrapperDefine: typeof rawDefine = function(name, ...args){
-  if(hasDefined.includes(name)){
-     return 
+if(window){
+  const hasDefined = new Array()
+  const rawDefine = window.customElements.define
+  const wrapperDefine: typeof rawDefine = function(name, ...args){
+    if(hasDefined.includes(name)){
+      return 
+    }
+    hasDefined.push(name)
+    return rawDefine.call(window.customElements, name , ...args)
   }
-  hasDefined.push(name)
-  return rawDefine.call(window.customElements, name , ...args)
+  window.customElements.define = wrapperDefine
 }
-window.customElements.define = wrapperDefine
 
 // defineCustomElement provides the same type inference as defineComponent
 // so most of the following overloads should be kept in sync w/ defineComponent.

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -28,7 +28,6 @@ export type VueElementConstructor<P = {}> = {
   new (initialProps?: Record<string, any>): VueElement & P
 }
 const win = (typeof window !== 'undefined' ? window : null) as Window
-const cacheCustomElement = new WeakMap()
 //HMR: if you use "define" before update.
 //After HMR, "define" will be re-run.
 //But the same "customElement" has been
@@ -144,9 +143,6 @@ export function defineCustomElement(
   options: any,
   hydrate?: RootHydrateFunction
 ): VueElementConstructor {
-  if(cacheCustomElement.has(options)){
-    return cacheCustomElement.get(options)
-  }
   const Comp = defineComponent(options as any)
   class VueCustomElement extends VueElement {
     static def = Comp
@@ -154,7 +150,7 @@ export function defineCustomElement(
       super(Comp, initialProps, hydrate)
     }
   }
-  cacheCustomElement.set(options, VueCustomElement)
+  
   return VueCustomElement
 }
 

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -34,15 +34,15 @@ const cacheCustomElement = new WeakMap()
 //But the same "customElement" has been
 //registered before update,it could be 
 //trigger an error by DOM.
-if(window){
+if(custemElements){
   const hasDefined = new Array()
-  const rawDefine = window.customElements.define
+  const rawDefine = customElements.define
   const wrapperDefine: typeof rawDefine = function(name, ...args){
     if(hasDefined.includes(name)){
       return 
     }
     hasDefined.push(name)
-    return rawDefine.call(window.customElements, name , ...args)
+    return rawDefine.call(customElements, name , ...args)
   }
   window.customElements.define = wrapperDefine
 }

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -121,15 +121,15 @@ const cacheCustomElement = new WeakMap()
 //registered before update,it could be 
 //trigger an error by DOM.
 const hasDefined = new Array()  
-const beforeDefine = window.customElements.define
-window.customElements.define = function(name, ...args){
+const rawDefine = window.customElements.define
+const wrapperDefine: typeof rawDefine = function(name, ...args){
   if(hasDefined.includes(name)){
      return 
   }
   hasDefined.push(name)
-  return beforeDefine.call(window.customElements, name , ...args)
+  return rawDefine.call(window.customElements, name , ...args)
 }
-
+window.customElements.define = wrapperDefine
 // overload 5: defining a custom element from the returned value of
 // `defineComponent`
 export function defineCustomElement(options: {


### PR DESCRIPTION
- [problem link](https://sfc.vuejs.org/#__DEV__eNp9UMtugzAQ/JWVLxAJzB3RSFXUY//AFwpLIbLXlh+gCPHvtQNto7aqfNnHzKxnVvZsDJ8Dspo1rrOT8eDQB3MWNCmjrYcVehwmwktwXqsXiQrJFyNsMFitIIvkTBCAoE6T8/B6u2hl4OkvWr4mJLUKa8ESTLAiTSxSjzY/3dep9cESjLlg/TRHDAUpi2xEKTUkWnZKwE3QFotlol4vvHs85Ph+Pc/Ureyw7BKpOP6WyIKaavcbnabXeFRGth5jD9B8085N9dAk3heSFWwPqVSt4VenKcZ49yCOhROshsOVYDGq1As2em9cXVVu6FL4V8e1fa9ixW0gPynk6FT5ZvXi0EbhI6ZDo4rDGW25p4b2P80f0F+6nzmy7QPVxLaJ)
- if you change this file,it will trigger Hmr. `customElements.define` will be triggered again. this will be caused an error with DOM.
![image](https://user-images.githubusercontent.com/79794654/198248079-3a5d04a3-ddf3-4bb2-a1b2-0e9c44832369.png)
- so I think it may needs a cache to check.