### PR TITLE
feat(compiler-sfc): `defultAssetUrlOptions` add audio tag

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
@@ -76,6 +76,25 @@ export function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler sfc: transform asset url > transform tag asset url 1`] = `
+"import { createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from \\"vue\\"
+import _imports_0 from '@/assets/bar.wav'
+import _imports_1 from '@/assets/bar.mp4'
+import _imports_2 from '@/assets/bar.png'
+
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [
+    _createElementVNode(\\"audio\\", { src: _imports_0 }),
+    _createElementVNode(\\"video\\", { src: _imports_1 }),
+    _createElementVNode(\\"source\\", { src: _imports_1 }),
+    _createElementVNode(\\"img\\", { src: _imports_2 }),
+    _createElementVNode(\\"image\\", { \\"xlink:href\\": _imports_2 }),
+    _createElementVNode(\\"use\\", { \\"xlink:href\\": _imports_2 })
+  ], 64 /* STABLE_FRAGMENT */))
+}"
+`;
+
 exports[`compiler sfc: transform asset url > transform with stringify 1`] = `
 "import { createElementVNode as _createElementVNode, createStaticVNode as _createStaticVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from \\"vue\\"
 import _imports_0 from './bar.png'

--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -87,6 +87,21 @@ describe('compiler sfc: transform asset url', () => {
     expect(code).toMatchSnapshot()
   })
 
+  test('transform tag asset url', () => {
+    const { code } = compileWithAssetUrls(
+      `<audio src="@/assets/bar.wav"></audio>` +
+        `<video src="@/assets/bar.mp4"></video>` +
+        `<source src="@/assets/bar.mp4"></source>` +
+        `<img src="@/assets/bar.png"></img>` +
+        `<image xlink:href="@/assets/bar.png"></image>` +
+        `<use xlink:href="@/assets/bar.png"></use>`
+    )
+    expect(code).toMatch(`import _imports_0 from '@/assets/bar.wav'`)
+    expect(code).toMatch(`import _imports_1 from '@/assets/bar.mp4'`)
+    expect(code).toMatch(`import _imports_2 from '@/assets/bar.png'`)
+    expect(code).toMatchSnapshot()
+  })
+
   test('with includeAbsolute: true', () => {
     const { code } = compileWithAssetUrls(
       `<img src="./bar.png"/>` +

--- a/packages/compiler-sfc/src/template/transformAssetUrl.ts
+++ b/packages/compiler-sfc/src/template/transformAssetUrl.ts
@@ -38,6 +38,7 @@ export const defaultAssetUrlOptions: Required<AssetURLOptions> = {
   base: null,
   includeAbsolute: false,
   tags: {
+    audio: ['src'],
     video: ['src', 'poster'],
     source: ['src'],
     img: ['src'],


### PR DESCRIPTION
Transforms audio relative asset urls into either imports or absolute urls.