### PR TITLE
fix(reactivity-transform): semicolon after statements with nested destructure

### DIFF
--- a/packages/reactivity-transform/__tests__/__snapshots__/reactivityTransform.spec.ts.snap
+++ b/packages/reactivity-transform/__tests__/__snapshots__/reactivityTransform.spec.ts.snap
@@ -159,11 +159,13 @@ exports[`nested destructure 1`] = `
 "import { toRef as _toRef } from 'vue'
 
     let __$temp_1 = (useFoo()),
-  b = _toRef(__$temp_1[0].a, 'b');
+  b = _toRef(__$temp_1[0].a, 'b'),
+  n = _toRef(__$temp_1[0].z, 'n');
     let __$temp_2 = (useBar()),
   d = _toRef(__$temp_2.c, 0),
-  e = _toRef(__$temp_2.c, 1);
-    console.log(b.value, d.value, e.value)
+  e = _toRef(__$temp_2.c, 1),
+  h = _toRef(__$temp_2.f, 0);
+    console.log(b.value, d.value, e.value, h.value, n.value)
     "
 `;
 

--- a/packages/reactivity-transform/__tests__/reactivityTransform.spec.ts
+++ b/packages/reactivity-transform/__tests__/reactivityTransform.spec.ts
@@ -281,14 +281,16 @@ test('array destructure', () => {
 
 test('nested destructure', () => {
   const { code, rootRefs } = transform(`
-    let [{ a: { b }}] = $(useFoo())
-    let { c: [d, e] } = $(useBar())
-    console.log(b, d, e)
+    let [{ a: { b }, z: { n }}] = $(useFoo())
+    let { c: [d, e], f: [h] } = $(useBar())
+    console.log(b, d, e, h, n)
     `)
   expect(code).toMatch(`b = _toRef(__$temp_1[0].a, 'b')`)
+  expect(code).toMatch(`n = _toRef(__$temp_1[0].z, 'n')`)
   expect(code).toMatch(`d = _toRef(__$temp_2.c, 0)`)
   expect(code).toMatch(`e = _toRef(__$temp_2.c, 1)`)
-  expect(rootRefs).toStrictEqual(['b', 'd', 'e'])
+  expect(code).toMatch(`h = _toRef(__$temp_2.f, 0)`)
+  expect(rootRefs).toStrictEqual(['b', 'n', 'd', 'e', 'h'])
   assertCode(code)
 })
 

--- a/packages/reactivity-transform/src/reactivityTransform.ts
+++ b/packages/reactivity-transform/src/reactivityTransform.ts
@@ -343,8 +343,10 @@ export function transformAST(
         registerRefBinding(id, isConst)
       } else if (id.type === 'ObjectPattern') {
         processRefObjectPattern(id, call, isConst)
+        s.appendLeft(call.end! + offset, ';')
       } else if (id.type === 'ArrayPattern') {
         processRefArrayPattern(id, call, isConst)
+        s.appendLeft(call.end! + offset, ';')
       }
     } else {
       // shorthands
@@ -451,9 +453,6 @@ export function transformAST(
         )
       }
     }
-    if (nameId) {
-      s.appendLeft(call.end! + offset, ';')
-    }
   }
 
   function processRefArrayPattern(
@@ -501,9 +500,6 @@ export function transformAST(
           )}(${source}, ${i}${defaultStr})`
         )
       }
-    }
-    if (nameId) {
-      s.appendLeft(call.end! + offset, ';')
     }
   }
 


### PR DESCRIPTION
[This commit](https://github.com/vuejs/core/pull/6303) adds a new semicolon after the reactivity-transform statements, but there may be problems with the nested destructure, here's a [demo](https://sfc.vuejs.org/#eNpFT8tuwzAM+xVB2CEFXOcedAO2w36iziHJ1CZF/IDlbMAM//tkZG11IiGKIjO+h6C/N8IOTzzFJSRgSlt4Mw5kVkpwzjB0kGGEouC3Igel9PAKL83G9Ol9czg85RmmDs5fCqhXcBE491Du4o8hPsSTd+xX0qu/NqOCeqFgVuBkf2r3MBJDSCIb1iHRztoHRYWLDT6mox2CvrF3UiNXd/O/YIMSeP9nUHpWbnBOKXDXtnyZavkbax+vrSAdN5cWS5rYHsfof5iiGBusFsW4guUPQqFitg==)

<img width="617" alt="image" src="https://user-images.githubusercontent.com/12960906/205825336-7481f0f4-9261-457d-aa40-0ffa145e3ec7.png">
