### PR TITLE
fix(runtime-core): use stack to store instance

### DIFF
--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -484,6 +484,7 @@ describe('component: proxy', () => {
       setup() {
         const instance = getCurrentInstance()
         show3()
+        expect(instance).toEqual(getCurrentInstance())
         onMounted(() => {
           expect(instance).toEqual(getCurrentInstance())
           tag2 = 1
@@ -498,6 +499,7 @@ describe('component: proxy', () => {
       setup() {
         const instance = getCurrentInstance()
         show2()
+        expect(instance).toEqual(getCurrentInstance())
         onMounted(() => {
           expect(instance).toEqual(getCurrentInstance())
           tag1 = 1

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -563,17 +563,20 @@ export function createComponentInstance(
 
 export let currentInstance: ComponentInternalInstance | null = null
 
+const instanceStack: ComponentInternalInstance[] = [];
+
 export const getCurrentInstance: () => ComponentInternalInstance | null = () =>
   currentInstance || currentRenderingInstance
 
 export const setCurrentInstance = (instance: ComponentInternalInstance) => {
+  currentInstance && instanceStack.push(currentInstance)
   currentInstance = instance
   instance.scope.on()
 }
 
 export const unsetCurrentInstance = () => {
   currentInstance && currentInstance.scope.off()
-  currentInstance = null
+  currentInstance = instanceStack.pop() || null
 }
 
 const isBuiltInTag = /*#__PURE__*/ makeMap('slot,component')

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -563,7 +563,7 @@ export function createComponentInstance(
 
 export let currentInstance: ComponentInternalInstance | null = null
 
-const instanceStack: ComponentInternalInstance[] = [];
+const instanceStack: ComponentInternalInstance[] = []
 
 export const getCurrentInstance: () => ComponentInternalInstance | null = () =>
   currentInstance || currentRenderingInstance


### PR DESCRIPTION
If a component is in setup and another component is rendered, the `onMounted` method of this component cannot be executed, because the currentInstance is lost. Also, the correct instance cannot be obtained after rendering.

I use the stack to save the historical instance, and take out the previous instance after the instance is used up, and solve this problem