### PR TITLE
build: fs.exists is deprecated

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -128,7 +128,7 @@ async function build(target) {
     if (extractorResult.succeeded) {
       // concat additional d.ts to rolled-up dts
       const typesDir = path.resolve(pkgDir, 'types')
-      if (await fs.exists(typesDir)) {
+      if (fs.existsSync(typesDir)) {
         const dtsPath = path.resolve(pkgDir, pkg.types)
         const existing = await fs.readFile(dtsPath, 'utf-8')
         const typeFiles = await fs.readdir(typesDir)


### PR DESCRIPTION
replace `fs.exists` with `fs.existsSync`

Signed-off-by: JayFate <37610029@qq.com>