### PR TITLE
fix(complier-core): warn if prop prefix with 'on' is not a event handler

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -451,6 +451,12 @@ describe('vnode', () => {
       expect(mergeProps(props1, props3)).toMatchObject({
         onClick: clickHandler1
       })
+
+      let props4: Data = { onNaming: 0 }
+      mergeProps(props1, props4)
+      expect(
+        `Prop with prefix 'on' is considered an event handler, avoid such naming if it is not. prop: onNaming.`
+      ).toHaveBeenWarned()
     })
 
     test('default', () => {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -827,6 +827,20 @@ export function mergeProps(...args: (Data & VNodeProps)[]) {
       } else if (isOn(key)) {
         const existing = ret[key]
         const incoming = toMerge[key]
+
+        if (
+          __DEV__ &&
+          incoming !== void 0 &&
+          !(
+            isFunction(incoming) ||
+            (isArray(incoming) && incoming.every(isFunction))
+          )
+        ) {
+          warn(
+            `Prop with prefix 'on' is considered an event handler, avoid such naming if it is not. prop: ${key}.`
+          )
+        }
+
         if (
           incoming &&
           existing !== incoming &&


### PR DESCRIPTION
related #7871