### PR TITLE
fix(watch): for immediate watch with single source, ensure cb is called with undefined as oldValue (fix: #7074)

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -745,7 +745,7 @@ describe('api: watch', () => {
     const state = ref()
     const spy = jest.fn()
     watch(() => state.value, spy, { immediate: true })
-    expect(spy).toHaveBeenCalled()
+    expect(spy).toHaveBeenCalledWith(undefined, undefined, expect.any(Function))
     state.value = 3
     await nextTick()
     expect(spy).toHaveBeenCalledTimes(2)

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -333,10 +333,11 @@ function doWatch(
         callWithAsyncErrorHandling(cb, instance, ErrorCodes.WATCH_CALLBACK, [
           newValue,
           // pass undefined as the old value when it's changed for the first time
-          oldValue === INITIAL_WATCHER_VALUE ||
-          (isMultiSource && oldValue[0] === INITIAL_WATCHER_VALUE)
-            ? []
-            : oldValue,
+          oldValue === INITIAL_WATCHER_VALUE 
+            ? undefined
+            : (isMultiSource && oldValue[0] === INITIAL_WATCHER_VALUE)
+              ? []
+              : oldValue,
           onCleanup
         ])
         oldValue = newValue


### PR DESCRIPTION
23e85e21a50926c48dea4f978e212e4301c20037 introduced a regression, this PR fixes it.
fix: #7074