### PR TITLE
test(runtime-dom): avoid dispatchEvent and bindEvent in the same loop

### DIFF
--- a/packages/runtime-dom/__tests__/patchEvents.spec.ts
+++ b/packages/runtime-dom/__tests__/patchEvents.spec.ts
@@ -160,6 +160,9 @@ describe(`runtime-dom: events patching`, () => {
       childFn()
       patchProp(el, 'onClick', null, parentFn)
     })
+
+    // avoid dispatchEvent and bindEvent in the same loop
+    await timeout()
     child.dispatchEvent(new Event('click', { bubbles: true }))
 
     await timeout()


### PR DESCRIPTION
Refer to: https://github.com/vuejs/core/actions/runs/3458391480/jobs/5772768354

In test:

```ts
patchProp(child, 'onClick', null, () => {
  childFn()
  patchProp(el, 'onClick', null, parentFn)
})
child.dispatchEvent(new Event('click', { bubbles: true }))
```

The above code (including the event handler) is executed in the same loop in nodejs.

Because use the same timestamp for all event listeners attached in the same tick in `createInvoker`. 
The attached timestamp of `parentFn` event will be earlier than the bubble event.
So the `parentFn`  will have been called.

To avoid unstable tests, move dispatchEvent to next loop.

