### PR TITLE
ci: add a ecosystem-ci-trigger workflow

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -58,18 +58,12 @@ jobs:
               branchName: pr.head.ref,
               repo: pr.head.repo.full_name
             }
-      - id: generate-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_ID }}
-          private_key: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY }}
-          repository: "${{ github.repository_owner }}/ecosystem-ci"
       - uses: actions/github-script@v6
         id: trigger
         env:
           COMMENT: ${{ github.event.comment.body }}
         with:
-          github-token: ${{ steps.generate-token.outputs.token }}
+          github-token: ${{ secrets.ECOSYSTEM_CI_ACCESS_TOKEN }}
           result-encoding: string
           script: |
             const comment = process.env.COMMENT.trim()

--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -1,0 +1,91 @@
+name: ecosystem-ci trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    if: github.repository == 'vuejs/core' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/ecosystem-ci run')
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const user = context.payload.sender.login
+            console.log(`Validate user: ${user}`)
+
+            let isVuejsMember = false
+            try {
+              const { status } = await github.rest.orgs.checkMembershipForUser({
+                org: 'vuejs',
+                username: user
+              });
+
+              isVuejsMember = (status === 204)
+            } catch (e) {}
+
+            if (isVuejsMember) {
+              console.log('Allowed')
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: '+1',
+              })
+            } else {
+              console.log('Not allowed')
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: '-1',
+              })
+              throw new Error('not allowed')
+            }
+      - uses: actions/github-script@v6
+        id: get-pr-data
+        with:
+          script: |
+            console.log(`Get PR info: ${context.repo.owner}/${context.repo.repo}#${context.issue.number}`)
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            })
+            return {
+              num: context.issue.number,
+              branchName: pr.head.ref,
+              repo: pr.head.repo.full_name
+            }
+      - id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_ID }}
+          private_key: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY }}
+          repository: "${{ github.repository_owner }}/ecosystem-ci"
+      - uses: actions/github-script@v6
+        id: trigger
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          result-encoding: string
+          script: |
+            const comment = process.env.COMMENT.trim()
+            const prData = ${{ steps.get-pr-data.outputs.result }}
+
+            const suite = comment.replace(/^\/ecosystem-ci run/, '').trim()
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'ecosystem-ci',
+              workflow_id: 'ecosystem-ci-from-pr.yml',
+              ref: 'main',
+              inputs: {
+                prNumber: '' + prData.num,
+                branchName: prData.branchName,
+                repo: prData.repo,
+                suite: suite === '' ? '-' : suite
+              }
+            })


### PR DESCRIPTION
Inspired by https://github.com/vitejs/vite/blob/main/.github/workflows/ecosystem-ci-trigger.yml with the following modifications:

- Allow all members of the `vuejs` organization to trigger the CI, instead of hard-coding the `allowedUsers` list
- Use a fine-grained personal access token instead of GitHub App, because we already have the `vue-bot` account, no need to create a new App.
	- The personal access token needs these permissions:
		- Actions: Read and Write
		- Pull requests: Read and Write
	- The token needs to be added to this repo & the `ecosystem-ci` repo's action secrets, in the name of `ECOSYSTEM_CI_ACCESS_TOKEN`
		- https://github.com/vuejs/core/settings/secrets/actions
		- https://github.com/vuejs/ecosystem-ci/settings/secrets/actions

Usage:
Add comment on any PR in the following format:
- `/ecosystem-ci run` to trigger a full run
- `/ecosystem-ci run vitepress` to trigger the CI for the specific suite (vitepress)