### PR TITLE
fix(compiler-sfc): missing semicolon in track function causing runtime error in production (#8353)

### DIFF
--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -355,7 +355,9 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     if (publicGetter) {
       if (key === '$attrs') {
         track(instance, TrackOpTypes.GET, key)
-        __DEV__ && markAttrsAccessed()
+        if (__DEV__) {
+        markAttrsAccessed()
+        }
       } else if (__DEV__ && key === '$slots') {
         track(instance, TrackOpTypes.GET, key)
       }


### PR DESCRIPTION
In production mode, the track function was missing a semicolon at the end of the statement, causing confusion with the __DEV__ check and resulting in a runtime error. 