### PR TITLE
chore(runtime-core): optimize the `registerLifecycleHook` function

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -809,7 +809,7 @@ export function applyOptions(instance: ComponentInternalInstance) {
     if (!hook) return
     if (isFunction(hook)) {
       register(hook.bind(publicThis))
-    } else if (isArray(hook)) {
+    } else {
       hook.forEach(_hook => register(_hook.bind(publicThis)))
     }
   }

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -806,10 +806,11 @@ export function applyOptions(instance: ComponentInternalInstance) {
     register: Function,
     hook?: Function | Function[]
   ) {
-    if (isArray(hook)) {
-      hook.forEach(_hook => register(_hook.bind(publicThis)))
-    } else if (hook) {
+    if (!hook) return
+    if (isFunction(hook)) {
       register(hook.bind(publicThis))
+    } else if (isArray(hook)) {
+      hook.forEach(_hook => register(_hook.bind(publicThis)))
     }
   }
 

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -8,7 +8,7 @@ import {
   compatUtils,
   DeprecationTypes
 } from '@vue/runtime-core'
-import { isObject, toNumber, extend, isArray } from '@vue/shared'
+import { isObject, toNumber, extend, isArray, isFunction } from '@vue/shared'
 
 const TRANSITION = 'transition'
 const ANIMATION = 'animation'
@@ -87,10 +87,11 @@ const callHook = (
   hook: Function | Function[] | undefined,
   args: any[] = []
 ) => {
-  if (isArray(hook)) {
-    hook.forEach(h => h(...args))
-  } else if (hook) {
+  if (!hook) return
+  if (isFunction(hook)) {
     hook(...args)
+  } else if (isArray(hook)) {
+    hook.forEach(h => h(...args))
   }
 }
 

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -90,7 +90,7 @@ const callHook = (
   if (!hook) return
   if (isFunction(hook)) {
     hook(...args)
-  } else if (isArray(hook)) {
+  } else {
     hook.forEach(h => h(...args))
   }
 }


### PR DESCRIPTION
In most cases, when the hook is undefined or a function, the priority of the array should be the lowest, placing it at the end would be better, as it can reduce unnecessary checks.
