### PR TITLE
dx(runtime-dom): warn when a style value ends in a semicolon

### DIFF
--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -87,6 +87,25 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.cssText).toBe('')
   })
 
+  it('should warn for trailing semicolons', () => {
+    const el = document.createElement('div')
+    patchProp(el, 'style', null, { color: 'red;' })
+    expect(
+      `Unexpected semicolon at the end of 'color' style value: 'red;'`
+    ).toHaveBeenWarned()
+
+    patchProp(el, 'style', null, { '--custom': '100; ' })
+    expect(
+      `Unexpected semicolon at the end of '--custom' style value: '100; '`
+    ).toHaveBeenWarned()
+  })
+
+  it('should not warn for escaped trailing semicolons', () => {
+    const el = document.createElement('div')
+    patchProp(el, 'style', null, { '--custom': '100\\;' })
+    expect(el.style.getPropertyValue('--custom')).toBe('100\\;')
+  })
+
   // JSDOM doesn't support custom properties on style object so we have to
   // mock it here.
   function mockElementWithStyle() {

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -1,5 +1,5 @@
 import { isString, hyphenate, capitalize, isArray } from '@vue/shared'
-import { camelize } from '@vue/runtime-core'
+import { camelize, warn } from '@vue/runtime-core'
 
 type Style = string | Record<string, string | string[]> | null
 
@@ -35,6 +35,7 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   }
 }
 
+const semicolonRE = /[^\\];\s*$/
 const importantRE = /\s*!important$/
 
 function setStyle(
@@ -46,6 +47,13 @@ function setStyle(
     val.forEach(v => setStyle(style, name, v))
   } else {
     if (val == null) val = ''
+    if (__DEV__) {
+      if (semicolonRE.test(val)) {
+        warn(
+          `Unexpected semicolon at the end of '${name}' style value: '${val}'`
+        )
+      }
+    }
     if (name.startsWith('--')) {
       // custom property definition
       style.setProperty(name, val)


### PR DESCRIPTION
This adds a warning when an object `style` value ends with a semicolon. e.g. `:style="{ color: 'red;' }"`.

When a value ends with a semicolon, the entire value gets discarded, with no apparent error or warning from the browser. If the style already has a previous value then that will be retained, leading to reports of 'reactivity' issues.

Typically when this has been reported on Vue Land it has been for complex values, such a gradients. Consider this example:

[SFC Playground](https://sfc.vuejs.org/#eNpNUsturDAM/RUrvdIwVwOkV+qGMr3qsv+QRQMYSEseSsJ0KsS/14G+JBY+xz7HjvHCHp0rLjOyitWh9cpFCBhn9yCM0s76CAu0Vrs5YncCjz2s0Hur4UCigzDCtNaESJkOzimf8eMP28j2dfB2Nin5ZZNlRzg/wCIMkCDO3iR1cZHTjIkD+A/PkzIofT542Sk0MfNDk/1ZvuvgL/y7u4MSbjlfT8DpO57gpu/74/3zblLB4YZzTjOuNFFd7q+jdxGIqN0kIxICeDKtRxkQ4qgCbPZV4mtlaF645Np2OJ0Fo+6CQXx3SMDMukFPWCtDkKdIXimiiQTbjOtOXaCdZAhEN/ZKJVWI71OSL793s5KgLqmaZHX5aziCm4DCggz2nTXWd+gruHVXCHZSHaR33qfUiGoYI6U4d9eN0dIPyuTRusR+km+qi+NP1bqtZ+vDTmz/7bmWrngJ1tBhbF3FZyIIVu1zJI6OIGHBxhhdqMoy9G06p5dQWD+UFBV+NlFpLDDovPH2LaAnY8GSBXVe2foBqTnV/A==)

I've already given away the punchline, the problem is the semicolon, but if you didn't already know, would that have been obvious? It might have been a misuse of `.value`, or a reactivity problem, or a mistake somewhere in the `linear-gradient()` syntax, or who knows what else?

Compounding the problem, if you tweak the code above to use ``:style="`background: ${background}`"`` it works fine. The semicolon is just treated as a delimiter and does no harm. This leads to the impression that it's a problem with Vue not handling the style object correctly.

We may not be able to fully validate all style values, but I think eliminating the semicolon problem would save a bit of frustration.

Browsers do allow semicolons at the end of style values, but as far as I'm aware this can only happen if they're escaped with a `\`. In practice I can't think of a legitimate use case for that, but I used custom properties to confirm that an escaped semicolon is retained, whereas an unescaped semicolon leads to the value being ignored. The RegExp in this PR will not match escaped semicolons.