### PR TITLE
fix(compiler-sfc): props destructing default value type checking with unresolved type (#8326)

### DIFF
--- a/packages/compiler-sfc/src/script/defineProps.ts
+++ b/packages/compiler-sfc/src/script/defineProps.ts
@@ -311,11 +311,7 @@ function genDestructuredDefaultValue(
     const value = ctx.getString(defaultVal)
     const unwrapped = unwrapTSNode(defaultVal)
 
-    if (
-      inferredType &&
-      inferredType.length &&
-      !inferredType.includes(UNKNOWN_TYPE)
-    ) {
+    if (inferredType && inferredType.length && !inferredType.includes('null')) {
       const valueType = inferValueType(unwrapped)
       if (valueType && !inferredType.includes(valueType)) {
         ctx.error(


### PR DESCRIPTION
The inferred type at this point is `['null']` and I don't think it can ever be the `UNKNOWN_TYPE` due to the code here https://github.com/vuejs/core/blob/a374d7e6ed973cde7fae36ee82618cf46a8ba68a/packages/compiler-sfc/src/script/defineProps.ts#L210

If it can be the `UNKNOWN_TYPE` via some other path, then I think would need to check for both. Null should be an allow any type so it shouldn't even bother trying to validate it default value here also,

closes #8326