### PR TITLE
fix(runtime-core): hydration should not be performed during the HMR reload process(fix #7706)

### DIFF
--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -13,6 +13,7 @@ import { extend, getGlobalThis } from '@vue/shared'
 type HMRComponent = ComponentOptions | ClassComponent
 
 export let isHmrUpdating = false
+export let isHmrReloading = false
 
 export const hmrDirtyComponents = new Set<ConcreteComponent>()
 
@@ -127,6 +128,8 @@ function reload(id: string, newComp: HMRComponent) {
     instance.appContext.emitsCache.delete(instance.type as any)
     instance.appContext.optionsCache.delete(instance.type as any)
 
+    isHmrReloading = true
+
     // 4. actually update
     if (instance.ceReload) {
       // custom element
@@ -153,6 +156,7 @@ function reload(id: string, newComp: HMRComponent) {
 
   // 5. make sure to cleanup dirty hmr components after update
   queuePostFlushCb(() => {
+    isHmrReloading = false
     for (const instance of instances) {
       hmrDirtyComponents.delete(
         normalizeClassComponent(instance.type as HMRComponent)

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -58,7 +58,12 @@ import {
 } from './components/Suspense'
 import { TeleportImpl, TeleportVNode } from './components/Teleport'
 import { isKeepAlive, KeepAliveContext } from './components/KeepAlive'
-import { registerHMR, unregisterHMR, isHmrUpdating } from './hmr'
+import {
+  registerHMR,
+  unregisterHMR,
+  isHmrUpdating,
+  isHmrReloading
+} from './hmr'
 import { createHydrationFunctions, RootHydrateFunction } from './hydration'
 import { invokeDirectiveHook } from './directives'
 import { startMeasure, endMeasure } from './profiling'
@@ -1327,7 +1332,7 @@ function baseCreateRenderer(
         }
         toggleRecurse(instance, true)
 
-        if (el && hydrateNode) {
+        if (el && hydrateNode && !isHmrReloading) {
           // vnode has adopted host node - perform hydration instead of mount.
           const hydrateSubTree = () => {
             if (__DEV__) {


### PR DESCRIPTION
Close [#7706](https://github.com/vuejs/core/issues/7706).

During HMR reload, the div element is unmounted. However, in SSR mode, the `mountComponent` process does not remount the div element but hydrates it instead, causing the issue of the div element is deleted.