### PR TITLE
fix(compiler-sfc): missing keywords of method property

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1744,12 +1744,14 @@ export default /*#__PURE__*/_defineComponent({
     bar: { type: Number, required: false },
     baz: { type: Boolean, required: true },
     qux: { type: Function, required: false, default() { return 1 } },
-    quux: { type: Function, required: false, default() { } }
+    quux: { type: Function, required: false, default() { } },
+    quuxx: { type: Promise, required: false, async default() { return await Promise.resolve('hi') } },
+    fred: { type: String, required: false, get default() { return 'fred' } }
   },
   setup(__props: any, { expose }) {
   expose();
 
-const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number, quux(): void };
+const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number, quux(): void, quuxx: Promise<string>, fred: string };
 
       
       

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1041,10 +1041,14 @@ const emit = defineEmits(['a', 'b'])
         baz: boolean;
         qux?(): number;
         quux?(): void
+        quuxx?: Promise<string>;
+        fred?: string
       }>(), {
         foo: 'hi',
         qux() { return 1 },
-        ['quux']() { }
+        ['quux']() { },
+        async quuxx() { return await Promise.resolve('hi') },
+        get fred() { return 'fred' }
       })
       </script>
       `)
@@ -1061,7 +1065,13 @@ const emit = defineEmits(['a', 'b'])
         `quux: { type: Function, required: false, default() { } }`
       )
       expect(content).toMatch(
-        `{ foo: string, bar?: number, baz: boolean, qux(): number, quux(): void }`
+        `quuxx: { type: Promise, required: false, async default() { return await Promise.resolve('hi') } }`
+      )
+      expect(content).toMatch(
+        `fred: { type: String, required: false, get default() { return 'fred' } }`
+      )
+      expect(content).toMatch(
+        `{ foo: string, bar?: number, baz: boolean, qux(): number, quux(): void, quuxx: Promise<string>, fred: string }`
       )
       expect(content).toMatch(`const props = __props`)
       expect(bindings).toStrictEqual({
@@ -1070,6 +1080,8 @@ const emit = defineEmits(['a', 'b'])
         baz: BindingTypes.PROPS,
         qux: BindingTypes.PROPS,
         quux: BindingTypes.PROPS,
+        quuxx: BindingTypes.PROPS,
+        fred: BindingTypes.PROPS,
         props: BindingTypes.SETUP_CONST
       })
     })

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -805,7 +805,9 @@ export function compileScript(
                 prop.value.end!
               )}`
             } else {
-              defaultString = `default() ${scriptSetupSource.slice(
+              defaultString = `${prop.async ? 'async ' : ''}${
+                prop.kind !== 'method' ? `${prop.kind} ` : ''
+              }default() ${scriptSetupSource.slice(
                 prop.body.start!,
                 prop.body.end!
               )}`


### PR DESCRIPTION
[Before](https://sfc.vuejs.org/#eNpNUFtugzAQvMrKPwGJgPKLaKpKPUAP4B+HGuIIP+RdiiLku3cNpKr8Yc/s7nh2VvERQv0za9GKDvtoAgFqmgNMyo1vUhBKcZUOYDF0/9SDmifC4lsPxumv6AN2a64CDN6/t8CUNag75Z7bFMBNReaRonFjZtK1KCs4hhQ+XZ9Hi/JFMbkoQ3DZYar2e9SUpfY+SflE9hkdnC6n/62plK5r9lXYAgPSNkyK9GZoXfN3kNIBWHMDXfPXJiphbPCRzlaF+oHecTibO3kUOJP25VcKTi9jKe5EAdumwaHPkT6w9nFs+FXH2ZGxutZoz7foF9SRhaXYDEuXRPoFHSSCLw==) | [After](https://deploy-preview-6972--vue-sfc-playground.netlify.app/#eNpNUNFqwzAM/BXjl7ZQJ3QPGwtZx2AfsA/wi9sqqUdiG0tpCMH/PjlpR/GDudNJOt0sv0IobgPIStZ4jjaQQKAhiM649kNLQi2P2gkxWrp+Q2OGjnB7gcY6+Ik+YD3nqhCN95+VYKq3CLVx09IlxMlE5pGidW1m0nG724t7k8HJnXPrdvegmByNJXFYYdqvfwuUR606TflF9hmd2Bw2z9K0064u11PYAgOCPnSGYDE0z3mdSOkOeOYC6vJfJvfS9sFHUr0JxS96x+Es7vS9wJlUD79acnoZa3klCliV5QVC5ycVItwsjOr1/e1FKVYpbM6Kd0xt9IO7FA6os81UmBBKLhdxcGR7KAB7dYp+RIi8XsvlLO2STH9s2ZAA)

---

closes #6971 
add `async` or `get` keyword of method property in `withDefaults`.