### PR TITLE
types: export `UnwrapRefSimple`, emit typecheck, markRaw/toReadonly return types improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ TODOs.md
 *.log
 .idea
 .eslintcache
+.types

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -12,6 +12,7 @@ export {
   ToRef,
   ToRefs,
   UnwrapRef,
+  UnwrapRefSimple,
   ShallowRef,
   ShallowUnwrapRef,
   RefUnwrapBailTypes,

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -236,7 +236,7 @@ export function isProxy(value: unknown): boolean {
   return isReactive(value) || isReadonly(value)
 }
 
-export function toRaw<T>(observed: T): T {
+export function toRaw<T>(observed: T): Raw<T> {
   const raw = observed && (observed as Target)[ReactiveFlags.RAW]
   return raw ? toRaw(raw) : observed
 }
@@ -251,5 +251,9 @@ export function markRaw<T extends object>(value: T): Raw<T> {
 export const toReactive = <T extends unknown>(value: T): T =>
   isObject(value) ? reactive(value) : value
 
-export const toReadonly = <T extends unknown>(value: T): T =>
-  isObject(value) ? readonly(value as Record<any, any>) : value
+export function toReadonly<T extends unknown>(
+  value: T
+): T extends Record<any, any> ? DeepReadonly<UnwrapNestedRefs<T>> : T
+export function toReadonly<T extends unknown>(value: T) {
+  return isObject(value) ? readonly(value) : value
+}

--- a/test-dts/reactivity.test-d.ts
+++ b/test-dts/reactivity.test-d.ts
@@ -71,3 +71,14 @@ describe('should unwrap tuple correctly', () => {
   const reactiveTuple = reactive(tuple)
   expectType<Ref<number>>(reactiveTuple[0])
 })
+
+// export checks
+export default {
+  a: reactive({}),
+  b: shallowReadonly({}),
+  c: markRaw({ a: 1 }),
+
+  d: <T extends object>(a: T) => reactive(a),
+
+  e: () => reactive({ test: markRaw({ a: 1 }) })
+}

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -319,3 +319,20 @@ describe('reactive in shallow ref', () => {
 
   expectType<number>(x.value.a.b)
 })
+
+// export checks
+export default {
+  // regular ref
+  a: ref(1),
+  // shallow
+  b: shallowRef(1),
+
+  // Generic Ref
+  c: <T>(a: T) => ref(a),
+
+  // #7278
+  d: function useFilter<T>() {
+    const data = ref<T[]>([])
+    return { data }
+  }
+}

--- a/test-dts/tsconfig.build.json
+++ b/test-dts/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "noEmit": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationDir": "./.types",
     "jsx": "preserve",
     "module": "esnext",
     "strict": true,


### PR DESCRIPTION
Fixes #7278 

> Note: This has 3 different commit messages:
- types(ref): fix ref<T>() when emitting types
- types(toRaw): fix returning type to Raw<T>
- types(toReadonly): make returning type Readonly


Added a declaration emit step to our types, to prevent regression on #7278.


Noticed the `markRaw({}` gives an error, the error makes sense but I don't know what should be the fix for it:
```ts
import { markRaw } from 'vue'

// error here, because the type is just { [RawSymbol]?: true }
export const a = markRaw({})

export const b = markRaw({
  a: 1
})
```
[playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbziAhlA1gJRQdzgXzgDMoIQ4ByANwFcBTCgWACgWB6NuOqUqOAC250ANHABGdAMYoaAZzpwYgxQE8wC4LLgArOfCQBtbDgDKKkGIgAbALoB+AFyKo9AizoAPSLDiSIAO1l4FDgAXmQ0LFwACgR8AEoWdy9oeD9A+DEwiIxjWJY4OBQnAEYWBJYgA)