### PR TITLE
test(compiler-core): add test for identifier collision

### DIFF
--- a/packages/compiler-sfc/__tests__/rewriteDefault.spec.ts
+++ b/packages/compiler-sfc/__tests__/rewriteDefault.spec.ts
@@ -149,6 +149,18 @@ describe('compiler sfc: rewriteDefault', () => {
     export { bar,    } from './index.js'
     const script = foo"
     `)
+
+    expect(
+      rewriteDefault(
+        `export { foo as default } from './index.js' \n const foo = 1`,
+        'script'
+      )
+    ).toMatchInlineSnapshot(`
+    "import { foo } from './index.js'
+    export {  } from './index.js' 
+     const foo = 1
+    const script = foo"
+    `)
   })
 
   test('export default class', async () => {


### PR DESCRIPTION
We do not use local alias when we rewrite `export { foo as default } ...` to `import { foo } ...`, this could result in identifier collision.

Depends on #7608 as it changes rewrite logic.

@sxzz maybe you can pull this in your PR.