### PR TITLE
fix(runtime-core): dimiss extended component props

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -442,6 +442,54 @@ describe('component props', () => {
     expect(renderProxy.$props).toMatchObject(props)
   })
 
+  test('merging props from global mixins and extend, and extended component should not have props cache', () => {
+    let renderProxy: any
+    let extendedRenderProxy: any
+
+    const defaultProp = ' from global '
+    const props = {
+      globalProp: {
+        type: String,
+        default: defaultProp
+      }
+    }
+    const globalMixin = {
+      props
+    }
+    const Comp = {
+      render(this: any) {
+        renderProxy = this
+        return h('div', ['Comp', this.globalProp])
+      }
+    }
+    const ExtendedComp = {
+      extends: Comp,
+      render(this: any) {
+        extendedRenderProxy = this
+        return h('div', ['ExtendedComp', this.globalProp])
+      }
+    }
+
+    const app = createApp(
+      {
+        render: () => [h(ExtendedComp), h(Comp)]
+      },
+      {}
+    )
+    app.mixin(globalMixin)
+
+    const root = nodeOps.createElement('div')
+    app.mount(root)
+
+    expect(serializeInner(root)).toMatch(
+      `<div>ExtendedComp from global </div><div>Comp from global </div>`
+    )
+    expect(renderProxy.$props).toMatchObject({ globalProp: defaultProp })
+    expect(extendedRenderProxy.$props).toMatchObject({
+      globalProp: defaultProp
+    })
+  })
+
   test('merging props from global mixins', () => {
     let setupProps: any
     let renderProxy: any

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -536,7 +536,7 @@ export function normalizePropsOptions(
     }
   }
 
-  if (!raw && !hasExtends) {
+  if (!raw && !hasExtends && !asMixin) {
     if (isObject(comp)) {
       cache.set(comp, EMPTY_ARR as any)
     }
@@ -579,7 +579,7 @@ export function normalizePropsOptions(
   }
 
   const res: NormalizedPropsOptions = [normalized, needCastKeys]
-  if (isObject(comp)) {
+  if (isObject(comp) && !asMixin) {
     cache.set(comp, res)
   }
   return res


### PR DESCRIPTION
when we have a vue app which has global mixin with props 
```
{ globalProp: { type: Boolean, default: true }}
```
and we have two components which is  described below

const A = { name: 'A' }
const B = { name: 'B', extend: A }

and we render B first and A

it will let A missing globalProp because it already cache with not extended global mode when we render B

