### PR TITLE
fix(compiler-sfc): compatible with regexp flag `s` in Firefox 72

### DIFF
--- a/packages/compiler-sfc/src/rewriteDefault.ts
+++ b/packages/compiler-sfc/src/rewriteDefault.ts
@@ -2,7 +2,7 @@ import { parse, ParserPlugin } from '@babel/parser'
 import MagicString from 'magic-string'
 
 const defaultExportRE = /((?:^|\n|;)\s*)export(\s*)default/
-const namedDefaultExportRE = /((?:^|\n|;)\s*)export(.+)(?:as)?(\s*)default/s
+const namedDefaultExportRE = /((?:^|\n|;)\s*)export((.|\n)+)(?:as)?(\s*)default/
 const exportDefaultClassRE =
   /((?:^|\n|;)\s*)export\s+default\s+class\s+([\w$]+)/
 


### PR DESCRIPTION
Fix #7267 

Related to #3917