### PR TITLE
fix(types/jsx): add loading attr for image element

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -451,6 +451,7 @@ export interface ImgHTMLAttributes extends HTMLAttributes {
   crossorigin?: 'anonymous' | 'use-credentials' | ''
   decoding?: 'async' | 'auto' | 'sync'
   height?: Numberish
+  loading?: 'eager' | 'lazy'
   referrerpolicy?: HTMLAttributeReferrerPolicy
   sizes?: string
   src?: string


### PR DESCRIPTION
Supports loading attributes for `img` element, see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes

![image](https://user-images.githubusercontent.com/25198337/231334648-736e89e6-8069-4fa3-93ee-dc4b629592a0.png)
