### PR TITLE
chore(shared): remove unnecessary type conversions

### DIFF
--- a/packages/shared/src/makeMap.ts
+++ b/packages/shared/src/makeMap.ts
@@ -14,5 +14,5 @@ export function makeMap(
   for (let i = 0; i < list.length; i++) {
     map[list[i]] = true
   }
-  return expectsLowerCase ? val => !!map[val.toLowerCase()] : val => !!map[val]
+  return expectsLowerCase ? val => map[val.toLowerCase()] : val => map[val]
 }


### PR DESCRIPTION
In the function makeMap, the type of the map is Record<string, boolean>, and its values are of type boolean, so no additional type conversion is needed.