### PR TITLE
fix(runtime-core): don't attempt to remove null fragments (fix #7966)

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2211,7 +2211,7 @@ function baseCreateRenderer(
     // For fragments, directly remove all contained DOM nodes.
     // (fragment child nodes cannot have transition)
     let next
-    while (cur !== end) {
+    while (cur && cur !== end) {
       next = hostNextSibling(cur)!
       hostRemove(cur)
       cur = next


### PR DESCRIPTION
As described in #7966, the vue renderer crashes when using Teleport in combination with Transition and Suspense. I don't really know anything about vue core, but this simple change seems to fix the issue without breaking anything else. All unit tests pass still too.