### PR TITLE
build: fix canary bundling issues

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -102,7 +102,8 @@ function createConfig(format, output, plugins = []) {
   const isServerRenderer = name === 'server-renderer'
   const isNodeBuild = format === 'cjs'
   const isGlobalBuild = /global/.test(format)
-  const isCompatPackage = pkg.name === '@vue/compat'
+  const isCompatPackage =
+    pkg.name === '@vue/compat' || pkg.name === '@vue/compat-canary'
   const isCompatBuild = !!packageOptions.compat
   const isBrowserBuild =
     (isGlobalBuild || isBrowserESMBuild || isBundlerESMBuild) &&
@@ -240,7 +241,10 @@ function createConfig(format, output, plugins = []) {
     // we are bundling forked consolidate.js in compiler-sfc which dynamically
     // requires a ton of template engines which should be ignored.
     let cjsIgnores = []
-    if (pkg.name === '@vue/compiler-sfc') {
+    if (
+      pkg.name === '@vue/compiler-sfc' ||
+      pkg.name === '@vue/compiler-sfc-canary'
+    ) {
       cjsIgnores = [
         ...Object.keys(consolidatePkg.devDependencies),
         'vm',

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -95,14 +95,21 @@ async function main() {
         ['view', `${pkgName}@~${canaryVersion}`, 'version', '--json'],
         { stdio: 'pipe' }
       )
-      const versions = JSON.parse(stdout)
+      let versions = JSON.parse(stdout)
+      versions = Array.isArray(versions) ? versions : [versions]
       const latestSameDayPatch = /** @type {string} */ (
         semver.maxSatisfying(versions, `~${canaryVersion}`)
       )
       canaryVersion = /** @type {string} */ (
         semver.inc(latestSameDayPatch, 'patch')
       )
-    } catch (e) {}
+    } catch (e) {
+      if (/E404/.test(e.message)) {
+        // the first patch version on that day
+      } else {
+        throw e
+      }
+    }
 
     targetVersion = canaryVersion
   }


### PR DESCRIPTION
1. correct the rollup config after the package name changed
2. fix the same-day patch version bump of canary releases