### PR TITLE
fix(types): accept arrays of functions for event props

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -1316,8 +1316,8 @@ export interface Events {
 
 type EventHandlers<E> = {
   [K in keyof E]?: E[K] extends (...args: any) => any
-    ? E[K]
-    : (payload: E[K]) => void
+    ? E[K] | E[K][]
+    : ((payload: E[K]) => void) | ((payload: E[K]) => void)[]
 }
 
 import { VNodeRef } from '@vue/runtime-core'


### PR DESCRIPTION
JSX types don't currently allow this but it works at runtime:

https://sfc.vuejs.org/#eNp9kD1uwzAMha9CcEkCJNJuuAXSHqPqYAtKqtQSBZFqh8B3L20HRaduenqPH3/ueC7FfLWAHfbsaywCHKSVZ5cvLXuJlGGA/QHuLgN4ykxTMBNd97vXKfpPOO8OLs9/0uN/6ZdHurdbM22jQkIq0yBBFUA/NhHldJTXmieHb8MRxneHqw+woVJY03aLq9XbXw4eMaZCVU5pKObGlHW/dSb3MNhht025/OkBFu3wQ6RwZy1f/HKVGxuqV6svU1uWmIIJnE5jpW8OVcEOF4QuNOP8AwdscIs=