### PR TITLE
build: do not throw when running `build --release` for the 1st time

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -47,6 +47,7 @@ async function run() {
   if (isRelease) {
     // remove build cache for release builds to avoid outdated enum values
     await fs.rm(path.resolve(__dirname, '../node_modules/.rts2_cache'), {
+      force: true,
       recursive: true
     })
   }


### PR DESCRIPTION
Fixes https://github.com/vuejs/ecosystem-ci/actions/runs/4022763262/jobs/6912842567#step:8:122

The bug was introduced in https://github.com/vuejs/core/commit/ab45f6f8a27fd4ce8af703c42914a94a10a4017a which replaced `fs-extra` with native `fs`.

The `remove` function in `fs-extra` ["silently does nothing" if the path does not exist](https://github.com/jprichardson/node-fs-extra/blob/f3a7f0beeb5858c628b10010ad819c813c7f3565/docs/remove.md). Meanwhile `fs.rm` would throw [unless the `force` flag is set](https://nodejs.org/dist/latest-v18.x/docs/api/fs.html#fspromisesrmpath-options).