### PR TITLE
Add Codecov for code coverage metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       - run: PUPPETEER_SKIP_DOWNLOAD=1 pnpm install
 
       - name: Run unit tests
-        run: pnpm run test-unit
+        run: pnpm run test-coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
 
   e2e-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          flags: unit
 
   e2e-test:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,67 @@
+coverage:
+  status:
+    project:
+      default:
+        # Status checks are set to be non-blocking
+        informational: true
+    patch:
+      default:
+        # Status checks are set to be non-blocking
+        informational: true
+
+comment:
+  layout: "header, diff, flags, components"
+
+component_management:
+  individual_components:
+    - component_id: packages
+      paths:
+        - packages/
+    - component_id: compiler-core
+      paths:
+        - packages/compiler-core/
+    - component_id: compiler-dom
+      paths:
+        - packages/compiler-dom/
+    - component_id: compiler-sfc
+      paths:
+        - packages/compiler-sfc/
+    - component_id: compiler-sfc
+      paths:
+        - packages/compiler-sfc/
+    - component_id: reactivity
+      paths:
+        - packages/reactivity/
+    - component_id: reactivity-transform
+      paths:
+        - packages/reactivity-transform/
+    - component_id: runtime-core
+      paths:
+        - packages/runtime-core/
+    - component_id: runtime-dom
+      paths:
+        - packages/runtime-dom/
+    - component_id: runtime-test
+      paths:
+        - packages/runtime-test/
+    - component_id: server-renderer
+      paths:
+        - packages/server-renderer/
+    - component_id: sfc-playground
+      paths:
+        - packages/sfc-playground/
+    - component_id: shared
+      paths:
+        - packages/shared/
+    - component_id: size-check
+      paths:
+        - packages/size-check/
+    - component_id: template-explorer
+      paths:
+        - packages/template-explorer/
+    - component_id: vue
+      paths:
+        - packages/vue/
+    - component_id: vue-compat
+      paths:
+        - packages/vue-compat/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'istanbul',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'cobertura'],
       exclude: [
         ...configDefaults.coverage.exclude!,
         // DOM transitions are tested via e2e so no coverage is collected


### PR DESCRIPTION
Hi, Tom from Codecov here. I'm a huge fan of Vue and realized you had the infrastructure to collect code coverage. I wanted to offer this PR in case getting some metrics in PRs is useful for you.

The way it's set up right now, the status checks aren't blocking (so that developers won't need to increase coverage for new code) and the PR comment will include components that show coverage for each package. Also, in case it's helpful, I added the `unit` flag on the upload, which might be useful down the road.

I pushed this on my own fork [here](https://app.codecov.io/gh/thomasrockhu-codecov/core) in case you want to see what coverage looks like. Let me know if you have any questions!