### PR TITLE
feat(runtime-core): 7203 hydrating custom elements

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -939,6 +939,29 @@ describe('SSR hydration', () => {
     expect((container.firstChild!.firstChild as any)._value).toBe(true)
   })
 
+  test('hydrate custom element with vue bindings', () => {
+    class MyElement extends HTMLElement {
+      foo = ''
+      constructor() {
+        super()
+      }
+    }
+    customElements.define('my-element', MyElement)
+
+    const msg = ref('bar')
+    const container = document.createElement('div')
+    container.innerHTML = '<my-element :foo="msg"></my-element>'
+    const app = createSSRApp({
+      render: () => h('my-element', { foo: msg.value })
+    })
+    // isCustomElement MUST be set at runtime
+    app.config.compilerOptions.isCustomElement = tag => tag.startsWith('my-')
+    const vnode = app.mount(container).$.subTree as VNode<Node, Element> & {
+      el: Element
+    }
+    expect((vnode.el as any).foo).toBe(msg.value)
+  })
+
   // #5728
   test('empty text node in slot', () => {
     const Comp = {

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -76,7 +76,7 @@ export function defineProps<
   PP extends ComponentObjectPropsOptions = ComponentObjectPropsOptions
 >(props: PP): Prettify<Readonly<ExtractPropTypes<PP>>>
 // overload 3: typed-based declaration
-export function defineProps<TypeProps>(): ResolveProps<TypeProps>
+export function defineProps<TypeProps>(): DefineProps<TypeProps>
 // implementation
 export function defineProps() {
   if (__DEV__) {
@@ -85,13 +85,9 @@ export function defineProps() {
   return null as any
 }
 
-type ResolveProps<T, BooleanKeys extends keyof T = BooleanKey<T>> = Prettify<
-  Readonly<
-    T & {
-      [K in BooleanKeys]-?: boolean
-    }
-  >
->
+type DefineProps<T> = Readonly<T> & {
+  readonly [K in BooleanKey<T>]-?: boolean
+}
 
 type BooleanKey<T, K extends keyof T = keyof T> = K extends any
   ? [T[K]] extends [boolean | undefined]
@@ -372,4 +368,12 @@ export function withAsyncContext(getAwaitable: () => any) {
     })
   }
   return [awaitable, () => setCurrentInstance(ctx)]
+}
+
+;<T extends string>() => {
+  interface Props {
+    foo: T
+  }
+  const props = defineProps<Props>()
+  props.foo
 }

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -311,9 +311,19 @@ export function createHydrationFunctions(
     // #4006 for form elements with non-string v-model value bindings
     // e.g. <option :value="obj">, <input type="checkbox" :true-value="1">
     const forcePatchValue = (type === 'input' && dirs) || type === 'option'
+    // #7203 elements registered as custom elements should have all properties bound
+    const isCustomElement =
+      parentComponent?.appContext.config.compilerOptions.isCustomElement?.(
+        el.localName
+      )
     // skip props & children if this is hoisted static nodes
     // #5405 in dev, always hydrate children for HMR
-    if (__DEV__ || forcePatchValue || patchFlag !== PatchFlags.HOISTED) {
+    if (
+      __DEV__ ||
+      forcePatchValue ||
+      patchFlag !== PatchFlags.HOISTED ||
+      isCustomElement
+    ) {
       if (dirs) {
         invokeDirectiveHook(vnode, null, parentComponent, 'created')
       }
@@ -327,7 +337,8 @@ export function createHydrationFunctions(
           for (const key in props) {
             if (
               (forcePatchValue && key.endsWith('value')) ||
-              (isOn(key) && !isReservedProp(key))
+              (isOn(key) && !isReservedProp(key)) ||
+              isCustomElement
             ) {
               patchProp(
                 el,


### PR DESCRIPTION
Resolves #7203 by checking for the presence of a custom element in the custom element registry and allowing that to be hydrated with vue properties.

Ideally, I'd use the isCustomElement compiler option - however, that is not available at runtime. This is the next best thing - however, it could potentially hydrate more components than the user intended if they have not specified all of their custom elements in the isCustomElement function.

This is required for hydration to function correctly in https://github.com/prashantpalikhe/nuxt-ssr-lit/issues/34

This PR superceedes #7300 as that one got out of sync with main