### PR TITLE
chore: fix typo in `compiler-sfc`'s thrown error

### DIFF
--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -159,7 +159,7 @@ function innerResolveTypeElements(
           return resolveBuiltin(ctx, node, typeName as any, scope)
         }
         return ctx.error(
-          `Unresolvable type reference or unsupported built-in utlility type`,
+          `Unresolvable type reference or unsupported built-in utility type`,
           node,
           scope
         )


### PR DESCRIPTION
I just noticed this small typo while experimenting with upcoming 3.3's long-awaited imported types support.

Definitely not trying to farm contributions, just pointing at the typo. Feel free to ignore this PR if you'd rather push a fix along with an actual contribution :) And thank you so much for all the work put into these imported types, this will definitely be a game-changer to a lot of people!