### PR TITLE
refactor: simplify vue-compat

### DIFF
--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -64,7 +64,7 @@ describe('renderer: teleport', () => {
     await nextTick()
 
     expect(root.innerHTML).toMatchInlineSnapshot(
-      `"<svg><circle></circle></svg><!--teleport start--><!--teleport end-->"`
+      '"<svg><circle></circle></svg><!--teleport start--><!--teleport end-->"'
     )
 
     expect(svg.value.namespaceURI).toBe('http://www.w3.org/2000/svg')
@@ -414,7 +414,7 @@ describe('renderer: teleport', () => {
     }
     render(h(App), root)
     expect(serializeInner(root)).toMatchInlineSnapshot(
-      `"<!--teleport start--><!--teleport end--><div>root</div>"`
+      '"<!--teleport start--><!--teleport end--><div>root</div>"'
     )
     expect(serializeInner(target)).toMatchInlineSnapshot(
       `"<div>teleported</div><span>false</span><!--v-if-->"`
@@ -423,7 +423,7 @@ describe('renderer: teleport', () => {
     disabled.value = true
     await nextTick()
     expect(serializeInner(root)).toMatchInlineSnapshot(
-      `"<!--teleport start--><div>teleported</div><span>true</span><span></span><!--teleport end--><div>root</div>"`
+      '"<!--teleport start--><div>teleported</div><span>true</span><span></span><!--teleport end--><div>root</div>"'
     )
     expect(serializeInner(target)).toBe(``)
 
@@ -431,7 +431,7 @@ describe('renderer: teleport', () => {
     disabled.value = false
     await nextTick()
     expect(serializeInner(root)).toMatchInlineSnapshot(
-      `"<!--teleport start--><!--teleport end--><div>root</div>"`
+      '"<!--teleport start--><!--teleport end--><div>root</div>"'
     )
     expect(serializeInner(target)).toMatchInlineSnapshot(
       `"<div>teleported</div><span>false</span><!--v-if-->"`

--- a/packages/vue-compat/package.json
+++ b/packages/vue-compat/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@babel/parser": "^7.16.4",
     "estree-walker": "^2.0.2",
-    "source-map": "^0.6.1"
+    "source-map": "^0.6.1",
+    "vue": "3.3.0-alpha.4"
   },
   "peerDependencies": {
     "vue": "3.3.0-alpha.4"

--- a/packages/vue-compat/src/createCompatVue.ts
+++ b/packages/vue-compat/src/createCompatVue.ts
@@ -1,6 +1,3 @@
-// This entry exports the runtime only, and is built as
-// `dist/vue.esm-bundler.js` which is used by default for bundlers.
-import { initDev } from './dev'
 import {
   compatUtils,
   createApp,
@@ -12,10 +9,6 @@ import {
   vModelDynamic
 } from '@vue/runtime-dom'
 import { extend } from '@vue/shared'
-
-if (__DEV__) {
-  initDev()
-}
 
 import * as runtimeDom from '@vue/runtime-dom'
 

--- a/packages/vue-compat/src/index.ts
+++ b/packages/vue-compat/src/index.ts
@@ -1,97 +1,12 @@
 // This entry is the "full-build" that includes both the runtime
 // and the compiler, and supports on-the-fly compilation of the template option.
+import { compile } from 'vue'
 import { createCompatVue } from './createCompatVue'
-import { compile, CompilerError, CompilerOptions } from '@vue/compiler-dom'
-import { registerRuntimeCompiler, RenderFunction, warn } from '@vue/runtime-dom'
-import { isString, NOOP, generateCodeFrame, extend } from '@vue/shared'
-import { InternalRenderFunction } from 'packages/runtime-core/src/component'
-import * as runtimeDom from '@vue/runtime-dom'
-import {
-  DeprecationTypes,
-  warnDeprecation
-} from '../../runtime-core/src/compat/compatConfig'
+import { registerRuntimeCompiler } from '@vue/runtime-dom'
 
-const compileCache: Record<string, RenderFunction> = Object.create(null)
-
-function compileToFunction(
-  template: string | HTMLElement,
-  options?: CompilerOptions
-): RenderFunction {
-  if (!isString(template)) {
-    if (template.nodeType) {
-      template = template.innerHTML
-    } else {
-      __DEV__ && warn(`invalid template option: `, template)
-      return NOOP
-    }
-  }
-
-  const key = template
-  const cached = compileCache[key]
-  if (cached) {
-    return cached
-  }
-
-  if (template[0] === '#') {
-    const el = document.querySelector(template)
-    if (__DEV__ && !el) {
-      warn(`Template element not found or is empty: ${template}`)
-    }
-    // __UNSAFE__
-    // Reason: potential execution of JS expressions in in-DOM template.
-    // The user must make sure the in-DOM template is trusted. If it's rendered
-    // by the server, the template should not contain any user data.
-    template = el ? el.innerHTML : ``
-  }
-
-  if (__DEV__ && !__TEST__ && (!options || !options.whitespace)) {
-    warnDeprecation(DeprecationTypes.CONFIG_WHITESPACE, null)
-  }
-
-  const { code } = compile(
-    template,
-    extend(
-      {
-        hoistStatic: true,
-        whitespace: 'preserve',
-        onError: __DEV__ ? onError : undefined,
-        onWarn: __DEV__ ? e => onError(e, true) : NOOP
-      } as CompilerOptions,
-      options
-    )
-  )
-
-  function onError(err: CompilerError, asWarning = false) {
-    const message = asWarning
-      ? err.message
-      : `Template compilation error: ${err.message}`
-    const codeFrame =
-      err.loc &&
-      generateCodeFrame(
-        template as string,
-        err.loc.start.offset,
-        err.loc.end.offset
-      )
-    warn(codeFrame ? `${message}\n${codeFrame}` : message)
-  }
-
-  // The wildcard import results in a huge object with every export
-  // with keys that cannot be mangled, and can be quite heavy size-wise.
-  // In the global build we know `Vue` is available globally so we can avoid
-  // the wildcard object.
-  const render = (
-    __GLOBAL__ ? new Function(code)() : new Function('Vue', code)(runtimeDom)
-  ) as RenderFunction
-
-  // mark the function as runtime compiled
-  ;(render as InternalRenderFunction)._rc = true
-
-  return (compileCache[key] = render)
-}
-
-registerRuntimeCompiler(compileToFunction)
+registerRuntimeCompiler(compile)
 
 const Vue = createCompatVue()
-Vue.compile = compileToFunction
+Vue.compile = compile
 
 export default Vue

--- a/packages/vue-compat/src/runtime.ts
+++ b/packages/vue-compat/src/runtime.ts
@@ -1,7 +1,12 @@
 // This entry exports the runtime only, and is built as
 // `dist/vue.esm-bundler.js` which is used by default for bundlers.
+import { initDev } from './dev'
 import { createCompatVue } from './createCompatVue'
 import { warn } from '@vue/runtime-core'
+
+if (__DEV__) {
+  initDev()
+}
 
 const Vue = createCompatVue()
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -6,6 +6,10 @@ import { registerRuntimeCompiler, RenderFunction, warn } from '@vue/runtime-dom'
 import * as runtimeDom from '@vue/runtime-dom'
 import { isString, NOOP, generateCodeFrame, extend } from '@vue/shared'
 import { InternalRenderFunction } from 'packages/runtime-core/src/component'
+import {
+  DeprecationTypes,
+  warnDeprecation
+} from '../../runtime-core/src/compat/compatConfig'
 
 if (__DEV__) {
   initDev()
@@ -44,9 +48,14 @@ function compileToFunction(
     template = el ? el.innerHTML : ``
   }
 
+  if (__COMPAT__ && __DEV__ && !__TEST__ && (!options || !options.whitespace)) {
+    warnDeprecation(DeprecationTypes.CONFIG_WHITESPACE, null)
+  }
+
   const opts = extend(
     {
       hoistStatic: true,
+      whitespace: __COMPAT__ && !__TEST__ ? 'preserve' : undefined,
       onError: __DEV__ ? onError : undefined,
       onWarn: __DEV__ ? e => onError(e, true) : NOOP
     } as CompilerOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,10 +300,12 @@ importers:
       '@babel/parser': ^7.16.4
       estree-walker: ^2.0.2
       source-map: ^0.6.1
+      vue: 3.3.0-alpha.4
     dependencies:
       '@babel/parser': 7.20.15
       estree-walker: 2.0.2
       source-map: 0.6.1
+      vue: link:../vue
 
 packages:
 


### PR DESCRIPTION
`function compileToFunction` is mostly duplicated in `vue-compat` and `vue`. so, I reused it.