### PR TITLE
chore: remove unnecessary imports

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { ParserOptions } from '../src/options'
 import { baseParse, TextModes } from '../src/parse'
 import { ErrorCodes } from '../src/errors'

--- a/packages/compiler-core/__tests__/transform.spec.ts
+++ b/packages/compiler-core/__tests__/transform.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { baseParse } from '../src/parse'
 import { transform, NodeTransform } from '../src/transform'
 import {

--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   CompilerOptions,
   baseParse as parse,

--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   transform,

--- a/packages/compiler-core/__tests__/transforms/transformSlotOutlet.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformSlotOutlet.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   CompilerOptions,
   baseParse as parse,

--- a/packages/compiler-core/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vBind.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   transform,

--- a/packages/compiler-core/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vFor.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { baseParse as parse } from '../../src/parse'
 import { transform } from '../../src/transform'
 import { transformIf } from '../../src/transforms/vIf'

--- a/packages/compiler-core/__tests__/transforms/vIf.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vIf.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { baseParse as parse } from '../../src/parse'
 import { transform } from '../../src/transform'
 import { transformIf } from '../../src/transforms/vIf'

--- a/packages/compiler-core/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vModel.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   transform,

--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   CompilerOptions,

--- a/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   CompilerOptions,
   baseParse as parse,

--- a/packages/compiler-dom/__tests__/transforms/Transition.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/Transition.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { compile } from '../../src'
 
 describe('Transition multi children warnings', () => {

--- a/packages/compiler-dom/__tests__/transforms/vHtml.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vHtml.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   transform,

--- a/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   transform,

--- a/packages/compiler-dom/__tests__/transforms/vShow.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vShow.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   transform,

--- a/packages/compiler-dom/__tests__/transforms/vText.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vText.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   baseParse as parse,
   transform,

--- a/packages/reactivity/__tests__/collections/Map.spec.ts
+++ b/packages/reactivity/__tests__/collections/Map.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { reactive, effect, toRaw, isReactive } from '../../src'
 
 describe('reactivity/collections', () => {

--- a/packages/reactivity/__tests__/collections/Set.spec.ts
+++ b/packages/reactivity/__tests__/collections/Set.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { reactive, effect, isReactive, toRaw } from '../../src'
 
 describe('reactivity/collections', () => {

--- a/packages/reactivity/__tests__/collections/WeakMap.spec.ts
+++ b/packages/reactivity/__tests__/collections/WeakMap.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { reactive, effect, toRaw, isReactive } from '../../src'
 
 describe('reactivity/collections', () => {

--- a/packages/reactivity/__tests__/collections/WeakSet.spec.ts
+++ b/packages/reactivity/__tests__/collections/WeakSet.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { reactive, isReactive, effect, toRaw } from '../../src'
 
 describe('reactivity/collections', () => {

--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   computed,
   reactive,

--- a/packages/reactivity/__tests__/deferredComputed.spec.ts
+++ b/packages/reactivity/__tests__/deferredComputed.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { computed, deferredComputed, effect, ref } from '../src'
 
 describe('deferred computed', () => {

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   ref,
   reactive,

--- a/packages/reactivity/__tests__/effectScope.spec.ts
+++ b/packages/reactivity/__tests__/effectScope.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { nextTick, watch, watchEffect } from '@vue/runtime-core'
 import {
   reactive,

--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { reactive, isReactive, toRaw } from '../src/reactive'
 import { ref, isRef } from '../src/ref'
 import { effect } from '../src/effect'

--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   ref,
   effect,

--- a/packages/reactivity/__tests__/shallowReactive.spec.ts
+++ b/packages/reactivity/__tests__/shallowReactive.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   isReactive,
   isShallow,

--- a/packages/runtime-core/__tests__/apiAsyncComponent.spec.ts
+++ b/packages/runtime-core/__tests__/apiAsyncComponent.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   defineAsyncComponent,
   h,

--- a/packages/runtime-core/__tests__/apiCreateApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiCreateApp.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   createApp,
   h,

--- a/packages/runtime-core/__tests__/apiLifecycle.spec.ts
+++ b/packages/runtime-core/__tests__/apiLifecycle.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   onBeforeMount,
   h,

--- a/packages/runtime-core/__tests__/apiSetupContext.spec.ts
+++ b/packages/runtime-core/__tests__/apiSetupContext.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { ref, reactive } from '@vue/reactivity'
 import {
   renderToString,

--- a/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
+++ b/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   ComponentInternalInstance,
   createApp,

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   watch,
   watchEffect,

--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -1,7 +1,6 @@
 // Note: emits and listener fallthrough is tested in
 // ./rendererAttrsFallthrough.spec.ts.
 
-import { vi } from 'vitest'
 import {
   render,
   defineComponent,

--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { vi } from 'vitest'
+
 import {
   ComponentInternalInstance,
   getCurrentInstance,

--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   h,
   render,

--- a/packages/runtime-core/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-core/__tests__/componentSlots.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   ref,
   render,

--- a/packages/runtime-core/__tests__/components/BaseTransition.spec.ts
+++ b/packages/runtime-core/__tests__/components/BaseTransition.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   nodeOps,
   render,

--- a/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   h,
   TestElement,

--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { vi } from 'vitest'
+
 import {
   h,
   ref,

--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { vi } from 'vitest'
+
 import {
   nodeOps,
   serializeInner,

--- a/packages/runtime-core/__tests__/directives.spec.ts
+++ b/packages/runtime-core/__tests__/directives.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   h,
   withDirectives,

--- a/packages/runtime-core/__tests__/errorHandling.spec.ts
+++ b/packages/runtime-core/__tests__/errorHandling.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   onMounted,
   onErrorCaptured,

--- a/packages/runtime-core/__tests__/hmr.spec.ts
+++ b/packages/runtime-core/__tests__/hmr.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { HMRRuntime } from '../src/hmr'
 import '../src/hmr'
 import { ComponentOptions, InternalRenderFunction } from '../src/component'

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { vi } from 'vitest'
+
 import {
   createSSRApp,
   h,

--- a/packages/runtime-core/__tests__/rendererAttrsFallthrough.spec.ts
+++ b/packages/runtime-core/__tests__/rendererAttrsFallthrough.spec.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 // using DOM renderer because this case is mostly DOM-specific
-import { vi } from 'vitest'
+
 import {
   h,
   render,

--- a/packages/runtime-core/__tests__/rendererComponent.spec.ts
+++ b/packages/runtime-core/__tests__/rendererComponent.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   ref,
   h,

--- a/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
+++ b/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   h,
   Fragment,

--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   ref,
   nodeOps,

--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   queueJob,
   nextTick,

--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   createBlock,
   createVNode,

--- a/packages/runtime-core/__tests__/vnodeHooks.spec.ts
+++ b/packages/runtime-core/__tests__/vnodeHooks.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   h,
   render,

--- a/packages/runtime-dom/__tests__/createApp.spec.ts
+++ b/packages/runtime-dom/__tests__/createApp.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { createApp, h } from '../src'
 
 describe('createApp for dom', () => {

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   defineAsyncComponent,
   defineComponent,

--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   h,
   render,

--- a/packages/runtime-dom/__tests__/directives/vOn.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vOn.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { patchEvent } from '../../src/modules/events'
 import { withModifiers, withKeys } from '@vue/runtime-dom'
 

--- a/packages/runtime-dom/__tests__/patchEvents.spec.ts
+++ b/packages/runtime-dom/__tests__/patchEvents.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { patchProp } from '../src/patchProp'
 
 const timeout = () => new Promise(r => setTimeout(r))

--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { patchProp } from '../src/patchProp'
 import { render, h } from '../src'
 

--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { patchProp } from '../src/patchProp'
 
 describe(`runtime-dom: style patching`, () => {

--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   createApp,
   h,

--- a/packages/server-renderer/__tests__/ssrComputed.spec.ts
+++ b/packages/server-renderer/__tests__/ssrComputed.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { createSSRApp, defineComponent, h, computed, reactive } from 'vue'
 import { renderToString } from '../src/renderToString'
 

--- a/packages/server-renderer/__tests__/ssrSuspense.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSuspense.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { createApp, h, Suspense } from 'vue'
 import { renderToString } from '../src/renderToString'
 

--- a/packages/vue-compat/__tests__/compiler.spec.ts
+++ b/packages/vue-compat/__tests__/compiler.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import Vue from '@vue/compat'
 import { nextTick } from '@vue/runtime-core'
 import { CompilerDeprecationTypes } from '../../compiler-core/src'

--- a/packages/vue-compat/__tests__/globalConfig.spec.ts
+++ b/packages/vue-compat/__tests__/globalConfig.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import Vue from '@vue/compat'
 import {
   DeprecationTypes,

--- a/packages/vue-compat/__tests__/misc.spec.ts
+++ b/packages/vue-compat/__tests__/misc.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import Vue from '@vue/compat'
 import { nextTick } from '../../runtime-core/src/scheduler'
 import {

--- a/packages/vue-compat/__tests__/options.spec.ts
+++ b/packages/vue-compat/__tests__/options.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import Vue from '@vue/compat'
 import { nextTick } from '../../runtime-core/src/scheduler'
 import {

--- a/packages/vue/__tests__/customElementCasing.spec.ts
+++ b/packages/vue/__tests__/customElementCasing.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { createApp } from '../src'
 
 // https://github.com/vuejs/docs/pull/1890

--- a/packages/vue/__tests__/e2e/Transition.spec.ts
+++ b/packages/vue/__tests__/e2e/Transition.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { E2E_TIMEOUT, setupPuppeteer } from './e2eUtils'
 import path from 'path'
 import { h, createApp, Transition, ref, nextTick } from 'vue'

--- a/packages/vue/__tests__/e2e/TransitionGroup.spec.ts
+++ b/packages/vue/__tests__/e2e/TransitionGroup.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { E2E_TIMEOUT, setupPuppeteer } from './e2eUtils'
 import path from 'path'
 import { createApp, ref } from 'vue'

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { EMPTY_ARR } from '@vue/shared'
 import { createApp, ref, nextTick, reactive } from '../src'
 


### PR DESCRIPTION
The commonly used APIs in vitest are global, so there is no need to import.