### PR TITLE
fix: prop value is symbol and invalid type throw error in dev

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -712,6 +712,9 @@ function getInvalidTypeMessage(
  * dev only
  */
 function styleValue(value: unknown, type: string): string {
+  if (typeof value === 'symbol') {
+    value = value.toString()
+  }
   if (type === 'String') {
     return `"${value}"`
   } else if (type === 'Number') {


### PR DESCRIPTION
Close #8487

Prod env can work but dev doesn't work.

Live Demo：
https://sfc.vuejs.org/#__DEV__eNp9Uk1PwzAM/Ssml20SawXcqm4IceGChMSBSy7d6o2ifClOC2jqf8dJP4ZAWlVFec7Lc/zsk3hwLutaFIUoae8bF7bSNNpZH+D5+9FqBwdvNSyyfICRvJgpJ2joYUdoAvQzcQplgZiJX4lZ46FqFd+QBmDPQtYwhYohAGOyuO+v41pXoVquplOPofVmQgCajgUsnlApC2/Wq/pqkW7Fb0o/4D5JSsN/mc8VMgionaoCMgIo32+2p1OUhb4vc0YpOjpQdJVqcSPFLC225ejHQGyMawN0a21rVExkIebElHMacS0G09a6ctkHWcOep4JYNx2QFLMdUrDPEUvxHoKjIs/psI/mf1Bm/THnXeZbExqNGZJe77z9JPQsLMVoRdLIOdihX3s0NXr0lzT/UP/pTlZyKedhOE8OEHfJgarMkS2I5bADe2sogPPWEWziFDQGXyIqU6XJ2fsCKPjGHFl7u1xd6JQMZd10yXOAm9u7YcOdSzrcu9SNfOD8Ml+aaP95LvnR41wO75uneAOv33pn1XIl+h+DFQ92