### PR TITLE
fix(types/reactivity): toRef(s) not respecting readonly properties (#5159)

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -5,7 +5,7 @@ import {
   triggerEffects
 } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
-import { isArray, hasChanged, IfAny } from '@vue/shared'
+import { isArray, hasChanged, IfAny, IfReadonlyKey } from '@vue/shared'
 import {
   isProxy,
   toRaw,
@@ -198,7 +198,9 @@ export function customRef<T>(factory: CustomRefFactory<T>): Ref<T> {
 }
 
 export type ToRefs<T = any> = {
-  [K in keyof T]: ToRef<T[K]>
+  -readonly [K in keyof T]: IfReadonlyKey<T, K> extends true
+    ? Readonly<ToRef<T[K]>>
+    : ToRef<T[K]>
 }
 export function toRefs<T extends object>(object: T): ToRefs<T> {
   if (__DEV__ && !isProxy(object)) {
@@ -235,7 +237,7 @@ export type ToRef<T> = IfAny<T, Ref<T>, [T] extends [Ref] ? T : Ref<T>>
 export function toRef<T extends object, K extends keyof T>(
   object: T,
   key: K
-): ToRef<T[K]>
+): IfReadonlyKey<T, K> extends true ? Readonly<ToRef<T[K]>> : ToRef<T[K]>
 
 export function toRef<T extends object, K extends keyof T>(
   object: T,

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -10,3 +10,15 @@ export type LooseRequired<T> = { [P in keyof (T & Required<T>)]: T[P] }
 // If the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
+
+// https://stackoverflow.com/a/52473108/3570903
+export type IfEquals<A1 extends any, A2 extends any> = (<A>() => A extends A2
+  ? true
+  : false) extends <A>() => A extends A1 ? true : false
+  ? true
+  : false
+
+export type IfReadonlyKey<O, K extends keyof O> = IfEquals<
+  { [L in K]: O[L] },
+  { readonly [L in K]: O[L] }
+>

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -17,3 +17,9 @@ export type IsUnion<T, U extends T = T> = (
   : true
 
 export type IsAny<T> = 0 extends 1 & T ? true : false
+
+export type Equals<A1 extends any, A2 extends any> = (<A>() => A extends A2
+  ? true
+  : false) extends <A>() => A extends A1 ? true : false
+  ? true
+  : false


### PR DESCRIPTION
- emit `Readonly<Ref<T>>` appropriately depending on `readonly`
- add test helper `Equal` which can assert equality of `Readonly<T>` vs `T`

----

This PR fixes the first example in #5159.

> ```ts
> const shouldHaveComputedRef = toRefs(readonly(reactive({ foo: 'foo' })))
> 
> // runtime warning, no TS error
> shouldHaveComputedRef.foo = 'bar'
> ```

This fix adds turn `readonly` properties into `Readonly<Ref>`.