### PR TITLE
fix(compiler-sfc): fix that semi may be required when removing macro …

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1261,6 +1261,24 @@ return () => {}
 }"
 `;
 
+exports[`SFC compile <script setup> > preserve semi when completely removing macro definitions 1`] = `
+"export default {
+  props: ['item'],
+  setup(__props, { expose }) {
+  expose();
+
+const props = __props;
+
+    console.log('test')
+    
+    ;(function () {})()
+    
+return { props }
+}
+
+}"
+`;
+
 exports[`SFC compile <script setup> > should expose top level declarations 1`] = `
 "import { x } from './x'
       

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -160,6 +160,21 @@ const myEmit = defineEmits(['foo', 'bar'])
     expect(content).toMatch(`emits: ['a'],`)
   })
 
+  // #7805
+  test('preserve semi when completely removing macro definitions', () => {
+    const { content } = compile(`
+    <script setup>
+    console.log('test')
+    const props = defineProps(['item']);
+    (function () {})()
+    </script>
+  `)
+    assertCode(content)
+    expect(content).toMatch(`console.log('test')`)
+    expect(content).toMatch(`props: ['item'],`)
+    expect(content).toMatch(`;(function () {})()`)
+  })
+
   test('defineProps/defineEmits in multi-variable declaration (full removal)', () => {
     const { content } = compile(`
     <script setup>


### PR DESCRIPTION
fixed #7805 
`<script setup>
import { ref } from 'vue'
console.log('test')
const props = defineProps(['item'])
(function(){})()
</script>`
I don't think the above situation needs to be handled because it contains syntax errors.

If there are more scenarios or better implementations, please communicate with me