### PR TITLE
chore: comment and order keywords in list alphabetically

### DIFF
--- a/packages/compiler-core/src/validateExpression.ts
+++ b/packages/compiler-core/src/validateExpression.ts
@@ -4,13 +4,13 @@ import { SimpleExpressionNode } from './ast'
 import { TransformContext } from './transform'
 import { createCompilerError, ErrorCodes } from './errors'
 
-// typeof, instanceof and in are allowed
+// keywords 'instanceof' and 'in' are allowed
 const prohibitedKeywordRE = new RegExp(
   '\\b' +
     (
-      'do,if,for,let,new,try,var,case,else,with,await,break,catch,class,const,' +
-      'super,throw,while,yield,delete,export,import,return,switch,default,' +
-      'extends,finally,continue,debugger,function,arguments,typeof,void'
+      'arguments,await,break,case,catch,class,const,continue,debugger,default,' +
+      'delete,do,else,export,extends,finally,for,function,if,import,let,new,' +
+      'return,super,switch,throw,try,typeof,var,void,while,with,yield'
     )
       .split(',')
       .join('\\b|\\b') +

--- a/packages/compiler-core/src/validateExpression.ts
+++ b/packages/compiler-core/src/validateExpression.ts
@@ -1,16 +1,15 @@
-// these keywords should not appear inside expressions, but operators like
-
 import { SimpleExpressionNode } from './ast'
 import { TransformContext } from './transform'
 import { createCompilerError, ErrorCodes } from './errors'
 
-// keywords 'instanceof' and 'in' are allowed
+// these keywords should not appear inside expressions, but operators like
+// 'typeof', 'instanceof', and 'in' are allowed
 const prohibitedKeywordRE = new RegExp(
   '\\b' +
     (
       'arguments,await,break,case,catch,class,const,continue,debugger,default,' +
       'delete,do,else,export,extends,finally,for,function,if,import,let,new,' +
-      'return,super,switch,throw,try,typeof,var,void,while,with,yield'
+      'return,super,switch,throw,try,var,void,while,with,yield'
     )
       .split(',')
       .join('\\b|\\b') +


### PR DESCRIPTION
`typeof` is actually a prohibited keyword. There was a mistake in the comment. I just fix the comment and ordered the keywords so it's easier to read and identify this kind of error in the future.