### PR TITLE
feat(runtime-core): add 'container' to component instance

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -225,6 +225,10 @@ export interface ComponentInternalInstance {
   root: ComponentInternalInstance
   appContext: AppContext
   /**
+   * The DOM element that app is mounted to, or shadowRoot of custom element.
+   */
+  container: any
+  /**
    * Vnode representing this component in its parent's vdom tree
    */
   vnode: VNode
@@ -497,6 +501,7 @@ export function createComponentInstance(
     type,
     parent,
     appContext,
+    container: null, // will be set synchronously before setup
     root: null!, // to be immediately set
     next: null,
     subTree: null!, // will be set synchronously right after creation

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -225,9 +225,9 @@ export interface ComponentInternalInstance {
   root: ComponentInternalInstance
   appContext: AppContext
   /**
-   * The DOM element that app is mounted to, or shadowRoot of custom element.
+   * ShadowRoot of custom element if it is
    */
-  container: any
+  container: ShadowRoot | null
   /**
    * Vnode representing this component in its parent's vdom tree
    */

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1201,7 +1201,7 @@ function baseCreateRenderer(
         parentComponent,
         parentSuspense
       ))
-    instance.container = container
+    instance.isCE && (instance.container = container as ShadowRoot)
 
     if (__DEV__ && instance.type.__hmrId) {
       registerHMR(instance)

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1201,6 +1201,7 @@ function baseCreateRenderer(
         parentComponent,
         parentSuspense
       ))
+    instance.container = container
 
     if (__DEV__ && instance.type.__hmrId) {
       registerHMR(instance)
@@ -2236,6 +2237,8 @@ function baseCreateRenderer(
     if (bum) {
       invokeArrayFns(bum)
     }
+
+    instance.container = null
 
     if (
       __COMPAT__ &&

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -2,6 +2,7 @@ import {
   defineAsyncComponent,
   defineComponent,
   defineCustomElement,
+  getCurrentInstance,
   h,
   inject,
   nextTick,
@@ -691,6 +692,26 @@ describe('defineCustomElement', () => {
       expect(e.shadowRoot!.innerHTML).toBe(
         `<div><slot><div>fallback</div></slot></div><div><slot name="named"></slot></div>`
       )
+    })
+  })
+
+  describe('shadowRoot', () => {
+    // # 6113
+    test('shadowRoot accessible for css-in-js', () => {
+      const Foo = defineCustomElement({
+        setup() {
+          const ins = getCurrentInstance()!
+          const style = document.createElement('style')
+          style.innerHTML = `div { color: red; }`
+          ins.container.appendChild(style)
+          return () => h('div', 'hello')
+        }
+      })
+      customElements.define('my-el', Foo)
+      container.innerHTML = `<my-el></my-el>`
+      const el = container.childNodes[0] as VueElement
+      const style = el.shadowRoot?.querySelector('style')!
+      expect(style.textContent).toBe(`div { color: red; }`)
     })
   })
 })

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -703,7 +703,7 @@ describe('defineCustomElement', () => {
           const ins = getCurrentInstance()!
           const style = document.createElement('style')
           style.innerHTML = `div { color: red; }`
-          ins.container.appendChild(style)
+          ins.container!.appendChild(style)
           return () => h('div', 'hello')
         }
       })

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -696,7 +696,7 @@ describe('defineCustomElement', () => {
   })
 
   describe('shadowRoot', () => {
-    // # 6113
+    // #6113
     test('shadowRoot accessible for css-in-js', () => {
       const Foo = defineCustomElement({
         setup() {


### PR DESCRIPTION
close #6113

Testcase shows how to use it in `setup` of a custom element.
If a component aims for both vue component and web component, one can use `ins.container instanceof DocumentFragment` to distinguish.