### PR TITLE
test(reactive): improve the test of ref

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -54,6 +54,11 @@ describe('reactivity/ref', () => {
     expect(dummy).toBe(1)
     a.value.count = 2
     expect(dummy).toBe(2)
+
+    a.value = {
+      count: 100
+    }
+    expect(dummy).toBe(100)
   })
 
   it('should work without initial value', () => {


### PR DESCRIPTION
```ts
const a = ref({  count: 1 })
let dummy
effect(() => {
  dummy = a.value.count
})
```

In this scenario, when `a.value` is modified, the value of dummy should also change. 

So, I added a test corresponding to this operation.