### PR TITLE
build: exit with code 1 on release failure

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -375,4 +375,5 @@ async function publishPackage(pkgName, version) {
 main().catch(err => {
   updateVersions(currentVersion)
   console.error(err)
+  process.exit(1)
 })


### PR DESCRIPTION
See https://github.com/vuejs/core/actions/runs/4527710331/jobs/7973811532#step:6:279

The canary release action should fail if the release script fails.