### PR TITLE
chore: fix contributors link

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -330,4 +330,4 @@ Funds donated via Patreon go directly to support Evan You's full-time work on Vu
 
 Thank you to all the people who have already contributed to Vue.js!
 
-<a href="https://github.com/vuejs/vue/graphs/contributors"><img src="https://opencollective.com/vuejs/contributors.svg?width=890" /></a>
+<a href="https://github.com/vuejs/core/graphs/contributors"><img src="https://opencollective.com/vuejs/contributors.svg?width=890" /></a>


### PR DESCRIPTION
The contributors' link have jumped to Vue2, changed to Vue3.