### PR TITLE
chore: check if the file exists

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -2,11 +2,15 @@
 import fs from 'node:fs'
 import chalk from 'chalk'
 import { createRequire } from 'node:module'
+import { resolve } from 'path'
 
 const require = createRequire(import.meta.url)
 
 export const targets = fs.readdirSync('packages').filter(f => {
-  if (!fs.statSync(`packages/${f}`).isDirectory()) {
+  if (
+    !fs.statSync(`packages/${f}`).isDirectory() ||
+    !fs.existsSync(resolve(resolve(), `./packages/${f}/package.json`))
+  ) {
     return false
   }
   const pkg = require(`../packages/${f}/package.json`)


### PR DESCRIPTION
在某些场景下，如分支切换，可能会在packages下出现多余的空文件夹导致打包失败

**issue：**#8020 