### PR TITLE
fix(compiler-sfc): infer runtime type in defineProps

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -2068,7 +2068,7 @@ function inferRuntimeType(
         case 'BigIntLiteral':
           return ['Number']
         default:
-          return [`UNKNOWN`]
+          return [UNKNOWN_TYPE]
       }
 
     case 'TSTypeReference':
@@ -2116,6 +2116,7 @@ function inferRuntimeType(
                 declaredTypes
               ).filter(t => t !== 'null')
             }
+            break
           case 'Extract':
             if (node.typeParameters && node.typeParameters.params[1]) {
               return inferRuntimeType(
@@ -2123,6 +2124,7 @@ function inferRuntimeType(
                 declaredTypes
               )
             }
+            break
           case 'Exclude':
           case 'OmitThisParameter':
             if (node.typeParameters && node.typeParameters.params[0]) {
@@ -2131,9 +2133,10 @@ function inferRuntimeType(
                 declaredTypes
               )
             }
-          // cannot infer, fallback to UNKNOWN: ThisParameterType
+            break
         }
       }
+      // cannot infer, fallback to UNKNOWN: ThisParameterType
       return [UNKNOWN_TYPE]
 
     case 'TSParenthesizedType':


### PR DESCRIPTION
relate 4355d2492dccdb175b18d083e20f3ec39a52801f

[demo](https://sfc.vuejs.org/#__DEV__eNqNj9FqwzAMRX/F+GmDpqaMMTBex/5gH+CHhlRdMhJbSGrYCP73yW0ppU99Evf63mNpsZ+I6/kI1tvAHQ0ohkGOaMY2fb8Lb2Paw2FI8EUZOSwxGXPI+cOb3S6msn16jim4c1OzKgQmHFuBqiT0G51a8GZZdJRSAcGd7OCuWbuyw4SZpJlaXP9wTrrQ6bN4eeBolVGd6unGVUfbi6B3bsxdO/aZxb9u3l4cU+c00uxhbpDy71+0q5uqY6AZqCHQ4wjoEdRd5RZdyXpXseUfG0hzjw==)