### PR TITLE
test(reactive): use vitest `vi.fn` instead of counting manually

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -28,19 +28,18 @@ describe('reactivity/ref', () => {
   it('should be reactive', () => {
     const a = ref(1)
     let dummy
-    let calls = 0
-    effect(() => {
-      calls++
+    const fn = vi.fn(() => {
       dummy = a.value
     })
-    expect(calls).toBe(1)
+    effect(fn)
+    expect(fn).toHaveBeenCalledTimes(1)
     expect(dummy).toBe(1)
     a.value = 2
-    expect(calls).toBe(2)
+    expect(fn).toHaveBeenCalledTimes(2)
     expect(dummy).toBe(2)
     // same value should not trigger
     a.value = 2
-    expect(calls).toBe(2)
+    expect(fn).toHaveBeenCalledTimes(2)
   })
 
   it('should make nested properties reactive', () => {


### PR DESCRIPTION
I think it is more recommended to use Vitest's way instead of manual counting.