### PR TITLE
fix(reactivity-transform): correct semicolon insertion with more complex destructuring

### DIFF
--- a/packages/reactivity-transform/__tests__/__snapshots__/reactivityTransform.spec.ts.snap
+++ b/packages/reactivity-transform/__tests__/__snapshots__/reactivityTransform.spec.ts.snap
@@ -163,7 +163,20 @@ exports[`nested destructure 1`] = `
     let __$temp_2 = (useBar()),
   d = _toRef(__$temp_2.c, 0),
   e = _toRef(__$temp_2.c, 1);
-    console.log(b.value, d.value, e.value)
+    let __$temp_3 = (useBaz()),
+  f = _toRef(__$temp_3, 0),
+  g = _toRef(__$temp_3[1], 'g'),
+  h = _toRef(__$temp_3[2], 1);
+    console.log(b.value, d.value, e.value, f.value, g.value, h.value)
+    "
+`;
+
+exports[`nested destructure w/ mid-path default values 1`] = `
+"import { toRef as _toRef } from 'vue'
+
+    let __$temp_1 = (useFoo()),
+  b = _toRef((__$temp_1[0].a || { b: 123 }), 'b');
+    console.log(b.value)
     "
 `;
 

--- a/packages/reactivity-transform/__tests__/reactivityTransform.spec.ts
+++ b/packages/reactivity-transform/__tests__/reactivityTransform.spec.ts
@@ -283,12 +283,26 @@ test('nested destructure', () => {
   const { code, rootRefs } = transform(`
     let [{ a: { b }}] = $(useFoo())
     let { c: [d, e] } = $(useBar())
-    console.log(b, d, e)
+    let [f, { g }, [ , h ]] = $(useBaz())
+    console.log(b, d, e, f, g, h)
     `)
   expect(code).toMatch(`b = _toRef(__$temp_1[0].a, 'b')`)
   expect(code).toMatch(`d = _toRef(__$temp_2.c, 0)`)
   expect(code).toMatch(`e = _toRef(__$temp_2.c, 1)`)
-  expect(rootRefs).toStrictEqual(['b', 'd', 'e'])
+  expect(code).toMatch(`f = _toRef(__$temp_3, 0)`)
+  expect(code).toMatch(`g = _toRef(__$temp_3[1], 'g')`)
+  expect(code).toMatch(`h = _toRef(__$temp_3[2], 1)`)
+  expect(rootRefs).toStrictEqual(['b', 'd', 'e', 'f', 'g', 'h'])
+  assertCode(code)
+})
+
+test('nested destructure w/ mid-path default values', () => {
+  const { code, rootRefs } = transform(`
+    let [{ a: { b } = { b: 123 }}] = $(useFoo())
+    console.log(b)
+    `)
+  expect(code).toMatch(`b = _toRef((__$temp_1[0].a || { b: 123 }), 'b')`)
+  expect(rootRefs).toStrictEqual(['b'])
   assertCode(code)
 })
 


### PR DESCRIPTION
input:
```js
let [a, { b }] = $(useBar())
```
output:

### before

```js
import { toRef as _toRef } from 'vue'
let __$temp_1 = (useBar()),
a = _toRef(__$temp_1, 0),
b = _toRef(__$temp_1[1], 'b');,
a = _toRef(__$temp_1, 1);
```

### after:
```js
import { toRef as _toRef } from 'vue'
let __$temp_1 = (useBar()),
a = _toRef(__$temp_1, 0),
b = _toRef(__$temp_1[1], 'b');
```

:heart: