### PR TITLE
chore(useModel): enable useModel to support array based parameters

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineModel.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineModel.spec.ts.snap
@@ -21,6 +21,26 @@ return { modelValue, c }
 }"
 `;
 
+exports[`defineModel() > w/ array model 1`] = `
+"import { useModel as _useModel } from 'vue'
+
+export default {
+  props: {
+    \\"count\\": {default:1},
+    \\"title\\": {default:0},
+  },
+  emits: [\\"update:count\\", \\"update:title\\"],
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      const c = _useModel(__props, [\\"count\\",\\"title\\"])
+      
+return { c }
+}
+
+}"
+`;
+
 exports[`defineModel() > w/ array props 1`] = `
 "import { useModel as _useModel, mergeModels as _mergeModels } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript/defineModel.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineModel.spec.ts
@@ -176,4 +176,28 @@ describe('defineModel()', () => {
       optional: BindingTypes.SETUP_REF
     })
   })
+
+  test('w/ array model', () => {
+    const { content, bindings } = compile(
+      `
+      <script setup>
+      const c = defineModel(['count','title'],[{default:1},{default:0}])
+      </script>
+      `,
+      { defineModel: true }
+    )
+    assertCode(content)
+    expect(content).toMatch('props: {')
+    expect(content).toMatch('"count": {default:1},')
+    expect(content).toMatch('"title": {default:0},')
+    expect(content).toMatch('emits: ["update:count", "update:title"],')
+    expect(content).toMatch(`const c = _useModel(__props, ["count","title"])`)
+    expect(content).toMatch(`return { c }`)
+    expect(content).not.toMatch('defineModel')
+    expect(bindings).toStrictEqual({
+      count: BindingTypes.PROPS,
+      title: BindingTypes.PROPS,
+      c: BindingTypes.SETUP_REF
+    })
+  })
 })

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -29,7 +29,7 @@ import {
 } from './componentProps'
 import { warn } from './warning'
 import { SlotsType, TypedSlots } from './componentSlots'
-import { Ref, ref } from '@vue/reactivity'
+import { reactive, Ref, ref, UnwrapNestedRefs } from '@vue/reactivity'
 import { watch } from './apiWatch'
 
 // dev only
@@ -247,6 +247,9 @@ export function defineSlots<
  * const count = defineModel<number>('count', { local: true, default: 0 })
  * ```
  */
+type ModelOptions<T> = {
+  [K in keyof T]: PropOptions<T[K]> & DefineModelOptions
+}
 export function defineModel<T>(
   options: { required: true } & PropOptions<T> & DefineModelOptions
 ): Ref<T>
@@ -268,6 +271,10 @@ export function defineModel<T>(
   name: string,
   options?: PropOptions<T> & DefineModelOptions
 ): Ref<T | undefined>
+export function defineModel<T>(
+  name: string[],
+  options?: ModelOptions<T>
+): UnwrapNestedRefs<T | undefined>
 export function defineModel(): any {
   if (__DEV__) {
     warnRuntimeUsage('defineModel')
@@ -338,7 +345,18 @@ export function useSlots(): SetupContext['slots'] {
 export function useAttrs(): SetupContext['attrs'] {
   return getContext().attrs
 }
-
+type ModelArray<T, K extends string[]> = K[number] extends keyof T
+  ? string[]
+  : never
+export function useModel<
+  T extends Record<string, any>,
+  K extends ModelArray<T, K>
+>(
+  props: T,
+  name: K
+): UnwrapNestedRefs<{
+  [k in keyof T as k extends K[number] ? k : never]: T[k]
+}>
 export function useModel<T extends Record<string, any>, K extends keyof T>(
   props: T,
   name: K,
@@ -346,7 +364,7 @@ export function useModel<T extends Record<string, any>, K extends keyof T>(
 ): Ref<T[K]>
 export function useModel(
   props: Record<string, any>,
-  name: string,
+  name: string | string[],
   options?: { local?: boolean }
 ): Ref {
   const i = getCurrentInstance()!
@@ -354,37 +372,60 @@ export function useModel(
     warn(`useModel() called without active instance.`)
     return ref() as any
   }
-
-  if (__DEV__ && !(i.propsOptions[0] as NormalizedProps)[name]) {
-    warn(`useModel() called with prop "${name}" which is not declared.`)
-    return ref() as any
+  const isAry = isArray(name)
+  if (__DEV__) {
+    if (!isAry && !(i.propsOptions[0] as NormalizedProps)[name]) {
+      warn(`useModel() called with prop "${name}" which is not declared.`)
+      return ref() as any
+    } else if (isAry) {
+      if (name.length === 0) {
+        warn(`useModel() called with prop name length can not be zero(0).`)
+        return reactive({}) as any
+      }
+      for (const key of name) {
+        if (!(i.propsOptions[0] as NormalizedProps)[key]) {
+          warn(`useModel() called with prop "${name}" which is not declared.`)
+          return reactive({}) as any
+        }
+      }
+    }
   }
 
-  if (options && options.local) {
-    const proxy = ref<any>(props[name])
+  if (!isArray(name)) {
+    if (options && options.local) {
+      const proxy = ref<any>(props[name])
+      watch(
+        () => props[name],
+        v => (proxy.value = v)
+      )
+      watch(proxy, value => {
+        if (value !== props[name]) {
+          i.emit(`update:${name}`, value)
+        }
+      })
 
-    watch(
-      () => props[name],
-      v => (proxy.value = v)
-    )
-
-    watch(proxy, value => {
-      if (value !== props[name]) {
-        i.emit(`update:${name}`, value)
-      }
-    })
-
-    return proxy
+      return proxy
+    } else {
+      return {
+        __v_isRef: true,
+        get value() {
+          return props[name]
+        },
+        set value(value) {
+          i.emit(`update:${name}`, value)
+        }
+      } as any
+    }
   } else {
-    return {
-      __v_isRef: true,
-      get value() {
-        return props[name]
+    return new Proxy(props, {
+      get(target, key) {
+        return target[key as string]
       },
-      set value(value) {
-        i.emit(`update:${name}`, value)
+      set(_, key, value) {
+        i.emit(`update:${key as string}`, value)
+        return true
       }
-    } as any
+    }) as any
   }
 }
 


### PR DESCRIPTION
如果组件上绑定了多个 v-model，那么在子组件中需要进行多次的 defineModel，这样的操作使用起来略显繁琐，对于这种情况，我为 useModel，defineModel 增添了接受数组的功能， 数组中可以存放多个 model，并且可以像 reactive 一样，通过object.key 的形式操作 v-model 当中的数据。

If multiple v-models are bound to a component, multiple defineMoels need to be performed in the subcomponent, which can be a bit cumbersome to use. In this case, I have added the function of accepting arrays to useModel and defineModel, where multiple models can be stored and the data in the v-model can be manipulated in the form of object.key like reactive

### In the composite API
before

```vue
<script setup>
  const c = defineModel('count')
  const t = defineModel('title')
  console.log( c.value, t.value )
</script>
```
```vue
<script setup>
  const c = defineModel<number>('count' , { default: 0 })
  const t = defineModel<string>('title' , { default: 's' })
</script>
```

after
```vue
<script setup>
  const foo = defineModel([ 'count', 'title' ])
  console.log( foo.count, foo.title )
</script>
```

```vue
<script setup>
  const foo = defineModel<[ number, string ]>([ 'count' , 'title' ],[ { default:0 }, { default:'s' } ])
</script>
```
### In the optional API

before
```javascript
const Comp = defineComponent({
    props: ['title', 'count'],
    emits: ['update:title', 'update:count'],
    setup(props) {
      title = useModel(props, 'title' )
      bar = useModel(props, 'count' )
      console.log(title.value) 
      console.log(count.value) 
    },
  })
```
```javascript
const Comp = defineComponent({
    props: ['title', 'count'],
    emits: ['update:title', 'update:count'],
    setup(props) {
      title = useModel(props, 'title' , { default: 0 } )
      bar = useModel(props, 'count' , { default: 1 } )
      console.log(title.value) 
      console.log(count.value) 
    },
  })
```
after
```javascript
const Comp = defineComponent({
    props: ['title', 'count'],
    emits: ['update:title', 'update:count'],
    setup(props) {
      foo = useModel(props, ['title', 'count'])
      console.log(foo.title) 
      console.log(foo.count) 
    },
  })
```
```javascript
const Comp = defineComponent({
    props: ['title', 'count'],
    emits: ['update:title', 'update:count'],
    setup(props) {
      foo = useModel(props, ['title', 'count'], [ { default:0 }, { default:'s' } ])
      console.log(foo.title) 
      console.log(foo.count) 
    },
  })
```
这个设计希望尤大可以看看，代码可能还需要优化的地方，如果可以接受的话，期待大家的建议

I hope you can take a look at this design. There may still be areas where the code needs to be optimized. If it is acceptable, I look forward to your suggestions