### PR TITLE
chore(vue): reorder the types field in package.json

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -19,22 +19,22 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/vue.d.ts",
       "import": {
         "node": "./index.mjs",
         "default": "./dist/vue.runtime.esm-bundler.js"
       },
-      "require": "./index.js",
-      "types": "./dist/vue.d.ts"
+      "require": "./index.js"
     },
     "./server-renderer": {
+      "types": "./server-renderer/index.d.ts",
       "import": "./server-renderer/index.mjs",
-      "require": "./server-renderer/index.js",
-      "types": "./server-renderer/index.d.ts"
+      "require": "./server-renderer/index.js"
     },
     "./compiler-sfc": {
+      "types": "./compiler-sfc/index.d.ts",
       "import": "./compiler-sfc/index.mjs",
-      "require": "./compiler-sfc/index.js",
-      "types": "./compiler-sfc/index.d.ts"
+      "require": "./compiler-sfc/index.js"
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json",


### PR DESCRIPTION
`types` field should be the first in the object as required by TypeScript.

reference: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

if we don't do this, we will not pass the publint rules;

please see: https://publint.dev/vue@3.2.45