### PR TITLE
fix (server-renderer): stop server crashing with unhandled promise rejection

### DIFF
--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -107,7 +107,11 @@ export function renderComponentVNode(
         // Note: error display is already done by the wrapped lifecycle hook function.
         .catch(() => {})
     }
-    return p.then(() => renderComponentSubTree(instance, slotScopeId))
+    const renderPromise = p.then(() => renderComponentSubTree(instance, slotScopeId))
+     // Note: error display is already done by the wrapped lifecycle hook function. But we must add a catch here to avoid unhandled promise rejection.
+    renderPromise.catch(() => {})
+
+    return renderPromise;
   } else {
     return renderComponentSubTree(instance, slotScopeId)
   }

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -107,7 +107,7 @@ export function renderComponentVNode(
         // Note: error display is already done by the wrapped lifecycle hook function.
         .catch(() => {})
     }
-    const renderPromise = p.then(() => renderComponentSubTree(instance, slotScopeId))
+   const renderPromise = p.then(() => renderComponentSubTree(instance, slotScopeId))
      // Note: error display is already done by the wrapped lifecycle hook function. But we must add a catch here to avoid unhandled promise rejection.
     renderPromise.catch(() => {})
 


### PR DESCRIPTION
If an async component throws an error whilst another async component is being rendered it results in a unhandled promise rejection and the server crashing. This is because the async components are processed in a synchronous loop (via unrollBuffer) creating this race condition.  

Much like if there are prefetches, we must explicitly add error handling to the promise. We are still returning the original promise so that the error handling hooks can still process the error correctly.