### PR TITLE
chore: update ts type export syntax

### DIFF
--- a/packages/compiler-core/src/index.ts
+++ b/packages/compiler-core/src/index.ts
@@ -1,26 +1,20 @@
 export { baseCompile } from './compile'
 
 // Also expose lower level APIs & types
-export {
-  type CompilerOptions,
-  type ParserOptions,
-  type TransformOptions,
-  type CodegenOptions,
-  type HoistTransform,
-  type BindingMetadata,
-  BindingTypes
-} from './options'
+export { BindingTypes } from './options'
+
+export type * from './options'
+
 export { baseParse, TextModes } from './parse'
 export {
   transform,
-  type TransformContext,
   createTransformContext,
   traverseNode,
-  createStructuralDirectiveTransform,
-  type NodeTransform,
-  type StructuralDirectiveTransform,
-  type DirectiveTransform
+  createStructuralDirectiveTransform
 } from './transform'
+
+export type * from './transform'
+
 export { generate, type CodegenContext, type CodegenResult } from './codegen'
 export {
   ErrorCodes,

--- a/packages/compiler-dom/src/index.ts
+++ b/packages/compiler-dom/src/index.ts
@@ -1,13 +1,13 @@
 import {
   baseCompile,
   baseParse,
-  CompilerOptions,
-  CodegenResult,
-  ParserOptions,
-  RootNode,
   noopDirectiveTransform,
-  NodeTransform,
-  DirectiveTransform
+  type CompilerOptions,
+  type CodegenResult,
+  type ParserOptions,
+  type RootNode,
+  type NodeTransform,
+  type DirectiveTransform
 } from '@vue/compiler-core'
 import { parserOptions } from './parserOptions'
 import { transformStyle } from './transforms/transformStyle'

--- a/packages/compiler-sfc/src/index.ts
+++ b/packages/compiler-sfc/src/index.ts
@@ -33,35 +33,18 @@ export {
 export { invalidateTypeCache, registerTS } from './script/resolveType'
 
 // Types
-export type {
-  SFCParseOptions,
-  SFCParseResult,
-  SFCDescriptor,
-  SFCBlock,
-  SFCTemplateBlock,
-  SFCScriptBlock,
-  SFCStyleBlock
-} from './parse'
-export type {
-  TemplateCompiler,
-  SFCTemplateCompileOptions,
-  SFCTemplateCompileResults
-} from './compileTemplate'
-export type {
-  SFCStyleCompileOptions,
-  SFCAsyncStyleCompileOptions,
-  SFCStyleCompileResults
-} from './compileStyle'
+export type * from './parse'
+export type * from './compileTemplate'
+export type * from './compileStyle'
+
 export type { SFCScriptCompileOptions } from './compileScript'
 export type { ScriptCompileContext } from './script/context'
+
 export type {
   TypeResolveContext,
   SimpleTypeResolveContext
 } from './script/resolveType'
-export type {
-  AssetURLOptions,
-  AssetURLTagConfig
-} from './template/transformAssetUrl'
+export type * from './template/transformAssetUrl'
 export type {
   CompilerOptions,
   CompilerError,

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -8,18 +8,11 @@ export {
   unref,
   proxyRefs,
   customRef,
-  triggerRef,
-  type Ref,
-  type MaybeRef,
-  type MaybeRefOrGetter,
-  type ToRef,
-  type ToRefs,
-  type UnwrapRef,
-  type ShallowRef,
-  type ShallowUnwrapRef,
-  type RefUnwrapBailTypes,
-  type CustomRefFactory
+  triggerRef
 } from './ref'
+
+export type * from './ref'
+
 export {
   reactive,
   readonly,
@@ -37,14 +30,11 @@ export {
   type ShallowReactive,
   type UnwrapNestedRefs
 } from './reactive'
-export {
-  computed,
-  type ComputedRef,
-  type WritableComputedRef,
-  type WritableComputedOptions,
-  type ComputedGetter,
-  type ComputedSetter
-} from './computed'
+
+export { computed } from './computed'
+
+export type * from './computed'
+
 export { deferredComputed } from './deferredComputed'
 export {
   effect,
@@ -55,20 +45,18 @@ export {
   pauseTracking,
   resetTracking,
   ITERATE_KEY,
-  ReactiveEffect,
-  type ReactiveEffectRunner,
-  type ReactiveEffectOptions,
-  type EffectScheduler,
-  type DebuggerOptions,
-  type DebuggerEvent,
-  type DebuggerEventExtraInfo
+  ReactiveEffect
 } from './effect'
+
+export type * from './effect'
+
 export {
   effectScope,
   EffectScope,
   getCurrentScope,
   onScopeDispose
 } from './effectScope'
+
 export {
   TrackOpTypes /* @remove */,
   TriggerOpTypes /* @remove */

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -155,58 +155,11 @@ declare module '@vue/reactivity' {
 }
 
 export { TrackOpTypes, TriggerOpTypes } from '@vue/reactivity'
-export type {
-  Ref,
-  MaybeRef,
-  MaybeRefOrGetter,
-  ToRef,
-  ToRefs,
-  UnwrapRef,
-  ShallowRef,
-  ShallowUnwrapRef,
-  CustomRefFactory,
-  ReactiveFlags,
-  DeepReadonly,
-  ShallowReactive,
-  UnwrapNestedRefs,
-  ComputedRef,
-  WritableComputedRef,
-  WritableComputedOptions,
-  ComputedGetter,
-  ComputedSetter,
-  ReactiveEffectRunner,
-  ReactiveEffectOptions,
-  EffectScheduler,
-  DebuggerOptions,
-  DebuggerEvent,
-  DebuggerEventExtraInfo,
-  Raw
-} from '@vue/reactivity'
-export type {
-  WatchEffect,
-  WatchOptions,
-  WatchOptionsBase,
-  WatchCallback,
-  WatchSource,
-  WatchStopHandle
-} from './apiWatch'
+export type * from '@vue/reactivity'
+export type * from './apiWatch'
 export type { InjectionKey } from './apiInject'
-export type {
-  App,
-  AppConfig,
-  AppContext,
-  Plugin,
-  CreateAppFunction,
-  OptionMergeFunction
-} from './apiCreateApp'
-export type {
-  VNode,
-  VNodeChild,
-  VNodeTypes,
-  VNodeProps,
-  VNodeArrayChildren,
-  VNodeNormalizedChildren
-} from './vnode'
+export type * from './apiCreateApp'
+export type * from './vnode'
 export type {
   Component,
   ConcreteComponent,


### PR DESCRIPTION
In TypeScript 5.x, we can use `export type * form "xxx"` to export all the types of the specified module instead of exporting them one by one, which can reduce the amount of code. For some files that do not want to export certain types, I have not deal with it.