### PR TITLE
fix(runtime-dom): <img width height> should be set as attribute

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -290,4 +290,13 @@ describe('runtime-dom: props patching', () => {
     expect(el.translate).toBeFalsy()
     expect(el.getAttribute('translate')).toBe('no')
   })
+  
+  // #7658
+  test('embedded tag with initial width and height', () => {
+    // Width and height of some embedded element such as img、video、source、canvas
+    // must be set as attribute
+    const el = document.createElement('img')
+    patchProp(el, 'width', null, '24px')
+    expect(el.getAttribute('width')).toBe('24px')
+  })
 })

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -8,6 +8,8 @@ import { RendererOptions } from '@vue/runtime-core'
 
 const nativeOnRE = /^on[a-z]/
 
+const embeddedTag = ['IMG', 'VIDEO', 'CANVAS', 'SOURCE']
+
 type DOMRendererOptions = RendererOptions<Node, Element>
 
 export const patchProp: DOMRendererOptions['patchProp'] = (
@@ -102,6 +104,15 @@ function shouldSetAsProp(
 
   // #2766 <textarea type> must be set as attribute
   if (key === 'type' && el.tagName === 'TEXTAREA') {
+    return false
+  }
+    
+  // #7658 <img width height> must be set as attribute
+  // <video>, <picture> and <source> are also
+  if (
+    key === 'width' ||
+    (key === 'height' && embeddedTag.includes(el.tagName))
+  ) {
     return false
   }
 


### PR DESCRIPTION
fix #7658 

When `height` and `width` of some embedded element such as `<img>`、`<video>`、`<source>` and `<canvas>` are string type, they will be rendered as `0`. And they are rendered normally when they are number type. This is because of the `height` and `width` of these elements must be set as attribute when they are string type.

So in `patchProp` they should be modified by `patchAttr` instead of `patchDOMProp`.