### PR TITLE
fix(runtime-core): the component may come from a js file, it does not have __hmrId (fix #7921)

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -418,3 +418,15 @@ export function updateHOCHostEl(
     parent = parent.parent
   }
 }
+
+export function traverseParentHmrId(
+  component: ComponentInternalInstance | null
+) {
+  while (component) {
+    if (component.type.__hmrId) {
+      return true
+    }
+    component = component.parent
+  }
+  return false
+}

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -24,6 +24,7 @@ import {
   filterSingleRoot,
   renderComponentRoot,
   shouldUpdateComponent,
+  traverseParentHmrId,
   updateHOCHostEl
 } from './componentRenderUtils'
 import {
@@ -1110,7 +1111,15 @@ function baseCreateRenderer(
           isSVG,
           slotScopeIds
         )
-        if (__DEV__ && parentComponent && parentComponent.type.__hmrId) {
+        // #7921 The parentComponent may come from a js file in node_modules,
+        // and such components do not have __hmrId.
+        // In this case, their hmr status depends on their ancestor components.
+        // Therefore, we need to traverse and check whether their ancestor components have __hmrId.
+        if (
+          __DEV__ &&
+          parentComponent &&
+          traverseParentHmrId(parentComponent)
+        ) {
           traverseStaticChildren(n1, n2)
         } else if (
           // #2080 if the stable fragment has a key, it's a <template v-for> that may


### PR DESCRIPTION
close: [#7921](https://github.com/vuejs/core/issues/7921).

The component may come from a js file in node_modules, and such components do not have __hmrId. 

In this case, their hmr status should depend on their ancestor components. 

Therefore, we need to traverse and check whether their ancestor components have __hmrId.