### PR TITLE
build: don't wait for changelog edits when `--skip-prompts` or `--canary` is specified

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -211,14 +211,16 @@ async function main() {
   await run(`pnpm`, ['run', 'changelog'])
 
   // @ts-ignore
-  const { yes: changelogOk } = await prompt({
-    type: 'confirm',
-    name: 'yes',
-    message: `Changelog generated. Does it look good?`
-  })
+  if (!skipPrompts) {
+    const { yes: changelogOk } = await prompt({
+      type: 'confirm',
+      name: 'yes',
+      message: `Changelog generated. Does it look good?`
+    })
 
-  if (!changelogOk) {
-    return
+    if (!changelogOk) {
+      return
+    }
   }
 
   // update pnpm-lock.yaml


### PR DESCRIPTION
The most recent release was blocked by this issue: https://github.com/vuejs/core/actions/runs/4532193370/jobs/7983273077#step:6:304