### PR TITLE
fix(types): all properties in type PropsWithDefaults to readonly

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -157,13 +157,15 @@ type InferDefault<P, T> = T extends
   ? T | ((props: P) => T)
   : (props: P) => T
 
-type PropsWithDefaults<Base, Defaults> = Base & {
-  [K in keyof Defaults]: K extends keyof Base
-    ? Defaults[K] extends undefined
-      ? Base[K]
-      : NotUndefined<Base[K]>
-    : never
-}
+type PropsWithDefaults<Base, Defaults> = Readonly<
+  Base & {
+    [K in keyof Defaults]: K extends keyof Base
+      ? Defaults[K] extends undefined
+        ? Base[K]
+        : NotUndefined<Base[K]>
+      : never
+  }
+>
 /**
  * Vue `<script setup>` compiler macro for providing props default values when
  * using type-based `defineProps` declaration.


### PR DESCRIPTION
```ts
const props = withDefaults(
  defineProps<{
    name?: string;
  }>(),
  {
    name: 'test',
  },
);

props.name = '123' // props.name is not a read-only attribute
```