### PR TITLE
fix(suspense): don't run post flush callbacks in suspended component (fix #6811)

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -1235,7 +1235,7 @@ describe('Suspense', () => {
     expect(serializeInner(root)).toBe(`<div>parent<!----></div>`)
   })
 
-  // #2215
+  // #6811
   test('post flush watchers in toggled components', async () => {
     let cnt = 0
 

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -769,7 +769,7 @@ export function queueEffectWithSuspense(
     } else {
       suspense.effects.push(fn)
     }
-  } else {
+  } else if (!suspense) {
     queuePostFlushCb(fn)
   }
 }


### PR DESCRIPTION
As described in #6811 post flush watchers are executed in suspended components that are currently being switched out. This has huge implications for example in routing, where switching pages executes both post flush watchers both on the new page and also on the old page. This PR fixes this issue and causes post flush watchers to be executed ONLY on the new component.

Closes #6811 