### PR TITLE
fix(types/reactivity): toRef/toRefs not respecting readonly properties

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -5,7 +5,7 @@ import {
   triggerEffects
 } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
-import { isArray, hasChanged, IfAny } from '@vue/shared'
+import { isArray, hasChanged, IfAny, IfReadonlyKey } from '@vue/shared'
 import {
   isProxy,
   toRaw,
@@ -198,7 +198,10 @@ export function customRef<T>(factory: CustomRefFactory<T>): Ref<T> {
 }
 
 export type ToRefs<T = any> = {
-  [K in keyof T]: ToRef<T[K]>
+  -readonly [K in keyof T]: {
+    0: ToRef<T[K]>
+    1: Readonly<ToRef<T[K]>>
+  }[IfReadonlyKey<T, K>]
 }
 export function toRefs<T extends object>(object: T): ToRefs<T> {
   if (__DEV__ && !isProxy(object)) {
@@ -235,7 +238,10 @@ export type ToRef<T> = IfAny<T, Ref<T>, [T] extends [Ref] ? T : Ref<T>>
 export function toRef<T extends object, K extends keyof T>(
   object: T,
   key: K
-): ToRef<T[K]>
+): {
+  0: ToRef<T[K]>
+  1: Readonly<ToRef<T[K]>>
+}[IfReadonlyKey<T, K>]
 
 export function toRef<T extends object, K extends keyof T>(
   object: T,

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -10,3 +10,15 @@ export type LooseRequired<T> = { [P in keyof (T & Required<T>)]: T[P] }
 // If the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
+
+// https://stackoverflow.com/a/52473108/3570903
+export type IfEquals<A1 extends any, A2 extends any> = (<A>() => A extends A2
+  ? 1
+  : 0) extends <A>() => A extends A1 ? 1 : 0
+  ? 1
+  : 0
+
+export type IfReadonlyKey<O, K extends keyof O> = IfEquals<
+  { [L in K]: O[L] },
+  { readonly [L in K]: O[L] }
+>

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -17,3 +17,9 @@ export type IsUnion<T, U extends T = T> = (
   : true
 
 export type IsAny<T> = 0 extends 1 & T ? true : false
+
+export type Equals<A1 extends any, A2 extends any> = (<A>() => A extends A2
+  ? 1
+  : 0) extends <A>() => A extends A1 ? 1 : 0
+  ? true
+  : false

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -11,7 +11,8 @@ import {
   toRefs,
   ToRefs,
   shallowReactive,
-  readonly
+  readonly,
+  Equals
 } from './index'
 
 function plainType(arg: number | Ref<number>) {
@@ -191,10 +192,13 @@ expectType<Ref<string>>(p2.obj.k)
     a: number
     b: Ref<number>
     c: number | string
+    readonly d: number
+    readonly e?: string | number
   } = {
     a: 1,
     b: ref(1),
-    c: 1
+    c: 1,
+    d: 3
   }
 
   // toRef
@@ -202,14 +206,28 @@ expectType<Ref<string>>(p2.obj.k)
   expectType<Ref<number>>(toRef(obj, 'b'))
   // Should not distribute Refs over union
   expectType<Ref<number | string>>(toRef(obj, 'c'))
+  // Should respect readonly properties
+  const d = toRef(obj, 'd')
+  expectType<Equals<Readonly<Ref<number>>, typeof d>>(true)
+  const e = toRef(obj, 'e')
+  expectType<Equals<Readonly<Ref<number | string | undefined>>, typeof e>>(true)
 
   // toRefs
-  expectType<{
-    a: Ref<number>
-    b: Ref<number>
-    // Should not distribute Refs over union
-    c: Ref<number | string>
-  }>(toRefs(obj))
+  const refs = toRefs(obj)
+  expectType<
+    Equals<
+      {
+        a: Ref<number>
+        b: Ref<number>
+        // Should not distribute Refs over union
+        c: Ref<number | string>
+        // Should respect readonly properties
+        d: Readonly<Ref<number>>
+        e?: Readonly<Ref<string | number | undefined>>
+      },
+      typeof refs
+    >
+  >(true)
 
   // Both should not do any unwrapping
   const someReactive = shallowReactive({
@@ -228,6 +246,12 @@ expectType<Ref<string>>(p2.obj.k)
   const props = { foo: 1 } as { foo: any }
   const { foo } = toRefs(props)
   expectType<Ref<any>>(foo)
+
+  // partially #5159
+  {
+    const ref = toRefs(readonly(reactive({ foo: 'foo' })))
+    expectType<Equals<{ foo: Readonly<Ref<string>> }, typeof ref>>(true)
+  }
 }
 
 // toRef default value


### PR DESCRIPTION
- emit `Readonly<Ref<T>>` appropriately depending on `readonly`
- add test helper `Equal` which can assert equality of `Readonly<T>` vs `T`