### PR TITLE
chore: dependent

### DIFF
--- a/scripts/setupVitest.ts
+++ b/scripts/setupVitest.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+/// <reference types="vitest/globals" />
 
 expect.extend({
   toHaveBeenWarned(received: string) {


### PR DESCRIPTION
ts check
```
import { vi } from 'vitest'
The name 'expect' was not found. ts(2304)
expect.extend(...)
The name 'beforeEach' was not found. ts(2304)
beforeEach(...)
The name 'afterEach' was not found. ts(2304)
afterEach(...)
```
->
```
import { vi, expect, beforeEach, afterEach } from 'vitest'
expect.extend(...)
beforeEach(...)
afterEach(...)
```