### PR TITLE
fix(server-renderer): Make sure dir is defined

### DIFF
--- a/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
+++ b/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
@@ -7,7 +7,7 @@ export function ssrGetDirectiveProps(
   arg?: string,
   modifiers: Record<string, boolean> = {}
 ): Record<string, any> {
-  if (typeof dir !== 'function' && dir.getSSRProps) {
+  if (dir !== undefined && typeof dir !== 'function' && dir.getSSRProps) {
     return (
       dir.getSSRProps(
         {

--- a/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
+++ b/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
@@ -7,7 +7,7 @@ export function ssrGetDirectiveProps(
   arg?: string,
   modifiers: Record<string, boolean> = {}
 ): Record<string, any> {
-  if (dir !== undefined && typeof dir !== 'function' && dir.getSSRProps) {
+  if (dir != undefined && typeof dir !== 'function' && dir.getSSRProps) {
     return (
       dir.getSSRProps(
         {


### PR DESCRIPTION
**PR summary**:
This PR is a slight yet beneficial change that fixes an issue accidentally discovered with v-model, which breaks the entire app for one reload. This issue, initially occurred in a nuxt v3 app (if it matters) upon launching an app after a start command (`npm run dev`, for example) would break it for the first reload with the following error message: `Cannot read properties of undefined (reading 'getSSRProps')`. This PR makes sure dir is defined before trying to access getSSRProps, which although only studied by me with v-model, would probably fix many more edge cases. 

**Current Behavior**:
You get hit with an error screen (at least in my case) and the error message and are required to manually reload the page for your content to render. Note: The content loads fine after the first reload, it will not show again until restarting your development server.

**Why this PR is useful**:
The current behavior is not ideal, it breaks the entire page and is just unnecessary to require a manual reload. Additionally, vue already warns about the directive it fails to resolve (again, at least in my case), so this PR makes sure that no matter what framework you use, you won't be hit with an error screen like I did.