### PR TITLE
fix(jsx-runtime): fix automatic runtime implementation

### DIFF
--- a/packages/vue/jsx-runtime/index.js
+++ b/packages/vue/jsx-runtime/index.js
@@ -1,4 +1,19 @@
 const Vue = require('vue')
-exports.jsx = Vue.h
-exports.jsxDEV = Vue.h
+
+function jsx(type, { children, ...props }) {
+  return Vue.h(type, props, children)
+}
+
+function jsxs(type, { children, ...props }) {
+  return Vue.h(type, props, ...children)
+}
+
+function jsxDEV(type, props, key, isStatic) {
+  const fn = isStatic ? jsxs : jsx
+  return fn(type, props)
+}
+
+exports.jsx = jsx
+exports.jsxs = jsxs
+exports.jsxDEV = jsxDEV
 exports.Fragment = Vue.Fragment

--- a/packages/vue/jsx-runtime/index.js
+++ b/packages/vue/jsx-runtime/index.js
@@ -1,19 +1,10 @@
-const Vue = require('vue')
+const { h, Fragment } = require('vue')
 
 function jsx(type, { children, ...props }) {
-  return Vue.h(type, props, children)
-}
-
-function jsxs(type, { children, ...props }) {
-  return Vue.h(type, props, ...children)
-}
-
-function jsxDEV(type, props, key, isStatic) {
-  const fn = isStatic ? jsxs : jsx
-  return fn(type, props)
+  return h(type, props, children)
 }
 
 exports.jsx = jsx
-exports.jsxs = jsxs
-exports.jsxDEV = jsxDEV
-exports.Fragment = Vue.Fragment
+exports.jsxs = jsx
+exports.jsxDEV = jsx
+exports.Fragment = Fragment

--- a/packages/vue/jsx-runtime/index.mjs
+++ b/packages/vue/jsx-runtime/index.mjs
@@ -1,16 +1,12 @@
 import { h, Fragment } from 'vue'
 
-export { Fragment }
-
-export function jsx(type, { children, ...props }) {
+function jsx(type, { children, ...props }) {
   return h(type, props, children)
 }
 
-export function jsxs(type, { children, ...props }) {
-  return h(type, props, ...children)
-}
-
-export function jsxDEV(type, props, key, isStatic) {
-  const fn = isStatic ? jsxs : jsx
-  return fn(type, props)
+export {
+  Fragment,
+  jsx,
+  jsx as jsxs,
+  jsx as jsxDEV
 }

--- a/packages/vue/jsx-runtime/index.mjs
+++ b/packages/vue/jsx-runtime/index.mjs
@@ -1,1 +1,16 @@
-export { h as jsx, h as jsxDEV, Fragment } from 'vue'
+import { h, Fragment } from 'vue'
+
+export { Fragment }
+
+export function jsx(type, { children, ...props }) {
+  return h(type, props, children)
+}
+
+export function jsxs(type, { children, ...props }) {
+  return h(type, props, ...children)
+}
+
+export function jsxDEV(type, props, key, isStatic) {
+  const fn = isStatic ? jsxs : jsx
+  return fn(type, props)
+}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -43,6 +43,11 @@
       "import": "./jsx-runtime/index.mjs",
       "require": "./jsx-runtime/index.js"
     },
+    "./jsx-dev-runtime": {
+      "types": "./jsx-runtime/index.d.ts",
+      "import": "./jsx-runtime/index.mjs",
+      "require": "./jsx-runtime/index.js"
+    },
     "./jsx": {
       "types": "./jsx.d.ts"
     },


### PR DESCRIPTION
The JSX automatic runtime consists of two modules. These modules require different exports.

- `vue/jsx-runtime` is for production. This has the following exports:
  - `jsx`
  - `jsxs`
  - `Fragment`
- `vue/jsx-dev-runtime` is for development. This has the following exports:
  - `jsxDEV`
  - `Fragment`

Whereas a JSX pragma of the classic runtime accepts children as the 3rd..nth arguments, in the automatic runtime this is passed as the `children` prop. If the JSX element has one child, the `jsx` function is used and `children` is that child. If the JSX element has more, the `jsxs` function is called and `children` is an array of all childrne. If no children are passed, this prop is omitted.

The third argument is the key. In the classic runtime this was part of props.

If the development transform is used, `jsxDEV` from the `vue/jsx-dev-runtime` module is used intead. This is similar to `jsx` / `jsxs`, but it accepts more arguments.

The 4th argument determines if the production runtime would use `jsxs` or `jsx`.

The 5th argument is positional information that you could use to enhance the developer experience. Note that different compilers compile the file name differently. (relative vs absolute paths)

The 6th argument is the value of `this` in the scopewhere the JSX element was created. React uses this to warn about string refs.

This implementation combines the production and development runtime in the same file, and uses an package exports to expose both import entry points.

---

This fixes some bugs introduced in #7958.

I am familiar with JSX transforms, but not with Vue. There may be better ways to fix this in a Vue specific way. Also I don’t know how to test this.

For reference, see the JS output in https://www.typescriptlang.org/play?jsx=4#code/KYDwDg9gTgLgBAYwgOwM7wGYQnAvHAbQCg44AeAEwEsA3OAegD4AaE86mxs+jlty2owDeAcgCGIgL7derUgM6iJk0QCMpMwXPaCyYJnoM8tRALpEgA. Try using both the `ReactJSX` and `ReactJSXDev` options for `JSX`. You can ignore the type errors.