### PR TITLE
fix(compiler-sfc): Returns binding when there is no render function in inline mode

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1212,7 +1212,7 @@ exports[`SFC compile <script setup> > inlineTemplate mode > with defineExpose() 
         const count = ref(0)
         __expose({ count })
         
-return () => {}
+return { count }
 }
 
 }"

--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/definePropsDestructure.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/definePropsDestructure.spec.ts.snap
@@ -71,7 +71,7 @@ export default {
 
       
       
-return () => {}
+return {  }
 }
 
 }"
@@ -91,7 +91,7 @@ export default {
 
       
       
-return () => {}
+return {  }
 }
 
 }"
@@ -109,7 +109,7 @@ export default {
 
       
       
-return () => {}
+return {  }
 }
 
 }"
@@ -129,7 +129,7 @@ export default /*#__PURE__*/_defineComponent({
 
       
       
-return () => {}
+return {  }
 }
 
 })"
@@ -148,7 +148,7 @@ export default /*#__PURE__*/_defineComponent({
 
       
       
-return () => {}
+return {  }
 }
 
 })"
@@ -170,7 +170,7 @@ export default /*#__PURE__*/_defineComponent({
 
       
       
-return () => {}
+return {  }
 }
 
 })"
@@ -205,7 +205,7 @@ exports[`sfc reactive props destructure > nested scope 1`] = `
         console.log(__props.bar)
       }
       
-return () => {}
+return { test }
 }
 
 }"
@@ -241,7 +241,7 @@ const rest = _createPropsRestProxy(__props, [\\"foo\\",\\"bar\\"]);
 
       
       
-return () => {}
+return {  }
 }
 
 }"

--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/hoistStatic.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/hoistStatic.spec.ts.snap
@@ -8,7 +8,7 @@ export default {
 
     const foo = 'bar'
     
-return () => {}
+return { foo }
 }
 
 }"
@@ -24,7 +24,7 @@ export default {
   setup(__props) {
 
     
-return () => {}
+return { unary, binary, conditional, sequence }
 }
 
 }"
@@ -42,7 +42,7 @@ export default {
   setup(__props) {
 
     
-return () => {}
+return { string, number, boolean, nil, bigint, template }
 }
 
 }"
@@ -61,7 +61,7 @@ export default {
 
     
     
-return () => {}
+return { defaultValue }
 }
 
 }"
@@ -84,7 +84,7 @@ export default /*#__PURE__*/_defineComponent({
     }
     const KEY6 = \`template\${i}\`
     
-return () => {}
+return { KEY1, KEY2, KEY3, get i() { return i }, set i(v) { i = v }, KEY4, KEY5, KEY6 }
 }
 
 })"
@@ -98,7 +98,7 @@ exports[`sfc hoist static > should not hoist a function or class 1`] = `
     function fn2() {}
     class Foo {}
     
-return () => {}
+return { fn, fn2, Foo }
 }
 
 }"
@@ -111,7 +111,7 @@ exports[`sfc hoist static > should not hoist a object or array 1`] = `
     const obj = { foo: 'bar' }
     const arr = [1, 2, 3]
     
-return () => {}
+return { obj, arr }
 }
 
 }"
@@ -126,7 +126,7 @@ exports[`sfc hoist static > should not hoist a variable 1`] = `
     const regex = /.*/g
     const undef = undefined
     
-return () => {}
+return { get KEY1() { return KEY1 }, set KEY1(v) { KEY1 = v }, get KEY2() { return KEY2 }, set KEY2(v) { KEY2 = v }, regex, undef }
 }
 
 }"
@@ -138,7 +138,7 @@ exports[`sfc hoist static > should not hoist when disabled 1`] = `
 
     const foo = 'bar'
     
-return () => {}
+return { foo }
 }
 
 }"

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -820,6 +820,8 @@ export function compileScript(
   let returned
   if (
     !options.inlineTemplate ||
+      // #8391
+     (!sfc.template && options.inlineTemplate) ||
     (!sfc.template && ctx.hasDefaultExportRender)
   ) {
     // non-inline mode, or has manual render in normal <script>

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -820,8 +820,8 @@ export function compileScript(
   let returned
   if (
     !options.inlineTemplate ||
-      // #8391
-     (!sfc.template && options.inlineTemplate) ||
+    // #8391
+    (!sfc.template && options.inlineTemplate) ||
     (!sfc.template && ctx.hasDefaultExportRender)
   ) {
     // non-inline mode, or has manual render in normal <script>
@@ -915,8 +915,6 @@ export function compileScript(
         ctx.helperImports.delete('unref')
       }
       returned = code
-    } else {
-      returned = `() => {}`
     }
   }
 


### PR DESCRIPTION
close: #8391 