### PR TITLE
ci: release canary versions every week

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,30 @@
+name: canary release
+on:
+  # Runs every Monday at 1 AM UTC (9:00 AM in Singapore)
+  schedule:
+    - cron: 0 1 * * MON
+  # TODO: a workflow_dispatch trigger to manually release a patch
+
+jobs:
+  canary:
+    # prevents this action from running on forks
+    if: github.repository == 'vuejs/core'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Set node version to 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - run: pnpm install
+
+      - run: pnpm release --canary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,7 +3,7 @@ on:
   # Runs every Monday at 1 AM UTC (9:00 AM in Singapore)
   schedule:
     - cron: 0 1 * * MON
-  # TODO: a workflow_dispatch trigger to manually release a patch
+  workflow_dispatch:
 
 jobs:
   canary:

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -156,7 +156,7 @@ async function main() {
 
   if (!skipTests) {
     step('Checking CI status for HEAD...')
-    let isCIPassed = await checkCIStatus()
+    let isCIPassed = await getCIResult()
     skipTests ||= isCIPassed
 
     if (isCIPassed && !skipPrompts) {
@@ -251,7 +251,7 @@ async function main() {
   console.log()
 }
 
-async function checkCIStatus() {
+async function getCIResult() {
   try {
     const { stdout: sha } = await execa('git', ['rev-parse', 'HEAD'])
     const res = await fetch(

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -221,9 +221,6 @@ async function main() {
     }
   }
 
-  // TODO: update README if isCanary
-  // Reference: <https://github.com/knightlyjs/knightly/blob/main/src/template.ts>
-
   // publish packages
   step('\nPublishing packages...')
   for (const pkg of packages) {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -297,7 +297,7 @@ function updateDeps(pkg, depType, version, getNewPackageName) {
       console.log(
         chalk.yellow(`${pkg.name} -> ${depType} -> ${dep}@${newVersion}`)
       )
-      deps[dep] = version
+      deps[dep] = newVersion
     }
   })
 }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -81,7 +81,7 @@ async function main() {
     const MM = (date.getUTCMonth() + 1).toString().padStart(2, '0')
     const dd = date.getUTCDate().toString().padStart(2, '0')
 
-    const major = 3
+    const major = semver.major(currentVersion)
     const minor = `${yyyy}${MM}${dd}`
     const patch = 0
     let canaryVersion = `${major}.${minor}.${patch}`

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -28,7 +28,7 @@ const packages = fs
 const isCorePackage = pkgName => {
   if (!pkgName) return
 
-  if (pkgName === 'vue') {
+  if (pkgName === 'vue' || pkgName === '@vue/compat') {
     return true
   }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -17,9 +17,37 @@ const preId = args.preid || semver.prerelease(currentVersion)?.[0]
 const isDryRun = args.dry
 let skipTests = args.skipTests
 const skipBuild = args.skipBuild
+const isCanary = args.canary
+const skipPrompts = args.skipPrompts || args.canary
+const skipGit = args.skipGit || args.canary
+
 const packages = fs
   .readdirSync(path.resolve(__dirname, '../packages'))
   .filter(p => !p.endsWith('.ts') && !p.startsWith('.'))
+const isCorePackage = pkgName => {
+  if (!pkgName) return
+
+  if (pkgName === 'vue') {
+    return true
+  }
+
+  return (
+    pkgName.startsWith('@vue') &&
+    packages.includes(pkgName.replace(/^@vue\//, ''))
+  )
+}
+const renamePackageToCanary = pkgName => {
+  if (pkgName === 'vue') {
+    return '@vue/canary'
+  }
+
+  if (isCorePackage(pkgName)) {
+    return `${pkgName}-canary`
+  }
+
+  return pkgName
+}
+const keepThePackageName = pkgName => pkgName
 
 const skippedPackages = []
 
@@ -41,6 +69,19 @@ const step = msg => console.log(chalk.cyan(msg))
 
 async function main() {
   let targetVersion = args._[0]
+
+  if (isCanary) {
+    // The canary version string format is `3.yyyyMMdd.0`.
+    // Use UTC date so that it's consistent across CI and maintainers' machines
+    const date = new Date()
+    const yyyy = date.getUTCFullYear()
+    const MM = (date.getUTCMonth() + 1).toString().padStart(2, '0')
+    const dd = date.getUTCDate().toString().padStart(2, '0')
+    const canaryVersion = `3.${yyyy}${MM}${dd}.0`
+    // TODO: allow manually releasing a patch canary version
+
+    targetVersion = canaryVersion
+  }
 
   if (!targetVersion) {
     // no explicit version, offer suggestions
@@ -70,40 +111,33 @@ async function main() {
     throw new Error(`invalid target version: ${targetVersion}`)
   }
 
-  // @ts-ignore
-  const { yes: confirmRelease } = await prompt({
-    type: 'confirm',
-    name: 'yes',
-    message: `Releasing v${targetVersion}. Confirm?`
-  })
-
-  if (!confirmRelease) {
-    return
-  }
-
-  step('Checking CI status for HEAD...')
-  let isCIPassed = true
-  try {
-    const { stdout: sha } = await execa('git', ['rev-parse', 'HEAD'])
-    const res = await fetch(
-      `https://api.github.com/repos/vuejs/core/actions/runs?head_sha=${sha}` +
-        `&status=success&exclude_pull_requests=true`
-    )
-    const data = await res.json()
-    isCIPassed = data.workflow_runs.length > 0
-  } catch (e) {
-    isCIPassed = false
-  }
-
-  if (isCIPassed) {
+  if (!skipPrompts) {
     // @ts-ignore
-    const { yes: promptSkipTests } = await prompt({
+    const { yes: confirmRelease } = await prompt({
       type: 'confirm',
       name: 'yes',
-      message: `CI for this commit passed. Skip local tests?`
+      message: `Releasing v${targetVersion}. Confirm?`
     })
-    if (promptSkipTests) {
-      skipTests = true
+
+    if (!confirmRelease) {
+      return
+    }
+  }
+
+  if (!skipTests) {
+    step('Checking CI status for HEAD...')
+    let isCIPassed = await checkCIStatus()
+    skipTests ||= isCIPassed
+
+    if (isCIPassed && !skipPrompts) {
+      // @ts-ignore
+      const { yes: promptSkipTests } = await prompt({
+        type: 'confirm',
+        name: 'yes',
+        message: `CI for this commit passed. Skip local tests?`
+      })
+
+      skipTests = promptSkipTests
     }
   }
 
@@ -120,7 +154,10 @@ async function main() {
 
   // update all package versions and inter-dependencies
   step('\nUpdating cross dependencies...')
-  updateVersions(targetVersion)
+  updateVersions(
+    targetVersion,
+    isCanary ? renamePackageToCanary : keepThePackageName
+  )
 
   // build all packages with types
   step('\nBuilding all packages...')
@@ -137,29 +174,39 @@ async function main() {
   await run(`pnpm`, ['run', 'changelog'])
 
   // update pnpm-lock.yaml
-  step('\nUpdating lockfile...')
-  await run(`pnpm`, ['install', '--prefer-offline'])
-
-  const { stdout } = await run('git', ['diff'], { stdio: 'pipe' })
-  if (stdout) {
-    step('\nCommitting changes...')
-    await runIfNotDry('git', ['add', '-A'])
-    await runIfNotDry('git', ['commit', '-m', `release: v${targetVersion}`])
-  } else {
-    console.log('No changes to commit.')
+  // skipped during canary release because the package names changed and installing with `workspace:*` would fail
+  if (!isCanary) {
+    step('\nUpdating lockfile...')
+    await run(`pnpm`, ['install', '--prefer-offline'])
   }
+
+  if (!skipGit) {
+    const { stdout } = await run('git', ['diff'], { stdio: 'pipe' })
+    if (stdout) {
+      step('\nCommitting changes...')
+      await runIfNotDry('git', ['add', '-A'])
+      await runIfNotDry('git', ['commit', '-m', `release: v${targetVersion}`])
+    } else {
+      console.log('No changes to commit.')
+    }
+  }
+
+  // TODO: update README if isCanary
+  // Reference: <https://github.com/knightlyjs/knightly/blob/main/src/template.ts>
 
   // publish packages
   step('\nPublishing packages...')
   for (const pkg of packages) {
-    await publishPackage(pkg, targetVersion, runIfNotDry)
+    await publishPackage(pkg, targetVersion)
   }
 
   // push to GitHub
-  step('\nPushing to GitHub...')
-  await runIfNotDry('git', ['tag', `v${targetVersion}`])
-  await runIfNotDry('git', ['push', 'origin', `refs/tags/v${targetVersion}`])
-  await runIfNotDry('git', ['push'])
+  if (!skipGit) {
+    step('\nPushing to GitHub...')
+    await runIfNotDry('git', ['tag', `v${targetVersion}`])
+    await runIfNotDry('git', ['push', 'origin', `refs/tags/v${targetVersion}`])
+    await runIfNotDry('git', ['push'])
+  }
 
   if (isDryRun) {
     console.log(`\nDry run finished - run git diff to see package changes.`)
@@ -177,42 +224,58 @@ async function main() {
   console.log()
 }
 
-function updateVersions(version) {
-  // 1. update root package.json
-  updatePackage(path.resolve(__dirname, '..'), version)
-  // 2. update all packages
-  packages.forEach(p => updatePackage(getPkgRoot(p), version))
+async function checkCIStatus() {
+  try {
+    const { stdout: sha } = await execa('git', ['rev-parse', 'HEAD'])
+    const res = await fetch(
+      `https://api.github.com/repos/vuejs/core/actions/runs?head_sha=${sha}` +
+        `&status=success&exclude_pull_requests=true`
+    )
+    const data = await res.json()
+    return data.workflow_runs.length > 0
+  } catch (e) {
+    return false
+  }
 }
 
-function updatePackage(pkgRoot, version) {
+function updateVersions(version, getNewPackageName = keepThePackageName) {
+  // 1. update root package.json
+  updatePackage(path.resolve(__dirname, '..'), version, getNewPackageName)
+  // 2. update all packages
+  packages.forEach(p =>
+    updatePackage(getPkgRoot(p), version, getNewPackageName)
+  )
+}
+
+function updatePackage(pkgRoot, version, getNewPackageName) {
   const pkgPath = path.resolve(pkgRoot, 'package.json')
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+  pkg.name = getNewPackageName(pkg.name)
   pkg.version = version
-  updateDeps(pkg, 'dependencies', version)
-  updateDeps(pkg, 'peerDependencies', version)
+  updateDeps(pkg, 'dependencies', version, getNewPackageName)
+  updateDeps(pkg, 'peerDependencies', version, getNewPackageName)
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
 }
 
-function updateDeps(pkg, depType, version) {
+function updateDeps(pkg, depType, version, getNewPackageName) {
   const deps = pkg[depType]
   if (!deps) return
   Object.keys(deps).forEach(dep => {
     if (deps[dep] === 'workspace:*') {
       return
     }
-    if (
-      dep === 'vue' ||
-      (dep.startsWith('@vue') && packages.includes(dep.replace(/^@vue\//, '')))
-    ) {
+    if (isCorePackage(dep)) {
+      const newName = getNewPackageName(dep)
+      const newVersion = newName === dep ? version : `npm:${newName}@${version}`
       console.log(
-        chalk.yellow(`${pkg.name} -> ${depType} -> ${dep}@${version}`)
+        chalk.yellow(`${pkg.name} -> ${depType} -> ${dep}@${newVersion}`)
       )
       deps[dep] = version
     }
   })
 }
 
-async function publishPackage(pkgName, version, runIfNotDry) {
+async function publishPackage(pkgName, version) {
   if (skippedPackages.includes(pkgName)) {
     return
   }
@@ -246,7 +309,8 @@ async function publishPackage(pkgName, version, runIfNotDry) {
         version,
         ...(releaseTag ? ['--tag', releaseTag] : []),
         '--access',
-        'public'
+        'public',
+        ...(skipGit ? ['--no-commit-hooks', '--no-git-tag-version'] : [])
       ],
       {
         cwd: pkgRoot,


### PR DESCRIPTION
Requires an `NPM_TOKEN` secret to be set in https://github.com/vuejs/core/settings/secrets/actions
It should be a granular access token with the write permission to the `@vue` *scope* (NOT *organization*).

---

Implementation details:

- Named as `canary` rather than `nightly` because it runs weekly;
- Runs every Monday at 9 AM GMT+8
- Can be manually triggered via the GitHub Actions interface
- Usage:
	- The easiest way is to use this companion package: `npx install-vue-canary` (https://github.com/sodatea/install-vue-canary)
	- `npm add vue@npm:@vue/canary` for the latest, or `npm add vue@npm:@vue/canary@3.20230313.0` for a specific version.
	- For other core packages, e.g. `@vue/reactivity`, it's `npm add @vue/reactivity@npm:@vue/reactivity-canary`
- Also added `--skip-git` and `--skip-prompts` flags in the release script, as they would be useful in `ecosystem-ci`

---

Remaining questions:

- where should I document it?
- shall we automate other release types too?