### PR TITLE
fix(compiler-core): pass `_cache` to ssr render functions

### DIFF
--- a/packages/compiler-core/__tests__/codegen.spec.ts
+++ b/packages/compiler-core/__tests__/codegen.spec.ts
@@ -479,7 +479,7 @@ describe('compiler: codegen', () => {
     )
     expect(code).toMatchInlineSnapshot(`
       "
-      export function ssrRender(_ctx, _push, _parent, _attrs) {
+      export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`foo\${_renderAttr(id, foo)}bar\`)
       }"
     `)
@@ -500,7 +500,7 @@ describe('compiler: codegen', () => {
       )
       expect(code).toMatchInlineSnapshot(`
         "
-        export function ssrRender(_ctx, _push, _parent, _attrs) {
+        export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (foo) {
             ok()
           }
@@ -523,7 +523,7 @@ describe('compiler: codegen', () => {
       )
       expect(code).toMatchInlineSnapshot(`
         "
-        export function ssrRender(_ctx, _push, _parent, _attrs) {
+        export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (foo) {
             foo()
           } else {
@@ -551,7 +551,7 @@ describe('compiler: codegen', () => {
       )
       expect(code).toMatchInlineSnapshot(`
         "
-        export function ssrRender(_ctx, _push, _parent, _attrs) {
+        export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (foo) {
             foo()
           } else if (bar) {
@@ -580,7 +580,7 @@ describe('compiler: codegen', () => {
       )
       expect(code).toMatchInlineSnapshot(`
         "
-        export function ssrRender(_ctx, _push, _parent, _attrs) {
+        export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (foo) {
             foo()
           } else if (bar) {

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -227,7 +227,9 @@ export function generate(
   }
   // enter render function
   const functionName = ssr ? `ssrRender` : `render`
-  const args = ssr ? ['_ctx', '_push', '_parent', '_attrs'] : ['_ctx', '_cache']
+  const args = ssr
+    ? ['_ctx', '_push', '_parent', '_attrs', '_cache']
+    : ['_ctx', '_cache']
   if (!__BROWSER__ && options.bindingMetadata && !options.inline) {
     // binding optimization args
     args.push('$props', '$setup', '$data', '$options')

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1068,7 +1068,7 @@ export default {
 
         const count = ref(0)
         
-return (_ctx, _push, _parent, _attrs) => {
+return (_ctx, _push, _parent, _attrs, _cache) => {
   const _cssVars = { style: {
   \\"--xxxxxxxx-count\\": (count.value)
 }}

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileTemplate.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileTemplate.spec.ts.snap
@@ -19,7 +19,7 @@ import _imports_0 from './img/foo.svg'
 import _imports_1 from './img/bar.svg'
 
 
-export function ssrRender(_ctx, _push, _parent, _attrs) {
+export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
   const _component_router_link = _resolveComponent(\\"router-link\\")
 
   _push(\`<!--[--><picture><source\${

--- a/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
@@ -6,7 +6,7 @@ describe('ssr: components', () => {
       "const { resolveComponent: _resolveComponent, mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
 
         _push(_ssrRenderComponent(_component_foo, _mergeProps({
@@ -23,7 +23,7 @@ describe('ssr: components', () => {
       "const { resolveComponent: _resolveComponent, mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
 
         _push(_ssrRenderComponent(_component_foo, _mergeProps({ onClick: _ctx.bar }, _attrs), null, _parent))
@@ -37,7 +37,7 @@ describe('ssr: components', () => {
         "const { resolveDynamicComponent: _resolveDynamicComponent, mergeProps: _mergeProps, createVNode: _createVNode } = require(\\"vue\\")
         const { ssrRenderVNode: _ssrRenderVNode } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _ssrRenderVNode(_push, _createVNode(_resolveDynamicComponent(\\"foo\\"), _mergeProps({ prop: \\"b\\" }, _attrs), null), _parent)
         }"
       `)
@@ -47,7 +47,7 @@ describe('ssr: components', () => {
         "const { resolveDynamicComponent: _resolveDynamicComponent, mergeProps: _mergeProps, createVNode: _createVNode } = require(\\"vue\\")
         const { ssrRenderVNode: _ssrRenderVNode } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _ssrRenderVNode(_push, _createVNode(_resolveDynamicComponent(_ctx.foo), _mergeProps({ prop: \\"b\\" }, _attrs), null), _parent)
         }"
       `)
@@ -59,7 +59,7 @@ describe('ssr: components', () => {
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createVNode: _createVNode, createTextVNode: _createTextVNode } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           const _component_foo = _resolveComponent(\\"foo\\")
 
           _push(_ssrRenderComponent(_component_foo, _attrs, {
@@ -85,7 +85,7 @@ describe('ssr: components', () => {
           "const { resolveComponent: _resolveComponent, withCtx: _withCtx, toDisplayString: _toDisplayString, createTextVNode: _createTextVNode } = require(\\"vue\\")
           const { ssrRenderComponent: _ssrRenderComponent, ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-          return function ssrRender(_ctx, _push, _parent, _attrs) {
+          return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
             const _component_foo = _resolveComponent(\\"foo\\")
 
             _push(_ssrRenderComponent(_component_foo, _attrs, {
@@ -119,7 +119,7 @@ describe('ssr: components', () => {
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createTextVNode: _createTextVNode } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           const _component_foo = _resolveComponent(\\"foo\\")
 
           _push(_ssrRenderComponent(_component_foo, _attrs, {
@@ -156,7 +156,7 @@ describe('ssr: components', () => {
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createTextVNode: _createTextVNode, createSlots: _createSlots } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           const _component_foo = _resolveComponent(\\"foo\\")
 
           _push(_ssrRenderComponent(_component_foo, _attrs, _createSlots({ _: 2 /* DYNAMIC */ }, [
@@ -189,7 +189,7 @@ describe('ssr: components', () => {
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, toDisplayString: _toDisplayString, createTextVNode: _createTextVNode, renderList: _renderList, createSlots: _createSlots } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent, ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           const _component_foo = _resolveComponent(\\"foo\\")
 
           _push(_ssrRenderComponent(_component_foo, _attrs, _createSlots({ _: 2 /* DYNAMIC */ }, [
@@ -230,7 +230,7 @@ describe('ssr: components', () => {
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           const _component_foo = _resolveComponent(\\"foo\\")
 
           _push(_ssrRenderComponent(_component_foo, _attrs, {
@@ -292,7 +292,7 @@ describe('ssr: components', () => {
           .toMatchInlineSnapshot(`
             "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-            return function ssrRender(_ctx, _push, _parent, _attrs) {
+            return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
               _push(\`<div\${_ssrRenderAttrs(_attrs)}></div>\`)
             }"
           `)
@@ -304,7 +304,7 @@ describe('ssr: components', () => {
             "const { resolveComponent: _resolveComponent } = require(\\"vue\\")
             const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-            return function ssrRender(_ctx, _push, _parent, _attrs) {
+            return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
               const _component_foo = _resolveComponent(\\"foo\\")
 
               _push(_ssrRenderComponent(_component_foo, _attrs, null, _parent))
@@ -321,7 +321,7 @@ describe('ssr: components', () => {
           "const { resolveComponent: _resolveComponent, withCtx: _withCtx, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode, Transition: _Transition, createVNode: _createVNode } = require(\\"vue\\")
           const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-          return function ssrRender(_ctx, _push, _parent, _attrs) {
+          return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
             const _component_foo = _resolveComponent(\\"foo\\")
 
             _push(_ssrRenderComponent(_component_foo, _attrs, {
@@ -360,7 +360,7 @@ describe('ssr: components', () => {
         "const { resolveComponent: _resolveComponent, resolveDirective: _resolveDirective, mergeProps: _mergeProps } = require(\\"vue\\")
         const { ssrGetDirectiveProps: _ssrGetDirectiveProps, ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           const _component_foo = _resolveComponent(\\"foo\\")
           const _directive_xxx = _resolveDirective(\\"xxx\\")
 

--- a/packages/compiler-ssr/__tests__/ssrElement.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrElement.spec.ts
@@ -59,7 +59,7 @@ describe('ssr: element', () => {
           "const { mergeProps: _mergeProps } = require(\\"vue\\")
           const { ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-          return function ssrRender(_ctx, _push, _parent, _attrs) {
+          return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
             let _temp0
 
             _push(\`<textarea\${
@@ -77,7 +77,7 @@ describe('ssr: element', () => {
       ).toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           let _temp0
 
           _push(\`<div\${
@@ -102,7 +102,7 @@ describe('ssr: element', () => {
         "const { mergeProps: _mergeProps } = require(\\"vue\\")
         const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<my-foo\${_ssrRenderAttrs(_mergeProps(_ctx.obj, _attrs), \\"my-foo\\")}></my-foo>\`)
         }"
       `)

--- a/packages/compiler-ssr/__tests__/ssrFallthroughAttrs.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrFallthroughAttrs.spec.ts
@@ -5,7 +5,7 @@ describe('ssr: attrs fallthrough', () => {
     expect(compile(`<div/>`).code).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${_ssrRenderAttrs(_attrs)}></div>\`)
       }"
     `)
@@ -15,7 +15,7 @@ describe('ssr: attrs fallthrough', () => {
     expect(compile(`<!--!--><div/>`).code).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[--><!--!--><div\${_ssrRenderAttrs(_attrs)}></div><!--]-->\`)
       }"
     `)
@@ -25,7 +25,7 @@ describe('ssr: attrs fallthrough', () => {
   test('should not inject to non-single-root if branches', () => {
     expect(compile(`<div v-if="true"/><div/>`).code).toMatchInlineSnapshot(`
       "
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         if (true) {
           _push(\`<div></div>\`)
@@ -42,7 +42,7 @@ describe('ssr: attrs fallthrough', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<!--[--><!--root--><div\${_ssrRenderAttrs(_attrs)}></div><!--]-->\`)
         }"
       `)
@@ -51,10 +51,10 @@ describe('ssr: attrs fallthrough', () => {
   test('should not inject to fallthrough component content if not root', () => {
     expect(compile(`<div/><transition><div/></transition>`).code)
       .toMatchInlineSnapshot(`
-              "
-              return function ssrRender(_ctx, _push, _parent, _attrs) {
-                _push(\`<!--[--><div></div><div></div><!--]-->\`)
-              }"
-          `)
+        "
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
+          _push(\`<!--[--><div></div><div></div><!--]-->\`)
+        }"
+      `)
   })
 })

--- a/packages/compiler-ssr/__tests__/ssrInjectCssVars.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrInjectCssVars.spec.ts
@@ -11,7 +11,7 @@ describe('ssr: inject <style vars>', () => {
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _cssVars = { style: { color: _ctx.color }}
         _push(\`<div\${_ssrRenderAttrs(_mergeProps(_attrs, _cssVars))}></div>\`)
       }"
@@ -26,7 +26,7 @@ describe('ssr: inject <style vars>', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _cssVars = { style: { color: _ctx.color }}
         _push(\`<!--[--><div\${
           _ssrRenderAttrs(_cssVars)
@@ -46,7 +46,7 @@ describe('ssr: inject <style vars>', () => {
       "const { resolveComponent: _resolveComponent } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs, ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
 
         const _cssVars = { style: { color: _ctx.color }}
@@ -66,7 +66,7 @@ describe('ssr: inject <style vars>', () => {
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _cssVars = { style: { color: _ctx.color }}
         if (_ctx.ok) {
           _push(\`<div\${_ssrRenderAttrs(_mergeProps(_attrs, _cssVars))}></div>\`)
@@ -98,7 +98,7 @@ describe('ssr: inject <style vars>', () => {
       "const { withCtx: _withCtx } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs, ssrRenderSuspense: _ssrRenderSuspense } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _cssVars = { style: { color: _ctx.color }}
         _ssrRenderSuspense(_push, {
           fallback: () => {
@@ -121,7 +121,7 @@ describe('ssr: inject <style vars>', () => {
     })
 
     expect(result.code).toMatchInlineSnapshot(`
-      "(_ctx, _push, _parent, _attrs) => {
+      "(_ctx, _push, _parent, _attrs, _cache) => {
         const _cssVars = { style: { \\"--hash\\": (_unref(dynamic)) }}
         _push(\`<div\${_ssrRenderAttrs(_mergeProps(_attrs, _cssVars))}></div>\`)
       }"

--- a/packages/compiler-ssr/__tests__/ssrPortal.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrPortal.spec.ts
@@ -6,7 +6,7 @@ describe('ssr compile: teleport', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderTeleport: _ssrRenderTeleport } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _ssrRenderTeleport(_push, (_push) => {
             _push(\`<div></div>\`)
           }, _ctx.target, false, _parent)
@@ -19,7 +19,7 @@ describe('ssr compile: teleport', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderTeleport: _ssrRenderTeleport } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _ssrRenderTeleport(_push, (_push) => {
             _push(\`<div></div>\`)
           }, _ctx.target, true, _parent)
@@ -31,7 +31,7 @@ describe('ssr compile: teleport', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderTeleport: _ssrRenderTeleport } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _ssrRenderTeleport(_push, (_push) => {
           _push(\`<div></div>\`)
         }, _ctx.target, _ctx.foo, _parent)

--- a/packages/compiler-ssr/__tests__/ssrScopeId.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrScopeId.spec.ts
@@ -12,7 +12,7 @@ describe('ssr: scopeId', () => {
     ).toMatchInlineSnapshot(`
       "import { ssrRenderAttrs as _ssrRenderAttrs } from \\"vue/server-renderer\\"
 
-      export function ssrRender(_ctx, _push, _parent, _attrs) {
+      export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${_ssrRenderAttrs(_attrs)} data-v-xxxxxxx><span data-v-xxxxxxx>hello</span></div>\`)
       }"
     `)
@@ -29,7 +29,7 @@ describe('ssr: scopeId', () => {
       "import { resolveComponent as _resolveComponent, withCtx as _withCtx, createTextVNode as _createTextVNode } from \\"vue\\"
       import { ssrRenderComponent as _ssrRenderComponent } from \\"vue/server-renderer\\"
 
-      export function ssrRender(_ctx, _push, _parent, _attrs) {
+      export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
 
         _push(_ssrRenderComponent(_component_foo, _attrs, {
@@ -58,7 +58,7 @@ describe('ssr: scopeId', () => {
       "import { resolveComponent as _resolveComponent, withCtx as _withCtx, createVNode as _createVNode } from \\"vue\\"
       import { ssrRenderComponent as _ssrRenderComponent } from \\"vue/server-renderer\\"
 
-      export function ssrRender(_ctx, _push, _parent, _attrs) {
+      export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
 
         _push(_ssrRenderComponent(_component_foo, _attrs, {
@@ -87,7 +87,7 @@ describe('ssr: scopeId', () => {
       "import { resolveComponent as _resolveComponent, withCtx as _withCtx, createVNode as _createVNode } from \\"vue\\"
       import { ssrRenderComponent as _ssrRenderComponent } from \\"vue/server-renderer\\"
 
-      export function ssrRender(_ctx, _push, _parent, _attrs) {
+      export function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
         const _component_bar = _resolveComponent(\\"bar\\")
 

--- a/packages/compiler-ssr/__tests__/ssrSlotOutlet.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrSlotOutlet.spec.ts
@@ -6,7 +6,7 @@ describe('ssr: <slot>', () => {
     expect(compile(`<slot/>`).code).toMatchInlineSnapshot(`
       "const { ssrRenderSlot: _ssrRenderSlot } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _ssrRenderSlot(_ctx.$slots, \\"default\\", {}, null, _push, _parent)
       }"
     `)
@@ -16,7 +16,7 @@ describe('ssr: <slot>', () => {
     expect(compile(`<slot name="foo" />`).code).toMatchInlineSnapshot(`
       "const { ssrRenderSlot: _ssrRenderSlot } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _ssrRenderSlot(_ctx.$slots, \\"foo\\", {}, null, _push, _parent)
       }"
     `)
@@ -26,7 +26,7 @@ describe('ssr: <slot>', () => {
     expect(compile(`<slot :name="bar.baz" />`).code).toMatchInlineSnapshot(`
       "const { ssrRenderSlot: _ssrRenderSlot } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _ssrRenderSlot(_ctx.$slots, _ctx.bar.baz, {}, null, _push, _parent)
       }"
     `)
@@ -37,7 +37,7 @@ describe('ssr: <slot>', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderSlot: _ssrRenderSlot } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _ssrRenderSlot(_ctx.$slots, \\"foo\\", {
             p: 1,
             bar: \\"2\\"
@@ -51,7 +51,7 @@ describe('ssr: <slot>', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderSlot: _ssrRenderSlot, ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _ssrRenderSlot(_ctx.$slots, \\"default\\", {}, () => {
             _push(\`some \${_ssrInterpolate(_ctx.fallback)} content\`)
           }, _push, _parent)
@@ -67,7 +67,7 @@ describe('ssr: <slot>', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderSlot: _ssrRenderSlot } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _ssrRenderSlot(_ctx.$slots, \\"default\\", {}, null, _push, _parent, \\"hello-s\\")
       }"
     `)
@@ -82,7 +82,7 @@ describe('ssr: <slot>', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderSlot: _ssrRenderSlot } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _ssrRenderSlot(_ctx.$slots, \\"default\\", {}, null, _push, _parent)
       }"
     `)
@@ -97,7 +97,7 @@ describe('ssr: <slot>', () => {
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx, renderSlot: _renderSlot } = require(\\"vue\\")
       const { ssrRenderSlot: _ssrRenderSlot, ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_Comp = _resolveComponent(\\"Comp\\")
 
         _push(_ssrRenderComponent(_component_Comp, _attrs, {
@@ -122,7 +122,7 @@ describe('ssr: <slot>', () => {
     expect(code).toMatchInlineSnapshot(`
       "const { ssrRenderSlotInner: _ssrRenderSlotInner } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _ssrRenderSlotInner(_ctx.$slots, \\"default\\", {}, null, _push, _parent, null, true)
       }"
     `)

--- a/packages/compiler-ssr/__tests__/ssrSuspense.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrSuspense.spec.ts
@@ -6,7 +6,7 @@ describe('ssr compile: suspense', () => {
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent, ssrRenderSuspense: _ssrRenderSuspense } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
 
         _ssrRenderSuspense(_push, {
@@ -33,7 +33,7 @@ describe('ssr compile: suspense', () => {
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent, ssrRenderSuspense: _ssrRenderSuspense } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         const _component_foo = _resolveComponent(\\"foo\\")
 
         _ssrRenderSuspense(_push, {

--- a/packages/compiler-ssr/__tests__/ssrText.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrText.spec.ts
@@ -45,7 +45,7 @@ describe('ssr: text', () => {
     expect(compile(`foo {{ bar }} baz`).code).toMatchInlineSnapshot(`
       "const { ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`foo \${_ssrInterpolate(_ctx.bar)} baz\`)
       }"
     `)
@@ -58,7 +58,7 @@ describe('ssr: text', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><span>\${

--- a/packages/compiler-ssr/__tests__/ssrTransitionGroup.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrTransitionGroup.spec.ts
@@ -10,7 +10,7 @@ describe('transition-group', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         _ssrRenderList(_ctx.list, (i) => {
           _push(\`<div></div>\`)
@@ -28,7 +28,7 @@ describe('transition-group', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<ul\${_ssrRenderAttrs(_attrs)}>\`)
         _ssrRenderList(_ctx.list, (i) => {
           _push(\`<div></div>\`)
@@ -46,7 +46,7 @@ describe('transition-group', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<\${
           _ctx.someTag
         }\${
@@ -72,7 +72,7 @@ describe('transition-group', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         _ssrRenderList(10, (i) => {
           _push(\`<div></div>\`)
@@ -100,7 +100,7 @@ describe('transition-group', () => {
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<ul\${_ssrRenderAttrs(_mergeProps({
           class: \\"red\\",
           id: \\"ok\\"

--- a/packages/compiler-ssr/__tests__/ssrVFor.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVFor.spec.ts
@@ -5,7 +5,7 @@ describe('ssr: v-for', () => {
     expect(compile(`<div v-for="i in list" />`).code).toMatchInlineSnapshot(`
       "const { ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         _ssrRenderList(_ctx.list, (i) => {
           _push(\`<div></div>\`)
@@ -20,7 +20,7 @@ describe('ssr: v-for', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<!--[-->\`)
           _ssrRenderList(_ctx.list, (i) => {
             _push(\`<div>foo<span>bar</span></div>\`)
@@ -40,7 +40,7 @@ describe('ssr: v-for', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrInterpolate: _ssrInterpolate, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         _ssrRenderList(_ctx.list, (row, i) => {
           _push(\`<div><!--[-->\`)
@@ -63,7 +63,7 @@ describe('ssr: v-for', () => {
       .toMatchInlineSnapshot(`
         "const { ssrInterpolate: _ssrInterpolate, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<!--[-->\`)
           _ssrRenderList(_ctx.list, (i) => {
             _push(\`<!--[-->\${_ssrInterpolate(i)}<!--]-->\`)
@@ -80,7 +80,7 @@ describe('ssr: v-for', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrInterpolate: _ssrInterpolate, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         _ssrRenderList(_ctx.list, (i) => {
           _push(\`<span>\${_ssrInterpolate(i)}</span>\`)
@@ -98,7 +98,7 @@ describe('ssr: v-for', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrInterpolate: _ssrInterpolate, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         _ssrRenderList(_ctx.list, (i) => {
           _push(\`<!--[--><span>\${
@@ -122,7 +122,7 @@ describe('ssr: v-for', () => {
     expect(code).toMatchInlineSnapshot(`
       "const { ssrInterpolate: _ssrInterpolate, ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<!--[-->\`)
         _ssrRenderList(_ctx.list, ({ foo }, index) => {
           _push(\`<div>\${_ssrInterpolate(foo + _ctx.bar + index)}</div>\`)

--- a/packages/compiler-ssr/__tests__/ssrVIf.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVIf.spec.ts
@@ -5,7 +5,7 @@ describe('ssr: v-if', () => {
     expect(compile(`<div v-if="foo"></div>`).code).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         if (_ctx.foo) {
           _push(\`<div\${_ssrRenderAttrs(_attrs)}></div>\`)
         } else {
@@ -20,7 +20,7 @@ describe('ssr: v-if', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (_ctx.foo) {
             _push(\`<div\${_ssrRenderAttrs(_attrs)}>hello<span>ok</span></div>\`)
           } else {
@@ -35,7 +35,7 @@ describe('ssr: v-if', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (_ctx.foo) {
             _push(\`<div\${_ssrRenderAttrs(_attrs)}></div>\`)
           } else {
@@ -50,7 +50,7 @@ describe('ssr: v-if', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (_ctx.foo) {
             _push(\`<div\${_ssrRenderAttrs(_attrs)}></div>\`)
           } else if (_ctx.bar) {
@@ -67,7 +67,7 @@ describe('ssr: v-if', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (_ctx.foo) {
             _push(\`<div\${_ssrRenderAttrs(_attrs)}></div>\`)
           } else if (_ctx.bar) {
@@ -82,15 +82,15 @@ describe('ssr: v-if', () => {
   test('<template v-if> (text)', () => {
     expect(compile(`<template v-if="foo">hello</template>`).code)
       .toMatchInlineSnapshot(`
-      "
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
-        if (_ctx.foo) {
-          _push(\`<!--[-->hello<!--]-->\`)
-        } else {
-          _push(\`<!---->\`)
-        }
-      }"
-    `)
+        "
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
+          if (_ctx.foo) {
+            _push(\`<!--[-->hello<!--]-->\`)
+          } else {
+            _push(\`<!---->\`)
+          }
+        }"
+      `)
   })
 
   test('<template v-if> (single element)', () => {
@@ -99,7 +99,7 @@ describe('ssr: v-if', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           if (_ctx.foo) {
             _push(\`<div\${_ssrRenderAttrs(_attrs)}>hi</div>\`)
           } else {
@@ -114,7 +114,7 @@ describe('ssr: v-if', () => {
       compile(`<template v-if="foo"><div>hi</div><div>ho</div></template>`).code
     ).toMatchInlineSnapshot(`
       "
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         if (_ctx.foo) {
           _push(\`<!--[--><div>hi</div><div>ho</div><!--]-->\`)
         } else {
@@ -130,7 +130,7 @@ describe('ssr: v-if', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderList: _ssrRenderList } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         if (_ctx.foo) {
           _push(\`<!--[-->\`)
           _ssrRenderList(_ctx.list, (i) => {
@@ -152,7 +152,7 @@ describe('ssr: v-if', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         if (_ctx.foo) {
           _push(\`<!--[--><div>hi</div><div>ho</div><!--]-->\`)
         } else {

--- a/packages/compiler-ssr/__tests__/ssrVModel.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVModel.spec.ts
@@ -10,7 +10,7 @@ describe('ssr: v-model', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttr: _ssrRenderAttr, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<div\${
             _ssrRenderAttrs(_attrs)
           }><input\${
@@ -23,7 +23,7 @@ describe('ssr: v-model', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttr: _ssrRenderAttr, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<div\${
             _ssrRenderAttrs(_attrs)
           }><input type=\\"email\\"\${
@@ -39,7 +39,7 @@ describe('ssr: v-model', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrLooseEqual: _ssrLooseEqual, ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><input type=\\"radio\\" value=\\"foo\\"\${
@@ -54,7 +54,7 @@ describe('ssr: v-model', () => {
       .toMatchInlineSnapshot(`
         "const { ssrLooseContain: _ssrLooseContain, ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<div\${
             _ssrRenderAttrs(_attrs)
           }><input type=\\"checkbox\\"\${
@@ -71,7 +71,7 @@ describe('ssr: v-model', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrLooseContain: _ssrLooseContain, ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><input type=\\"checkbox\\" value=\\"foo\\"\${
@@ -89,7 +89,7 @@ describe('ssr: v-model', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrLooseEqual: _ssrLooseEqual, ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><input type=\\"checkbox\\"\${
@@ -105,7 +105,7 @@ describe('ssr: v-model', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrLooseEqual: _ssrLooseEqual, ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><input type=\\"checkbox\\"\${
@@ -120,7 +120,7 @@ describe('ssr: v-model', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<div\${
             _ssrRenderAttrs(_attrs)
           }><textarea>\${
@@ -135,7 +135,7 @@ describe('ssr: v-model', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderAttr: _ssrRenderAttr, ssrRenderDynamicModel: _ssrRenderDynamicModel, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<div\${
             _ssrRenderAttrs(_attrs)
           }><input\${
@@ -151,7 +151,7 @@ describe('ssr: v-model', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderAttr: _ssrRenderAttr, ssrRenderDynamicModel: _ssrRenderDynamicModel, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><input\${
@@ -167,7 +167,7 @@ describe('ssr: v-model', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderAttr: _ssrRenderAttr, ssrRenderDynamicModel: _ssrRenderDynamicModel, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><input\${
@@ -187,7 +187,7 @@ describe('ssr: v-model', () => {
         "const { mergeProps: _mergeProps } = require(\\"vue\\")
         const { ssrRenderAttrs: _ssrRenderAttrs, ssrGetDynamicModelProps: _ssrGetDynamicModelProps } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           let _temp0
 
           _push(\`<div\${
@@ -205,7 +205,7 @@ describe('ssr: v-model', () => {
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs, ssrGetDynamicModelProps: _ssrGetDynamicModelProps } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         let _temp0
 
         _push(\`<div\${

--- a/packages/compiler-ssr/__tests__/ssrVOnce.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVOnce.spec.ts
@@ -1,0 +1,34 @@
+import { compile } from '../src'
+
+describe('ssr: v-once', () => {
+  test('basic', () => {
+    expect(compile(`<v-app><v-main v-once /></v-app>`).code)
+      .toMatchInlineSnapshot(`
+      "const { resolveComponent: _resolveComponent, withCtx: _withCtx, setBlockTracking: _setBlockTracking, createVNode: _createVNode } = require(\\"vue\\")
+      const { ssrRenderComponent: _ssrRenderComponent } = require(\\"vue/server-renderer\\")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
+        const _component_v_app = _resolveComponent(\\"v-app\\")
+        const _component_v_main = _resolveComponent(\\"v-main\\")
+
+        _push(_ssrRenderComponent(_component_v_app, _attrs, {
+          default: _withCtx((_, _push, _parent, _scopeId) => {
+            if (_push) {
+              _push(_ssrRenderComponent(_component_v_main, null, null, _parent, _scopeId))
+            } else {
+              return [
+                _cache[0] || (
+                  _setBlockTracking(-1),
+                  _cache[0] = _createVNode(_component_v_main),
+                  _setBlockTracking(1),
+                  _cache[0]
+                )
+              ]
+            }
+          }),
+          _: 1 /* STABLE */
+        }, _parent))
+      }"
+    `)
+  })
+})

--- a/packages/compiler-ssr/__tests__/ssrVShow.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVShow.spec.ts
@@ -10,7 +10,7 @@ describe('ssr: v-show', () => {
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${_ssrRenderAttrs(_mergeProps({
           style: (_ctx.foo) ? null : { display: \\"none\\" }
         }, _attrs))}></div>\`)
@@ -23,7 +23,7 @@ describe('ssr: v-show', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderStyle: _ssrRenderStyle, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<div\${
             _ssrRenderAttrs(_attrs)
           }><div style=\\"\${
@@ -38,7 +38,7 @@ describe('ssr: v-show', () => {
       .toMatchInlineSnapshot(`
         "const { ssrRenderStyle: _ssrRenderStyle, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-        return function ssrRender(_ctx, _push, _parent, _attrs) {
+        return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
           _push(\`<div\${
             _ssrRenderAttrs(_attrs)
           }><div style=\\"\${
@@ -57,7 +57,7 @@ describe('ssr: v-show', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderStyle: _ssrRenderStyle, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><div style=\\"\${
@@ -78,7 +78,7 @@ describe('ssr: v-show', () => {
     ).toMatchInlineSnapshot(`
       "const { ssrRenderStyle: _ssrRenderStyle, ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><div style=\\"\${
@@ -101,7 +101,7 @@ describe('ssr: v-show', () => {
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs } = require(\\"vue/server-renderer\\")
 
-      return function ssrRender(_ctx, _push, _parent, _attrs) {
+      return function ssrRender(_ctx, _push, _parent, _attrs, _cache) {
         _push(\`<div\${
           _ssrRenderAttrs(_attrs)
         }><div\${


### PR DESCRIPTION
despite the diff, this is a very brief fix. we were relying on (but omitting to pass) the `_cache` argument in ssr, meaning in some cases `v-once` would generate code that relied on an object that wasn't present. Test added.

resolves #7644