### PR TITLE
chore(compat): fix the compatibility issue with the `/gs` syntax in Firefox versions below 79

### DIFF
--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -28,7 +28,7 @@ export function normalizeStyle(
 
 const listDelimiterRE = /;(?![^(]*\))/g
 const propertyDelimiterRE = /:([^]+)/
-const styleCommentRE = /\/\*.*?\*\//gs
+const styleCommentRE = /\/\*.*?\*\/[\s\S]/g
 
 export function parseStringStyle(cssText: string): NormalizedStyle {
   const ret: NormalizedStyle = {}


### PR DESCRIPTION
Due to the fact that Firefox browser versions below 79 do not support the /gs regular expression syntax, the application built with this syntax will throw an error when running on Firefox browsers with versions lower than 79. The specific error message is as follows:

![企业微信截图_16838154935957](https://github.com/vuejs/core/assets/65117011/2380bdcd-f376-4d47-9005-18b460aad7f5)
