### PR TITLE
fix(compiler-sfc): support nested namespaces in global types

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -436,6 +436,35 @@ describe('resolveType', () => {
       })
       expect(deps && [...deps]).toStrictEqual(Object.keys(files))
     })
+
+    test('global types with ambient references', () => {
+      const files = {
+        // with references
+        '/backend.d.ts': `
+          declare namespace App.Data {
+            export type AircraftData = {
+              id: string
+              manufacturer: App.Data.Listings.ManufacturerData
+            }
+          }
+          declare namespace App.Data.Listings {
+            export type ManufacturerData = {
+              id: string
+            }
+          }
+        `
+      }
+
+      const { props } = resolve(`defineProps<App.Data.AircraftData>()`, files, {
+        globalTypeFiles: Object.keys(files)
+      })
+
+      expect(props).toStrictEqual({
+        id: ['String']
+        // manufacturer: ['String'] // TODO
+      })
+      // expect(deps && [...deps]).toStrictEqual(Object.keys(files))
+    })
   })
 
   describe('errors', () => {


### PR DESCRIPTION
This draft PR is an attempt at supporting references in the global types support recently added by Evan in https://github.com/vuejs/core/commit/4e028b966991937c83fb2529973fd3d41080bb61.

For now the PR only contains a failing test that demonstrates the issue. cc @yyx990803 if you know how to support this — I'm still currently figuring out the source code to try and fix this myself in the meantime.

Related: https://github.com/vuejs/core/pull/8083

EDIT: after a bit more of debugging, it seems the issue is nested namespaces actually. eg. `App.AircraftData` is recognized but not `App.Data.AircraftData`.