### PR TITLE
fix(compiler-sfc): fix macro definition to preserve semicolons in some sceniarios

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -705,6 +705,24 @@ return { props, emit }
 }"
 `;
 
+exports[`SFC compile <script setup> > defineProps/defineEmits in multi-variable declaration (full removal) and the following begins with [,(,{ 1`] = `
+"export default {
+  props: ['item'],
+  emits: ['a'],
+  setup(__props, { expose, emit }) {
+  expose();
+
+const props = __props;
+
+    
+    ;(function(){})()
+    
+return { props, emit }
+}
+
+}"
+`;
+
 exports[`SFC compile <script setup> > defineProps/defineEmits in multi-variable declaration 1`] = `
 "export default {
   props: ['item'],

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -172,6 +172,19 @@ const myEmit = defineEmits(['foo', 'bar'])
     expect(content).toMatch(`emits: ['a'],`)
   })
 
+  test('defineProps/defineEmits in multi-variable declaration (full removal) and the following begins with [,(,{', () => {
+    const { content } = compile(`
+    <script setup>
+    const props = defineProps(['item']),
+          emit = defineEmits(['a']);
+    ;(function(){})()
+    </script>
+  `)
+    assertCode(content)
+    expect(content).toMatch(`props: ['item'],`)
+    expect(content).toMatch(`emits: ['a'],`)
+  })
+
   test('defineExpose()', () => {
     const { content } = compile(`
 <script setup>
@@ -1136,7 +1149,7 @@ const emit = defineEmits(['a', 'b'])
       `)
       assertCode(content)
     })
-    
+
     // #7111
     test('withDefaults (static) w/ production mode', () => {
       const { content } = compile(
@@ -1277,7 +1290,6 @@ const emit = defineEmits(['a', 'b'])
       expect(content).toMatch(`emits: ["foo", "bar"]`)
     })
 
-    
     test('defineEmits w/ type from normal script', () => {
       const { content } = compile(`
       <script lang="ts">

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1221,7 +1221,18 @@ export function compileScript(
           const isDefineEmits = processDefineEmits(decl.init, decl.id)
           if (isDefineProps || isDefineEmits) {
             if (left === 1) {
-              s.remove(node.start! + startOffset, node.end! + startOffset)
+              const index = scriptSetupAst.body.indexOf(node)
+              let semi = 0
+              if (index < scriptSetupAst.body.length - 1) {
+                const nextNode = scriptSetupAst.body[index + 1]
+                if (nextNode.start! === node.end!) {
+                  semi = -1
+                }
+              }
+              s.remove(
+                node.start! + startOffset,
+                node.end! + startOffset + semi
+              )
             } else {
               let start = decl.start! + startOffset
               let end = decl.end! + startOffset


### PR DESCRIPTION
fix #7805 