### PR TITLE
chore: replace brotli with node:zlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@typescript-eslint/parser": "^5.56.0",
     "@vitest/coverage-istanbul": "^0.29.7",
     "@vue/consolidate": "0.17.3",
-    "brotli": "^1.3.2",
     "chalk": "^4.1.0",
     "conventional-changelog-cli": "^2.0.31",
     "enquirer": "^2.3.2",

--- a/packages/size-check/brotli.js
+++ b/packages/size-check/brotli.js
@@ -1,6 +1,6 @@
-const { compress } = require('brotli')
+const { brotliCompressSync } = require('zlib')
 
 const file = require('fs').readFileSync('dist/index.js')
-const compressed = compress(file)
+const compressed = brotliCompressSync(file)
 const compressedSize = (compressed.length / 1024).toFixed(2) + 'kb'
 console.log(`brotli: ${compressedSize}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ importers:
       '@typescript-eslint/parser': ^5.56.0
       '@vitest/coverage-istanbul': ^0.29.7
       '@vue/consolidate': 0.17.3
-      brotli: ^1.3.2
       chalk: ^4.1.0
       conventional-changelog-cli: ^2.0.31
       enquirer: ^2.3.2
@@ -65,7 +64,6 @@ importers:
       '@typescript-eslint/parser': 5.56.0_qesohl5arz7pvqyycxtsqomlr4
       '@vitest/coverage-istanbul': 0.29.7_vitest@0.29.7
       '@vue/consolidate': 0.17.3
-      brotli: 1.3.3
       chalk: 4.1.2
       conventional-changelog-cli: 2.2.2
       enquirer: 2.3.6
@@ -1465,12 +1463,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
-
-  /brotli/1.3.3:
-    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
-    dependencies:
-      base64-js: 1.5.1
     dev: true
 
   /browserslist/4.21.5:

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,8 +20,7 @@ import fs from 'node:fs/promises'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
 import path from 'node:path'
 import minimist from 'minimist'
-import { gzipSync } from 'node:zlib'
-import { compress } from 'brotli'
+import { gzipSync, brotliCompressSync } from 'node:zlib'
 import chalk from 'chalk'
 import execa from 'execa'
 import { cpus } from 'node:os'
@@ -143,7 +142,7 @@ function checkFileSize(filePath) {
   const minSize = (file.length / 1024).toFixed(2) + 'kb'
   const gzipped = gzipSync(file)
   const gzippedSize = (gzipped.length / 1024).toFixed(2) + 'kb'
-  const compressed = compress(file)
+  const compressed = brotliCompressSync(file)
   // @ts-ignore
   const compressedSize = (compressed.length / 1024).toFixed(2) + 'kb'
   console.log(


### PR DESCRIPTION
we don't need `brotli` as devDependencies now.

Comparison:

![2d730aeaf8bc8b3c79bdfb5cf3c2575c.jpg](https://user-images.githubusercontent.com/48240828/202642468-2cd12a41-6a50-4512-91a4-b279d2c4d1bb.jpg)


Signed-off-by: JayFate <37610029@qq.com>