### PR TITLE
fix(runtime-dom): style update error when component use shorthand properties

### DIFF
--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -106,6 +106,18 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.getPropertyValue('--custom')).toBe('100\\;')
   })
 
+  it('shorthand properties', () => {
+    const el = document.createElement('div')
+    patchProp(
+      el as any,
+      'style',
+      { borderBottom: '1px solid red' },
+      { border: '1px solid green' }
+    )
+    expect(el.style.border).toBe('1px solid green')
+    expect(el.style.borderBottom).toBe('1px solid green')
+  })
+
   // JSDOM doesn't support custom properties on style object so we have to
   // mock it here.
   function mockElementWithStyle() {

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -7,15 +7,15 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   const style = (el as HTMLElement).style
   const isCssString = isString(next)
   if (next && !isCssString) {
-    for (const key in next) {
-      setStyle(style, key, next[key])
-    }
     if (prev && !isString(prev)) {
       for (const key in prev) {
         if (next[key] == null) {
           setStyle(style, key, '')
         }
       }
+    }
+    for (const key in next) {
+      setStyle(style, key, next[key])
     }
   } else {
     const currentDisplay = style.display


### PR DESCRIPTION
[demo](https://sfc.vuejs.org/#eNp9UttOwzAM/RWTl4K0NRKPXcdF/EZeenG3bs1FiTtAU/8dJ+1QAYmnxPbx8fFJruLVufwyoihEGRrfO4KANLonZRT12llPcAWPHUzQeashY3C2Kr5Z7ZZKLmMQ2RgAEEEDEnRDdYB95LgnP+KDMqWcR8UhpiTUbqgIOQIo65HIGnhphr4575VYuu/iqUTCADTHyhwwMacmOXcl0WVSVAT6HPDW/wxZbX2LvoBH9wHBDn3LgtpdBsWttK0tc+g1oh6q5rzLeGyZVmP+Un7LFRsxe7DVlctPwRo28Zo2XwpBiQJSJubYlxgrcSRyoZAydE006xRy6w+Sb7kfDfuKOQa9rb19D+iZWInNikNy8sJyPRpWjf4/zl/QP7yRdlJm4lVuTxc/ws8XafvLYjthoNnvObcyQxkxfQFGTMkN)