### PR TITLE
fix: copy-paste jsx-runtime types for global JSX namespace registration

### DIFF
--- a/packages/vue/jsx.d.ts
+++ b/packages/vue/jsx.d.ts
@@ -1,15 +1,34 @@
 // global JSX namespace registration
-import { JSX as JSXInternal } from './jsx-runtime'
+// somehow we have to copy=pase the jsx-runtime types here to make TypeScript happy
+import { VNode, VNodeRef } from '@vue/runtime-dom'
+import { IntrinsicElementAttributes } from './jsx-runtime/dom'
+
+export type ReservedProps = {
+  key?: string | number | symbol
+  ref?: VNodeRef
+  ref_for?: boolean
+  ref_key?: string
+}
+
+export type NativeElements = {
+  [K in keyof IntrinsicElementAttributes]: IntrinsicElementAttributes[K] &
+    ReservedProps
+}
 
 declare global {
   namespace JSX {
-    interface Element extends JSXInternal.Element {}
-    interface ElementClass extends JSXInternal.ElementClass {}
-    interface ElementAttributesProperty
-      extends JSXInternal.ElementAttributesProperty {}
-    interface IntrinsicElements extends JSXInternal.IntrinsicElements {}
-    interface IntrinsicAttributes extends JSXInternal.IntrinsicAttributes {}
+    export interface Element extends VNode {}
+    export interface ElementClass {
+      $props: {}
+    }
+    export interface ElementAttributesProperty {
+      $props: {}
+    }
+    export interface IntrinsicElements extends NativeElements {
+      // allow arbitrary elements
+      // @ts-ignore suppress ts:2374 = Duplicate string index signature.
+      [name: string]: any
+    }
+    export interface IntrinsicAttributes extends ReservedProps {}
   }
 }
-
-export {}

--- a/packages/vue/jsx.d.ts
+++ b/packages/vue/jsx.d.ts
@@ -3,6 +3,8 @@
 import { VNode, VNodeRef } from '@vue/runtime-dom'
 import { IntrinsicElementAttributes } from './jsx-runtime/dom'
 
+export * from './jsx-runtime/dom'
+
 export type ReservedProps = {
   key?: string | number | symbol
   ref?: VNodeRef

--- a/packages/vue/types/jsx-register.d.ts
+++ b/packages/vue/types/jsx-register.d.ts
@@ -2,3 +2,5 @@
 // imports the global JSX namespace registration for compat.
 // TODO: remove in 3.4
 import '../jsx'
+
+export * from '../jsx-runtime/dom'


### PR DESCRIPTION
Otherwise, TypeScript will raise TS2322 errors. I have no idea why and
how the fix works. But it does.

Even importing the `ReservedProps` and `NativeElements` types from
`jsx-runtime` instead of declaring them in the module would fail the
tests. I have no idea why, either.

The failing tests are at https://github.com/vuejs/ecosystem-ci/actions/runs/4538928668/jobs/7998297656#step:7:3

JSX DOM interfaces need to be exported too.

After these changes a few more tests are passed in the ecosystem CI: https://github.com/vuejs/ecosystem-ci/actions/runs/4544919366/jobs/8011786793

The remaining ones are mostly related to `expose` types and snapshot tests; the vuetify ones are related to [module declaration augmentation of `@vue/runtime-dom`](https://github.com/vuetifyjs/vuetify/blob/29777628ac8839c0548e869d3d350ed9fdcbb149/packages/vuetify/src/shims.d.ts#L18-L25).