### PR TITLE
fix(playground): fix github button style

### DIFF
--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -290,19 +290,14 @@ h1 img {
 }
 
 .links button,
-.links button a {
-  color: var(--btn);
-}
-
-.links .github:hover,
-.links button:hover,
-.links button:hover a {
-  color: var(--highlight);
-}
-
 .links .github {
-  color: var(--btn);
   padding: 1px 6px;
+  color: var(--btn);
+}
+
+.links button:hover,
+.links .github:hover {
+  color: var(--highlight);
 }
 
 .version:hover .active-version::after {

--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -149,14 +149,14 @@ async function fetchVersions(): Promise<string[]> {
       >
         <Download />
       </button>
-      <button title="View on GitHub" class="github">
-        <a
-          href="https://github.com/vuejs/core/tree/main/packages/sfc-playground"
-          target="_blank"
-        >
-          <GitHub />
-        </a>
-      </button>
+      <a
+        href="https://github.com/vuejs/core/tree/main/packages/sfc-playground"
+        target="_blank"
+        title="View on GitHub"
+        class="github"
+      >
+        <GitHub />
+      </a>
     </div>
   </nav>
 </template>
@@ -296,6 +296,15 @@ h1 img {
 
 .links button:hover,
 .links button:hover a {
+  color: var(--highlight);
+}
+
+.links .github {
+  color: var(--btn);
+  padding: 1px 6px;
+}
+
+.links .github:hover {
   color: var(--highlight);
 }
 

--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -294,6 +294,7 @@ h1 img {
   color: var(--btn);
 }
 
+.links .github:hover,
 .links button:hover,
 .links button:hover a {
   color: var(--highlight);
@@ -302,10 +303,6 @@ h1 img {
 .links .github {
   color: var(--btn);
   padding: 1px 6px;
-}
-
-.links .github:hover {
-  color: var(--highlight);
 }
 
 .version:hover .active-version::after {


### PR DESCRIPTION
![WechatIMG7893](https://user-images.githubusercontent.com/34639100/218923262-dbaad414-4f64-4c86-83d0-4b77bd41d73a.jpeg)

The size of button content is larger than inner a tag and has set `cursor: pointer` so when we click the padding part of button will not open github