### PR TITLE
test(reactivity): replace isReactive with isReadonly

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -434,7 +434,7 @@ describe('reactivity/readonly', () => {
       bar: markRaw({ b: 2 })
     })
     expect(isReadonly(obj.foo)).toBe(true)
-    expect(isReactive(obj.bar)).toBe(false)
+    expect(isReadonly(obj.bar)).toBe(false)
   })
 
   test('should make ref readonly', () => {


### PR DESCRIPTION
In readonly.spec.ts, use `isReadonly` to test `markRaw` instead of `isReactive`.