### PR TITLE
workflow: respect `--skipGit` on `pnpm publish`

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -353,7 +353,8 @@ async function publishPackage(pkgName, version) {
         ...(releaseTag ? ['--tag', releaseTag] : []),
         '--access',
         'public',
-        ...(isDryRun ? ['--dry-run'] : [])
+        ...(isDryRun ? ['--dry-run'] : []),
+        ...(skipGit ? ['--no-git-checks'] : [])
       ],
       {
         cwd: pkgRoot,


### PR DESCRIPTION
Fixes errors like https://github.com/vuejs/core/actions/runs/4924472857/jobs/8797539690#step:6:332