### PR TITLE
fix(hmr): fix the page not updating when using computed value as slot…

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -15,9 +15,14 @@ import {
   blockStack
 } from './vnode'
 import { handleError, ErrorCodes } from './errorHandling'
-import { PatchFlags, ShapeFlags, isOn, isModelListener } from '@vue/shared'
+import {
+  PatchFlags,
+  ShapeFlags,
+  isOn,
+  isModelListener,
+  isHmrUpdating
+} from '@vue/shared'
 import { warn } from './warning'
-import { isHmrUpdating } from './hmr'
 import { NormalizedProps } from './componentProps'
 import { isEmitListener } from './componentEmits'
 import { setCurrentRenderingInstance } from './componentRenderContext'

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -13,12 +13,12 @@ import {
   ShapeFlags,
   extend,
   def,
-  SlotFlags
+  SlotFlags,
+  isHmrUpdating
 } from '@vue/shared'
 import { warn } from './warning'
 import { isKeepAlive } from './components/KeepAlive'
 import { ContextualRenderFn, withCtx } from './componentRenderContext'
-import { isHmrUpdating } from './hmr'
 import { DeprecationTypes, isCompatEnabled } from './compat/compatConfig'
 import { toRaw } from '@vue/reactivity'
 

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -9,9 +9,8 @@ import {
   traverseStaticChildren
 } from '../renderer'
 import { VNode, VNodeArrayChildren, VNodeProps } from '../vnode'
-import { isString, ShapeFlags } from '@vue/shared'
+import { isHmrUpdating, isString, ShapeFlags } from '@vue/shared'
 import { warn } from '../warning'
-import { isHmrUpdating } from '../hmr'
 
 export type TeleportVNode = VNode<RendererNode, RendererElement, TeleportProps>
 

--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -8,11 +8,9 @@ import {
   isClassComponent
 } from './component'
 import { queueJob, queuePostFlushCb } from './scheduler'
-import { extend, getGlobalThis } from '@vue/shared'
+import { extend, getGlobalThis, setHmrUpdating } from '@vue/shared'
 
 type HMRComponent = ComponentOptions | ClassComponent
-
-export let isHmrUpdating = false
 
 export const hmrDirtyComponents = new Set<ConcreteComponent>()
 
@@ -92,9 +90,9 @@ function rerender(id: string, newRender?: Function) {
     }
     instance.renderCache = []
     // this flag forces child components with slot content to update
-    isHmrUpdating = true
+    setHmrUpdating(true)
     instance.update()
-    isHmrUpdating = false
+    setHmrUpdating(false)
   })
 }
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -35,7 +35,8 @@ import {
   NOOP,
   invokeArrayFns,
   isArray,
-  getGlobalThis
+  getGlobalThis,
+  isHmrUpdating
 } from '@vue/shared'
 import {
   queueJob,
@@ -58,7 +59,7 @@ import {
 } from './components/Suspense'
 import { TeleportImpl, TeleportVNode } from './components/Teleport'
 import { isKeepAlive, KeepAliveContext } from './components/KeepAlive'
-import { registerHMR, unregisterHMR, isHmrUpdating } from './hmr'
+import { registerHMR, unregisterHMR } from './hmr'
 import { createHydrationFunctions, RootHydrateFunction } from './hydration'
 import { invokeDirectiveHook } from './directives'
 import { startMeasure, endMeasure } from './profiling'

--- a/packages/shared/src/hmr.ts
+++ b/packages/shared/src/hmr.ts
@@ -1,0 +1,2 @@
+export let isHmrUpdating = false
+export const setHmrUpdating = (v: boolean) => (isHmrUpdating = v)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,6 +13,7 @@ export * from './escapeHtml'
 export * from './looseEqual'
 export * from './toDisplayString'
 export * from './typeUtils'
+export * from './hmr'
 
 export const EMPTY_OBJ: { readonly [key: string]: any } = __DEV__
   ? Object.freeze({})


### PR DESCRIPTION
… (#7155)

fix #7155 

I found that there are component libraries (e.g. [here)](https://github.com/primefaces/primevue/blob/bafec4b8fb81e760e4a58a1847aeacc329b43583/src/components/tabview/TabView.vue#L335-L349) that render component slots by computed wrapping and then rendering them dynamically in the template. This can lead to a situation where HMR does not cause the page to update when the user changes the template content.