### PR TITLE
dx(runtime-core): warn when expose() is misused

### DIFF
--- a/packages/runtime-core/__tests__/apiExpose.spec.ts
+++ b/packages/runtime-core/__tests__/apiExpose.spec.ts
@@ -225,4 +225,43 @@ describe('api: expose', () => {
     expect(grandChildRef.value.$parent).toBe(childRef.value)
     expect(grandChildRef.value.$parent.$parent).toBe(grandChildRef.value.$root)
   })
+
+  test('warning for ref', () => {
+    const Comp = defineComponent({
+      setup(_, { expose }) {
+        expose(ref(1))
+        return () => null
+      }
+    })
+    render(h(Comp), nodeOps.createElement('div'))
+    expect(
+      'expose() should be passed a plain object, received ref'
+    ).toHaveBeenWarned()
+  })
+
+  test('warning for array', () => {
+    const Comp = defineComponent({
+      setup(_, { expose }) {
+        expose(['focus'])
+        return () => null
+      }
+    })
+    render(h(Comp), nodeOps.createElement('div'))
+    expect(
+      'expose() should be passed a plain object, received array'
+    ).toHaveBeenWarned()
+  })
+
+  test('warning for function', () => {
+    const Comp = defineComponent({
+      setup(_, { expose }) {
+        expose(() => null)
+        return () => null
+      }
+    })
+    render(h(Comp), nodeOps.createElement('div'))
+    expect(
+      'expose() should be passed a plain object, received function'
+    ).toHaveBeenWarned()
+  })
 })

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -1,5 +1,6 @@
 import { VNode, VNodeChild, isVNode } from './vnode'
 import {
+  isRef,
   pauseTracking,
   resetTracking,
   shallowReadonly,
@@ -47,6 +48,7 @@ import {
 } from './componentEmits'
 import {
   EMPTY_OBJ,
+  isArray,
   isFunction,
   NOOP,
   isObject,
@@ -913,8 +915,25 @@ export function createSetupContext(
   instance: ComponentInternalInstance
 ): SetupContext {
   const expose: SetupContext['expose'] = exposed => {
-    if (__DEV__ && instance.exposed) {
-      warn(`expose() should be called only once per setup().`)
+    if (__DEV__) {
+      if (instance.exposed) {
+        warn(`expose() should be called only once per setup().`)
+      }
+      if (exposed != null) {
+        let exposedType: string = typeof exposed
+        if (exposedType === 'object') {
+          if (isArray(exposed)) {
+            exposedType = 'array'
+          } else if (isRef(exposed)) {
+            exposedType = 'ref'
+          }
+        }
+        if (exposedType !== 'object') {
+          warn(
+            `expose() should be passed a plain object, received ${exposedType}.`
+          )
+        }
+      }
     }
     instance.exposed = exposed || {}
   }


### PR DESCRIPTION
This PR adds a warning when invalid values are passed to `expose()` or `defineExpose()`.

Passing a `ref` directly to `defineExpose()` doesn't work, at least not in dev mode. The template ref on the setup proxy is replaced by the exposed ref, rather than having its value updated. This leads to the confusing scenario where the Vue Devtools show the correct value in the parent, even though the internal ref hasn't actually updated:

[Playground example](https://sfc.vuejs.org/#__DEV__eNqFkctugzAQRX9l5A1EIvY+IpGqqstuqi69oTAUUmNbtiGNIv69Yx5tlEiNxIJ5Hc/ce2FP1vKhR7ZjuS9dawN4DL09SN121rgAF3BYZ3AqQtnACLUzHSQ0kfx2vJ6fm1ZVS4mLJY5YapK6NNoH6M5vWMM+0lLdK7WJJSHgvWk90KdxQAdloRRWUk/PpdNMBukG9geIGKOQK/OZJvM6J+O+sEqyGc6HQvW4IXAu5lvoCgoCdlYVASkCyNdtaY+9ZNOgZCComIurTpax+bxtV1h+9EaTRJdIkEvBS7aDKRNzdGyMJWtCsH4nhK/LqMDRc+M+Bf1x1+vQdsjRd9sPZ04eHYEly64YgpKkw9ahrtCh+49503rHjdhR6pFOubLkgdM3Fq/ulXH8z8DJvArrVuPLtzUe07XhgfpVOyzKrwOSHabdckG1OxfGH8Wt62c=)

One reason why people pass a ref to `defineExpose()` directly is because they think they just need to pass the things they want to expose. A common example of this involves trying to expose a function:

```js
const focus = () => { ... }
defineExpose(focus)
```

This should be `defineExpose({ focus })`, but this isn't necessarily obvious to someone who isn't used to using it. The code above does actually work, sort of, in that the function is used as the exposed instance and can be invoked, e.g. via `childRef.value()`. But this kind of usage isn't intended.

Another common misunderstanding is to think that `defineExpose()` works like the `expose` option, with an array of property names. e.g.:

```js
defineExpose(['focus', 'blur', 'reset'])
```

This will use the array as the exposed instance, so theoretically items in the array can be accessed using `childRef.value[0]`, etc., but again I don't believe this is intended usage and it is almost certainly being done in error.

None of the three cases described above are caught by TS checks.