### PR TITLE
fix(types): type inference with no props

### DIFF
--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -350,6 +350,25 @@ describe('type inference w/ optional props declaration', () => {
   ;<MyComponent msg="1" />
 })
 
+// #5731
+describe('type inference w/ optional props declaration', () => {
+  type Props = {
+    reset: () => number
+  }
+  const MyComponent = defineComponent<Props>({
+    setup(props) {
+      expectType<() => number>(props.reset)
+      return {
+        b: 1
+      }
+    }
+  })
+
+  expectType<JSX.Element>(<MyComponent reset={() => 1} />)
+  // @ts-expect-error
+  expectError(<MyComponent />)
+})
+
 describe('type inference w/ direct setup function', () => {
   const MyComponent = defineComponent((_props: { msg: string }) => {})
   expectType<JSX.Element>(<MyComponent msg="foo" />)
@@ -1040,7 +1059,7 @@ describe('inject', () => {
       expectType<unknown>(this.foo)
       expectType<unknown>(this.bar)
       //  @ts-expect-error
-      this.foobar = 1
+      expectError((this.foobar = 1))
     }
   })
 
@@ -1052,7 +1071,7 @@ describe('inject', () => {
       expectType<unknown>(this.foo)
       expectType<unknown>(this.bar)
       //  @ts-expect-error
-      this.foobar = 1
+      expectError((this.foobar = 1))
     }
   })
 
@@ -1072,7 +1091,7 @@ describe('inject', () => {
       expectType<unknown>(this.foo)
       expectType<unknown>(this.bar)
       //  @ts-expect-error
-      this.foobar = 1
+      expectError((this.foobar = 1))
     }
   })
 
@@ -1081,9 +1100,9 @@ describe('inject', () => {
     props: ['a', 'b'],
     created() {
       //  @ts-expect-error
-      this.foo = 1
+      expectError((this.foo = 1))
       //  @ts-expect-error
-      this.bar = 1
+      expectError((this.bar = 1))
     }
   })
 })

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -122,7 +122,19 @@ export function defineComponent<
     I,
     II
   >
-): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
+): DefineComponent<
+  Props,
+  RawBindings,
+  D,
+  C,
+  M,
+  Mixin,
+  Extends,
+  E,
+  EE,
+  PublicProps,
+  Readonly<Props> & ({} extends E ? {} : EmitsToProps<E>)
+>
 
 // overload 3: object format with array props declaration
 // props inferred as { [key in PropNames]?: any }


### PR DESCRIPTION
Fixes #5731

## TS Playground
[playground](https://www.typescriptlang.org/play?ts=4.9.4#code/JYWwDg9gTgLgBAbzjAnmApnAwhcEB26+MAClBGAM4DyYMwBlcAvnAGbkhwDkAbgK7puAWABQY1BjhkKlHOACCcALyIxcOFHSV0MAFxwAFAEoVAPjj5+IAEbooY5mODF7bAIYBjTDKrywAEIaCOqa2roGJuaW1nYOok6iAPRJyFCCEmiYAGIANu4A5kqqvnK4YEroAB4wRAAmTP4ERKTkVLT0jHAA-GmCcAYeuTpiKezuw+iZUnmFQSVtZeBB1bX4DdjlzcSlHQz4TL0w6ZiDEyOiQA)

## Problem 
It's hard to distinguish between `type A` and `type B` in the case. 
And `ExtractPropTypes<A>` will return type `{ title: string }`
```
type A = {
  title: () => string
}
type B = {
  title: StringConstructor
}
```

## Solution
I think it is enough to use `type A` instead of `type B`, so I just remove the code of the judgment here.
https://github.com/vuejs/core/blob/58ae8fa9bcfe47eea26409e1e11cf894912fb92b/packages/runtime-core/src/apiDefineComponent.ts#L45-L48

## Notice
This PR will disabled the way below.
```vue
const props = {
  title: {
      type: String
  }
}
// fail
const Comp = defineComponent<typeof props>({
  setup(props) {
    return {
      b: 1
    }
  }
})
```


