### PR TITLE
feat(types): enhance the event type in defineEmits

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -154,6 +154,9 @@ describe('defineEmits w/ alt type declaration', () => {
     foo: [id: string]
     bar: any[]
     baz: []
+    'foo-bar': []
+    fooBar: [id: string]
+    'update:fooBar': []
   }>()
 
   emit('foo', 'hi')
@@ -166,6 +169,14 @@ describe('defineEmits w/ alt type declaration', () => {
   emit('baz')
   // @ts-expect-error
   emit('baz', 1)
+
+  emit('foo-bar')
+  // @ts-expect-error
+  emit('fooBar')
+  emit('fooBar', 'hi')
+
+  emit('update:fooBar')
+  emit('update:foo-bar')
 })
 
 describe('defineEmits w/ runtime declaration', () => {

--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -132,18 +132,34 @@ describe('defineProps w/ runtime declaration', () => {
 })
 
 describe('defineEmits w/ type declaration', () => {
-  const emit = defineEmits<(e: 'change') => void>()
+  const emit =
+    defineEmits<(e: 'change' | 'foo-bar' | 'update:fooBar') => void>()
   emit('change')
+  emit('foo-bar')
+  emit('fooBar')
+  emit('update:fooBar')
+  emit('update:foo-bar')
   // @ts-expect-error
   emit()
   // @ts-expect-error
   emit('bar')
 
-  type Emits = { (e: 'foo' | 'bar'): void; (e: 'baz', id: number): void }
+  type Emits = {
+    (e: 'foo' | 'bar' | 'foo-bar'): void
+    (e: 'fooBar', id: string): void
+    (e: 'update:fooBar', id: string): void
+    (e: 'baz', id: number): void
+  }
   const emit2 = defineEmits<Emits>()
 
   emit2('foo')
   emit2('bar')
+  emit2('foo-bar')
+  emit2('fooBar', 'hi')
+  // @ts-expect-error
+  emit2('fooBar')
+  emit2('update:fooBar', 'hi')
+  emit2('update:foo-bar', 'hi')
   emit2('baz', 123)
   // @ts-expect-error
   emit2('baz')

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -13,7 +13,12 @@ import {
   createSetupContext,
   unsetCurrentInstance
 } from './component'
-import { EmitFn, EmitsOptions, ObjectEmitsOptions } from './componentEmits'
+import {
+  EmitFn,
+  EmitsOptions,
+  EnrichEmitEvent,
+  ObjectEmitsOptions
+} from './componentEmits'
 import {
   ComponentOptionsMixin,
   ComponentOptionsWithoutProps,
@@ -145,9 +150,12 @@ export function defineEmits() {
 
 type RecordToUnion<T extends Record<string, any>> = T[keyof T]
 
-type ShortEmits<T extends Record<string, any>> = UnionToIntersection<
+type ShortEmits<
+  T extends Record<string, any>,
+  Event extends keyof T = keyof T
+> = UnionToIntersection<
   RecordToUnion<{
-    [K in keyof T]: (evt: K, ...args: T[K]) => void
+    [K in Event]: (evt: EnrichEmitEvent<K, Event>, ...args: T[K]) => void
   }>
 >
 

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -57,7 +57,7 @@ export type EmitsToProps<T extends EmitsOptions> = T extends string[]
     }
   : {}
 
-type EnhanceEmitEvent<T, Event = T> = T extends string
+export type EnrichEmitEvent<T, Event = T> = T extends string
   ?
       | T
       | ((
@@ -74,14 +74,14 @@ export type EmitFn<
   Options = ObjectEmitsOptions,
   Event extends keyof Options = keyof Options
 > = Options extends Array<infer V>
-  ? (event: EnhanceEmitEvent<V>, ...args: any[]) => void
+  ? (event: EnrichEmitEvent<V>, ...args: any[]) => void
   : {} extends Options // if the emit is empty object (usually the default value for emit) should be converted to function
   ? (event: string, ...args: any[]) => void
   : UnionToIntersection<
       {
         [key in Event]: Options[key] extends (...args: infer Args) => any
-          ? (event: EnhanceEmitEvent<key, Event>, ...args: Args) => void
-          : (event: EnhanceEmitEvent<key, Event>, ...args: any[]) => void
+          ? (event: EnrichEmitEvent<key, Event>, ...args: Args) => void
+          : (event: EnrichEmitEvent<key, Event>, ...args: any[]) => void
       }[Event]
     >
 

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -57,6 +57,9 @@ export type EmitsToProps<T extends EmitsOptions> = T extends string[]
     }
   : {}
 
+export type ExtractEmitEvent<T extends (...args: any[]) => any> =
+  Parameters<T>[0] & string
+
 export type EnrichEmitEvent<T, Event = T> = T extends string
   ?
       | T

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -12,3 +12,44 @@ export type LooseRequired<T> = { [P in keyof (T & Required<T>)]: T[P] }
 // If the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
+
+export type Camelize<T extends string> =
+  T extends `${infer FirstPart}-${infer SecondPart}`
+    ? `${FirstPart}${Camelize<Capitalize<SecondPart>>}`
+    : T
+
+export type Hyphenate<T extends string> = Hyphenate_<Uncapitalize<T>>
+type Hyphenate_<T extends string> =
+  T extends `${infer FirstPart}${infer SecondPart}`
+    ? FirstPart extends UpperCaseCharacters
+      ? `-${Lowercase<FirstPart>}${Hyphenate_<SecondPart>}`
+      : `${FirstPart}${Hyphenate_<SecondPart>}`
+    : T
+
+export type UpperCaseCharacters =
+  | 'A'
+  | 'B'
+  | 'C'
+  | 'D'
+  | 'E'
+  | 'F'
+  | 'G'
+  | 'H'
+  | 'I'
+  | 'J'
+  | 'K'
+  | 'L'
+  | 'M'
+  | 'N'
+  | 'O'
+  | 'P'
+  | 'Q'
+  | 'R'
+  | 'S'
+  | 'T'
+  | 'U'
+  | 'V'
+  | 'W'
+  | 'X'
+  | 'Y'
+  | 'Z'


### PR DESCRIPTION
closes vuejs/language-tools#3197

Enhance the event type in `defineEmits` so that it conforms to the triggering mechanism of emit.

For normal events, we allow them to contain camelized copies:
```ts
defineEmits(['value-change'])
->
{
  'value-change': () => void
  valueChange: () => void
}
```

For v-model update:xxx events, we allow them to contain hyphenate copies:
```ts
defineEmits(['update:modelValue'])
->
{
  'update:modelValue': () => void
  'update:model-value': () => void
}
```

It also filters the types that already exist and are defined in events:
```ts
defineEmits({
  'value-change': () => void
  valueChange: null
})
->
{
  'value-change': () => void
  valueChange: (value: any) => void
}
```

