### PR TITLE
fix(runtime): declare generic in expose setup context

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -190,7 +190,7 @@ export type SetupContext<
       attrs: Data
       slots: UnwrapSlotsType<S>
       emit: EmitFn<E>
-      expose: (exposed?: Record<string, any>) => void
+      expose: <Exposed extends Record<string, any> = Record<string, any>>(exposed?: Exposed) => void
     }
   : never
 


### PR DESCRIPTION
The `defineExpose` method takes an optional generic to declare the type of the exposed object (it was introduced in https://github.com/vuejs/core/pull/5035). However, it seems like that generic is missing from the type definitions in another file.

I found this error because I'm authoring a library with components that are declared using the generic, but the compiled code is using this other type without the generic and it throws an error.