### PR TITLE
fix(compiler-core): Add original filename to TransformContext

### DIFF
--- a/packages/compiler-core/__tests__/transform.spec.ts
+++ b/packages/compiler-core/__tests__/transform.spec.ts
@@ -35,7 +35,8 @@ describe('compiler: transform', () => {
     }
 
     transform(ast, {
-      nodeTransforms: [plugin]
+      nodeTransforms: [plugin],
+      filename: 'example.vue'
     })
 
     const div = ast.children[0] as ElementNode
@@ -43,6 +44,7 @@ describe('compiler: transform', () => {
     expect(calls[0]).toMatchObject([
       ast,
       {
+        filename: 'example.vue',
         parent: null,
         currentNode: ast
       }

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -82,9 +82,7 @@ export interface ImportItem {
 }
 
 export interface TransformContext
-  extends Required<
-      Omit<TransformOptions, 'filename' | keyof CompilerCompatOptions>
-    >,
+  extends Required<Omit<TransformOptions, keyof CompilerCompatOptions>>,
     CompilerCompatOptions {
   selfName: string | null
   root: RootNode
@@ -152,6 +150,7 @@ export function createTransformContext(
   const context: TransformContext = {
     // options
     selfName: nameMatch && capitalize(camelize(nameMatch[1])),
+    filename,
     prefixIdentifiers,
     hoistStatic,
     cacheHandlers,


### PR DESCRIPTION
This PR exposes the original `filename` variable to the TransformContext so that NodeTransform functions can use it [(#6164)](https://github.com/vuejs/core/issues/6164).