### PR TITLE
fix(types): readonly is not respected in reactive / toRef(s)  (#5159)

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -5,7 +5,14 @@ import {
   triggerEffects
 } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
-import { isArray, hasChanged, IfAny } from '@vue/shared'
+import {
+  isArray,
+  hasChanged,
+  IfAny,
+  IsReadonlyKey,
+  MarkReadonly,
+  IsEqual
+} from '@vue/shared'
 import {
   isProxy,
   toRaw,
@@ -17,6 +24,7 @@ import {
 import type { ShallowReactiveMarker } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
 import { createDep, Dep } from './dep'
+import { ComputedRef } from './computed'
 
 declare const RefSymbol: unique symbol
 export declare const RawSymbol: unique symbol
@@ -198,7 +206,9 @@ export function customRef<T>(factory: CustomRefFactory<T>): Ref<T> {
 }
 
 export type ToRefs<T = any> = {
-  [K in keyof T]: ToRef<T[K]>
+  -readonly [K in keyof T]: IsReadonlyKey<T, K> extends true
+    ? Readonly<ToRef<T[K]>>
+    : ToRef<T[K]>
 }
 export function toRefs<T extends object>(object: T): ToRefs<T> {
   if (__DEV__ && !isProxy(object)) {
@@ -235,7 +245,7 @@ export type ToRef<T> = IfAny<T, Ref<T>, [T] extends [Ref] ? T : Ref<T>>
 export function toRef<T extends object, K extends keyof T>(
   object: T,
   key: K
-): ToRef<T[K]>
+): IsReadonlyKey<T, K> extends true ? Readonly<ToRef<T[K]>> : ToRef<T[K]>
 
 export function toRef<T extends object, K extends keyof T>(
   object: T,
@@ -305,7 +315,24 @@ export type UnwrapRefSimple<T> = T extends
   : T extends ReadonlyArray<any>
   ? { [K in keyof T]: UnwrapRefSimple<T[K]> }
   : T extends object & { [ShallowReactiveMarker]?: never }
-  ? {
-      [P in keyof T]: P extends symbol ? T[P] : UnwrapRef<T[P]>
-    }
+  ? MarkReadonly<
+      {
+        [P in keyof T]: P extends symbol ? T[P] : UnwrapRef<T[P]>
+      },
+      ReadonlyKeysAfterUnwrapRef<T>
+    >
   : T
+
+type ReadonlyKeysAfterUnwrapRef<T> = {
+  [K in keyof T]: IsReadonlyKey<T, K> extends true
+    ? K
+    : T[K] extends ComputedRef
+    ? K
+    : IsReadonlyRef<T[K]> extends true
+    ? K
+    : never
+}[keyof T]
+
+type IsReadonlyRef<T> = T extends Ref<infer U>
+  ? IsEqual<Readonly<Ref<U>>, T>
+  : false

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -10,3 +10,21 @@ export type LooseRequired<T> = { [P in keyof (T & Required<T>)]: T[P] }
 // If the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
+
+// https://stackoverflow.com/a/52473108/3570903
+export type IsEqual<A1 extends any, A2 extends any> = (<A>() => A extends A2
+  ? true
+  : false) extends <A>() => A extends A1 ? true : false
+  ? true
+  : false
+
+export type IsReadonlyKey<O, K extends keyof O> = IsEqual<
+  { [L in K]: O[L] },
+  { readonly [L in K]: O[L] }
+>
+
+export type MarkReadonly<O, K extends keyof O> = {
+  [L in keyof ({ [M in Exclude<keyof O, K>]: unknown } & {
+    readonly [M in K]: unknown
+  })]: O[L]
+}

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -17,3 +17,9 @@ export type IsUnion<T, U extends T = T> = (
   : true
 
 export type IsAny<T> = 0 extends 1 & T ? true : false
+
+export type Equals<A1 extends any, A2 extends any> = (<A>() => A extends A2
+  ? true
+  : false) extends <A>() => A extends A1 ? true : false
+  ? true
+  : false

--- a/test-dts/reactivity.test-d.ts
+++ b/test-dts/reactivity.test-d.ts
@@ -7,7 +7,9 @@ import {
   expectType,
   Ref,
   reactive,
-  markRaw
+  markRaw,
+  Equals,
+  computed
 } from './index'
 
 describe('should support DeepReadonly', () => {
@@ -70,4 +72,16 @@ describe('should unwrap tuple correctly', () => {
   const tuple: [Ref<number>] = [ref(0)]
   const reactiveTuple = reactive(tuple)
   expectType<Ref<number>>(reactiveTuple[0])
+})
+
+describe('should add readonly accordingly', () => {
+  test('readonly ref', () => {
+    const r = reactive({ foo: readonly(ref('foo')), bar: 3 })
+    expectType<Equals<{ readonly foo: string; bar: number }, typeof r>>(true)
+  })
+  test('computed ', () => {
+    // #5159
+    const r = reactive({ foo: computed(() => 'foo') })
+    expectType<Equals<{ readonly foo: string }, typeof r>>(true)
+  })
 })

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -1,4 +1,5 @@
 import {
+  computed,
   Ref,
   ref,
   shallowRef,
@@ -11,7 +12,8 @@ import {
   toRefs,
   ToRefs,
   shallowReactive,
-  readonly
+  readonly,
+  Equals
 } from './index'
 
 function plainType(arg: number | Ref<number>) {
@@ -191,10 +193,15 @@ expectType<Ref<string>>(p2.obj.k)
     a: number
     b: Ref<number>
     c: number | string
+    readonly d: number
+    readonly e?: string | number
+    f: Readonly<Ref<number>>
   } = {
     a: 1,
     b: ref(1),
-    c: 1
+    c: 1,
+    d: 3,
+    f: ref(3)
   }
 
   // toRef
@@ -202,14 +209,31 @@ expectType<Ref<string>>(p2.obj.k)
   expectType<Ref<number>>(toRef(obj, 'b'))
   // Should not distribute Refs over union
   expectType<Ref<number | string>>(toRef(obj, 'c'))
+  // Should respect readonly properties
+  const d = toRef(obj, 'd')
+  expectType<Equals<Readonly<Ref<number>>, typeof d>>(true)
+  const e = toRef(obj, 'e')
+  expectType<Equals<Readonly<Ref<number | string | undefined>>, typeof e>>(true)
+  const f = toRef(obj, 'f')
+  expectType<Equals<Readonly<Ref<number>>, typeof f>>(true)
 
   // toRefs
-  expectType<{
-    a: Ref<number>
-    b: Ref<number>
-    // Should not distribute Refs over union
-    c: Ref<number | string>
-  }>(toRefs(obj))
+  const refs = toRefs(obj)
+  expectType<
+    Equals<
+      {
+        a: Ref<number>
+        b: Ref<number>
+        // Should not distribute Refs over union
+        c: Ref<number | string>
+        // Should respect readonly properties
+        d: Readonly<Ref<number>>
+        e?: Readonly<Ref<string | number | undefined>>
+        f: Readonly<Ref<number>>
+      },
+      typeof refs
+    >
+  >(true)
 
   // Both should not do any unwrapping
   const someReactive = shallowReactive({
@@ -228,6 +252,20 @@ expectType<Ref<string>>(p2.obj.k)
   const props = { foo: 1 } as { foo: any }
   const { foo } = toRefs(props)
   expectType<Ref<any>>(foo)
+
+  // #5159
+  {
+    const r = toRefs(readonly(reactive({ foo: 'foo' })))
+    expectType<Equals<{ foo: Readonly<Ref<string>> }, typeof r>>(true)
+  }
+  {
+    const r = toRefs(reactive({ foo: readonly(ref('foo')) }))
+    expectType<Equals<{ foo: Readonly<Ref<string>> }, typeof r>>(true)
+  }
+  {
+    const r = toRefs(reactive({ foo: computed(() => 'foo') }))
+    expectType<Equals<{ foo: Readonly<Ref<string>> }, typeof r>>(true)
+  }
 }
 
 // toRef default value


### PR DESCRIPTION
- emit `Readonly<Ref<T>>` accordingly in `toRef(s)`
- emit `readonly [key]: value` accordingly in `reactive`
- add test helper `Equals` which assert equality of `Readonly<T>` vs `T`

fixes #5159