### PR TITLE
fix(runtime-core): pruneCacheEntry rectify the judgment logic  (fix #7355)

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -13,7 +13,8 @@ import {
   cloneVNode,
   isVNode,
   VNodeProps,
-  invokeVNodeHook
+  invokeVNodeHook,
+  isSameVNodeType
 } from '../vnode'
 import { warn } from '../warning'
 import {
@@ -193,7 +194,7 @@ const KeepAliveImpl: ComponentOptions = {
 
     function pruneCacheEntry(key: CacheKey) {
       const cached = cache.get(key) as VNode
-      if (!current || cached.type !== current.type) {
+      if (!current || !isSameVNodeType(cached, current)) {
         unmount(cached)
       } else if (current) {
         // current active instance should no longer be kept-alive.


### PR DESCRIPTION
keep-alive component status abnormal when cache items more than its max, after debugging, I found that its judge 2 VNode is same logic is wrong(as `cached.type !== current.type`).
Issues link: https://github.com/vuejs/core/issues/7355
Playground Before:
https://codesandbox.io/s/emit-issue-kezqfe