### PR TITLE
fix(devtools): allow devtools to identify parent components of hydrated elements.

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -354,6 +354,16 @@ export function createHydrationFunctions(
           )
         }
       }
+      if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
+        Object.defineProperty(el, '__vnode', {
+          value: vnode,
+          enumerable: false
+        })
+        Object.defineProperty(el, '__vueParentComponent', {
+          value: parentComponent,
+          enumerable: false
+        })
+      }
       // vnode / directive hooks
       let vnodeHooks: VNodeHook | null | undefined
       if ((vnodeHooks = props && props.onVnodeBeforeMount)) {


### PR DESCRIPTION
See: https://github.com/vuejs/devtools/issues/2004

This PR replicates the following code, which runs for devtools during `mountElement()`, so that it also runs during `hydrateElement()`

https://github.com/vuejs/core/blob/bef85e7975084b05af00b60ecd171c83f251c6d5/packages/runtime-core/src/renderer.ts#L685-L694