### PR TITLE
fix(compiler-sfc): allow declaring variables after defineProps

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScriptPropsTransform.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScriptPropsTransform.spec.ts.snap
@@ -136,6 +136,24 @@ return () => {}
 })"
 `;
 
+exports[`sfc props transform multiple variable declarations 1`] = `
+"import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default {
+  props: ['foo'],
+  setup(__props) {
+
+      const bar = 'fish', hello = 'world'
+      
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(__props.foo) + " " + _toDisplayString(hello) + " " + _toDisplayString(bar), 1 /* TEXT */))
+}
+}
+
+}"
+`;
+
 exports[`sfc props transform nested scope 1`] = `
 "export default {
   props: ['foo', 'bar'],

--- a/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
@@ -28,6 +28,26 @@ describe('sfc props transform', () => {
     })
   })
 
+  test('multiple variable declarations', () => {
+    const { content, bindings } = compile(`
+      <script setup>
+      const bar = 'fish', { foo } = defineProps(['foo']), hello = 'world'
+      </script>
+      <template><div>{{ foo }} {{ hello }} {{ bar }}</div></template>
+    `)
+    expect(content).not.toMatch(`const { foo } =`)
+    expect(content).toMatch(`const bar = 'fish', hello = 'world'`)
+    expect(content).toMatch(`_toDisplayString(hello)`)
+    expect(content).toMatch(`_toDisplayString(bar)`)
+    expect(content).toMatch(`_toDisplayString(__props.foo)`)
+    assertCode(content)
+    expect(bindings).toStrictEqual({
+      foo: BindingTypes.PROPS,
+      bar: BindingTypes.SETUP_CONST,
+      hello: BindingTypes.SETUP_CONST
+    })
+  })
+
   test('nested scope', () => {
     const { content, bindings } = compile(`
       <script setup>

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1758,8 +1758,7 @@ function walkDeclaration(
         registerBinding(bindings, id, bindingType)
       } else {
         if (isCallOf(init, DEFINE_PROPS)) {
-          // skip walking props destructure
-          return
+          continue
         }
         if (id.type === 'ObjectPattern') {
           walkObjectPattern(id, bindings, isConst, isDefineCall)


### PR DESCRIPTION
hi :wave: this PR fix #7460.

It allow declaring multiple variables with a single variable declaration.
this would fail because of a `return` which has been changed to `continue` in this pr 
`const   {hello} = defineProps(['hello']), test = "HALLO"`