### PR TITLE
fix(runtime-core): ensure mergeProps skips undefined event handlers but preserve other nullish value;

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -451,6 +451,17 @@ describe('vnode', () => {
       expect(mergeProps(props1, props3)).toMatchObject({
         onClick: clickHandler1
       })
+      let props4: Data = {
+        onNaming1: 0,
+        onNaming2: null,
+        onNaming3: ''
+      }
+      expect(mergeProps(props1, props4)).toMatchObject({
+        onClick: clickHandler1,
+        onNaming1: 0,
+        onNaming2: null,
+        onNaming3: ''
+      })
     })
 
     test('default', () => {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -827,8 +827,9 @@ export function mergeProps(...args: (Data & VNodeProps)[]) {
       } else if (isOn(key)) {
         const existing = ret[key]
         const incoming = toMerge[key]
+
         if (
-          incoming &&
+          incoming !== undefined &&
           existing !== incoming &&
           !(isArray(existing) && existing.includes(incoming))
         ) {


### PR DESCRIPTION
fix #8183 