### PR TITLE
fix(reactivity): not trigger Map.size when setting existing keys

### DIFF
--- a/packages/reactivity/__tests__/collections/Map.spec.ts
+++ b/packages/reactivity/__tests__/collections/Map.spec.ts
@@ -473,5 +473,17 @@ describe('reactivity/collections', () => {
       const result = map.set('a', 'a')
       expect(result).toBe(map)
     })
+    it('should not trigger Map.size when setting existing keys', () => {
+      const map = reactive(new Map())
+      map.set('a', 'a')
+      const fn = jest.fn(() => map.size)
+      effect(fn)
+      expect(fn).toBeCalledTimes(1)
+      map.set('a', 'b')
+      expect(fn).toBeCalledTimes(1)
+
+      map.set('b', 'b')
+      expect(fn).toBeCalledTimes(2)
+    })
   })
 })

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -62,7 +62,13 @@ function has(this: CollectionTypes, key: unknown, isReadonly = false): boolean {
 
 function size(target: IterableCollections, isReadonly = false) {
   target = (target as any)[ReactiveFlags.RAW]
-  !isReadonly && track(toRaw(target), TrackOpTypes.ITERATE, ITERATE_KEY)
+  const rawTarget = toRaw(target)
+  !isReadonly &&
+    track(
+      rawTarget,
+      TrackOpTypes.ITERATE,
+      isMap(rawTarget) ? MAP_KEY_ITERATE_KEY : ITERATE_KEY
+    )
   return Reflect.get(target, 'size', target)
 }
 


### PR DESCRIPTION
close #7322 