### PR TITLE
fix(runtime-core): named ref, Non-ref data should not be contaminated

### DIFF
--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -522,7 +522,7 @@ describe('api: template refs', () => {
     )
   })
 
-  // #7518
+  // #7529
   test('named ref, Non-ref data should not be contaminated', async () => {
     const root = nodeOps.createElement('div')
 

--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -203,24 +203,6 @@ describe('api: template refs', () => {
     expect(spy).toHaveBeenCalledWith('div')
   })
 
-  it('should work with direct reactive property', () => {
-    const root = nodeOps.createElement('div')
-    const state = reactive({
-      refKey: null
-    })
-
-    const Comp = {
-      setup() {
-        return state
-      },
-      render() {
-        return h('div', { ref: 'refKey' })
-      }
-    }
-    render(h(Comp), root)
-    expect(state.refKey).toBe(root.children[0])
-  })
-
   test('multiple root refs', () => {
     const root = nodeOps.createElement('div')
     const refKey1 = ref(null)
@@ -538,5 +520,39 @@ describe('api: template refs', () => {
     expect(serializeInner(root)).toBe(
       '<div><div>[object Object],[object Object]</div><ul><li>2</li><li>3</li></ul></div>'
     )
+  })
+
+  // #7518
+  test('named ref, Non-ref data should not be contaminated', async () => {
+    const root = nodeOps.createElement('div')
+
+    const refKey1 = 1
+    const refKey2 = reactive({ a: 1 })
+    const refKey3 = [1]
+    const refKey4 = { a: 1 }
+
+    const Comp = {
+      setup() {
+        return {
+          refKey1,
+          refKey2,
+          refKey3,
+          refKey4
+        }
+      },
+      render() {
+        return [
+          h('div', { ref: 'refKey1' }),
+          h('div', { ref: 'refKey2' }),
+          h('div', { ref: 'refKey3' }),
+          h('div', { ref: 'refKey4' })
+        ]
+      }
+    }
+    render(h(Comp), root)
+    expect(refKey1).toBe(1)
+    expect(refKey2.a).toEqual(1)
+    expect(refKey3[0]).toEqual(1)
+    expect(refKey4.a).toEqual(1)
   })
 })

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -68,7 +68,10 @@ export function setRef(
   if (oldRef != null && oldRef !== ref) {
     if (isString(oldRef)) {
       refs[oldRef] = null
-      if (hasOwn(setupState, oldRef)) {
+      if (
+        hasOwn(setupState, oldRef) &&
+        isRef(Object.getOwnPropertyDescriptor(setupState, oldRef)?.value)
+      ) {
         setupState[oldRef] = null
       }
     } else if (isRef(oldRef)) {
@@ -80,12 +83,15 @@ export function setRef(
     callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [value, refs])
   } else {
     const _isString = isString(ref)
+    const _isRefKey =
+      _isString &&
+      isRef(Object.getOwnPropertyDescriptor(setupState, ref)?.value)
     const _isRef = isRef(ref)
     if (_isString || _isRef) {
       const doSet = () => {
         if (rawRef.f) {
           const existing = _isString
-            ? hasOwn(setupState, ref)
+            ? hasOwn(setupState, ref) && _isRefKey
               ? setupState[ref]
               : refs[ref]
             : ref.value
@@ -95,7 +101,7 @@ export function setRef(
             if (!isArray(existing)) {
               if (_isString) {
                 refs[ref] = [refValue]
-                if (hasOwn(setupState, ref)) {
+                if (hasOwn(setupState, ref) && _isRefKey) {
                   setupState[ref] = refs[ref]
                 }
               } else {
@@ -108,7 +114,7 @@ export function setRef(
           }
         } else if (_isString) {
           refs[ref] = value
-          if (hasOwn(setupState, ref)) {
+          if (hasOwn(setupState, ref) && _isRefKey) {
             setupState[ref] = value
           }
         } else if (_isRef) {


### PR DESCRIPTION
close #7529 

**TemplateRef** overwrites **reactive** data

named ref, Non-ref data should not be contaminated


> In Composition API, the reference will be stored in a ref with matching name: [https://vuejs.org//api/built-in-special-attributes.html#ref](https://vuejs.org//api/built-in-special-attributes.html#ref)


**Playground Before:**
[https://sfc.vuejs.org/#__DEV__eNp9Ustu4zAM/BVCWCApUEvAPi6GW2SPe96rLonNNNpaj5UoN4Xhfy8lB23aAvWJj9EMOfQsfocgp4yiFV3qowkECSmHe+2MDT4SzBBx35OZEBY4Rm9hw/iNdtr13iWCo48W7l5R25lbRHimFjbn85mRy412nVrpmZgTQhvGPSFnAF1liHi806KEWsAu5YM1JEPECV15BPx1KezdfYHIlZ9JS+XSNS5kgqmxfsDxwlWBTEjPAbm0ZquqKv0a1rSsXGiu6K9UIdHzWBh6P/rYPkREx0Tz/IaHZXk3z/YPe3nyeRzggFC8Mol4GXgydII6LPtSBlmla3zIRN7Brh9N/8hy39iWJKtGxP8ZE/2tzmxvWH01qVPrIybp1Kux4lasB2zsPsh/yTs+MZ+GdS6NpEULtVJqfNOSa3EiCqlVKrvw+CB7b9WOeypmR8ZiM3i7+yG/y5+/1MD7XNclJtscon9KGFlRi9srcsXFCWMT0Q0YMX4p9gH7TvBD75No0Vz4nxPLC5tJ/Sc=](https://sfc.vuejs.org/#__DEV__eNp9Ustu4zAM/BVCWCApUEvAPi6GW2SPe96rLonNNNpaj5UoN4Xhfy8lB23aAvWJj9EMOfQsfocgp4yiFV3qowkECSmHe+2MDT4SzBBx35OZEBY4Rm9hw/iNdtr13iWCo48W7l5R25lbRHimFjbn85mRy412nVrpmZgTQhvGPSFnAF1liHi806KEWsAu5YM1JEPECV15BPx1KezdfYHIlZ9JS+XSNS5kgqmxfsDxwlWBTEjPAbm0ZquqKv0a1rSsXGiu6K9UIdHzWBh6P/rYPkREx0Tz/IaHZXk3z/YPe3nyeRzggFC8Mol4GXgydII6LPtSBlmla3zIRN7Brh9N/8hy39iWJKtGxP8ZE/2tzmxvWH01qVPrIybp1Kux4lasB2zsPsh/yTs+MZ+GdS6NpEULtVJqfNOSa3EiCqlVKrvw+CB7b9WOeypmR8ZiM3i7+yG/y5+/1MD7XNclJtscon9KGFlRi9srcsXFCWMT0Q0YMX4p9gH7TvBD75No0Vz4nxPLC5tJ/Sc=)

**Playground After:**
[https://deploy-preview-7522--vue-sfc-playground.netlify.app/#__DEV__eNqlkk1r3DAQhv/KIAq7gciGQCkYJ6THnnvVxWuPs2qtj0oj7xrj/96RvKTb9hifNB96n9E7XsVX76s5oWhEG/ugPUFESv5FWW28CwQrBOx60jPCBmNwBg7cf1BW2d7ZSDC6YOD5veu4cokIr9TA4Xq9cuf2oGxb7/IszAGh8VNHyBFAWxQCjs9K5KMS8BrTyWiqfMAZbb4E/LXRd/Ylt1S7PovmzK2qrU8EszRuwOmmVRpZkBaPnNqjnVrnejmWMD85y9zJ31Eh0jJlhd5NLjRvAdGy0Lr+6Ydt+2ue4zf28uzSNMAJIXulI/Fj4KLpDGVY9iUPsqPL+ZSInIXXftL9T8Z9YltiVRgBfyWM9L04c3xg+m5SW++XWKSt340Vj2JfoDSdr35EZ3nFvBrm3ApRiQZKJud4pzlW4kzkY1PXA/rJLTJvQONFfvn89CQld8k49pIZy1twyQ6VRZr0uFSd9zWXq5AsaYMVRiNPwV0iBsYr8XhHqjk5Y5AB7YABw8fJ/wj+R8/wjf9Esf0GgRgGzQ==](https://deploy-preview-7522--vue-sfc-playground.netlify.app/#__DEV__eNqlkk1r3DAQhv/KIAq7gciGQCkYJ6THnnvVxWuPs2qtj0oj7xrj/96RvKTb9hifNB96n9E7XsVX76s5oWhEG/ugPUFESv5FWW28CwQrBOx60jPCBmNwBg7cf1BW2d7ZSDC6YOD5veu4cokIr9TA4Xq9cuf2oGxb7/IszAGh8VNHyBFAWxQCjs9K5KMS8BrTyWiqfMAZbb4E/LXRd/Ylt1S7PovmzK2qrU8EszRuwOmmVRpZkBaPnNqjnVrnejmWMD85y9zJ31Eh0jJlhd5NLjRvAdGy0Lr+6Ydt+2ue4zf28uzSNMAJIXulI/Fj4KLpDGVY9iUPsqPL+ZSInIXXftL9T8Z9YltiVRgBfyWM9L04c3xg+m5SW++XWKSt340Vj2JfoDSdr35EZ3nFvBrm3ApRiQZKJud4pzlW4kzkY1PXA/rJLTJvQONFfvn89CQld8k49pIZy1twyQ6VRZr0uFSd9zWXq5AsaYMVRiNPwV0iBsYr8XhHqjk5Y5AB7YABw8fJ/wj+R8/wjf9Esf0GgRgGzQ==)




This PR fixes it.

