### PR TITLE
fix(compiler-sfc): rename expose variable name

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -4,8 +4,8 @@ exports[`SFC analyze <script> bindings > auto name inference > basic 1`] = `
 "const a = 1
 export default {
   __name: 'FooBar',
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 return { a }
 }
@@ -20,8 +20,8 @@ exports[`SFC analyze <script> bindings > auto name inference > do not overwrite 
         })
         
 export default /*#__PURE__*/Object.assign(__default__, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 const a = 1
 return { a, defineComponent }
 }
@@ -35,8 +35,8 @@ exports[`SFC analyze <script> bindings > auto name inference > do not overwrite 
         }
         
 export default /*#__PURE__*/Object.assign(__default__, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 const a = 1
 return { a }
 }
@@ -49,8 +49,8 @@ exports[`SFC compile <script setup> > <script> after <script setup> the script c
     const n = 1
 
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
     
 return { n, get x() { return x } }
@@ -67,8 +67,8 @@ exports[`SFC compile <script setup> > <script> and <script setup> co-usage > scr
       const __default__ = {}
       
 export default /*#__PURE__*/Object.assign(__default__, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       x()
       
@@ -86,8 +86,8 @@ exports[`SFC compile <script setup> > <script> and <script setup> co-usage > scr
       
 
 export default /*#__PURE__*/Object.assign(__default__, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       x()
       
@@ -108,8 +108,8 @@ import { x } from './x'
 
 export default /*#__PURE__*/_defineComponent({
   ...__default__,
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       x()
       
@@ -130,8 +130,8 @@ const __default__ = def
 
 
 export default /*#__PURE__*/Object.assign(__default__, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       x()
       
@@ -150,8 +150,8 @@ exports[`SFC compile <script setup> > <script> and <script setup> co-usage > spa
         }
         
 export default /*#__PURE__*/Object.assign(__default__, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         x()
         
@@ -170,8 +170,8 @@ exports[`SFC compile <script setup> > <script> and <script setup> co-usage > spa
         }
         
 export default /*#__PURE__*/Object.assign(__default__, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         x()
         
@@ -185,8 +185,8 @@ exports[`SFC compile <script setup> > async/await detection > expression stateme
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 ;(
@@ -204,8 +204,8 @@ exports[`SFC compile <script setup> > async/await detection > multiple \`if for\
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 if (ok) {
@@ -239,8 +239,8 @@ exports[`SFC compile <script setup> > async/await detection > multiple \`if whil
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 if (ok) {
@@ -294,8 +294,8 @@ exports[`SFC compile <script setup> > async/await detection > multiple \`if\` ne
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 if (ok) {
@@ -371,8 +371,8 @@ exports[`SFC compile <script setup> > async/await detection > nested await 1`] =
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 ;(
@@ -395,8 +395,8 @@ exports[`SFC compile <script setup> > async/await detection > nested await 2`] =
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 ;(
@@ -419,8 +419,8 @@ exports[`SFC compile <script setup> > async/await detection > nested await 3`] =
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 ;(
@@ -448,8 +448,8 @@ exports[`SFC compile <script setup> > async/await detection > nested leading awa
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 foo()
@@ -474,8 +474,8 @@ exports[`SFC compile <script setup> > async/await detection > nested statements 
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 if (ok) { (
@@ -497,8 +497,8 @@ exports[`SFC compile <script setup> > async/await detection > ref 1`] = `
 "import { withAsyncContext as _withAsyncContext, ref as _ref } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 let a = _ref(1 + ((
@@ -515,8 +515,8 @@ return { a }
 
 exports[`SFC compile <script setup> > async/await detection > should ignore await inside functions 1`] = `
 "export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 async function foo() { await bar }
 return { foo }
 }
@@ -526,8 +526,8 @@ return { foo }
 
 exports[`SFC compile <script setup> > async/await detection > should ignore await inside functions 2`] = `
 "export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 const foo = async () => { await bar }
 return { foo }
 }
@@ -537,8 +537,8 @@ return { foo }
 
 exports[`SFC compile <script setup> > async/await detection > should ignore await inside functions 3`] = `
 "export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 const obj = { async method() { await bar }}
 return { obj }
 }
@@ -548,8 +548,8 @@ return { obj }
 
 exports[`SFC compile <script setup> > async/await detection > should ignore await inside functions 4`] = `
 "export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 const cls = class Foo { async method() { await bar }}
 return { cls }
 }
@@ -561,8 +561,8 @@ exports[`SFC compile <script setup> > async/await detection > single line condit
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 if (false) (
@@ -580,8 +580,8 @@ exports[`SFC compile <script setup> > async/await detection > variable 1`] = `
 "import { withAsyncContext as _withAsyncContext } from 'vue'
 
 export default {
-  async setup(__props, { expose }) {
-  expose();
+  async setup(__props, { expose: __expose }) {
+  __expose();
 
 let __temp, __restore
 const a = 1 + ((
@@ -598,8 +598,8 @@ return { a }
 
 exports[`SFC compile <script setup> > binding analysis for destructure 1`] = `
 "export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       const { foo, b: bar, ['x' + 'y']: baz, x: { y, zz: { z }}} = {}
       
@@ -612,8 +612,8 @@ return { foo, bar, baz, y, z }
 exports[`SFC compile <script setup> > defineEmits() 1`] = `
 "export default {
   emits: ['foo', 'bar'],
-  setup(__props, { expose, emit: myEmit }) {
-  expose();
+  setup(__props, { expose: __expose, emit: myEmit }) {
+  __expose();
 
 
 
@@ -625,7 +625,7 @@ return { myEmit }
 
 exports[`SFC compile <script setup> > defineExpose() 1`] = `
 "export default {
-  setup(__props, { expose }) {
+  setup(__props, { expose: __expose }) {
 
 expose({ foo: 123 })
 
@@ -637,8 +637,8 @@ return {  }
 
 exports[`SFC compile <script setup> > defineOptions() > basic usage 1`] = `
 "export default /*#__PURE__*/Object.assign({ name: 'FooApp' }, {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 
 
@@ -653,8 +653,8 @@ exports[`SFC compile <script setup> > defineProps w/ external definition 1`] = `
     
 export default {
   props: propsModel,
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 const props = __props;
 
@@ -671,8 +671,8 @@ exports[`SFC compile <script setup> > defineProps w/ leading code 1`] = `
     
 export default {
   props: {},
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 const props = __props;
 
@@ -690,8 +690,8 @@ export default {
   props: {
   foo: String
 },
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 const props = __props;
 
@@ -707,8 +707,8 @@ exports[`SFC compile <script setup> > defineProps/defineEmits in multi-variable 
 "export default {
   props: ['item'],
   emits: ['a'],
-  setup(__props, { expose, emit }) {
-  expose();
+  setup(__props, { expose: __expose, emit }) {
+  __expose();
 
 const props = __props;
 
@@ -724,8 +724,8 @@ exports[`SFC compile <script setup> > defineProps/defineEmits in multi-variable 
 "export default {
   props: ['item'],
   emits: ['a'],
-  setup(__props, { expose, emit }) {
-  expose();
+  setup(__props, { expose: __expose, emit }) {
+  __expose();
 
 const props = __props;
 
@@ -741,8 +741,8 @@ exports[`SFC compile <script setup> > defineProps/defineEmits in multi-variable 
 "export default {
   props: ['item'],
   emits: ['a'],
-  setup(__props, { expose, emit }) {
-  expose();
+  setup(__props, { expose: __expose, emit }) {
+  __expose();
 
 const props = __props;
 
@@ -760,8 +760,8 @@ import { Foo, Bar, Baz, Qux, Fred } from './x'
         const a = 1
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         function b() {}
         
@@ -777,8 +777,8 @@ import { bar, baz } from './x'
         const cond = true
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { cond, get bar() { return bar }, get baz() { return baz } }
@@ -793,8 +793,8 @@ import { FooBar, FooBaz, FooQux, foo } from './x'
         const fooBar: FooBar = 1
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { fooBar, get FooBaz() { return FooBaz }, get FooQux() { return FooQux }, get foo() { return foo } }
@@ -808,8 +808,8 @@ exports[`SFC compile <script setup> > dev mode import usage check > directive 1`
 import { vMyDir } from './x'
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { get vMyDir() { return vMyDir } }
@@ -823,8 +823,8 @@ exports[`SFC compile <script setup> > dev mode import usage check > js template 
 import { VAR, VAR2, VAR3 } from './x'
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { get VAR() { return VAR }, get VAR3() { return VAR3 } }
@@ -838,8 +838,8 @@ exports[`SFC compile <script setup> > dev mode import usage check > last tag 1`]
 import { FooBaz, Last } from './x'
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { get FooBaz() { return FooBaz }, get Last() { return Last } }
@@ -853,8 +853,8 @@ exports[`SFC compile <script setup> > dev mode import usage check > vue interpol
 import { x, y, z, x$y } from './x'
       
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       
 return { get x() { return x }, get z() { return z }, get x$y() { return x$y } }
@@ -875,8 +875,8 @@ export default {
   emits: {
           foo: () => bar > 1
         },
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
         
@@ -899,8 +899,8 @@ export default {
   emits: {
             foo: bar => bar > 1
           },
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
           
           
@@ -916,8 +916,8 @@ exports[`SFC compile <script setup> > imports > dedupe between user & helper 1`]
 import { ref } from 'vue'
       
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       let foo = _ref(1)
       
@@ -931,8 +931,8 @@ exports[`SFC compile <script setup> > imports > import dedupe between <script> a
 "import { x } from './x'
         
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         x()
         
@@ -948,8 +948,8 @@ exports[`SFC compile <script setup> > imports > should allow defineProps/Emit at
 export default {
   props: ['foo'],
   emits: ['bar'],
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       
       
@@ -966,8 +966,8 @@ exports[`SFC compile <script setup> > imports > should extract comment for impor
         import b from 'b'
         
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { get a() { return a }, get b() { return b } }
@@ -981,8 +981,8 @@ exports[`SFC compile <script setup> > imports > should hoist and expose imports 
           import 'foo/css'
         
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
           
 return { ref }
@@ -1266,7 +1266,7 @@ return (_ctx, _cache) => {
 
 exports[`SFC compile <script setup> > inlineTemplate mode > with defineExpose() 1`] = `
 "export default {
-  setup(__props, { expose }) {
+  setup(__props, { expose: __expose }) {
 
         const count = ref(0)
         expose({ count })
@@ -1288,8 +1288,8 @@ exports[`SFC compile <script setup> > should expose top level declarations 1`] =
       
 
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
       let a = 1
       const b = 2
@@ -1307,8 +1307,8 @@ exports[`SFC compile <script setup> > with TypeScript > const Enum 1`] = `
 const enum Foo { A = 123 }
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { Foo }
@@ -1323,8 +1323,8 @@ export interface Emits { (e: 'foo' | 'bar'): void }
       
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1340,8 +1340,8 @@ export type Emits = { (e: 'foo' | 'bar'): void }
       
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1357,8 +1357,8 @@ interface Emits { (e: 'foo'): void }
       
 export default /*#__PURE__*/_defineComponent({
   emits: ['foo'],
-  setup(__props, { expose, emit }) {
-  expose();
+  setup(__props, { expose: __expose, emit }) {
+  __expose();
 
       
       
@@ -1374,8 +1374,8 @@ interface Emits { (e: 'foo' | 'bar'): void }
       
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1391,8 +1391,8 @@ export type Emits = (e: 'foo' | 'bar') => void
       
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1408,8 +1408,8 @@ type Emits = (e: 'foo' | 'bar') => void
       
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1425,8 +1425,8 @@ type Emits = { (e: 'foo' | 'bar'): void }
       
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1441,8 +1441,8 @@ exports[`SFC compile <script setup> > with TypeScript > defineEmits w/ type (typ
 
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  setup(__props, { expose, emit }: { emit: ({(e: 'foo' | 'bar'): void; (e: 'baz', id: number): void;}), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ({(e: 'foo' | 'bar'): void; (e: 'baz', id: number): void;}), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1457,8 +1457,8 @@ exports[`SFC compile <script setup> > with TypeScript > defineEmits w/ type 1`] 
 
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1475,8 +1475,8 @@ exports[`SFC compile <script setup> > with TypeScript > defineEmits w/ type from
       
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
-  setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose();
+  setup(__props, { expose: __expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
+  __expose();
 
       
       
@@ -1494,8 +1494,8 @@ export default /*#__PURE__*/_defineComponent({
   props: {
     x: { type: Number, required: false }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
       
       
@@ -1514,8 +1514,8 @@ export default /*#__PURE__*/_defineComponent({
   props: {
     x: { type: Number, required: false }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
         
       
@@ -1533,8 +1533,8 @@ export default /*#__PURE__*/_defineComponent({
   props: {
     x: { type: Number, required: false }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
       
       
@@ -1560,8 +1560,8 @@ export default /*#__PURE__*/_defineComponent({
     y: { type: String, required: true },
     x: { type: Number, required: false }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
         
       
@@ -1579,8 +1579,8 @@ export default /*#__PURE__*/_defineComponent({
   props: {
     x: { type: Number, required: false }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
       
       
@@ -1627,8 +1627,8 @@ export default /*#__PURE__*/_defineComponent({
     intersection: { type: Object, required: true },
     foo: { type: [Function, null], required: true }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
       
       
@@ -1646,8 +1646,8 @@ export default /*#__PURE__*/_defineComponent({
   props: {
     x: { type: Number, required: false }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
       
       
@@ -1663,8 +1663,8 @@ exports[`SFC compile <script setup> > with TypeScript > defineProps/Emit w/ runt
 export default /*#__PURE__*/_defineComponent({
   props: { foo: String },
   emits: ['a', 'b'],
-  setup(__props, { expose, emit }) {
-  expose();
+  setup(__props, { expose: __expose, emit }) {
+  __expose();
 
 const props = __props;
 
@@ -1683,8 +1683,8 @@ export interface Foo {}
         type Bar = {}
       
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return {  }
@@ -1699,8 +1699,8 @@ import type { Foo } from './main.ts'
         import { type Bar, Baz } from './main.ts'
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { get Baz() { return Baz } }
@@ -1714,8 +1714,8 @@ exports[`SFC compile <script setup> > with TypeScript > runtime Enum 1`] = `
 enum Foo { A = 123 }
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         
 return { Foo }
@@ -1732,8 +1732,8 @@ exports[`SFC compile <script setup> > with TypeScript > runtime Enum in normal s
           enum B { B = \\"B\\" }
         
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         enum Foo { A = 123 }
         
@@ -1753,8 +1753,8 @@ export default /*#__PURE__*/_defineComponent({
     bar: { type: Number, required: false },
     baz: { type: Boolean, required: true }
   }, { ...defaults }),
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
 const props = __props as {
         foo?: string
@@ -1781,8 +1781,8 @@ export default /*#__PURE__*/_defineComponent({
     baz: { type: [Boolean, Function] },
     qux: null
   }, { ...defaults }),
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
 const props = __props as {
         foo: () => void
@@ -1810,8 +1810,8 @@ export default /*#__PURE__*/_defineComponent({
   props: {
     a: { type: String, required: false, default: \\"a\\" }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
 const props = __props as { a: string };
 
@@ -1836,8 +1836,8 @@ export default /*#__PURE__*/_defineComponent({
     quuxx: { type: Promise, required: false, async default() { return await Promise.resolve('hi') } },
     fred: { type: String, required: false, get default() { return 'fred' } }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
 const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number, quux(): void, quuxx: Promise<string>, fred: string };
 
@@ -1859,8 +1859,8 @@ export default /*#__PURE__*/_defineComponent({
     baz: { type: [Boolean, Function], default: true },
     qux: { default: 'hi' }
   },
-  setup(__props: any, { expose }) {
-  expose();
+  setup(__props: any, { expose: __expose }) {
+  __expose();
 
 const props = __props as { foo: () => void, bar: boolean, baz: boolean | (() => void), qux: string | number };
 

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScriptRefTransform.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScriptRefTransform.spec.ts.snap
@@ -4,8 +4,8 @@ exports[`sfc ref transform > $ unwrapping 1`] = `
 "import { ref, shallowRef } from 'vue'
     
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
     let foo = (ref())
     let a = (ref(1))
@@ -25,8 +25,8 @@ exports[`sfc ref transform > $ref & $shallowRef declarations 1`] = `
 "import { ref as _ref, shallowRef as _shallowRef } from 'vue'
 
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
     let foo = _ref()
     let a = _ref(1)
@@ -46,8 +46,8 @@ exports[`sfc ref transform > usage /w typescript 1`] = `
 "import { ref as _ref, defineComponent as _defineComponent } from 'vue'
 
 export default /*#__PURE__*/_defineComponent({
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
         let msg = _ref<string | number>('foo');
         let bar = _ref <string | number>('bar');
@@ -77,8 +77,8 @@ exports[`sfc ref transform > usage with normal <script> (has macro usage) + <scr
     let data = _ref()
     
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
     console.log(data.value)
     
@@ -95,8 +95,8 @@ exports[`sfc ref transform > usage with normal <script> + <script setup> 1`] = `
     let c = _ref(0)
     
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
     let b = _ref(0)
     let c = 0

--- a/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
@@ -53,8 +53,8 @@ exports[`CSS vars injection > codegen > should ignore comments 1`] = `
 "import { useCssVars as _useCssVars, unref as _unref } from 'vue'
 const color = 'red';const width = 100
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-width\\": (width)
@@ -70,8 +70,8 @@ exports[`CSS vars injection > codegen > should work with w/ complex expression 1
 "import { useCssVars as _useCssVars, unref as _unref } from 'vue'
 
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-foo\\": (_unref(foo)),
@@ -94,8 +94,8 @@ exports[`CSS vars injection > codegen > w/ <script setup> 1`] = `
 "import { useCssVars as _useCssVars, unref as _unref } from 'vue'
 const color = 'red'
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-color\\": (color)
@@ -112,8 +112,8 @@ exports[`CSS vars injection > codegen > w/ <script setup> using the same var mul
 const color = 'red'
         
 export default {
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-color\\": (color)
@@ -152,8 +152,8 @@ export default {
   props: {
           foo: String
         },
-  setup(__props, { expose }) {
-  expose();
+  setup(__props, { expose: __expose }) {
+  __expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-color\\": (color),

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -78,7 +78,7 @@ const bar = 1
     // should remove defineOptions import and call
     expect(content).not.toMatch('defineProps')
     // should generate correct setup signature
-    expect(content).toMatch(`setup(__props, { expose }) {`)
+    expect(content).toMatch(`setup(__props, { expose: __expose }) {`)
     // should assign user identifier to it
     expect(content).toMatch(`const props = __props`)
     // should include context options in default export
@@ -125,7 +125,9 @@ const myEmit = defineEmits(['foo', 'bar'])
     // should remove defineOptions import and call
     expect(content).not.toMatch('defineEmits')
     // should generate correct setup signature
-    expect(content).toMatch(`setup(__props, { expose, emit: myEmit }) {`)
+    expect(content).toMatch(
+      `setup(__props, { expose: __expose, emit: myEmit }) {`
+    )
     // should include context options in default export
     expect(content).toMatch(`export default {
   emits: ['foo', 'bar'],`)
@@ -244,7 +246,7 @@ defineExpose({ foo: 123 })
     // should remove defineOptions import and call
     expect(content).not.toMatch('defineExpose')
     // should generate correct setup signature
-    expect(content).toMatch(`setup(__props, { expose }) {`)
+    expect(content).toMatch(`setup(__props, { expose: __expose }) {`)
     // should replace callee
     expect(content).toMatch(/\bexpose\(\{ foo: 123 \}\)/)
   })
@@ -651,7 +653,7 @@ defineExpose({ foo: 123 })
         { inlineTemplate: true }
       )
       assertCode(content)
-      expect(content).toMatch(`setup(__props, { expose })`)
+      expect(content).toMatch(`setup(__props, { expose: __expose })`)
       expect(content).toMatch(`expose({ count })`)
     })
 
@@ -929,7 +931,7 @@ const emit = defineEmits(['a', 'b'])
       expect(content).toMatch(`export default /*#__PURE__*/_defineComponent({
   props: { foo: String },
   emits: ['a', 'b'],
-  setup(__props, { expose, emit }) {`)
+  setup(__props, { expose: __expose, emit }) {`)
     })
 
     test('defineProps w/ type', () => {
@@ -1418,7 +1420,7 @@ const emit = defineEmits(['a', 'b'])
       </script>
       `)
       assertCode(content)
-      expect(content).toMatch(`setup(__props, { expose, emit }) {`)
+      expect(content).toMatch(`setup(__props, { expose: __expose, emit }) {`)
       expect(content).toMatch(`emits: ['foo']`)
     })
 

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1528,7 +1528,7 @@ export function compileScript(
   }
 
   const destructureElements =
-    hasDefineExposeCall || !options.inlineTemplate ? [`expose`] : []
+    hasDefineExposeCall || !options.inlineTemplate ? [`expose: __expose`] : []
   if (emitIdentifier) {
     destructureElements.push(
       emitIdentifier === `emit` ? `emit` : `emit: ${emitIdentifier}`
@@ -1706,7 +1706,7 @@ export function compileScript(
   // <script setup> components are closed by default. If the user did not
   // explicitly call `defineExpose`, call expose() with no args.
   const exposeCall =
-    hasDefineExposeCall || options.inlineTemplate ? `` : `  expose();\n`
+    hasDefineExposeCall || options.inlineTemplate ? `` : `  __expose();\n`
   // wrap setup code with function.
   if (isTS) {
     // for TS, make sure the exported type is still valid type with


### PR DESCRIPTION
rename `expose` to `__expose` to avoid duplicate identifier

relate #7890