### PR TITLE
fix(compiler/runtime-dom): firefox do not support regexp flag `s`

### DIFF
--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -38,6 +38,23 @@ test('should work with style comment', () => {
   expect(result.code).toMatch(`{"width":"300px","height":"100px"}`)
 })
 
+// #7267
+test('should work with style comment', () => {
+  const source = `
+  <div style="
+    /* noth
+    ing */
+    width: 300px;
+    height: 100px/* nothing */
+    ">{{ render }}</div>
+  `
+
+  const result = compile({ filename: 'example.vue', source })
+  expect(result.errors.length).toBe(0)
+  expect(result.source).toBe(source)
+  expect(result.code).toMatch(`{"width":"300px","height":"100px"}`)
+})
+
 test('preprocess pug', () => {
   const template = parse(
     `

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -28,7 +28,7 @@ export function normalizeStyle(
 
 const listDelimiterRE = /;(?![^(]*\))/g
 const propertyDelimiterRE = /:([^]+)/
-const styleCommentRE = /\/\*(\n|.)*?\*\//g
+const styleCommentRE = /\/\*[\s\S]*?\*\//g
 
 export function parseStringStyle(cssText: string): NormalizedStyle {
   const ret: NormalizedStyle = {}

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -28,7 +28,7 @@ export function normalizeStyle(
 
 const listDelimiterRE = /;(?![^(]*\))/g
 const propertyDelimiterRE = /:([^]+)/
-const styleCommentRE = /\/\*.*?\*\//gs
+const styleCommentRE = /\/\*(\n|.)*?\*\//g
 
 export function parseStringStyle(cssText: string): NormalizedStyle {
   const ret: NormalizedStyle = {}


### PR DESCRIPTION
Fix #7267 

Related to #6808 #3917

[Playground](https://deploy-preview-7268--vue-sfc-playground.netlify.app/#eNqljr1Ow0AQhF9lucYg5XyCAlDkRKLjDWiuMfY6Mbqf1d7ZkWX53Vk7CCEoKWdmd76Z1QtROQ6o9qpKDfeUIWEe6GhD7ylyhhkYO1ig4+ihkNPCBhuaGFIGn05wWPPb4hWdi/AW2bU3xZ0NlbnWSZGIjJ5cnVEUQHW+P87z9rwslRG1uX2gIcOofWzRHayS3CqJKvP9rXbqukr7msqPFIPsntdv+xUkq/awOasna1dt1TlnSntjWiQXJ02MY48X/fTw+Ky1XOnUNVoY04njENoyYHZ9N5U1kZG45CHk3mOJyet3jpeELHirdj9IRswRWTOGFhn5/+RfhX/oK3yxYVHLJ2Y3nyI=)