### PR TITLE
fix(reactivity): observe redfined property of readonly

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -329,7 +329,6 @@ describe('reactivity/reactive', () => {
     expect(
       '[Vue warn] Set operation on key "bar" failed: target is readonly.'
     ).toHaveBeenWarned()
-
     expect(trigger).toHaveBeenCalledTimes(1)
     expect(foo.bar).toBe(0)
 
@@ -343,7 +342,6 @@ describe('reactivity/reactive', () => {
     expect(
       '[Vue warn] Set operation on key "cat" failed: target is readonly.'
     ).toHaveBeenWarned()
-
     expect(trigger).toHaveBeenCalledTimes(1)
     expect(foo.cat).toBe(0)
   })

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -867,6 +867,34 @@ describe('api: watch', () => {
       key: 'foo',
       oldValue: 2
     })
+
+    await nextTick()
+    Object.defineProperty(obj, 'foo', {
+      value: 3,
+      configurable: true
+    })
+    expect(dummy).toBeUndefined()
+    expect(onTrigger).toHaveBeenCalledTimes(3)
+    expect(events[2]).toMatchObject({
+      type: TriggerOpTypes.ADD,
+      key: 'foo',
+      newValue: 3
+    })
+
+    await nextTick()
+    Object.defineProperty(obj, 'foo', {
+      get() {
+        return 4
+      }
+    })
+    expect(dummy).toBe(3)
+    expect(onTrigger).toHaveBeenCalledTimes(4)
+    expect(events[3]).toMatchObject({
+      type: TriggerOpTypes.SET,
+      key: 'foo',
+      oldValue: 3,
+      newValue: 4
+    })
   })
 
   it('should work sync', () => {


### PR DESCRIPTION
**Description**
fixes https://github.com/vuejs/core/issues/7602

**Additional context**

There is a PR that can solve the problems involved in [#7604](https://github.com/vuejs/core/pull/7604), but it seems to ignore the judgment of readonly or shallowReadonly. If it is not checked, it will indirectly change the value of the original object represented by readonly. Therefore, I added some judgments on the basis of  [#7604](https://github.com/vuejs/core/pull/7604) and made relevant tests.