### PR TITLE
fix(runtime-core): fix suspense crash when patch non-resolved async setup component

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -864,7 +864,7 @@ describe('SSR hydration', () => {
 
     const AsyncComp = {
       async setup() {
-        await new Promise<void>(r => r())
+        await new Promise<void>(r => setTimeout(r, 10))
         return () => h('h1', 'Async component')
       }
     }
@@ -921,9 +921,7 @@ describe('SSR hydration', () => {
     container.innerHTML = html
     createSSRApp(App).mount(container)
 
-    await new Promise<void>(resolve => {
-      setTimeout(resolve, 0)
-    })
+    await new Promise(r => setTimeout(r, 10))
 
     expect(toggle.value).toBe(false)
 
@@ -938,7 +936,7 @@ describe('SSR hydration', () => {
 
     const AsyncComp = {
       async setup() {
-        await new Promise<void>(r => r())
+        await new Promise<void>(r => setTimeout(r, 10))
         return () => h('h1', 'Async component')
       }
     }
@@ -992,9 +990,7 @@ describe('SSR hydration', () => {
     container.innerHTML = html
     createSSRApp(App).mount(container)
 
-    await new Promise<void>(resolve => {
-      setTimeout(resolve, 0)
-    })
+    await new Promise(r => setTimeout(r, 10))
 
     expect(toggle.value).toBe(false)
 

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -812,17 +812,17 @@ describe('SSR hydration', () => {
         })
     )
 
-    const bol = ref(true)
+    const toggle = ref(true)
     const App = {
       setup() {
         onMounted(() => {
           // change state, this makes updateComponent(AsyncComp) execute before
           // the async component is resolved
-          bol.value = false
+          toggle.value = false
         })
 
         return () => {
-          return [bol.value ? 'hello' : 'world', h(AsyncComp)]
+          return [toggle.value ? 'hello' : 'world', h(AsyncComp)]
         }
       }
     }
@@ -860,14 +860,12 @@ describe('SSR hydration', () => {
   })
 
   test('hydrate safely when property used by async setup changed before render', async () => {
-    // let serverResolve: any
+    const toggle = ref(true)
 
     const AsyncComp = {
       async setup() {
         await new Promise<void>(r => r())
-        return () => {
-          return h('h1', 'Async component')
-        }
+        return () => h('h1', 'Async component')
       }
     }
 
@@ -879,53 +877,45 @@ describe('SSR hydration', () => {
 
     const SiblingComp = {
       setup() {
-        return () => {
-          bol.value = false
-          return h('span')
-        }
+        toggle.value = false
+        return () => h('span')
       }
     }
 
-    const bol = ref(true)
-
     const App = {
       setup() {
-        return () => {
-          return [
-            h(
-              Suspense,
-              {},
-              {
-                default: () => {
-                  return [
-                    h('main', {}, [
-                      h(AsyncWrapper, { prop: bol.value ? 'hello' : 'world' }),
-                      h(SiblingComp)
-                    ])
-                  ]
-                }
-              }
-            )
-          ]
-        }
+        return () =>
+          h(
+            Suspense,
+            {},
+            {
+              default: () => [
+                h('main', {}, [
+                  h(AsyncWrapper, {
+                    prop: toggle.value ? 'hello' : 'world'
+                  }),
+                  h(SiblingComp)
+                ])
+              ]
+            }
+          )
       }
     }
 
     // server render
-
     const html = await renderToString(h(App))
 
     expect(html).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="hello">Async component</h1><span></span></main><!--]-->"`
+      `"<main><h1 prop="hello">Async component</h1><span></span></main>"`
     )
 
-    expect(bol.value).toBe(false)
+    expect(toggle.value).toBe(false)
 
     // hydration
 
     // reset the value
-    bol.value = true
-    expect(bol.value).toBe(true)
+    toggle.value = true
+    expect(toggle.value).toBe(true)
 
     const container = document.createElement('div')
     container.innerHTML = html
@@ -935,89 +925,68 @@ describe('SSR hydration', () => {
       setTimeout(resolve, 0)
     })
 
-    expect(bol.value).toBe(false)
+    expect(toggle.value).toBe(false)
 
     // should be hydrated now
-    // expect(`Hydration node mismatch`).toHaveBeenWarned()
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="world">Async component</h1><span></span></main><!--]-->"`
+      `"<main><h1 prop="world">Async component</h1><span></span></main>"`
     )
   })
 
   test('hydrate safely when property used by deep nested async setup changed before render', async () => {
-    // let serverResolve: any
+    const toggle = ref(true)
 
     const AsyncComp = {
       async setup() {
         await new Promise<void>(r => r())
-        return () => {
-          return h('h1', 'Async component')
-        }
+        return () => h('h1', 'Async component')
       }
     }
 
-    const AsyncWrapper = {
-      render() {
-        return h(AsyncComp)
-      }
-    }
-    const AsyncWrapperWrapper = {
-      render() {
-        return h(AsyncWrapper)
-      }
-    }
+    const AsyncWrapper = { render: () => h(AsyncComp) }
+    const AsyncWrapperWrapper = { render: () => h(AsyncWrapper) }
 
     const SiblingComp = {
       setup() {
-        return () => {
-          bol.value = false
-          return h('span')
-        }
+        toggle.value = false
+        return () => h('span')
       }
     }
 
-    const bol = ref(true)
-
     const App = {
       setup() {
-        return () => {
-          return [
-            h(
-              Suspense,
-              {},
-              {
-                default: () => {
-                  return [
-                    h('main', {}, [
-                      h(AsyncWrapperWrapper, {
-                        prop: bol.value ? 'hello' : 'world'
-                      }),
-                      h(SiblingComp)
-                    ])
-                  ]
-                }
-              }
-            )
-          ]
-        }
+        return () =>
+          h(
+            Suspense,
+            {},
+            {
+              default: () => [
+                h('main', {}, [
+                  h(AsyncWrapperWrapper, {
+                    prop: toggle.value ? 'hello' : 'world'
+                  }),
+                  h(SiblingComp)
+                ])
+              ]
+            }
+          )
       }
     }
 
     // server render
-
     const html = await renderToString(h(App))
 
     expect(html).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="hello">Async component</h1><span></span></main><!--]-->"`
+      `"<main><h1 prop="hello">Async component</h1><span></span></main>"`
     )
 
-    expect(bol.value).toBe(false)
+    expect(toggle.value).toBe(false)
 
     // hydration
 
     // reset the value
-    bol.value = true
-    expect(bol.value).toBe(true)
+    toggle.value = true
+    expect(toggle.value).toBe(true)
 
     const container = document.createElement('div')
     container.innerHTML = html
@@ -1027,14 +996,14 @@ describe('SSR hydration', () => {
       setTimeout(resolve, 0)
     })
 
-    expect(bol.value).toBe(false)
+    expect(toggle.value).toBe(false)
 
     // should be hydrated now
-    // expect(`Hydration node mismatch`).toHaveBeenWarned()
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="world">Async component</h1><span></span></main><!--]-->"`
+      `"<main><h1 prop="world">Async component</h1><span></span></main>"`
     )
   })
+
   // #3787
   test('unmount async wrapper before load', async () => {
     let resolve: any

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -916,7 +916,7 @@ describe('SSR hydration', () => {
     const html = await renderToString(h(App))
 
     expect(html).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop=\\"hello\\">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop="hello">Async component</h1><span></span></main><!--]-->"`
     )
 
     expect(bol.value).toBe(false)
@@ -940,7 +940,7 @@ describe('SSR hydration', () => {
     // should be hydrated now
     // expect(`Hydration node mismatch`).toHaveBeenWarned()
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop=\\"world\\">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop="world">Async component</h1><span></span></main><!--]-->"`
     )
   })
 
@@ -1008,7 +1008,7 @@ describe('SSR hydration', () => {
     const html = await renderToString(h(App))
 
     expect(html).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop=\\"hello\\">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop="hello">Async component</h1><span></span></main><!--]-->"`
     )
 
     expect(bol.value).toBe(false)
@@ -1032,7 +1032,7 @@ describe('SSR hydration', () => {
     // should be hydrated now
     // expect(`Hydration node mismatch`).toHaveBeenWarned()
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop=\\"world\\">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop="world">Async component</h1><span></span></main><!--]-->"`
     )
   })
   // #3787

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -916,7 +916,7 @@ describe('SSR hydration', () => {
     const html = await renderToString(h(App))
 
     expect(html).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="hello">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop=\\"hello\\">Async component</h1><span></span></main><!--]-->"`
     )
 
     expect(bol.value).toBe(false)
@@ -940,7 +940,7 @@ describe('SSR hydration', () => {
     // should be hydrated now
     // expect(`Hydration node mismatch`).toHaveBeenWarned()
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="world">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop=\\"world\\">Async component</h1><span></span></main><!--]-->"`
     )
   })
 
@@ -1008,7 +1008,7 @@ describe('SSR hydration', () => {
     const html = await renderToString(h(App))
 
     expect(html).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="hello">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop=\\"hello\\">Async component</h1><span></span></main><!--]-->"`
     )
 
     expect(bol.value).toBe(false)
@@ -1032,7 +1032,7 @@ describe('SSR hydration', () => {
     // should be hydrated now
     // expect(`Hydration node mismatch`).toHaveBeenWarned()
     expect(container.innerHTML).toMatchInlineSnapshot(
-      `"<!--[--><main><h1 prop="world">Async component</h1><span></span></main><!--]-->"`
+      `"<!--[--><main><h1 prop=\\"world\\">Async component</h1><span></span></main><!--]-->"`
     )
   })
   // #3787

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -859,6 +859,90 @@ describe('SSR hydration', () => {
     )
   })
 
+  test('hydrate safely when property used by async setup changed before render', async () => {
+    // let serverResolve: any
+
+    const AsyncComp = {
+      async setup() {
+        await new Promise<void>(r => r())
+        return () => {
+          return h('h1', 'Async component')
+        }
+      }
+    }
+
+    const AsyncWrapper = {
+      render() {
+        return h(AsyncComp)
+      }
+    }
+
+    const SiblingComp = {
+      setup() {
+        return () => {
+          bol.value = false
+          return h('span')
+        }
+      }
+    }
+
+    const bol = ref(true)
+
+    const App = {
+      setup() {
+        return () => {
+          return [
+            h(
+              Suspense,
+              {},
+              {
+                default: () => {
+                  return [
+                    h('main', {}, [
+                      h(AsyncWrapper, { prop: bol.value ? 'hello' : 'world' }),
+                      h(SiblingComp)
+                    ])
+                  ]
+                }
+              }
+            )
+          ]
+        }
+      }
+    }
+
+    // server render
+
+    const html = await renderToString(h(App))
+
+    expect(html).toMatchInlineSnapshot(
+      `"<!--[--><main><h1 prop="hello">Async component</h1><span></span></main><!--]-->"`
+    )
+
+    expect(bol.value).toBe(false)
+
+    // hydration
+
+    // reset the value
+    bol.value = true
+    expect(bol.value).toBe(true)
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    createSSRApp(App).mount(container)
+
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(bol.value).toBe(false)
+
+    // should be hydrated now
+    // expect(`Hydration node mismatch`).toHaveBeenWarned()
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><main><h1 prop="world">Async component</h1><span></span></main><!--]-->"`
+    )
+  })
   // #3787
   test('unmount async wrapper before load', async () => {
     let resolve: any

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -226,18 +226,24 @@ function patchSuspense(
       if (suspense.deps <= 0) {
         suspense.resolve()
       } else if (isInFallback) {
-        patch(
-          activeBranch,
-          newFallback,
-          container,
-          anchor,
-          parentComponent,
-          null, // fallback tree will not have suspense context
-          namespace,
-          slotScopeIds,
-          optimized
-        )
-        setActiveBranch(suspense, newFallback)
+        // It's possible that the app is in hydrating state when patching the suspense instance
+        //   if someone update the dependency during component setup in children of suspense boundary
+        // And that would be problemtic because we aren't actually showing a fallback content when patchSuspense is called.
+        // In such case, patch of fallback content should be no op
+        if (!isHydrating) {
+          patch(
+            activeBranch,
+            newFallback,
+            container,
+            anchor,
+            parentComponent,
+            null, // fallback tree will not have suspense context
+            namespace,
+            slotScopeIds,
+            optimized
+          )
+          setActiveBranch(suspense, newFallback)
+        }
       }
     } else {
       // toggled before pending tree is resolved

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -226,10 +226,12 @@ function patchSuspense(
       if (suspense.deps <= 0) {
         suspense.resolve()
       } else if (isInFallback) {
-        // It's possible that the app is in hydrating state when patching the suspense instance
-        //   if someone update the dependency during component setup in children of suspense boundary
-        // And that would be problemtic because we aren't actually showing a fallback content when patchSuspense is called.
-        // In such case, patch of fallback content should be no op
+        // It's possible that the app is in hydrating state when patching the
+        // suspense instance. If someone updates the dependency during component
+        // setup in children of suspense boundary, that would be problemtic
+        // because we aren't actually showing a fallback content when
+        // patchSuspense is called. In such case, patch of fallback content
+        // should be no op
         if (!isHydrating) {
           patch(
             activeBranch,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1241,6 +1241,9 @@ function baseCreateRenderer(
       if (!initialVNode.el) {
         const placeholder = (instance.subTree = createVNode(Comment))
         processCommentNode(null, placeholder, container!, anchor)
+        // This noramlly gets setup by the following `setupRenderEffect`.
+        // But the call is skipped in initial mounting of async element.
+        // Thus, manually patching is required here or it will result in a crash during parent component update.
         initialVNode.el = placeholder.el
       }
       return

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1453,9 +1453,8 @@ function baseCreateRenderer(
           ): ComponentInternalInstance | null => {
             if (instance.subTree.shapeFlag & ShapeFlags.COMPONENT) {
               if (
-                // this happens only during hydration
-                instance.subTree.component?.subTree == null &&
-                // we don't know the subTree yet because we haven't resolve it
+                // this happens during hydration or updating a component that resolve to a unresolved async component
+                instance.subTree.component?.asyncDep != null &&
                 instance.subTree.component?.asyncResolved === false
               ) {
                 return instance.subTree.component!

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1241,6 +1241,7 @@ function baseCreateRenderer(
       if (!initialVNode.el) {
         const placeholder = (instance.subTree = createVNode(Comment))
         processCommentNode(null, placeholder, container!, anchor)
+        initialVNode.el = placeholder.el
       }
       return
     }
@@ -1453,8 +1454,9 @@ function baseCreateRenderer(
           ): ComponentInternalInstance | null => {
             if (instance.subTree.shapeFlag & ShapeFlags.COMPONENT) {
               if (
-                // this happens during hydration or updating a component that resolve to a unresolved async component
-                instance.subTree.component?.asyncDep != null &&
+                // this happens only during hydration
+                instance.subTree.component?.subTree == null &&
+                // we don't know the subTree yet because we haven't resolve it
                 instance.subTree.component?.asyncResolved === false
               ) {
                 return instance.subTree.component!

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1459,13 +1459,18 @@ function baseCreateRenderer(
         ) {
           // only sync the properties and abort the rest of operations
           let { next, vnode } = instance
+          toggleRecurse(instance, false)
           if (next) {
             next.el = vnode.el
             updateComponentPreRender(instance, next, optimized)
           }
+          toggleRecurse(instance, true)
           // and continue the rest of operations once the deps are resolved
           instance.subTree.component?.asyncDep?.then(() => {
-            componentUpdateFn()
+            // the instance may be destroyed during the time period
+            if (!instance.isUnmounted) {
+              componentUpdateFn()
+            }
           })
           return
         }


### PR DESCRIPTION
*The previous one is closed because I rename the source patch.*

Fixes: #6949 
Fixes: #6463

## #6949

This is a patch that intended to properly fix crash caused by #6949 , a crash caused by race condition between the component update and component hydration.

There are actually two bugs triggered by doing such actions.

1. The suspense boundary try to render the fallback content even it totally shouldn't (We already have the content of default slot because SSR)
2. The update of the component that wrap async component crashed 
  a. Because host node relies on the subTree of async component it wraps.
  b. And the async component is not rendered yet.
  
This pull request does two things.

1. Make patch of fallback content during hydration no-op
2. Delay the patch of content when the subTree is missing until the async children resolved.

There are a few things that need to be addressed before this being a proper pull request.

- [x] Is delaying update a safe way to handle the race, would it be safer to just ignore it? 
  - seems it will desync otherwise
- [x] Is go one level down for find a async root component deep enough? Do I need to go recursively?
  - It indeed need to
- [x] Is it okay to just ignore vNode of fallback content in a hydrating suspense boundary?
  - probably, the assumption is we are [hydrating resolved content](https://github.com/vuejs/core/blob/a3cc970030579f2c55d893d6e83bbc05324adad4/packages/runtime-core/src/components/Suspense.ts#L498), so it is pointless to update fallback content anyway.

## #6463

And this also fix #6463, a crash caused by missing placeholder element in async element `initialVNode` (thus `subTree.el` of parent component).

This pull request fix the initial mounting of non-resolved async element. So the `el` of `initialVNode` isn't null at initial mounting

In non-async elements, the `el` of `initialVNode` gets set up during the [setupRenderEffect(](https://github.com/vuejs/core/blob/19d8b77da0833200a0ebc117a675a8bea4565d49/packages/runtime-core/src/renderer.ts#L1388) call. But async element mounting skips that, result in a `initialVNode` without `el` field set. This pull request address this by manually set the `initialVNode.el` to placeholder element it is currently using.

Besides these, proper tests are added so we can confirm that this issue is indeed patched.  
Or it can be checkout into current version to see how it breaks currently.