### PR TITLE
feat: 令`componentName("/**/dirName/Index.vue") = dirName.capitalize()`

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -992,7 +992,7 @@ export function formatComponentName(
     if (match) {
       if(match?.at(4) === "Index"){
         const dirName = match?.at(2)
-        name = dirName?.charAt(0)?.toUpperCase() + dirName?.slice(1)
+        name = dirName!!.charAt(0).toUpperCase() + dirName!!.slice(1)
       } else {
         name = match?.at(4)
       }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -988,9 +988,14 @@ export function formatComponentName(
 ): string {
   let name = getComponentName(Component)
   if (!name && Component.__file) {
-    const match = Component.__file.match(/([^/\\]+)\.\w+$/)
+    const match = Component.__file.match(/(\/(\w+))?(\/(\w+))\.\w+$/)
     if (match) {
-      name = match[1]
+      if(match?.length == 5 && match?.at(4) === "Index"){
+        const dirName = match?.at(2)
+        name = dirName.charAt(0).toUpperCase() + dirName.slice(1)
+      }else{
+        name = match[2]
+      }
     }
   }
 

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -992,7 +992,7 @@ export function formatComponentName(
     if (match) {
       if(match?.at(4) === "Index"){
         const dirName = match?.at(2)
-        name = dirName.charAt(0).toUpperCase() + dirName.slice(1)
+        name = dirName?.charAt(0)?.toUpperCase() + dirName?.slice(1)
       } else {
         name = match?.at(4)
       }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -990,11 +990,11 @@ export function formatComponentName(
   if (!name && Component.__file) {
     const match = Component.__file.match(/(\/(\w+))?(\/(\w+))\.\w+$/)
     if (match) {
-      if(match?.length == 5 && match?.at(4) === "Index"){
+      if(match?.at(4) === "Index"){
         const dirName = match?.at(2)
         name = dirName.charAt(0).toUpperCase() + dirName.slice(1)
-      }else{
-        name = match[2]
+      } else {
+        name = match?.at(4)
       }
     }
   }


### PR DESCRIPTION
较复杂的组件，通常一个目录下会包含多个"*.vue"文件，建议根组件使用“Index.vue”命名，更直观些。比如，实现九九乘法表，可以分成两个组件，目录结构如下：
```
/multiplicationTable
|--  /Index.vue
|-- /Item.vue
```
但，组件名称却是"Index"。
 修改后的代码，可以让默认的组件名称是上一级的目录名"MultiplicationTable"。

测试代码如下：
```
test("file path match", ()=>{
    const regex = /(\/(\w+))?(\/(\w+))\.\w+$/
    const matchNestedDir = "/components/multiplicationTable/Index.vue".match(regex)
    expect(matchNestedDir?.at(2)).toBe("multiplicationTable")
    expect(matchNestedDir?.at(4)).toBe("Index")
    expect(matchNestedDir?.length).toBe(5)

    const matchDir = "/components/multiplicationTable/multiplicationTable.vue".match(regex)
    expect(matchDir?.at(2)).toBe("multiplicationTable")
    expect(matchDir?.at(4)).toBe("multiplicationTable")
    expect(matchDir?.length).toBe(5)
})
```
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/7019517/202153388-98eaa24c-ebae-4a7e-b46c-2a4191c21c80.png">


