### PR TITLE
fix(runtime-dom): should not set css vars when `instance.subtree` is null

### DIFF
--- a/packages/runtime-dom/src/helpers/useCssVars.ts
+++ b/packages/runtime-dom/src/helpers/useCssVars.ts
@@ -26,6 +26,7 @@ export function useCssVars(getter: (ctx: any) => Record<string, string>) {
   }
 
   const setVars = () =>
+    instance.subTree &&
     setVarsOnVNode(instance.subTree, getter(instance.proxy!))
   watchPostEffect(setVars)
   onMounted(() => {


### PR DESCRIPTION
Closes #7015 