### PR TITLE
chore: use `node:` protocol when importing built-in modules

### DIFF
--- a/packages/size-check/brotli.js
+++ b/packages/size-check/brotli.js
@@ -1,4 +1,4 @@
-const { compress } = require('brotli')
+const { compress } = require('node:brotli')
 
 const file = require('fs').readFileSync('dist/index.js')
 const compressed = compress(file)

--- a/packages/size-check/brotli.js
+++ b/packages/size-check/brotli.js
@@ -1,4 +1,4 @@
-const { compress } = require('node:brotli')
+const { compress } = require('brotli')
 
 const file = require('fs').readFileSync('dist/index.js')
 const compressed = compress(file)

--- a/rollup.dts.config.js
+++ b/rollup.dts.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { parse } from '@babel/parser'
-import { existsSync, readdirSync, readFileSync } from 'fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import MagicString from 'magic-string'
 import dts from 'rollup-plugin-dts'
 import { walk } from 'estree-walker'

--- a/scripts/verifyCommit.js
+++ b/scripts/verifyCommit.js
@@ -1,7 +1,7 @@
 // @ts-check
 import chalk from 'chalk'
-import { readFileSync } from 'fs'
-import path from 'path'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 
 const msgPath = path.resolve('.git/COMMIT_EDITMSG')
 const msg = readFileSync(msgPath, 'utf-8').trim()


### PR DESCRIPTION
```
import xxx from 'fs'
import xxx from 'path'

```
->

```

import xxx from 'node:fs'
import xxx from 'node:path'
```
