### PR TITLE
fix(runtime-core): allow using `getCurrentInstance` with multiple builds of vue

### DIFF
--- a/packages/runtime-core/__tests__/directives.spec.ts
+++ b/packages/runtime-core/__tests__/directives.spec.ts
@@ -114,7 +114,7 @@ describe('directives', () => {
     let _prevVnode: VNode | null = null
     const Comp = {
       setup() {
-        _instance = currentInstance
+        _instance = currentInstance.value
       },
       render() {
         _prevVnode = _vnode
@@ -174,7 +174,7 @@ describe('directives', () => {
     let _prevVnode: VNode | null = null
     const Comp = {
       setup() {
-        _instance = currentInstance
+        _instance = currentInstance.value
       },
       render() {
         _prevVnode = _vnode
@@ -310,7 +310,7 @@ describe('directives', () => {
 
     const Comp = {
       setup() {
-        _instance = currentInstance
+        _instance = currentInstance.value
       },
       render() {
         return withDirectives(h(Child, { count: count.value }), [

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -121,7 +121,7 @@ export function defineAsyncComponent<
     },
 
     setup() {
-      const instance = currentInstance!
+      const instance = currentInstance.value!
 
       // already resolved
       if (resolvedComp) {

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -6,21 +6,21 @@ import { warn } from './warning'
 export interface InjectionKey<T> extends Symbol {}
 
 export function provide<T>(key: InjectionKey<T> | string | number, value: T) {
-  if (!currentInstance) {
+  if (!currentInstance.value) {
     if (__DEV__) {
       warn(`provide() can only be used inside setup().`)
     }
   } else {
-    let provides = currentInstance.provides
+    let provides = currentInstance.value.provides
     // by default an instance inherits its parent's provides object
     // but when it needs to provide values of its own, it creates its
     // own provides object using parent provides object as prototype.
     // this way in `inject` we can simply look up injections from direct
     // parent and let the prototype chain do the work.
     const parentProvides =
-      currentInstance.parent && currentInstance.parent.provides
+      currentInstance.value.parent && currentInstance.value.parent.provides
     if (parentProvides === provides) {
-      provides = currentInstance.provides = Object.create(parentProvides)
+      provides = currentInstance.value.provides = Object.create(parentProvides)
     }
     // TS doesn't allow symbol as index type
     provides[key as string] = value
@@ -45,7 +45,7 @@ export function inject(
 ) {
   // fallback to `currentRenderingInstance` so that this can be called in
   // a functional component
-  const instance = currentInstance || currentRenderingInstance
+  const instance = currentInstance.value || currentRenderingInstance
   if (instance) {
     // #2400
     // to support `app.use` plugins,

--- a/packages/runtime-core/src/apiLifecycle.ts
+++ b/packages/runtime-core/src/apiLifecycle.ts
@@ -17,7 +17,7 @@ export { onActivated, onDeactivated } from './components/KeepAlive'
 export function injectHook(
   type: LifecycleHooks,
   hook: Function & { __weh?: Function },
-  target: ComponentInternalInstance | null = currentInstance,
+  target: ComponentInternalInstance | null = currentInstance.value,
   prepend: boolean = false
 ): Function | undefined {
   if (target) {
@@ -65,7 +65,7 @@ export function injectHook(
 
 export const createHook =
   <T extends Function = () => any>(lifecycle: LifecycleHooks) =>
-  (hook: T, target: ComponentInternalInstance | null = currentInstance) =>
+  (hook: T, target: ComponentInternalInstance | null = currentInstance.value) =>
     // post-create lifecycle registrations are noops during SSR (except for serverPrefetch)
     (!isInSSRComponentSetup || lifecycle === LifecycleHooks.SERVER_PREFETCH) &&
     injectHook(lifecycle, (...args: unknown[]) => hook(...args), target)
@@ -94,7 +94,7 @@ export type ErrorCapturedHook<TError = unknown> = (
 
 export function onErrorCaptured<TError = Error>(
   hook: ErrorCapturedHook<TError>,
-  target: ComponentInternalInstance | null = currentInstance
+  target: ComponentInternalInstance | null = currentInstance.value
 ) {
   injectHook(LifecycleHooks.ERROR_CAPTURED, hook, target)
 }

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -200,8 +200,9 @@ function doWatch(
   }
 
   const instance =
-    getCurrentScope() === currentInstance?.scope ? currentInstance : null
-  // const instance = currentInstance
+    getCurrentScope() === currentInstance.value?.scope
+      ? currentInstance.value
+      : null
   let getter: () => any
   let forceTrigger = false
   let isMultiSource = false
@@ -418,7 +419,7 @@ export function instanceWatch(
     cb = value.handler as Function
     options = value
   }
-  const cur = currentInstance
+  const cur = currentInstance.value
   setCurrentInstance(this)
   const res = doWatch(getter, cb.bind(publicThis), options)
   if (cur) {

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -56,7 +56,8 @@ import {
   makeMap,
   isPromise,
   ShapeFlags,
-  extend
+  extend,
+  getGlobalThis
 } from '@vue/shared'
 import { SuspenseBoundary } from './components/Suspense'
 import { CompilerOptions } from '@vue/compiler-core'
@@ -560,19 +561,23 @@ export function createComponentInstance(
   return instance
 }
 
-export let currentInstance: ComponentInternalInstance | null = null
+export const currentInstance =
+  getGlobalThis().__vue_ctx__ ||
+  ({ value: null } as {
+    value: ComponentInternalInstance | null
+  })
 
 export const getCurrentInstance: () => ComponentInternalInstance | null = () =>
-  currentInstance || currentRenderingInstance
+  currentInstance.value || currentRenderingInstance
 
 export const setCurrentInstance = (instance: ComponentInternalInstance) => {
-  currentInstance = instance
+  currentInstance.value = instance
   instance.scope.on()
 }
 
 export const unsetCurrentInstance = () => {
-  currentInstance && currentInstance.scope.off()
-  currentInstance = null
+  currentInstance.value && currentInstance.value.scope.off()
+  currentInstance.value = null
 }
 
 const isBuiltInTag = /*#__PURE__*/ makeMap('slot,component')

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -68,7 +68,7 @@ const normalizeSlot = (
     return rawSlot as Slot
   }
   const normalized = withCtx((...args: any[]) => {
-    if (__DEV__ && currentInstance) {
+    if (__DEV__ && currentInstance.value) {
       warn(
         `Slot "${key}" invoked outside of the render function: ` +
           `this will not track dependencies used in the slot. ` +

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -376,7 +376,7 @@ export function onDeactivated(
 function registerKeepAliveHook(
   hook: Function & { __wdc?: Function },
   type: LifecycleHooks,
-  target: ComponentInternalInstance | null = currentInstance
+  target: ComponentInternalInstance | null = currentInstance.value
 ) {
   // cache the deactivate branch check wrapper for injected hooks so the same
   // hook can be properly deduped by the scheduler. "__wdc" stands for "with

--- a/packages/runtime-core/src/helpers/resolveAssets.ts
+++ b/packages/runtime-core/src/helpers/resolveAssets.ts
@@ -80,7 +80,7 @@ function resolveAsset(
   warnMissing = true,
   maybeSelfReference = false
 ) {
-  const instance = currentRenderingInstance || currentInstance
+  const instance = currentRenderingInstance || currentInstance.value
   if (instance) {
     const Component = instance.type
 

--- a/packages/runtime-core/src/helpers/useSsrContext.ts
+++ b/packages/runtime-core/src/helpers/useSsrContext.ts
@@ -1,7 +1,7 @@
 import { inject } from '../apiInject'
 import { warn } from '../warning'
 
-export const ssrContextKey = Symbol(__DEV__ ? `ssrContext` : ``)
+export const ssrContextKey = Symbol.for(`ssrContext`)
 
 export const useSSRContext = <T = Record<string, any>>() => {
   if (!__GLOBAL__) {


### PR DESCRIPTION
**Context:** Changes in this pull request, are an attempt to fix the root cause of a long-lasting issue we had with Nuxt 3, composition API, and especially during the server-side-rendering phase but it can be related to any Vue SSR setup with the same situation. There is no single issue or reproduction I could refer to (1) but trying to explain as best as I can.

Vue 3 uses an internal singleton variable for CAPI that temporarily keeps the Vue instance while rendering components. it is used internally and can be accessed using `getCurrentInstance()` from other compostables.

This works perfectly fine as long as both user and all libraries import `getCurrentInstance()` from exactly the same file && the same evaluated instance. If for any reason they (or an intermediate composable) is not, the whole CAPI API will be broken with untraceable errors such as `Server rendering context not provided` or `Cannot read property something of undefined`. 

There could be many reasons for this situation to happen:
- Package managers hoist and install different versions of Vue for libraries, frameworks and user
- Same version of Vue from different `node_modules` directories (when npm linking)
- Same version of Vue with different builds (Vite picks `esm-bundler`, externalized dependencies pick `cjs` build)
- Same version and build of Vue with different instances (One can be inlined by bundler and one externalized)
- Vue and @vue/runtime-core (however it didn't happen, but I noticed `vue` package also has a standalone build of runtime-core)

The proposed changes fix this issue by storing temporary variables in a context stored in `globalThis` instead of local scope. This allows to `getCurrentInstance()` to work no matter from which version/build/format or instance as long as being in the same tick, the instance is available. It doesn't add perf overhead and wouldn't break concurrency constraints too since we unset it with the same strategy as before. An additional fix I made was is to use `Symbol.for` for `ssrContext` injection, deduplicating it using the global Symbol registry otherwise, two Symbol instances differ. (2)

---

Updates:

- Using shared current instance is opt-in with internal API `globalThis.__vue__`. When it is set, vue uses this object over package local instance.

---

Notes:


(1) Linked issues: There were many older issues we solved with different methods in Nuxt 3 before. I finally made and verified it in order to fix the root cause of https://github.com/nuxt/nuxt/issues/18563. If needed, happy will list more relevant issues.

(2) Fixes to the core of CAPI for this, are impossible to be done at the userland or framework level. However, if for any reason you are against using `globalThis`, we can make it opt-in by optionally using `globalThis` if set by the framework and then falling back to a local variable.



