### PR TITLE
fix(hmr):using customElements after hmr will trigger an error

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -28,6 +28,26 @@ export type VueElementConstructor<P = {}> = {
   new (initialProps?: Record<string, any>): VueElement & P
 }
 
+const win = (typeof window !== 'undefined' ? window : null) as Window
+//HMR: if you use "define" before update.
+//After HMR, "define" will be re-run.
+//But the same "customElement" has been
+//registered before update,it could be 
+//trigger an error by DOM.
+if(win){
+  const customElements = win.customElements
+  const hasDefined = new Array()
+  const rawDefine = customElements.define
+  const wrapperDefine: typeof rawDefine = function(name, ...args){
+    if(hasDefined.includes(name)){
+      return 
+    }
+    hasDefined.push(name)
+    return rawDefine.call(customElements, name , ...args)
+  }
+  customElements.define = wrapperDefine
+}
+
 // defineCustomElement provides the same type inference as defineComponent
 // so most of the following overloads should be kept in sync w/ defineComponent.
 


### PR DESCRIPTION
- [problem link](https://sfc.vuejs.org/#eNp9kN1ugzAMhV/Fyg1U4kfb7hCrNFV7i9x0YAYVcSInME2Id59T6DRtU+987OOT+FvUi3PFPKGqVO0bHlwAj2FyR02DcZYDLMDYZS12A+Fp8sGa1xENUsj6FTq2BhLZTzRpaiz5ACdrHDzDPxvpogmAzgYrraJNqyx2GKlFTg/XcZRhYoI+1aodZvHQNI7Zw+PTIc5XTasUzc9gX2yvpYn5zBsJTrIYL7a63K6Se0QENG48BxQFUO/eY13eqtiOO98+lakNQ27Orrh4SwLq+k29D7xWFewf10pIRK1VH4LzVVn6rol4L76w/F5KVfBEYTBYoDf5G9sPjyzBO4k9o5TmjJxvYJDvZf6y/sm9MVPrF2LLrBw=)
- when I use customElements it's ok. but after changing file will trigger hmr.,it will be rerun `window.customElements.define`. so there is an error will be caused.
![image](https://user-images.githubusercontent.com/79794654/198289706-1a6cacfc-e0bb-4655-8b30-24968c147440.png)
- I think just need to set a cache to check that customElement has been registered or not.