### PR TITLE
perf(runtime-core): improved defineAsyncComponent rendering logic

### DIFF
--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -11,7 +11,7 @@ import { ComponentPublicInstance } from './componentPublicInstance'
 import { createVNode, VNode } from './vnode'
 import { defineComponent } from './apiDefineComponent'
 import { warn } from './warning'
-import { pauseTracking, ref, resetTracking } from '@vue/reactivity'
+import { ref } from '@vue/reactivity'
 import { handleError, ErrorCodes } from './errorHandling'
 import { isKeepAlive } from './components/KeepAlive'
 import { queueJob } from './scheduler'
@@ -196,9 +196,6 @@ export function defineAsyncComponent<
 
       return () => {
         if (loaded.value && resolvedComp) {
-          pauseTracking()
-          delayed.value = false
-          resetTracking()
           return createInnerComp(resolvedComp, instance)
         } else if (error.value && errorComponent) {
           return createVNode(errorComponent as ConcreteComponent, {


### PR DESCRIPTION
1. I think Loading components should be handled after asynchronous components.Otherwise, when the asynchronous component time is close to the delay time passed by the user, it will cause the asynchronous component to be rendered immediately after Loading component, even if the loading component does not appear on the interface, but it carries out the rendering logic
2. I created an extreme example to illustrate this.   Although in practice it is rare for the delay time set by the user to be the same as the actual time taken for the asynchronous component, in this case, although the asynchronous component is displayed directly on the interface, the Loading component is actually rendered first, followed by the asynchronous component.
```javascript
    const App = {
      name: 'app',
      setup() {
      },
      render() {
        function foo() {
          return new Promise((resolve) => {
            setTimeout(() => {
              resolve(Child) // Child onMounted is called
            }, 3000)
          })
        }
        return h(defineAsyncComponent({
          loader: foo,
          loadingComponent: Loading,
          delay: 3000
        }))
      },
    }
``` 
3. When the asynchronous component takes less time than the delay passed in by the user, the dependency should be pause collected, set delayed to false, and then re-enable the dependency, when the delay countdown is triggered, it will be intercepted when the dependency is triggered, because they have the same value.
