### PR TITLE
chore: enable experimental `propsDestructure` in SFC playground

### DIFF
--- a/packages/sfc-playground/src/App.vue
+++ b/packages/sfc-playground/src/App.vue
@@ -38,6 +38,7 @@ const sfcOptions: SFCOptions = {
     inlineTemplate: !useDevMode.value,
     isProd: !useDevMode.value,
     reactivityTransform: true,
+    propsDestructure: true,
     defineModel: true
   },
   style: {


### PR DESCRIPTION
Previously this feature is under `reactivityTransform`, so it's a bit confusing to see previously valid code no longer works in the SFC playground.