### PR TITLE
fix(compat): ensure proper handling of render function from SFC using Vue.extend (fix: #7766)

### DIFF
--- a/packages/runtime-core/src/compat/component.ts
+++ b/packages/runtime-core/src/compat/component.ts
@@ -18,6 +18,15 @@ export function convertLegacyComponent(
 
   // 2.x constructor
   if (isFunction(comp) && comp.cid) {
+    // #7766
+    if (comp.render) {
+      // only necessary when compiled from SFC
+      comp.options.render = comp.render
+    }
+    // copy over internal properties set by the SFC compiler
+    comp.options.__file = comp.__file
+    comp.options.__hmrId = comp.__hmrId
+    comp.options.__scopeId = comp.__scopeId
     comp = comp.options
   }
 


### PR DESCRIPTION
*This only affects compat mode*

When a SFC uses `Vue.extend()` to define the component script, the compiler adds the render function as a property on the constructor, not the options object in `.options`

The same goes for internal properties added by the SFC compiler like `__hmrId`.

So when we create a vnode for such a component in compat mode, we have to re-assign these properties to the options object, which we then consequently use to create the actual component from.

If we don't do that, we get a `template or render function missing`error.
 
fix: #7766