### PR TITLE
fix(runtime-core): Support for custom transition classes when running in compat mode

### DIFF
--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -194,7 +194,7 @@ export function resolveTransitionProps(
       callHook(hook, [el, resolve])
       nextFrame(() => {
         removeTransitionClass(el, isAppear ? appearFromClass : enterFromClass)
-        if (__COMPAT__ && legacyClassEnabled) {
+        if (__COMPAT__ && legacyClassEnabled && legacyAppearFromClass && legacyEnterFromClass) {
           removeTransitionClass(
             el,
             isAppear ? legacyAppearFromClass : legacyEnterFromClass
@@ -212,7 +212,7 @@ export function resolveTransitionProps(
     onBeforeEnter(el) {
       callHook(onBeforeEnter, [el])
       addTransitionClass(el, enterFromClass)
-      if (__COMPAT__ && legacyClassEnabled) {
+      if (__COMPAT__ && legacyClassEnabled && legacyEnterFromClass) {
         addTransitionClass(el, legacyEnterFromClass)
       }
       addTransitionClass(el, enterActiveClass)
@@ -220,7 +220,7 @@ export function resolveTransitionProps(
     onBeforeAppear(el) {
       callHook(onBeforeAppear, [el])
       addTransitionClass(el, appearFromClass)
-      if (__COMPAT__ && legacyClassEnabled) {
+      if (__COMPAT__ && legacyClassEnabled && legacyAppearFromClass) {
         addTransitionClass(el, legacyAppearFromClass)
       }
       addTransitionClass(el, appearActiveClass)
@@ -231,7 +231,7 @@ export function resolveTransitionProps(
       el._isLeaving = true
       const resolve = () => finishLeave(el, done)
       addTransitionClass(el, leaveFromClass)
-      if (__COMPAT__ && legacyClassEnabled) {
+      if (__COMPAT__ && legacyClassEnabled && legacyLeaveFromClass) {
         addTransitionClass(el, legacyLeaveFromClass)
       }
       // force reflow so *-leave-from classes immediately take effect (#2593)
@@ -243,7 +243,7 @@ export function resolveTransitionProps(
           return
         }
         removeTransitionClass(el, leaveFromClass)
-        if (__COMPAT__ && legacyClassEnabled) {
+        if (__COMPAT__ && legacyClassEnabled && legacyLeaveFromClass) {
           removeTransitionClass(el, legacyLeaveFromClass)
         }
         addTransitionClass(el, leaveToClass)

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -194,11 +194,13 @@ export function resolveTransitionProps(
       callHook(hook, [el, resolve])
       nextFrame(() => {
         removeTransitionClass(el, isAppear ? appearFromClass : enterFromClass)
-        if (__COMPAT__ && legacyClassEnabled && legacyAppearFromClass && legacyEnterFromClass) {
-          removeTransitionClass(
-            el,
-            isAppear ? legacyAppearFromClass : legacyEnterFromClass
-          )
+        if (__COMPAT__ && legacyClassEnabled) {
+          const legacyClass = isAppear
+            ? legacyAppearFromClass
+            : legacyEnterFromClass
+          if (legacyClass) {
+            removeTransitionClass(el, legacyClass)
+          }
         }
         addTransitionClass(el, isAppear ? appearToClass : enterToClass)
         if (!hasExplicitCallback(hook)) {


### PR DESCRIPTION
As reported in https://github.com/vuejs/core/issues/6253 custom transition classes (e.g. with tailwind) are currently not working when vue is running in compat/migration mode.

This PR just adds a few checks to the `Transition` component to fix this.
We have been running a vue version with this fix applied in production for months and found no problems.

close: https://github.com/vuejs/core/issues/6253