### PR TITLE
fix(types): accept sync `serverPrefetch()`

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -147,7 +147,7 @@ export interface ComponentOptionsBase<
   emits?: (E | EE[]) & ThisType<void>
   // TODO infer public instance type based on exposed keys
   expose?: string[]
-  serverPrefetch?(): Promise<any>
+  serverPrefetch?(): void | Promise<any>
 
   // Runtime compiler only -----------------------------------------------------
   compilerOptions?: RuntimeCompilerOptions


### PR DESCRIPTION
Currently `serverPrefetch()` explicitly requires returning a Promise, making the sync version not acceptable on types.

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/11247099/199174082-505a9b62-5dda-48e2-b1d2-8a43759a10a3.png">
