### PR TITLE
build: use git default short commit-id

### DIFF
--- a/packages/sfc-playground/vite.config.ts
+++ b/packages/sfc-playground/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import execa from 'execa'
 
-const commit = execa.sync('git', ['rev-parse', 'HEAD']).stdout.slice(0, 7)
+const commit = execa.sync('git', ['rev-parse', '--short', 'HEAD']).stdout
 
 export default defineConfig({
   plugins: [vue(), copyVuePlugin()],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -38,7 +38,7 @@ const prodOnly = !devOnly && (args.prodOnly || args.p)
 const sourceMap = args.sourcemap || args.s
 const isRelease = args.release
 const buildAllMatching = args.all || args.a
-const commit = execa.sync('git', ['rev-parse', 'HEAD']).stdout.slice(0, 7)
+const commit = execa.sync('git', ['rev-parse', '--short', 'HEAD']).stdout
 
 run()
 


### PR DESCRIPTION
before

```js
console.log(`commit`, commit)
# commit fe77e2b
```

after

```js
console.log(`commit`, commit)
# commit fe77e2bd
```