### PR TITLE
fix(types): remove `defineProps` optional properties

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -18,6 +18,7 @@ describe('defineProps w/ type declaration', () => {
   // type declaration
   const props = defineProps<{
     foo: string
+    baz?: number
     bool?: boolean
     boolAndUndefined: boolean | undefined
   }>()
@@ -26,6 +27,12 @@ describe('defineProps w/ type declaration', () => {
   // @ts-expect-error
   props.bar
 
+  expectType<{
+    foo: string
+    baz: number | undefined
+    bool: boolean
+    boolAndUndefined: boolean
+  }>(props)
   expectType<boolean>(props.bool)
   expectType<boolean>(props.boolAndUndefined)
 })

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -4,7 +4,8 @@ import {
   isFunction,
   Prettify,
   UnionToIntersection,
-  extend
+  extend,
+  LooseRequired
 } from '@vue/shared'
 import {
   getCurrentInstance,
@@ -93,7 +94,7 @@ export function defineProps() {
   return null as any
 }
 
-type DefineProps<T, BKeys extends keyof T> = Readonly<T> & {
+type DefineProps<T, BKeys extends keyof T> = Readonly<LooseRequired<T>> & {
   readonly [K in BKeys]-?: boolean
 }
 


### PR DESCRIPTION
closes #6420 

---

`defineProps` infers optional properties as optional
![image](https://github.com/vuejs/core/assets/51162910/036c7f25-7707-4177-99e1-5ced6029d9da)

but they actually should by defined with `undefined`
![image](https://github.com/vuejs/core/assets/51162910/63b84aad-b213-488b-bbeb-a6cd9646a489)