### PR TITLE
feat(reactivity): export `propertyToRef` function

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -440,7 +440,7 @@ export function toRef(
   }
 }
 
-function propertyToRef(source: object, key: string, defaultValue?: unknown) {
+export function propertyToRef(source: object, key: string, defaultValue?: unknown) {
   const val = (source as any)[key]
   return isRef(val)
     ? val


### PR DESCRIPTION
Due to changes in the behavior of toRef, we need `propertyToRef` to obtain the property reactivity value from a responsive ref

```ts
import { extendRef } from '@vueuse/core'
import { toRef, ref } from 'vue'
const loading = ref(false)
const value= ref([])
const extendValue = extendRef(value, { loading })
const toLoading = toRef(extendValue, 'loading')
toLoading.value // []
```