### PR TITLE
fix(runtime-core): Suspense can correctly call the resolved of parent suspense when there is no async deps

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -755,7 +755,7 @@ function hydrateSuspense(
     optimized
   )
   if (suspense.deps === 0) {
-    suspense.resolve()
+    suspense.resolve(false, true)
   }
   return result
   /* eslint-enable no-restricted-globals */


### PR DESCRIPTION
close: #8206
relate: 
[62e71b5](https://github.com/vuejs/core/commit/62e71b5320cd9bff57e2f515342dfb0a3ba208ec)
#8242 