### PR TITLE
fix(ssr): fix hydration mismatch warning about mutiple continuous tex…

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -136,6 +136,15 @@ describe('SSR hydration', () => {
     expect(container.innerHTML).toBe(`<div class="bar">bar</div>`)
   })
 
+  // #7285
+  test('element with multiple continuous text vnodes', async () => {
+    // should no mismatch warning
+    const { container } = mountWithHydration('<div>foo</div>', () =>
+      h('div', ['fo', 'o'])
+    )
+    expect(container.textContent).toBe('foo')
+  })
+
   test('element with elements children', async () => {
     const msg = ref('foo')
     const fn = vi.fn()
@@ -222,6 +231,16 @@ describe('SSR hydration', () => {
     expect(vnode.el.innerHTML).toBe(
       `<!--[--><span>bar</span><!--[--><span class="bar"></span><!--]--><!--]-->`
     )
+  })
+
+  // #7285
+  test('Fragment (multiple continuous text vnodes)', async () => {
+    // should no mismatch warning
+    const { container } = mountWithHydration('<!--[-->foo<!--]-->', () => [
+      'fo',
+      'o'
+    ])
+    expect(container.textContent).toBe('foo')
   })
 
   test('Teleport', async () => {


### PR DESCRIPTION
…t vnodes (#7285)

fix #7285 

The following ```Comp``` will be rendered as a ```"<div>foo</div>"``` on the ssr side.

```js
const Comp = defineComponent(() => h('div', ['fo', 'o']))
```

The ```"<div>foo</div>"``` will be rendered as a div element with a single child text node in the browser, but the above ```Comp``` will be rendered by ```Vue``` as a div element with two child vnodes, so will cause a mismatch warning during hydration.