### PR TITLE
feat(reactivity-transform)!: add $defineProps

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
@@ -14,7 +14,7 @@ describe('sfc props transform', () => {
   test('basic usage', () => {
     const { content, bindings } = compile(`
       <script setup>
-      const { foo } = defineProps(['foo'])
+      const { foo } = $defineProps(['foo'])
       console.log(foo)
       </script>
       <template>{{ foo }}</template>
@@ -31,7 +31,7 @@ describe('sfc props transform', () => {
   test('nested scope', () => {
     const { content, bindings } = compile(`
       <script setup>
-      const { foo, bar } = defineProps(['foo', 'bar'])
+      const { foo, bar } = $defineProps(['foo', 'bar'])
       function test(foo) {
         console.log(foo)
         console.log(bar)
@@ -52,7 +52,7 @@ describe('sfc props transform', () => {
   test('default values w/ runtime declaration', () => {
     const { content } = compile(`
       <script setup>
-      const { foo = 1, bar = {} } = defineProps(['foo', 'bar'])
+      const { foo = 1, bar = {} } = $defineProps(['foo', 'bar'])
       </script>
     `)
     // literals can be used as-is, non-literals are always returned from a
@@ -67,7 +67,7 @@ describe('sfc props transform', () => {
   test('default values w/ type declaration', () => {
     const { content } = compile(`
       <script setup lang="ts">
-      const { foo = 1, bar = {} } = defineProps<{ foo?: number, bar?: object }>()
+      const { foo = 1, bar = {} } = $defineProps<{ foo?: number, bar?: object }>()
       </script>
     `)
     // literals can be used as-is, non-literals are always returned from a
@@ -83,7 +83,7 @@ describe('sfc props transform', () => {
     const { content } = compile(
       `
       <script setup lang="ts">
-      const { foo = 1, bar = {}, func = () => {} } = defineProps<{ foo?: number, bar?: object, baz?: any, boola?: boolean, boolb?: boolean | number, func?: Function }>()
+      const { foo = 1, bar = {}, func = () => {} } = $defineProps<{ foo?: number, bar?: object, baz?: any, boola?: boolean, boolb?: boolean | number, func?: Function }>()
       </script>
     `,
       { isProd: true }
@@ -104,7 +104,7 @@ describe('sfc props transform', () => {
   test('aliasing', () => {
     const { content, bindings } = compile(`
       <script setup>
-      const { foo: bar } = defineProps(['foo'])
+      const { foo: bar } = $defineProps(['foo'])
       let x = foo
       let y = bar
       </script>
@@ -131,7 +131,7 @@ describe('sfc props transform', () => {
   test('non-identifier prop names', () => {
     const { content, bindings } = compile(`
       <script setup>
-      const { 'foo.bar': fooBar } = defineProps({ 'foo.bar': Function })
+      const { 'foo.bar': fooBar } = $defineProps({ 'foo.bar': Function })
       let x = fooBar
       </script>
       <template>{{ fooBar }}</template>
@@ -152,7 +152,7 @@ describe('sfc props transform', () => {
   test('rest spread', () => {
     const { content, bindings } = compile(`
       <script setup>
-      const { foo, bar, ...rest } = defineProps(['foo', 'bar', 'baz'])
+      const { foo, bar, ...rest } = $defineProps(['foo', 'bar', 'baz'])
       </script>
     `)
     expect(content).toMatch(
@@ -170,7 +170,7 @@ describe('sfc props transform', () => {
   test('$$() escape', () => {
     const { content } = compile(`
       <script setup>
-      const { foo, bar: baz } = defineProps(['foo'])
+      const { foo, bar: baz } = $defineProps(['foo'])
       console.log($$(foo))
       console.log($$(baz))
       $$({ foo, baz })
@@ -206,13 +206,13 @@ describe('sfc props transform', () => {
     test('should error on deep destructure', () => {
       expect(() =>
         compile(
-          `<script setup>const { foo: [bar] } = defineProps(['foo'])</script>`
+          `<script setup>const { foo: [bar] } = $defineProps(['foo'])</script>`
         )
       ).toThrow(`destructure does not support nested patterns`)
 
       expect(() =>
         compile(
-          `<script setup>const { foo: { bar } } = defineProps(['foo'])</script>`
+          `<script setup>const { foo: { bar } } = $defineProps(['foo'])</script>`
         )
       ).toThrow(`destructure does not support nested patterns`)
     })
@@ -220,7 +220,7 @@ describe('sfc props transform', () => {
     test('should error on computed key', () => {
       expect(() =>
         compile(
-          `<script setup>const { [foo]: bar } = defineProps(['foo'])</script>`
+          `<script setup>const { [foo]: bar } = $defineProps(['foo'])</script>`
         )
       ).toThrow(`destructure cannot use computed key`)
     })
@@ -229,7 +229,7 @@ describe('sfc props transform', () => {
       expect(() =>
         compile(
           `<script setup lang="ts">
-          const { foo } = withDefaults(defineProps<{ foo: string }>(), { foo: 'foo' })
+          const { foo } = withDefaults($defineProps<{ foo: string }>(), { foo: 'foo' })
           </script>`
         )
       ).toThrow(`withDefaults() is unnecessary when using destructure`)
@@ -242,7 +242,7 @@ describe('sfc props transform', () => {
           const x = 1
           const {
             foo = () => x
-          } = defineProps(['foo'])
+          } = $defineProps(['foo'])
           </script>`
         )
       ).toThrow(`cannot reference locally declared variables`)

--- a/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
@@ -188,7 +188,7 @@ describe('sfc props transform', () => {
   test('computed static key', () => {
     const { content, bindings } = compile(`
     <script setup>
-    const { ['foo']: foo } = defineProps(['foo'])
+    const { ['foo']: foo } = $defineProps(['foo'])
     console.log(foo)
     </script>
     <template>{{ foo }}</template>

--- a/packages/reactivity-transform/src/reactivityTransform.ts
+++ b/packages/reactivity-transform/src/reactivityTransform.ts
@@ -299,10 +299,10 @@ export function transformAST(
         processRefDeclaration(refCall, decl.id, decl.init as CallExpression)
       } else {
         const isProps =
-          isRoot && isCall && (decl as any).init.callee.name === 'defineProps'
+          isRoot && isCall && (decl as any).init.callee.name === '$defineProps'
         for (const id of extractIdentifiers(decl.id)) {
           if (isProps) {
-            // for defineProps destructure, only exclude them since they
+            // for $defineProps destructure, only exclude them since they
             // are already passed in as knownProps
             excludedIds.add(id)
           } else {

--- a/packages/vue/macros.d.ts
+++ b/packages/vue/macros.d.ts
@@ -5,7 +5,9 @@ import {
   WritableComputedOptions,
   DebuggerOptions,
   WritableComputedRef,
-  CustomRefFactory
+  CustomRefFactory,
+  ComponentObjectPropsOptions,
+  ExtractPropTypes
 } from '@vue/runtime-dom'
 
 export declare const RefType: unique symbol
@@ -17,6 +19,10 @@ export declare const enum RefTypes {
 }
 
 type RefValue<T> = T extends null | undefined ? T : ReactiveVariable<T>
+
+type RefObject<T> = {
+  [Key in keyof T]: RefValue<T[Key]>
+}
 
 type ReactiveVariable<T> = T & { [RefType]?: RefTypes.Ref }
 
@@ -110,3 +116,14 @@ export declare function $computed<T>(
   options: WritableComputedOptions<T>,
   debuggerOptions?: DebuggerOptions
 ): WritableComputedRefValue<T>
+
+// overload 1: runtime props w/ array
+export function $defineProps<PropNames extends string = string>(
+  props: PropNames[]
+): { [key in PropNames]?: any }
+// overload 2: runtime props w/ object
+export function $defineProps<
+  PP extends ComponentObjectPropsOptions = ComponentObjectPropsOptions
+>(props: PP): RefObject<ExtractPropTypes<PP>>
+// overload 3: typed-based declaration
+export function $defineProps<TypeProps>(): RefObject<TypeProps>


### PR DESCRIPTION
closes #6876

---

**BREAKING CHANGE**

Process the destructure variables of `$defineProps`, instead `defineProps`. It will cause a breaking change. It's not a big problem since Reactivity Transform is under experimental.

WIP
- `$(defineProps(...))`

See also: [RFC - Unresolved Questions](https://github.com/vuejs/rfcs/blob/reactivity-transform/active-rfcs/0000-reactivity-transform.md#defineprops-destructure-details)