### PR TITLE
feat(types): `defineComponent()` with generics support

### DIFF
--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -351,7 +351,7 @@ describe('type inference w/ optional props declaration', () => {
 })
 
 describe('type inference w/ direct setup function', () => {
-  const MyComponent = defineComponent((_props: { msg: string }) => {})
+  const MyComponent = defineComponent((_props: { msg: string }) => () => {})
   expectType<JSX.Element>(<MyComponent msg="foo" />)
   // @ts-expect-error
   ;<MyComponent />
@@ -1250,10 +1250,121 @@ describe('prop starting with `on*` is broken', () => {
   })
 })
 
+describe('function syntax w/ generics', () => {
+  const Comp = defineComponent(
+    // TODO: babel plugin to auto infer runtime props options from type
+    // similar to defineProps<{...}>()
+    <T extends string | number>(props: { msg: T; list: T[] }) => {
+      // use Composition API here like in <script setup>
+      const count = ref(0)
+
+      return () => (
+        // return a render function (both JSX and h() works)
+        <div>
+          {props.msg} {count.value}
+        </div>
+      )
+    }
+  )
+
+  expectType<JSX.Element>(<Comp msg="fse" list={['foo']} />)
+  expectType<JSX.Element>(<Comp msg={123} list={[123]} />)
+
+  expectType<JSX.Element>(
+    // @ts-expect-error missing prop
+    <Comp msg={123} />
+  )
+
+  expectType<JSX.Element>(
+    // @ts-expect-error generics don't match
+    <Comp msg="fse" list={[123]} />
+  )
+  expectType<JSX.Element>(
+    // @ts-expect-error generics don't match
+    <Comp msg={123} list={['123']} />
+  )
+})
+
+describe('function syntax w/ emits', () => {
+  const Foo = defineComponent(
+    (props: { msg: string }, ctx) => {
+      ctx.emit('foo')
+      // @ts-expect-error
+      ctx.emit('bar')
+      return () => {}
+    },
+    {
+      emits: ['foo']
+    }
+  )
+  expectType<JSX.Element>(<Foo msg="hi" onFoo={() => {}} />)
+  // @ts-expect-error
+  expectType<JSX.Element>(<Foo msg="hi" onBar={() => {}} />)
+})
+
+describe('function syntax w/ runtime props', () => {
+  // with runtime props, the runtime props must match
+  // manual type declaration
+  defineComponent(
+    (_props: { msg: string }) => {
+      return () => {}
+    },
+    {
+      props: ['msg']
+    }
+  )
+
+  defineComponent(
+    (_props: { msg: string }) => {
+      return () => {}
+    },
+    {
+      props: {
+        msg: String
+      }
+    }
+  )
+
+  // @ts-expect-error string prop names don't match
+  defineComponent(
+    (_props: { msg: string }) => {
+      return () => {}
+    },
+    {
+      props: ['bar']
+    }
+  )
+
+  // @ts-expect-error prop type mismatch
+  defineComponent(
+    (_props: { msg: string }) => {
+      return () => {}
+    },
+    {
+      props: {
+        msg: Number
+      }
+    }
+  )
+
+  // @ts-expect-error prop keys don't match
+  defineComponent(
+    (_props: { msg: string }, ctx) => {
+      return () => {}
+    },
+    {
+      props: {
+        msg: String,
+        bar: String
+      }
+    }
+  )
+})
+
 // check if defineComponent can be exported
 export default {
   // function components
-  a: defineComponent(_ => h('div')),
+  a: defineComponent(_ => () => h('div')),
   // no props
   b: defineComponent({
     data() {

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -1315,7 +1315,16 @@ describe('function syntax w/ runtime props', () => {
   )
 
   defineComponent(
-    (_props: { msg: string }) => {
+    <T extends string>(_props: { msg: T }) => {
+      return () => {}
+    },
+    {
+      props: ['msg']
+    }
+  )
+
+  defineComponent(
+    <T extends string>(_props: { msg: T }) => {
       return () => {}
     },
     {

--- a/packages/dts-test/h.test-d.ts
+++ b/packages/dts-test/h.test-d.ts
@@ -157,7 +157,7 @@ describe('h support for generic component type', () => {
 describe('describeComponent extends Component', () => {
   // functional
   expectAssignable<Component>(
-    defineComponent((_props: { foo?: string; bar: number }) => {})
+    defineComponent((_props: { foo?: string; bar: number }) => () => {})
   )
 
   // typed props

--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -817,6 +817,22 @@ describe('api: options', () => {
     ])
   })
 
+  test('unlikely mixin usage', () => {
+    const MixinA = {
+      data() {}
+    }
+    const MixinB = {
+      data() {}
+    }
+    defineComponent({
+      // @ts-expect-error edge case after #7963, unlikely to happen in practice
+      // since the user will want to type the mixins themselves.
+      mixins: [defineComponent(MixinA), defineComponent(MixinB)],
+      // @ts-expect-error
+      data() {}
+    })
+  })
+
   test('chained extends in mixins', () => {
     const calls: string[] = []
 

--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -122,7 +122,7 @@ describe('api: options', () => {
     expect(serializeInner(root)).toBe(`<div>4</div>`)
   })
 
-  test('component’s own methods have higher priority than global properties', async () => {
+  test("component's own methods have higher priority than global properties", async () => {
     const app = createApp({
       methods: {
         foo() {
@@ -667,7 +667,7 @@ describe('api: options', () => {
 
   test('mixins', () => {
     const calls: string[] = []
-    const mixinA = {
+    const mixinA = defineComponent({
       data() {
         return {
           a: 1
@@ -682,8 +682,8 @@ describe('api: options', () => {
       mounted() {
         calls.push('mixinA mounted')
       }
-    }
-    const mixinB = {
+    })
+    const mixinB = defineComponent({
       props: {
         bP: {
           type: String
@@ -705,7 +705,7 @@ describe('api: options', () => {
       mounted() {
         calls.push('mixinB mounted')
       }
-    }
+    })
     const mixinC = defineComponent({
       props: ['cP1', 'cP2'],
       data() {
@@ -727,7 +727,7 @@ describe('api: options', () => {
       props: {
         aaa: String
       },
-      mixins: [defineComponent(mixinA), defineComponent(mixinB), mixinC],
+      mixins: [mixinA, mixinB, mixinC],
       data() {
         return {
           c: 4,
@@ -863,7 +863,7 @@ describe('api: options', () => {
 
   test('extends', () => {
     const calls: string[] = []
-    const Base = {
+    const Base = defineComponent({
       data() {
         return {
           a: 1,
@@ -878,9 +878,9 @@ describe('api: options', () => {
         expect(this.b).toBe(2)
         calls.push('base')
       }
-    }
+    })
     const Comp = defineComponent({
-      extends: defineComponent(Base),
+      extends: Base,
       data() {
         return {
           b: 2
@@ -900,7 +900,7 @@ describe('api: options', () => {
 
   test('extends with mixins', () => {
     const calls: string[] = []
-    const Base = {
+    const Base = defineComponent({
       data() {
         return {
           a: 1,
@@ -916,8 +916,8 @@ describe('api: options', () => {
         expect(this.c).toBe(2)
         calls.push('base')
       }
-    }
-    const Mixin = {
+    })
+    const Mixin = defineComponent({
       data() {
         return {
           b: true,
@@ -930,10 +930,10 @@ describe('api: options', () => {
         expect(this.c).toBe(2)
         calls.push('mixin')
       }
-    }
+    })
     const Comp = defineComponent({
-      extends: defineComponent(Base),
-      mixins: [defineComponent(Mixin)],
+      extends: Base,
+      mixins: [Mixin],
       data() {
         return {
           c: 2


### PR DESCRIPTION
## Breaking Changes

The type of `defineComponent()` when passing in a function has changed. This overload signature is rarely used in practice and the breakage will be minimal, so repurposing it to something more useful should be worth it.

Previously the return type was `DefineComponent`, now it is a function type that inherits the generics of the function passed in. The function passed in as the first argument now also requires a return type of a render function, as the signature is no longer meant to be used for other use cases.

Another side effect is that a very specific case of mixins usage breaks:

```ts
const a = {}
const b = {}
defineComponent({
  mixins: [defineComponent(a), defineComponent(b)],
  data() {}
})
```

Note the breakage only happens when calling `defineComponent()` inline in the `mixins` option on a separately declared plain object. This should be extremely unlikely in userland code because if one wants typed mixins, one will certainly define it like this to get type inference for the mixin itself:

```ts
const a = defineComponent({})
const b = defineComponent({})
defineComponent({
  mixins: [a, b],
  data() {}
})
```

This continues to work, so I believe this issue is negligible in practice. It would be nice to fix, but I couldn't figure it out.

## Generics Example

```tsx
const Comp = defineComponent(
    // TODO: babel plugin to auto infer runtime props options from type
    // similar to defineProps<{...}>()
    <T extends string | number>(props: { msg: T; list: T[] }) => {
      // use Composition API here like in <script setup>
      const count = ref(0)

      return () => (
        // return a render function (both JSX and h() works)
        <div>
          {props.msg} {count.value}
        </div>
      )
    }
  )

  expectType<JSX.Element>(<Comp msg="fse" list={['foo']} />)
  expectType<JSX.Element>(<Comp msg={123} list={[123]} />)

  expectType<JSX.Element>(
    // @ts-expect-error missing prop
    <Comp msg={123} />
  )

  expectType<JSX.Element>(
    // @ts-expect-error generics don't match
    <Comp msg="fse" list={[123]} />
  )
  expectType<JSX.Element>(
    // @ts-expect-error generics don't match
    <Comp msg={123} list={['123']} />
  )
```

## Extra Options

This signature is expected to only be used with Composition API. Misc options can be passed via the second argument:

```tsx
defineComponent(() => () => {}, {
  name: 'Foo',
  inheritAttrs: false
})
```

Only `name`, `inheritAttrs`, `props` and `emits` are allowed.
  
## Runtime Props

The final component still need runtime props declared. This can be done automatically via a babel plugin, or manually like so:

```tsx
defineComponent((props: { msg: string }) => () => {}, {
  props: ['msg']
  // OR
  props: { msg: String }
})
```

The type definition ensures that the manual type and the runtime options must match.

## Emits Validation

Type inference based on runtime `emits` option is supported, including the matching `onXXX` prop on the resulting props interface.

```tsx
const Foo = defineComponent(
  (props: { msg: string }, ctx) => {
    ctx.emit('foo')
    // @ts-expect-error
    ctx.emit('bar')
    return () => {}
  },
  {
    emits: ['foo']
  }
)
expectType<JSX.Element>(<Foo msg="hi" onFoo={() => {}} />)
// @ts-expect-error
expectType<JSX.Element>(<Foo msg="hi" onBar={() => {}} />)
```