### PR TITLE
fix(runtime-core): use parent element's `scopeId` if current element's `scopeId` is `null` when mounting children.

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -775,6 +775,13 @@ function baseCreateRenderer(
       const child = (children[i] = optimized
         ? cloneIfMounted(children[i] as VNode)
         : normalizeVNode(children[i]))
+
+      // #7980
+      // This makes sure that all functional components' children can get `scopeId` from their parent
+      if (child.scopeId == null && parentComponent?.vnode.scopeId != null) {
+        child.scopeId = parentComponent.vnode.scopeId
+      }
+
       patch(
         null,
         child,


### PR DESCRIPTION
Fixes #7980
This fixes `<style scoped>` not being applied to functional components' children because FC's `scopeId` isn't passed down on its children created in a SFC file.