### PR TITLE
feat: add `defineSlots` macro and `slots` option

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1785,45 +1785,45 @@ return { props, emit }
 })"
 `;
 
-exports[`SFC compile <script setup> > with TypeScript > defineSlots 1`] = `
+exports[`SFC compile <script setup> > with TypeScript > defineSlots() > basic usage 1`] = `
 "import { useSlots as _useSlots, defineComponent as _defineComponent } from 'vue'
 
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose: __expose }) {
   __expose();
 
-      const slots = _useSlots()
-      
+          const slots = _useSlots()
+          
 return { slots }
 }
 
 })"
 `;
 
-exports[`SFC compile <script setup> > with TypeScript > defineSlots w/o generic params 1`] = `
+exports[`SFC compile <script setup> > with TypeScript > defineSlots() > w/o generic params 1`] = `
 "import { useSlots as _useSlots } from 'vue'
 
 export default {
   setup(__props, { expose: __expose }) {
   __expose();
 
-      const slots = _useSlots()
-      
+          const slots = _useSlots()
+          
 return { slots }
 }
 
 }"
 `;
 
-exports[`SFC compile <script setup> > with TypeScript > defineSlots w/o return value 1`] = `
+exports[`SFC compile <script setup> > with TypeScript > defineSlots() > w/o return value 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose: __expose }) {
   __expose();
 
-      
-      
+          
+          
 return {  }
 }
 

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1785,6 +1785,51 @@ return { props, emit }
 })"
 `;
 
+exports[`SFC compile <script setup> > with TypeScript > defineSlots 1`] = `
+"import { useSlots as _useSlots, defineComponent as _defineComponent } from 'vue'
+
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      const slots = _useSlots()
+      
+return { slots }
+}
+
+})"
+`;
+
+exports[`SFC compile <script setup> > with TypeScript > defineSlots w/o generic params 1`] = `
+"import { useSlots as _useSlots } from 'vue'
+
+export default {
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      const slots = _useSlots()
+      
+return { slots }
+}
+
+}"
+`;
+
+exports[`SFC compile <script setup> > with TypeScript > defineSlots w/o return value 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      
+      
+return {  }
+}
+
+})"
+`;
+
 exports[`SFC compile <script setup> > with TypeScript > hoist type declarations 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 export interface Foo {}

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1585,38 +1585,43 @@ const emit = defineEmits(['a', 'b'])
       assertCode(content)
     })
 
-    test('defineSlots', () => {
-      const { content } = compile(`
-      <script setup lang="ts">
-      const slots = defineSlots<{
-        default: { msg: string }
-      }>()
-      </script>
-      `)
-      assertCode(content)
-      expect(content).toMatch(`const slots = _useSlots()`)
-    })
+    describe('defineSlots()', () => {
+      test('basic usage', () => {
+        const { content } = compile(`
+          <script setup lang="ts">
+          const slots = defineSlots<{
+            default: { msg: string }
+          }>()
+          </script>
+        `)
+        assertCode(content)
+        expect(content).toMatch(`const slots = _useSlots()`)
+        expect(content).not.toMatch('defineSlots')
+      })
 
-    test('defineSlots w/o return value', () => {
-      const { content } = compile(`
-      <script setup lang="ts">
-      defineSlots<{
-        default: { msg: string }
-      }>()
-      </script>
-      `)
-      assertCode(content)
-      expect(content).not.toMatch(`_useSlots`)
-    })
+      test('w/o return value', () => {
+        const { content } = compile(`
+          <script setup lang="ts">
+          defineSlots<{
+            default: { msg: string }
+          }>()
+          </script>
+        `)
+        assertCode(content)
+        expect(content).not.toMatch('defineSlots')
+        expect(content).not.toMatch(`_useSlots`)
+      })
 
-    test('defineSlots w/o generic params', () => {
-      const { content } = compile(`
-      <script setup>
-      const slots = defineSlots()
-      </script>
-      `)
-      assertCode(content)
-      expect(content).toMatch(`const slots = _useSlots()`)
+      test('w/o generic params', () => {
+        const { content } = compile(`
+          <script setup>
+          const slots = defineSlots()
+          </script>
+        `)
+        assertCode(content)
+        expect(content).toMatch(`const slots = _useSlots()`)
+        expect(content).not.toMatch('defineSlots')
+      })
     })
 
     test('runtime Enum', () => {

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1585,6 +1585,40 @@ const emit = defineEmits(['a', 'b'])
       assertCode(content)
     })
 
+    test('defineSlots', () => {
+      const { content } = compile(`
+      <script setup lang="ts">
+      const slots = defineSlots<{
+        default: [msg: string]
+      }>()
+      </script>
+      `)
+      assertCode(content)
+      expect(content).toMatch(`const slots = _useSlots()`)
+    })
+
+    test('defineSlots w/o return value', () => {
+      const { content } = compile(`
+      <script setup lang="ts">
+      defineSlots<{
+        default: [msg: string]
+      }>()
+      </script>
+      `)
+      assertCode(content)
+      expect(content).not.toMatch(`_useSlots`)
+    })
+
+    test('defineSlots w/o generic params', () => {
+      const { content } = compile(`
+      <script setup>
+      const slots = defineSlots()
+      </script>
+      `)
+      assertCode(content)
+      expect(content).toMatch(`const slots = _useSlots()`)
+    })
+
     test('runtime Enum', () => {
       const { content, bindings } = compile(
         `<script setup lang="ts">

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1589,7 +1589,7 @@ const emit = defineEmits(['a', 'b'])
       const { content } = compile(`
       <script setup lang="ts">
       const slots = defineSlots<{
-        default: [msg: string]
+        default: { msg: string }
       }>()
       </script>
       `)
@@ -1601,7 +1601,7 @@ const emit = defineEmits(['a', 'b'])
       const { content } = compile(`
       <script setup lang="ts">
       defineSlots<{
-        default: [msg: string]
+        default: { msg: string }
       }>()
       </script>
       `)

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -709,6 +709,7 @@ export function compileScript(
     let propsOption = undefined
     let emitsOption = undefined
     let exposeOption = undefined
+    let slotsOption = undefined
     if (optionsRuntimeDecl.type === 'ObjectExpression') {
       for (const prop of optionsRuntimeDecl.properties) {
         if (
@@ -718,6 +719,7 @@ export function compileScript(
           if (prop.key.name === 'props') propsOption = prop
           if (prop.key.name === 'emits') emitsOption = prop
           if (prop.key.name === 'expose') exposeOption = prop
+          if (prop.key.name === 'slots') slotsOption = prop
         }
       }
     }
@@ -738,6 +740,12 @@ export function compileScript(
       error(
         `${DEFINE_OPTIONS}() cannot be used to declare expose. Use ${DEFINE_EXPOSE}() instead.`,
         exposeOption
+      )
+    }
+    if (slotsOption) {
+      error(
+        `${DEFINE_OPTIONS}() cannot be used to declare slots. Use ${DEFINE_SLOTS}() instead.`,
+        slotsOption
       )
     }
 

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1347,8 +1347,9 @@ export function compileScript(
           const isDefineProps =
             processDefineProps(init, decl.id) ||
             processWithDefaults(init, decl.id)
-          const isDefineEmits = processDefineEmits(init, decl.id)
-          processDefineSlots(init, decl.id)
+          const isDefineEmits =
+            !isDefineProps && processDefineEmits(init, decl.id)
+          !isDefineEmits && processDefineSlots(init, decl.id)
 
           if (isDefineProps || isDefineEmits) {
             if (left === 1) {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -601,6 +601,10 @@ export function compileScript(
     }
     hasDefineSlotsCall = true
 
+    if (node.arguments) {
+      error(`${DEFINE_SLOTS}() cannot accept arguments`, node)
+    }
+
     if (declId) {
       s.overwrite(
         startOffset + node.start!,

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -601,7 +601,7 @@ export function compileScript(
     }
     hasDefineSlotsCall = true
 
-    if (node.arguments) {
+    if (node.arguments.length > 0) {
       error(`${DEFINE_SLOTS}() cannot accept arguments`, node)
     }
 

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -67,7 +67,7 @@ const DEFINE_EMITS = 'defineEmits'
 const DEFINE_EXPOSE = 'defineExpose'
 const WITH_DEFAULTS = 'withDefaults'
 const DEFINE_OPTIONS = 'defineOptions'
-const DEFINT_SLOTS = 'defineSlots'
+const DEFINE_SLOTS = 'defineSlots'
 
 const isBuiltInDir = makeMap(
   `once,memo,if,for,else,else-if,slot,text,html,on,bind,model,show,cloak,is`
@@ -593,11 +593,11 @@ export function compileScript(
   }
 
   function processDefineSlots(node: Node, declId?: LVal): boolean {
-    if (!isCallOf(node, DEFINT_SLOTS)) {
+    if (!isCallOf(node, DEFINE_SLOTS)) {
       return false
     }
     if (hasDefineSlotsCall) {
-      error(`duplicate ${DEFINT_SLOTS}() call`, node)
+      error(`duplicate ${DEFINE_SLOTS}() call`, node)
     }
     hasDefineSlotsCall = true
 

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -8,7 +8,10 @@ import {
   ComponentPublicInstance,
   ComponentOptions,
   SetupContext,
-  h
+  h,
+  SlotsType,
+  useSlots,
+  Slots
 } from 'vue'
 import { describe, expectType, IsUnion } from './utils'
 
@@ -1406,6 +1409,32 @@ export default {
   })
 }
 
+describe('slots', () => {
+  defineComponent({
+    slots: Object as SlotsType<{
+      default: [foo: string, bar: number]
+      item: [number]
+    }>,
+    setup(props, { slots }) {
+      expectType<(foo: string, bar: number) => any>(slots.default)
+      expectType<(scope: number) => any>(slots.item)
+    }
+  })
+
+  defineComponent({
+    // @ts-expect-error `default` should be an array
+    slots: Object as SlotsType<{ default: string }>
+  })
+
+  defineComponent({
+    setup(props, { slots }) {
+      // unknown slots
+      expectType<Slots>(slots)
+      expectType<((...args: any[]) => any) | undefined>(slots.default)
+    }
+  })
+})
+
 import {
   DefineComponent,
   ComponentOptionsMixin,
@@ -1428,6 +1457,7 @@ declare const MyButton: DefineComponent<
   ComponentOptionsMixin,
   EmitsOptions,
   string,
+  {},
   VNodeProps & AllowedComponentProps & ComponentCustomProps,
   Readonly<ExtractPropTypes<{}>>,
   {}

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -1415,8 +1415,8 @@ describe('slots', () => {
       item: [number]
     }>,
     setup(props, { slots }) {
-      expectType<(foo: string, bar: number) => any>(slots.default)
-      expectType<(scope: number) => any>(slots.item)
+      expectType<undefined | ((foo: string, bar: number) => any)>(slots.default)
+      expectType<undefined | ((scope: number) => any)>(slots.item)
     }
   })
 

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -10,7 +10,6 @@ import {
   SetupContext,
   h,
   SlotsType,
-  useSlots,
   Slots
 } from 'vue'
 import { describe, expectType, IsUnion } from './utils'

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -1414,6 +1414,8 @@ describe('slots', () => {
     slots: Object as SlotsType<{
       default: { foo: string; bar: number }
       optional?: { data: string }
+      undefinedScope: undefined | { data: string }
+      optionalUndefinedScope?: undefined | { data: string }
     }>,
     setup(props, { slots }) {
       expectType<(scope: { foo: string; bar: number }) => VNode[]>(
@@ -1428,6 +1430,33 @@ describe('slots', () => {
       // @ts-expect-error it's optional
       slots.optional({ data: 'foo' })
       slots.optional?.({ data: 'foo' })
+
+      expectType<{
+        (): VNode[]
+        (scope: undefined | { data: string }): VNode[]
+      }>(slots.undefinedScope)
+
+      expectType<
+        | { (): VNode[]; (scope: undefined | { data: string }): VNode[] }
+        | undefined
+      >(slots.optionalUndefinedScope)
+
+      slots.default({ foo: 'foo', bar: 1 })
+      // @ts-expect-error it's optional
+      slots.optional({ data: 'foo' })
+      slots.optional?.({ data: 'foo' })
+      slots.undefinedScope()
+      slots.undefinedScope(undefined)
+      // @ts-expect-error
+      slots.undefinedScope('foo')
+
+      slots.optionalUndefinedScope?.()
+      slots.optionalUndefinedScope?.(undefined)
+      slots.optionalUndefinedScope?.({ data: 'foo' })
+      // @ts-expect-error
+      slots.optionalUndefinedScope()
+      // @ts-expect-error
+      slots.optionalUndefinedScope?.('foo')
 
       expectType<typeof slots | undefined>(new comp1().$slots)
     }

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -10,7 +10,8 @@ import {
   SetupContext,
   h,
   SlotsType,
-  Slots
+  Slots,
+  VNode
 } from 'vue'
 import { describe, expectType, IsUnion } from './utils'
 
@@ -1409,26 +1410,37 @@ export default {
 }
 
 describe('slots', () => {
-  defineComponent({
+  const comp1 = defineComponent({
     slots: Object as SlotsType<{
       default: { foo: string; bar: number }
-      item: { data: number }
+      optional?: { data: string }
     }>,
     setup(props, { slots }) {
-      expectType<undefined | ((scope: { foo: string; bar: number }) => any)>(
+      expectType<(scope: { foo: string; bar: number }) => VNode[]>(
         slots.default
       )
-      expectType<undefined | ((scope: { data: number }) => any)>(slots.item)
+      expectType<((scope: { data: string }) => VNode[]) | undefined>(
+        slots.optional
+      )
+
+      slots.default({ foo: 'foo', bar: 1 })
+
+      // @ts-expect-error it's optional
+      slots.optional({ data: 'foo' })
+      slots.optional?.({ data: 'foo' })
+
+      expectType<typeof slots | undefined>(new comp1().$slots)
     }
   })
 
-  defineComponent({
+  const comp2 = defineComponent({
     setup(props, { slots }) {
       // unknown slots
       expectType<Slots>(slots)
-      expectType<((...args: any[]) => any) | undefined>(slots.default)
+      expectType<((...args: any[]) => VNode[]) | undefined>(slots.default)
     }
   })
+  expectType<Slots | undefined>(new comp2().$slots)
 })
 
 import {

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -1411,18 +1411,15 @@ export default {
 describe('slots', () => {
   defineComponent({
     slots: Object as SlotsType<{
-      default: [foo: string, bar: number]
-      item: [number]
+      default: { foo: string; bar: number }
+      item: { data: number }
     }>,
     setup(props, { slots }) {
-      expectType<undefined | ((foo: string, bar: number) => any)>(slots.default)
-      expectType<undefined | ((scope: number) => any)>(slots.item)
+      expectType<undefined | ((scope: { foo: string; bar: number }) => any)>(
+        slots.default
+      )
+      expectType<undefined | ((scope: { data: number }) => any)>(slots.item)
     }
-  })
-
-  defineComponent({
-    // @ts-expect-error `default` should be an array
-    slots: Object as SlotsType<{ default: string }>
   })
 
   defineComponent({

--- a/packages/dts-test/functionalComponent.test-d.tsx
+++ b/packages/dts-test/functionalComponent.test-d.tsx
@@ -69,11 +69,13 @@ const Qux: FunctionalComponent<{}, ['foo', 'bar']> = (props, { emit }) => {
 
 expectType<Component>(Qux)
 
-const Quux: FunctionalComponent<{}, {}, { default: [foo: number] }> = (
+const Quux: FunctionalComponent<{}, {}, { default: { foo: number } }> = (
   props,
   { emit, slots }
 ) => {
-  expectType<{ default: undefined | ((foo: number) => VNode[]) }>(slots)
+  expectType<{ default: undefined | ((scope: { foo: number }) => VNode[]) }>(
+    slots
+  )
 }
 expectType<Component>(Quux)
 ;<Quux />

--- a/packages/dts-test/functionalComponent.test-d.tsx
+++ b/packages/dts-test/functionalComponent.test-d.tsx
@@ -1,4 +1,4 @@
-import { h, Text, FunctionalComponent, Component } from 'vue'
+import { h, Text, FunctionalComponent, Component, SlotsType, VNode } from 'vue'
 import { expectType } from './utils'
 
 // simple function signature
@@ -68,3 +68,12 @@ const Qux: FunctionalComponent<{}, ['foo', 'bar']> = (props, { emit }) => {
 }
 
 expectType<Component>(Qux)
+
+const Quux: FunctionalComponent<{}, {}, { default: [foo: number] }> = (
+  props,
+  { emit, slots }
+) => {
+  expectType<{ default: (foo: number) => VNode[] }>(slots)
+}
+expectType<Component>(Quux)
+;<Quux />

--- a/packages/dts-test/functionalComponent.test-d.tsx
+++ b/packages/dts-test/functionalComponent.test-d.tsx
@@ -1,4 +1,4 @@
-import { h, Text, FunctionalComponent, Component, SlotsType, VNode } from 'vue'
+import { h, Text, FunctionalComponent, Component, VNode } from 'vue'
 import { expectType } from './utils'
 
 // simple function signature
@@ -73,7 +73,7 @@ const Quux: FunctionalComponent<{}, {}, { default: [foo: number] }> = (
   props,
   { emit, slots }
 ) => {
-  expectType<{ default: (foo: number) => VNode[] }>(slots)
+  expectType<{ default: undefined | ((foo: number) => VNode[]) }>(slots)
 }
 expectType<Component>(Quux)
 ;<Quux />

--- a/packages/dts-test/functionalComponent.test-d.tsx
+++ b/packages/dts-test/functionalComponent.test-d.tsx
@@ -69,13 +69,28 @@ const Qux: FunctionalComponent<{}, ['foo', 'bar']> = (props, { emit }) => {
 
 expectType<Component>(Qux)
 
-const Quux: FunctionalComponent<{}, {}, { default: { foo: number } }> = (
-  props,
-  { emit, slots }
-) => {
-  expectType<{ default: undefined | ((scope: { foo: number }) => VNode[]) }>(
-    slots
-  )
+const Quux: FunctionalComponent<
+  {},
+  {},
+  {
+    default: { foo: number }
+    optional?: { foo: number }
+  }
+> = (props, { emit, slots }) => {
+  expectType<{
+    default: (scope: { foo: number }) => VNode[]
+    optional?: (scope: { foo: number }) => VNode[]
+  }>(slots)
+
+  slots.default({ foo: 123 })
+  // @ts-expect-error
+  slots.default({ foo: 'fesf' })
+
+  slots.optional?.({ foo: 123 })
+  // @ts-expect-error
+  slots.optional?.({ foo: 'fesf' })
+  // @ts-expect-error
+  slots.optional({ foo: 123 })
 }
 expectType<Component>(Quux)
 ;<Quux />

--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -184,8 +184,10 @@ describe('defineEmits w/ runtime declaration', () => {
 describe('defineSlots', () => {
   const slots = defineSlots<{
     default: { foo: string; bar: number }
+    optional?: string
   }>()
   expectType<(scope: { foo: string; bar: number }) => VNode[]>(slots.default)
+  expectType<undefined | ((scope: string) => VNode[])>(slots.optional)
 
   const slotsUntype = defineSlots()
   expectType<Slots>(slotsUntype)

--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -4,7 +4,9 @@ import {
   useAttrs,
   useSlots,
   withDefaults,
-  Slots
+  Slots,
+  defineSlots,
+  VNode
 } from 'vue'
 import { describe, expectType } from './utils'
 
@@ -177,6 +179,19 @@ describe('defineEmits w/ runtime declaration', () => {
   emit2('bar', 123)
   // @ts-expect-error
   emit2('baz')
+})
+
+describe('defineSlots', () => {
+  const slots = defineSlots<{
+    default: [foo: string, bar: number]
+  }>()
+  expectType<(foo: string, bar: number) => VNode[]>(slots.default)
+
+  const slotsUntype = defineSlots()
+  expectType<Slots>(slotsUntype)
+
+  // @ts-expect-error `default` should be an array
+  defineSlots<{ default: string }>()
 })
 
 describe('useAttrs', () => {

--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -183,15 +183,12 @@ describe('defineEmits w/ runtime declaration', () => {
 
 describe('defineSlots', () => {
   const slots = defineSlots<{
-    default: [foo: string, bar: number]
+    default: { foo: string; bar: number }
   }>()
-  expectType<(foo: string, bar: number) => VNode[]>(slots.default)
+  expectType<(scope: { foo: string; bar: number }) => VNode[]>(slots.default)
 
   const slotsUntype = defineSlots()
   expectType<Slots>(slotsUntype)
-
-  // @ts-expect-error `default` should be an array
-  defineSlots<{ default: string }>()
 })
 
 describe('useAttrs', () => {

--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -182,12 +182,21 @@ describe('defineEmits w/ runtime declaration', () => {
 })
 
 describe('defineSlots', () => {
+  // short syntax
   const slots = defineSlots<{
     default: { foo: string; bar: number }
     optional?: string
   }>()
   expectType<(scope: { foo: string; bar: number }) => VNode[]>(slots.default)
   expectType<undefined | ((scope: string) => VNode[])>(slots.optional)
+
+  // literal fn syntax (allow for specifying return type)
+  const fnSlots = defineSlots<{
+    default(props: { foo: string; bar: number }): any
+    optional?(props: string): any
+  }>()
+  expectType<(scope: { foo: string; bar: number }) => VNode[]>(fnSlots.default)
+  expectType<undefined | ((scope: string) => VNode[])>(fnSlots.optional)
 
   const slotsUntype = defineSlots()
   expectType<Slots>(slotsUntype)

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -28,6 +28,7 @@ import {
   CreateComponentPublicInstance,
   ComponentPublicInstanceConstructor
 } from './componentPublicInstance'
+import { SlotsType } from './componentSlots'
 
 export type PublicProps = VNodeProps &
   AllowedComponentProps &
@@ -43,6 +44,7 @@ export type DefineComponent<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = {},
   EE extends string = string,
+  S extends SlotsType = {},
   PP = PublicProps,
   Props = Readonly<
     PropsOrPropOptions extends ComponentPropsOptions
@@ -61,6 +63,7 @@ export type DefineComponent<
     Mixin,
     Extends,
     E,
+    S,
     PP & Props,
     Defaults,
     true
@@ -77,6 +80,7 @@ export type DefineComponent<
     Extends,
     E,
     EE,
+    S,
     Defaults
   > &
   PP
@@ -91,29 +95,33 @@ export type DefineComponent<
 export function defineComponent<
   Props extends Record<string, any>,
   E extends EmitsOptions = {},
-  EE extends string = string
+  EE extends string = string,
+  S extends SlotsType = {}
 >(
   setup: (
     props: Props,
-    ctx: SetupContext<E>
+    ctx: SetupContext<E, S>
   ) => RenderFunction | Promise<RenderFunction>,
   options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
     props?: (keyof Props)[]
     emits?: E | EE[]
+    slots?: S
   }
 ): (props: Props & EmitsToProps<E>) => any
 export function defineComponent<
   Props extends Record<string, any>,
   E extends EmitsOptions = {},
-  EE extends string = string
+  EE extends string = string,
+  S extends SlotsType = {}
 >(
   setup: (
     props: Props,
-    ctx: SetupContext<E>
+    ctx: SetupContext<E, S>
   ) => RenderFunction | Promise<RenderFunction>,
   options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
     props?: ComponentObjectPropsOptions<Props>
     emits?: E | EE[]
+    slots?: S
   }
 ): (props: Props & EmitsToProps<E>) => any
 
@@ -130,6 +138,7 @@ export function defineComponent<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = {},
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string
 >(
@@ -143,10 +152,11 @@ export function defineComponent<
     Extends,
     E,
     EE,
+    S,
     I,
     II
   >
-): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
+): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE, S>
 
 // overload 3: object format with array props declaration
 // props inferred as { [key in PropNames]?: any }
@@ -161,6 +171,7 @@ export function defineComponent<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = {},
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string
 >(
@@ -174,6 +185,7 @@ export function defineComponent<
     Extends,
     E,
     EE,
+    S,
     I,
     II
   >
@@ -186,7 +198,8 @@ export function defineComponent<
   Mixin,
   Extends,
   E,
-  EE
+  EE,
+  S
 >
 
 // overload 4: object format with object props declaration
@@ -203,6 +216,7 @@ export function defineComponent<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = {},
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string
 >(
@@ -216,10 +230,11 @@ export function defineComponent<
     Extends,
     E,
     EE,
+    S,
     I,
     II
   >
-): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE>
+): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE, S>
 
 // implementation, close to no-op
 export function defineComponent(

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -25,7 +25,7 @@ import {
   ExtractPropTypes
 } from './componentProps'
 import { warn } from './warning'
-import { VNode } from './vnode'
+import { Slot } from './componentSlots'
 
 // dev only
 const warnRuntimeUsage = (method: string) =>
@@ -194,11 +194,11 @@ export function defineOptions<
 }
 
 export function defineSlots<
-  T extends Record<string, any>
+  T extends Record<string, any[]> = Record<string, any[]>
 >(): // @ts-expect-error
-{
-  [K in keyof T]: (scope: T[K]) => VNode[] | undefined
-} {
+Readonly<{
+  [K in keyof T]: Slot<T[K]>
+}> {
   if (__DEV__) {
     warnRuntimeUsage(`defineSlots`)
   }

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -25,7 +25,7 @@ import {
   ExtractPropTypes
 } from './componentProps'
 import { warn } from './warning'
-import { Slot } from './componentSlots'
+import { SlotsType, TypedSlots } from './componentSlots'
 
 // dev only
 const warnRuntimeUsage = (method: string) =>
@@ -190,11 +190,9 @@ export function defineOptions<
 }
 
 export function defineSlots<
-  T extends Record<string, any> = Record<string, any>
+  S extends Record<string, any> = Record<string, any>
 >(): // @ts-expect-error
-Readonly<{
-  [K in keyof T]: Slot<[T[K]]>
-}> {
+TypedSlots<SlotsType<S>> {
   if (__DEV__) {
     warnRuntimeUsage(`defineSlots`)
   }

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -25,6 +25,7 @@ import {
   ExtractPropTypes
 } from './componentProps'
 import { warn } from './warning'
+import { VNode } from './vnode'
 
 // dev only
 const warnRuntimeUsage = (method: string) =>
@@ -189,6 +190,17 @@ export function defineOptions<
 ): void {
   if (__DEV__) {
     warnRuntimeUsage(`defineOptions`)
+  }
+}
+
+export function defineSlots<
+  T extends Record<string, any>
+>(): // @ts-expect-error
+{
+  [K in keyof T]: (scope: T[K]) => VNode[] | undefined
+} {
+  if (__DEV__) {
+    warnRuntimeUsage(`defineSlots`)
   }
 }
 

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -190,10 +190,10 @@ export function defineOptions<
 }
 
 export function defineSlots<
-  T extends Record<string, any[]> = Record<string, any[]>
+  T extends Record<string, any> = Record<string, any>
 >(): // @ts-expect-error
 Readonly<{
-  [K in keyof T]: Slot<T[K]>
+  [K in keyof T]: Slot<[T[K]]>
 }> {
   if (__DEV__) {
     warnRuntimeUsage(`defineSlots`)

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -172,9 +172,7 @@ export function defineOptions<
   C extends ComputedOptions = {},
   M extends MethodOptions = {},
   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = EmitsOptions,
-  EE extends string = string
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin
 >(
   options?: ComponentOptionsWithoutProps<
     {},
@@ -183,10 +181,8 @@ export function defineOptions<
     C,
     M,
     Mixin,
-    Extends,
-    E,
-    EE
-  > & { emits?: undefined; expose?: undefined }
+    Extends
+  > & { emits?: undefined; expose?: undefined; slots?: undefined }
 ): void {
   if (__DEV__) {
     warnRuntimeUsage(`defineOptions`)

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -27,7 +27,13 @@ import {
   initProps,
   normalizePropsOptions
 } from './componentProps'
-import { Slots, initSlots, InternalSlots } from './componentSlots'
+import {
+  Slots,
+  initSlots,
+  InternalSlots,
+  SlotsType,
+  TypedSlots
+} from './componentSlots'
 import { warn } from './warning'
 import { ErrorCodes, callWithErrorHandling, handleError } from './errorHandling'
 import { AppContext, createAppContext, AppConfig } from './apiCreateApp'
@@ -117,10 +123,13 @@ export interface ComponentInternalOptions {
   __name?: string
 }
 
-export interface FunctionalComponent<P = {}, E extends EmitsOptions = {}>
-  extends ComponentInternalOptions {
+export interface FunctionalComponent<
+  P = {},
+  E extends EmitsOptions = {},
+  S extends SlotsType = {}
+> extends ComponentInternalOptions {
   // use of any here is intentional so it can be a valid JSX Element constructor
-  (props: P, ctx: Omit<SetupContext<E>, 'expose'>): any
+  (props: P, ctx: Omit<SetupContext<E, S>, 'expose'>): any
   props?: ComponentPropsOptions<P>
   emits?: E | (keyof E)[]
   inheritAttrs?: boolean
@@ -168,10 +177,13 @@ export type { ComponentOptions }
 type LifecycleHook<TFn = Function> = TFn[] | null
 
 // use `E extends any` to force evaluating type to fix #2362
-export type SetupContext<E = EmitsOptions> = E extends any
+export type SetupContext<
+  E = EmitsOptions,
+  S extends SlotsType = {}
+> = E extends any
   ? {
       attrs: Data
-      slots: Slots
+      slots: [keyof S] extends [never] ? Slots : TypedSlots<S>
       emit: EmitFn<E>
       expose: (exposed?: Record<string, any>) => void
     }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -125,7 +125,7 @@ export interface ComponentInternalOptions {
 export interface FunctionalComponent<
   P = {},
   E extends EmitsOptions = {},
-  S extends Record<string, any[]> = Record<string, any[]>
+  S extends Record<string, any> = Record<string, any>
 > extends ComponentInternalOptions {
   // use of any here is intentional so it can be a valid JSX Element constructor
   (props: P, ctx: Omit<SetupContext<E, SlotsType<S>>, 'expose'>): any

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -30,6 +30,7 @@ import {
 import {
   initSlots,
   InternalSlots,
+  Slots,
   SlotsType,
   TypedSlots
 } from './componentSlots'
@@ -62,7 +63,8 @@ import {
   isPromise,
   ShapeFlags,
   extend,
-  getGlobalThis
+  getGlobalThis,
+  IfAny
 } from '@vue/shared'
 import { SuspenseBoundary } from './components/Suspense'
 import { CompilerOptions } from '@vue/compiler-core'
@@ -125,13 +127,16 @@ export interface ComponentInternalOptions {
 export interface FunctionalComponent<
   P = {},
   E extends EmitsOptions = {},
-  S extends Record<string, any> = Record<string, any>
+  S extends Record<string, any> = any
 > extends ComponentInternalOptions {
   // use of any here is intentional so it can be a valid JSX Element constructor
-  (props: P, ctx: Omit<SetupContext<E, SlotsType<S>>, 'expose'>): any
+  (
+    props: P,
+    ctx: Omit<SetupContext<E, IfAny<S, {}, SlotsType<S>>>, 'expose'>
+  ): any
   props?: ComponentPropsOptions<P>
   emits?: E | (keyof E)[]
-  slots?: SlotsType<S>
+  slots?: IfAny<S, Slots, SlotsType<S>>
   inheritAttrs?: boolean
   displayName?: string
   compatConfig?: CompatConfig

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -28,7 +28,6 @@ import {
   normalizePropsOptions
 } from './componentProps'
 import {
-  Slots,
   initSlots,
   InternalSlots,
   SlotsType,
@@ -126,12 +125,13 @@ export interface ComponentInternalOptions {
 export interface FunctionalComponent<
   P = {},
   E extends EmitsOptions = {},
-  S extends SlotsType = {}
+  S extends Record<string, any[]> = {}
 > extends ComponentInternalOptions {
   // use of any here is intentional so it can be a valid JSX Element constructor
-  (props: P, ctx: Omit<SetupContext<E, S>, 'expose'>): any
+  (props: P, ctx: Omit<SetupContext<E, SlotsType<S>>, 'expose'>): any
   props?: ComponentPropsOptions<P>
   emits?: E | (keyof E)[]
+  slots?: SlotsType<S>
   inheritAttrs?: boolean
   displayName?: string
   compatConfig?: CompatConfig
@@ -156,7 +156,7 @@ export type ConcreteComponent<
   M extends MethodOptions = MethodOptions
 > =
   | ComponentOptions<Props, RawBindings, D, C, M>
-  | FunctionalComponent<Props, any>
+  | FunctionalComponent<Props, any, any>
 
 /**
  * A type used in public APIs where a component type is expected.
@@ -183,7 +183,7 @@ export type SetupContext<
 > = E extends any
   ? {
       attrs: Data
-      slots: [keyof S] extends [never] ? Slots : TypedSlots<S>
+      slots: TypedSlots<S>
       emit: EmitFn<E>
       expose: (exposed?: Record<string, any>) => void
     }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -125,7 +125,7 @@ export interface ComponentInternalOptions {
 export interface FunctionalComponent<
   P = {},
   E extends EmitsOptions = {},
-  S extends Record<string, any[]> = {}
+  S extends Record<string, any[]> = Record<string, any[]>
 > extends ComponentInternalOptions {
   // use of any here is intentional so it can be a valid JSX Element constructor
   (props: P, ctx: Omit<SetupContext<E, SlotsType<S>>, 'expose'>): any

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -74,6 +74,7 @@ import {
 } from './compat/compatConfig'
 import { OptionMergeFunction } from './apiCreateApp'
 import { LifecycleHooks } from './enums'
+import { SlotsType } from './componentSlots'
 
 /**
  * Interface for declaring custom options.
@@ -105,6 +106,7 @@ export interface ComponentOptionsBase<
   Extends extends ComponentOptionsMixin,
   E extends EmitsOptions,
   EE extends string = string,
+  S extends SlotsType = {},
   Defaults = {},
   I extends ComponentInjectOptions = {},
   II extends string = string
@@ -122,7 +124,7 @@ export interface ComponentOptionsBase<
           >
         >
     >,
-    ctx: SetupContext<E>
+    ctx: SetupContext<E, S>
   ) => Promise<RawBindings> | RawBindings | RenderFunction | void
   name?: string
   template?: string | object // can be a direct DOM node
@@ -136,6 +138,7 @@ export interface ComponentOptionsBase<
   directives?: Record<string, Directive>
   inheritAttrs?: boolean
   emits?: (E | EE[]) & ThisType<void>
+  slots?: S
   // TODO infer public instance type based on exposed keys
   expose?: string[]
   serverPrefetch?(): void | Promise<any>
@@ -216,6 +219,7 @@ export type ComponentOptionsWithoutProps<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = EmitsOptions,
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string,
   PE = Props & EmitsToProps<E>
@@ -229,6 +233,7 @@ export type ComponentOptionsWithoutProps<
   Extends,
   E,
   EE,
+  S,
   {},
   I,
   II
@@ -244,6 +249,7 @@ export type ComponentOptionsWithoutProps<
       Mixin,
       Extends,
       E,
+      S,
       PE,
       {},
       false,
@@ -261,6 +267,7 @@ export type ComponentOptionsWithArrayProps<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = EmitsOptions,
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string,
   Props = Prettify<Readonly<{ [key in PropNames]?: any } & EmitsToProps<E>>>
@@ -274,6 +281,7 @@ export type ComponentOptionsWithArrayProps<
   Extends,
   E,
   EE,
+  S,
   {},
   I,
   II
@@ -289,6 +297,7 @@ export type ComponentOptionsWithArrayProps<
       Mixin,
       Extends,
       E,
+      S,
       Props,
       {},
       false,
@@ -306,6 +315,7 @@ export type ComponentOptionsWithObjectProps<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = EmitsOptions,
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string,
   Props = Prettify<Readonly<ExtractPropTypes<PropsOptions> & EmitsToProps<E>>>,
@@ -320,6 +330,7 @@ export type ComponentOptionsWithObjectProps<
   Extends,
   E,
   EE,
+  S,
   Defaults,
   I,
   II
@@ -335,6 +346,7 @@ export type ComponentOptionsWithObjectProps<
       Mixin,
       Extends,
       E,
+      S,
       Props,
       Defaults,
       false,
@@ -350,8 +362,20 @@ export type ComponentOptions<
   M extends MethodOptions = any,
   Mixin extends ComponentOptionsMixin = any,
   Extends extends ComponentOptionsMixin = any,
-  E extends EmitsOptions = any
-> = ComponentOptionsBase<Props, RawBindings, D, C, M, Mixin, Extends, E> &
+  E extends EmitsOptions = any,
+  S extends SlotsType = any
+> = ComponentOptionsBase<
+  Props,
+  RawBindings,
+  D,
+  C,
+  M,
+  Mixin,
+  Extends,
+  E,
+  string,
+  S
+> &
   ThisType<
     CreateComponentPublicInstance<
       {},
@@ -367,6 +391,7 @@ export type ComponentOptions<
   >
 
 export type ComponentOptionsMixin = ComponentOptionsBase<
+  any,
   any,
   any,
   any,

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -40,7 +40,7 @@ import {
   ComponentInjectOptions
 } from './componentOptions'
 import { EmitsOptions, EmitFn } from './componentEmits'
-import { Slots, SlotsType } from './componentSlots'
+import { SlotsType, TypedSlots } from './componentSlots'
 import { markAttrsAccessed } from './componentRenderUtils'
 import { currentRenderingInstance } from './componentRenderContext'
 import { warn } from './warning'
@@ -164,6 +164,7 @@ export type CreateComponentPublicInstance<
   PublicC,
   PublicM,
   E,
+  S,
   PublicProps,
   PublicDefaults,
   MakeDefaultsOptional,
@@ -180,6 +181,7 @@ export type ComponentPublicInstance<
   C extends ComputedOptions = {},
   M extends MethodOptions = {},
   E extends EmitsOptions = {},
+  S extends SlotsType = {},
   PublicProps = P,
   Defaults = {},
   MakeDefaultsOptional extends boolean = false,
@@ -195,7 +197,7 @@ export type ComponentPublicInstance<
   >
   $attrs: Data
   $refs: Data
-  $slots: Slots
+  $slots: TypedSlots<S>
   $root: ComponentPublicInstance | null
   $parent: ComponentPublicInstance | null
   $emit: EmitFn<E>

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -40,7 +40,7 @@ import {
   ComponentInjectOptions
 } from './componentOptions'
 import { EmitsOptions, EmitFn } from './componentEmits'
-import { Slots } from './componentSlots'
+import { Slots, SlotsType } from './componentSlots'
 import { markAttrsAccessed } from './componentRenderUtils'
 import { currentRenderingInstance } from './componentRenderContext'
 import { warn } from './warning'
@@ -87,6 +87,7 @@ type MixinToOptionTypes<T> = T extends ComponentOptionsBase<
   infer M,
   infer Mixin,
   infer Extends,
+  any,
   any,
   any,
   infer Defaults
@@ -141,6 +142,7 @@ export type CreateComponentPublicInstance<
   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = {},
+  S extends SlotsType = {},
   PublicProps = P,
   Defaults = {},
   MakeDefaultsOptional extends boolean = false,
@@ -165,7 +167,7 @@ export type CreateComponentPublicInstance<
   PublicProps,
   PublicDefaults,
   MakeDefaultsOptional,
-  ComponentOptionsBase<P, B, D, C, M, Mixin, Extends, E, string, Defaults>,
+  ComponentOptionsBase<P, B, D, C, M, Mixin, Extends, E, string, S, Defaults>,
   I
 >
 

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -102,7 +102,7 @@ export function renderComponentRoot(
                       markAttrsAccessed()
                       return attrs
                     },
-                    slots,
+                    slots: slots,
                     emit
                   }
                 : { attrs, slots, emit }

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -102,7 +102,7 @@ export function renderComponentRoot(
                       markAttrsAccessed()
                       return attrs
                     },
-                    slots: slots,
+                    slots,
                     emit
                   }
                 : { attrs, slots, emit }

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -39,13 +39,16 @@ export type SlotsType<T extends Record<string, any> = Record<string, any>> = {
   [SlotSymbol]?: T
 }
 
-export type TypedSlots<S extends SlotsType> = [keyof S] extends [never]
+export type TypedSlots<
+  S extends SlotsType,
+  T = NonNullable<S[typeof SlotSymbol]>
+> = [keyof S] extends [never]
   ? Slots
   : Readonly<
       Prettify<{
-        [K in keyof NonNullable<S[typeof SlotSymbol]>]: Slot<
-          NonNullable<S[typeof SlotSymbol]>[K]
-        >
+        [K in keyof T]: NonNullable<T[K]> extends (...args: any[]) => any
+          ? T[K]
+          : Slot<T[K]>
       }>
     >
 

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -14,7 +14,8 @@ import {
   extend,
   def,
   SlotFlags,
-  Prettify
+  Prettify,
+  IfAny
 } from '@vue/shared'
 import { warn } from './warning'
 import { isKeepAlive } from './components/KeepAlive'
@@ -23,8 +24,8 @@ import { isHmrUpdating } from './hmr'
 import { DeprecationTypes, isCompatEnabled } from './compat/compatConfig'
 import { toRaw } from '@vue/reactivity'
 
-export type Slot<T extends any[] = any[]> = (
-  ...args: T extends [any] ? any[] : T
+export type Slot<T extends any = any> = (
+  ...args: IfAny<T, any[], [T]>
 ) => VNode[]
 
 export type InternalSlots = {
@@ -42,9 +43,9 @@ export type TypedSlots<S extends SlotsType> = [keyof S] extends [never]
   ? Slots
   : Readonly<
       Prettify<{
-        [K in keyof NonNullable<S[typeof SlotSymbol]>]:
-          | Slot<[NonNullable<S[typeof SlotSymbol]>[K]]>
-          | undefined
+        [K in keyof NonNullable<S[typeof SlotSymbol]>]: Slot<
+          NonNullable<NonNullable<S[typeof SlotSymbol]>[K]>
+        >
       }>
     >
 

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -23,7 +23,9 @@ import { isHmrUpdating } from './hmr'
 import { DeprecationTypes, isCompatEnabled } from './compat/compatConfig'
 import { toRaw } from '@vue/reactivity'
 
-export type Slot<T extends any[] = any[]> = (...args: T) => VNode[]
+export type Slot<T extends any[] = any[]> = (
+  ...args: T extends [any] ? any[] : T
+) => VNode[]
 
 export type InternalSlots = {
   [name: string]: Slot | undefined
@@ -32,17 +34,16 @@ export type InternalSlots = {
 export type Slots = Readonly<InternalSlots>
 
 declare const SlotSymbol: unique symbol
-export type SlotsType<T extends Record<string, any[]> = Record<string, any[]>> =
-  {
-    [SlotSymbol]?: T
-  }
+export type SlotsType<T extends Record<string, any> = Record<string, any>> = {
+  [SlotSymbol]?: T
+}
 
 export type TypedSlots<S extends SlotsType> = [keyof S] extends [never]
   ? Slots
   : Readonly<
       Prettify<{
         [K in keyof NonNullable<S[typeof SlotSymbol]>]:
-          | Slot<NonNullable<S[typeof SlotSymbol]>[K]>
+          | Slot<[NonNullable<S[typeof SlotSymbol]>[K]]>
           | undefined
       }>
     >

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -13,7 +13,8 @@ import {
   ShapeFlags,
   extend,
   def,
-  SlotFlags
+  SlotFlags,
+  Prettify
 } from '@vue/shared'
 import { warn } from './warning'
 import { isKeepAlive } from './components/KeepAlive'
@@ -22,13 +23,26 @@ import { isHmrUpdating } from './hmr'
 import { DeprecationTypes, isCompatEnabled } from './compat/compatConfig'
 import { toRaw } from '@vue/reactivity'
 
-export type Slot = (...args: any[]) => VNode[]
+export type Slot<T extends any[] = any[]> = (...args: T) => VNode[]
 
 export type InternalSlots = {
   [name: string]: Slot | undefined
 }
 
 export type Slots = Readonly<InternalSlots>
+
+declare const SlotSymbol: unique symbol
+export type SlotsType<T extends Record<string, any[]> = Record<string, any[]>> =
+  {
+    [SlotSymbol]?: T
+  }
+export type TypedSlots<S extends SlotsType> = Readonly<
+  Prettify<{
+    [K in keyof NonNullable<S[typeof SlotSymbol]>]: Slot<
+      NonNullable<S[typeof SlotSymbol]>[K]
+    >
+  }>
+>
 
 export type RawSlots = {
   [name: string]: unknown

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -25,7 +25,7 @@ import { DeprecationTypes, isCompatEnabled } from './compat/compatConfig'
 import { toRaw } from '@vue/reactivity'
 
 export type Slot<T extends any = any> = (
-  ...args: IfAny<T, any[], [T]>
+  ...args: IfAny<T, any[], [T] | (T extends undefined ? [] : never)>
 ) => VNode[]
 
 export type InternalSlots = {
@@ -44,7 +44,7 @@ export type TypedSlots<S extends SlotsType> = [keyof S] extends [never]
   : Readonly<
       Prettify<{
         [K in keyof NonNullable<S[typeof SlotSymbol]>]: Slot<
-          NonNullable<NonNullable<S[typeof SlotSymbol]>[K]>
+          NonNullable<S[typeof SlotSymbol]>[K]
         >
       }>
     >

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -41,9 +41,9 @@ export type TypedSlots<S extends SlotsType> = [keyof S] extends [never]
   ? Slots
   : Readonly<
       Prettify<{
-        [K in keyof NonNullable<S[typeof SlotSymbol]>]: Slot<
-          NonNullable<S[typeof SlotSymbol]>[K]
-        >
+        [K in keyof NonNullable<S[typeof SlotSymbol]>]:
+          | Slot<NonNullable<S[typeof SlotSymbol]>[K]>
+          | undefined
       }>
     >
 

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -36,13 +36,16 @@ export type SlotsType<T extends Record<string, any[]> = Record<string, any[]>> =
   {
     [SlotSymbol]?: T
   }
-export type TypedSlots<S extends SlotsType> = Readonly<
-  Prettify<{
-    [K in keyof NonNullable<S[typeof SlotSymbol]>]: Slot<
-      NonNullable<S[typeof SlotSymbol]>[K]
+
+export type TypedSlots<S extends SlotsType> = [keyof S] extends [never]
+  ? Slots
+  : Readonly<
+      Prettify<{
+        [K in keyof NonNullable<S[typeof SlotSymbol]>]: Slot<
+          NonNullable<S[typeof SlotSymbol]>[K]
+        >
+      }>
     >
-  }>
->
 
 export type RawSlots = {
   [name: string]: unknown

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -120,8 +120,12 @@ export function h(
 ): VNode
 
 // functional component
-export function h<P, E extends EmitsOptions = {}>(
-  type: FunctionalComponent<P, E>,
+export function h<
+  P,
+  E extends EmitsOptions = {},
+  S extends Record<string, any[]> = {}
+>(
+  type: FunctionalComponent<P, E, S>,
   props?: (RawProps & P) | ({} extends P ? null : never),
   children?: RawChildren | RawSlots
 ): VNode

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -123,7 +123,7 @@ export function h(
 export function h<
   P,
   E extends EmitsOptions = {},
-  S extends Record<string, any[]> = {}
+  S extends Record<string, any> = {}
 >(
   type: FunctionalComponent<P, E, S>,
   props?: (RawProps & P) | ({} extends P ? null : never),

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -69,6 +69,7 @@ export {
   defineEmits,
   defineExpose,
   defineOptions,
+  defineSlots,
   withDefaults,
   // internal
   mergeDefaults,

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -241,7 +241,7 @@ export type {
   RootRenderFunction
 } from './renderer'
 export type { RootHydrateFunction } from './hydration'
-export type { Slot, Slots } from './componentSlots'
+export type { Slot, Slots, SlotsType } from './componentSlots'
 export type {
   Prop,
   PropType,

--- a/packages/runtime-core/types/scriptSetupHelpers.d.ts
+++ b/packages/runtime-core/types/scriptSetupHelpers.d.ts
@@ -4,6 +4,7 @@ type _defineProps = typeof defineProps
 type _defineEmits = typeof defineEmits
 type _defineExpose = typeof defineExpose
 type _defineOptions = typeof defineOptions
+type _defineSlots = typeof defineSlots
 type _withDefaults = typeof withDefaults
 
 declare global {
@@ -11,5 +12,6 @@ declare global {
   const defineEmits: _defineEmits
   const defineExpose: _defineExpose
   const defineOptions: _defineOptions
+  const defineSlots: _defineSlots
   const withDefaults: _withDefaults
 }

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -20,7 +20,8 @@ import {
   warn,
   ConcreteComponent,
   ComponentOptions,
-  ComponentInjectOptions
+  ComponentInjectOptions,
+  SlotsType
 } from '@vue/runtime-core'
 import { camelize, extend, hyphenate, isArray, toNumber } from '@vue/shared'
 import { hydrate, render } from '.'
@@ -51,6 +52,7 @@ export function defineCustomElement<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = EmitsOptions,
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string
 >(
@@ -64,6 +66,7 @@ export function defineCustomElement<
     Extends,
     E,
     EE,
+    S,
     I,
     II
   > & { styles?: string[] }
@@ -80,6 +83,7 @@ export function defineCustomElement<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = Record<string, any>,
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string
 >(
@@ -93,6 +97,7 @@ export function defineCustomElement<
     Extends,
     E,
     EE,
+    S,
     I,
     II
   > & { styles?: string[] }
@@ -109,6 +114,7 @@ export function defineCustomElement<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   E extends EmitsOptions = Record<string, any>,
   EE extends string = string,
+  S extends SlotsType = {},
   I extends ComponentInjectOptions = {},
   II extends string = string
 >(
@@ -122,6 +128,7 @@ export function defineCustomElement<
     Extends,
     E,
     EE,
+    S,
     I,
     II
   > & { styles?: string[] }


### PR DESCRIPTION
## Summary

This PR adds slots type checking for:

- Non-SFC Composition API via the new `slots` option and `SlotsType` utility type.
- SFC w/ `<script setup lang="ts">` via the new `defineSlots` macro.
  - Volar will be updated to support `defineSlots` type checking

## Basic Usage

### Options API

```ts
import { SlotsType } from 'vue'

defineComponent({
  slots: Object as SlotsType<{
    default: { foo: string; bar: number }
    item: { data: number }
  }>,
  setup(props, { slots }) {
    expectType<undefined | ((scope: { foo: string; bar: number }) => any)>(
      slots.default
    )
    expectType<undefined | ((scope: { data: number }) => any)>(slots.item)
  }
})
```

### `<script setup lang="ts">`

```vue
<script setup lang="ts">
const slots = defineSlots<{
  default: { foo: string; bar: number }
}>()
</script>
```

### Alternative Full Function Syntax

`SlotsType` and `defineSlots` also support using direct function types to declare slots. This may be needed if Volar supports strict children type checks in the future, or in cases where some component libraries internally use multiple arguments for slots.

```vue
<script setup lang="ts">
const slots = defineSlots<{
  default(props: { foo: string; bar: number }): any // or VNode[]
}>()
</script>
```

---

- The returning value of `defineSlots` is the same thing as `useSlots`.
- This PR did not add any runtime code, but only included TypeScript types and SFC compiler features.

## Related

RFC: https://github.com/vuejs/rfcs/pull/192 (**not quite according to RFC**)

