### PR TITLE
chore(compat): change 'vnode-' to 'vue:' in event hooks warning

### DIFF
--- a/packages/runtime-core/src/compat/compatConfig.ts
+++ b/packages/runtime-core/src/compat/compatConfig.ts
@@ -207,8 +207,8 @@ export const deprecationData: Record<DeprecationTypes, DeprecationData> = {
   [DeprecationTypes.INSTANCE_EVENT_HOOKS]: {
     message: event =>
       `"${event}" lifecycle events are no longer supported. From templates, ` +
-      `use the "vnode" prefix instead of "hook:". For example, @${event} ` +
-      `should be changed to @vnode-${event.slice(5)}. ` +
+      `use the "vue:" prefix instead of "hook:". For example, @${event} ` +
+      `should be changed to @vue:${event.slice(5)}. ` +
       `From JavaScript, use Composition API to dynamically register lifecycle ` +
       `hooks.`,
     link: `https://v3-migration.vuejs.org/breaking-changes/vnode-lifecycle-events.html`


### PR DESCRIPTION
The compatibility warning for `@hook:` events currently recommends using the `@vnode-` prefix instead. However, the docs page linked in the warning message suggests using `@vue:`. I believe the latter is preferred.

There is a related PR in the migration guide repo: <https://github.com/vuejs/v3-migration-guide/pull/16>. That attempts to change the docs back to match the current warning. I believe it is the warning that should be changed rather than the docs, but either PR would make the two consistent.