### PR TITLE
fix(reactivity): clear on readonly collections return undefined

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -275,6 +275,13 @@ describe('reactivity/readonly', () => {
             expect(isReactive(value)).toBe(true)
           }
         })
+        test('should undefined from Map.clear call', () => {
+          const wrapped = readonly(new Collection())
+          expect(wrapped.clear()).toBeUndefined()
+          expect(
+            `Clear operation failed: target is readonly.`
+          ).toHaveBeenWarned()
+        })
       }
     })
   })
@@ -331,6 +338,14 @@ describe('reactivity/readonly', () => {
             expect(isReadonly(v1)).toBe(true)
             expect(isReadonly(v2)).toBe(true)
           }
+        })
+
+        test('should undefined from Set.clear call', () => {
+          const wrapped = readonly(new Collection())
+          expect(wrapped.clear()).toBeUndefined()
+          expect(
+            `Clear operation failed: target is readonly.`
+          ).toHaveBeenWarned()
         })
       }
     })

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -275,7 +275,8 @@ describe('reactivity/readonly', () => {
             expect(isReactive(value)).toBe(true)
           }
         })
-        test('should undefined from Map.clear call', () => {
+
+        test('should return undefined from Map.clear() call', () => {
           const wrapped = readonly(new Collection())
           expect(wrapped.clear()).toBeUndefined()
           expect(
@@ -340,7 +341,7 @@ describe('reactivity/readonly', () => {
           }
         })
 
-        test('should undefined from Set.clear call', () => {
+        test('should return undefined from Set.clear() call', () => {
           const wrapped = readonly(new Collection())
           expect(wrapped.clear()).toBeUndefined()
           expect(

--- a/packages/reactivity/__tests__/shallowReadonly.spec.ts
+++ b/packages/reactivity/__tests__/shallowReadonly.spec.ts
@@ -114,7 +114,7 @@ describe('reactivity/shallowReadonly', () => {
       })
     })
 
-    test('should undefined from Map.clear call', () => {
+    test('should return undefined from Map.clear() call', () => {
       const sroMap = shallowReadonly(new Map())
       expect(sroMap.clear()).toBeUndefined()
       expect(`Clear operation failed: target is readonly.`).toHaveBeenWarned()
@@ -204,7 +204,7 @@ describe('reactivity/shallowReadonly', () => {
       })
     })
 
-    test('should undefined from Set.clear call', () => {
+    test('should return undefined from Set.clear() call', () => {
       const sroSet = shallowReadonly(new Set())
       expect(sroSet.clear()).toBeUndefined()
       expect(`Clear operation failed: target is readonly.`).toHaveBeenWarned()

--- a/packages/reactivity/__tests__/shallowReadonly.spec.ts
+++ b/packages/reactivity/__tests__/shallowReadonly.spec.ts
@@ -113,6 +113,12 @@ describe('reactivity/shallowReadonly', () => {
         ).not.toHaveBeenWarned()
       })
     })
+
+    test('should undefined from Map.clear call', () => {
+      const sroMap = shallowReadonly(new Map())
+      expect(sroMap.clear()).toBeUndefined()
+      expect(`Clear operation failed: target is readonly.`).toHaveBeenWarned()
+    })
   })
 
   describe('collection/Set', () => {
@@ -196,6 +202,12 @@ describe('reactivity/shallowReadonly', () => {
           `Set operation on key "foo" failed: target is readonly.`
         ).not.toHaveBeenWarned()
       })
+    })
+
+    test('should undefined from Set.clear call', () => {
+      const sroSet = shallowReadonly(new Set())
+      expect(sroSet.clear()).toBeUndefined()
+      expect(`Clear operation failed: target is readonly.`).toHaveBeenWarned()
     })
   })
 })

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -223,7 +223,11 @@ function createReadonlyMethod(type: TriggerOpTypes): Function {
         toRaw(this)
       )
     }
-    return type === TriggerOpTypes.DELETE ? false : this
+    return type === TriggerOpTypes.DELETE
+      ? false
+      : type === TriggerOpTypes.CLEAR
+      ? undefined
+      : this
   }
 }
 


### PR DESCRIPTION
clear on readonly collections return the proxy
```javascript
const warp = readonly(new Map())
console.log(warp.clear() === warp)  // true
```
This fix now return undefined
```javascript
const warp = readonly(new Map())
console.log(warp.clear())  // undefined
```
