### PR TITLE
fix(runtime-core): merged boolean type returned by the function in `withDefaults` parameter

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -36,7 +36,8 @@ describe('defineProps w/ type declaration + withDefaults', () => {
       y?: string
       z?: string
       bool?: boolean
-      boolAndUndefined: boolean | undefined
+      boolAndUndefined: boolean | undefined,
+      boolFn?: boolean
     }>(),
     {
       number: 123,
@@ -45,7 +46,8 @@ describe('defineProps w/ type declaration + withDefaults', () => {
       fn: () => {},
       genStr: () => '',
       y: undefined,
-      z: 'string'
+      z: 'string',
+      boolFn: () => (Math.random() > 0.5)
     }
   )
 

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -155,7 +155,7 @@ type InferDefault<P, T> = T extends
   | symbol
   | Function
   ? T | (T extends boolean ? (props: P) => boolean : (props: P) => T)
-  : (props: P) => T;
+  : (props: P) => T
 
 type PropsWithDefaults<Base, Defaults> = Base & {
   [K in keyof Defaults]: K extends keyof Base

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -154,8 +154,8 @@ type InferDefault<P, T> = T extends
   | boolean
   | symbol
   | Function
-  ? T | ((props: P) => T)
-  : (props: P) => T
+  ? T | (T extends boolean ? (props: P) => boolean : (props: P) => T)
+  : (props: P) => T;
 
 type PropsWithDefaults<Base, Defaults> = Base & {
   [K in keyof Defaults]: K extends keyof Base


### PR DESCRIPTION
fix #7677 

```ts
type prev = boolean | ((props: Props) => false) | ((props: Props) => true) | undefined
```
--> 
```ts
type now =  boolean | ((props: Props) => boolean) | undefined
```