### PR TITLE
test: replace deprecated `initEvent`

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vOn.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vOn.spec.ts
@@ -6,8 +6,10 @@ function triggerEvent(
   event: string,
   process?: (e: any) => any
 ) {
-  const e = document.createEvent('HTMLEvents')
-  e.initEvent(event, true, true)
+  const e = new Event(event, {
+    bubbles: true,
+    cancelable: true
+  })
   if (event === 'click') {
     ;(e as any).button = 0
   }

--- a/packages/vue-compat/__tests__/utils.ts
+++ b/packages/vue-compat/__tests__/utils.ts
@@ -3,8 +3,10 @@ export function triggerEvent(
   event: string,
   process?: (e: any) => any
 ) {
-  const e = document.createEvent('HTMLEvents')
-  e.initEvent(event, true, true)
+  const e = new Event(event, {
+    bubbles: true,
+    cancelable: true
+  })
   if (process) process(e)
   target.dispatchEvent(e)
   return e


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent, use `Event` instead.