### PR TITLE
perf: mark `defineComponent` as side-effects-free

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "prettier": "^2.7.1",
     "pug": "^3.0.1",
     "puppeteer": "~19.6.0",
-    "rollup": "^3.20.2",
+    "rollup": "^3.26.0",
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-polyfill-node": "^0.12.0",

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -40,6 +40,7 @@ export interface AsyncComponentOptions<T = any> {
 export const isAsyncWrapper = (i: ComponentInternalInstance | VNode): boolean =>
   !!(i.type as ComponentOptions).__asyncLoader
 
+/*! #__NO_SIDE_EFFECTS__ */
 export function defineAsyncComponent<
   T extends Component = { new (): ComponentPublicInstance }
 >(source: AsyncComponentLoader<T> | AsyncComponentOptions<T>): T {

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -96,7 +96,7 @@ export type DefineComponent<
 // for TSX / manual render function / IDE support.
 
 // overload 1: direct setup function
-// (uses user defined props interface)]
+// (uses user defined props interface)
 export function defineComponent<
   Props extends Record<string, any>,
   E extends EmitsOptions = {},

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -96,7 +96,7 @@ export type DefineComponent<
 // for TSX / manual render function / IDE support.
 
 // overload 1: direct setup function
-// (uses user defined props interface)
+// (uses user defined props interface)]
 export function defineComponent<
   Props extends Record<string, any>,
   E extends EmitsOptions = {},
@@ -274,6 +274,7 @@ export function defineComponent<
 >
 
 // implementation, close to no-op
+/*! #__NO_SIDE_EFFECTS__ */
 export function defineComponent(
   options: unknown,
   extraOptions?: ComponentOptions

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -140,6 +140,7 @@ export function defineCustomElement(options: {
   new (...args: any[]): ComponentPublicInstance
 }): VueElementConstructor
 
+/*! #__NO_SIDE_EFFECTS__ */
 export function defineCustomElement(
   options: any,
   hydrate?: RootHydrateFunction
@@ -155,6 +156,7 @@ export function defineCustomElement(
   return VueCustomElement
 }
 
+/*! #__NO_SIDE_EFFECTS__ */
 export const defineSSRCustomElement = ((options: any) => {
   // @ts-ignore
   return defineCustomElement(options, hydrate)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,22 +16,22 @@ importers:
         version: 7.21.3
       '@rollup/plugin-alias':
         specifier: ^4.0.3
-        version: 4.0.4(rollup@3.20.2)
+        version: 4.0.4(rollup@3.26.2)
       '@rollup/plugin-commonjs':
         specifier: ^24.0.1
-        version: 24.1.0(rollup@3.20.2)
+        version: 24.1.0(rollup@3.26.2)
       '@rollup/plugin-json':
         specifier: ^6.0.0
-        version: 6.0.0(rollup@3.20.2)
+        version: 6.0.0(rollup@3.26.2)
       '@rollup/plugin-node-resolve':
         specifier: ^15.0.1
-        version: 15.1.0(rollup@3.20.2)
+        version: 15.1.0(rollup@3.26.2)
       '@rollup/plugin-replace':
         specifier: ^5.0.2
-        version: 5.0.2(rollup@3.20.2)
+        version: 5.0.2(rollup@3.26.2)
       '@rollup/plugin-terser':
         specifier: ^0.4.0
-        version: 0.4.0(rollup@3.20.2)
+        version: 0.4.0(rollup@3.26.2)
       '@types/hash-sum':
         specifier: ^1.0.0
         version: 1.0.0
@@ -105,17 +105,17 @@ importers:
         specifier: ~19.6.0
         version: 19.6.3
       rollup:
-        specifier: ^3.20.2
-        version: 3.20.2
+        specifier: ^3.26.0
+        version: 3.26.2
       rollup-plugin-dts:
         specifier: ^5.3.0
-        version: 5.3.0(rollup@3.20.2)(typescript@5.0.2)
+        version: 5.3.0(rollup@3.26.2)(typescript@5.0.2)
       rollup-plugin-esbuild:
         specifier: ^5.0.0
-        version: 5.0.0(esbuild@0.17.19)(rollup@3.20.2)
+        version: 5.0.0(esbuild@0.17.19)(rollup@3.26.2)
       rollup-plugin-polyfill-node:
         specifier: ^0.12.0
-        version: 0.12.0(rollup@3.20.2)
+        version: 0.12.0(rollup@3.26.2)
       semver:
         specifier: ^7.3.2
         version: 7.5.3
@@ -1130,7 +1130,7 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@rollup/plugin-alias@4.0.4(rollup@3.20.2):
+  /@rollup/plugin-alias@4.0.4(rollup@3.26.2):
     resolution: {integrity: sha512-0CaAY238SMtYAWEXXptWSR8iz8NYZnH7zNBKuJ14xFJSGwLtPgjvXYsoApAHfzYXXH1ejxpVw7WlHss3zhh9SQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1139,11 +1139,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.20.2
+      rollup: 3.26.2
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs@24.1.0(rollup@3.20.2):
+  /@rollup/plugin-commonjs@24.1.0(rollup@3.26.2):
     resolution: {integrity: sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1152,16 +1152,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.20.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.20.2
+      rollup: 3.26.2
     dev: true
 
-  /@rollup/plugin-inject@5.0.3(rollup@3.20.2):
+  /@rollup/plugin-inject@5.0.3(rollup@3.26.2):
     resolution: {integrity: sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1170,13 +1170,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.20.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
       estree-walker: 2.0.2
       magic-string: 0.27.0
-      rollup: 3.20.2
+      rollup: 3.26.2
     dev: true
 
-  /@rollup/plugin-json@6.0.0(rollup@3.20.2):
+  /@rollup/plugin-json@6.0.0(rollup@3.26.2):
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1185,11 +1185,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.20.2)
-      rollup: 3.20.2
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
+      rollup: 3.26.2
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.20.2):
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.26.2):
     resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1198,16 +1198,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.20.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.0
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 3.20.2
+      rollup: 3.26.2
     dev: true
 
-  /@rollup/plugin-replace@5.0.2(rollup@3.20.2):
+  /@rollup/plugin-replace@5.0.2(rollup@3.26.2):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1216,12 +1216,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.20.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
       magic-string: 0.27.0
-      rollup: 3.20.2
+      rollup: 3.26.2
     dev: true
 
-  /@rollup/plugin-terser@0.4.0(rollup@3.20.2):
+  /@rollup/plugin-terser@0.4.0(rollup@3.26.2):
     resolution: {integrity: sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1230,13 +1230,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.20.2
+      rollup: 3.26.2
       serialize-javascript: 6.0.1
       smob: 0.0.6
       terser: 5.18.2
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.20.2):
+  /@rollup/pluginutils@5.0.2(rollup@3.26.2):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1248,7 +1248,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.20.2
+      rollup: 3.26.2
     dev: true
 
   /@tootallnate/once@2.0.0:
@@ -4996,7 +4996,7 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup-plugin-dts@5.3.0(rollup@3.20.2)(typescript@5.0.2):
+  /rollup-plugin-dts@5.3.0(rollup@3.26.2)(typescript@5.0.2):
     resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -5004,45 +5004,37 @@ packages:
       typescript: ^4.1 || ^5.0
     dependencies:
       magic-string: 0.30.0
-      rollup: 3.20.2
+      rollup: 3.26.2
       typescript: 5.0.2
     optionalDependencies:
       '@babel/code-frame': 7.22.5
     dev: true
 
-  /rollup-plugin-esbuild@5.0.0(esbuild@0.17.19)(rollup@3.20.2):
+  /rollup-plugin-esbuild@5.0.0(esbuild@0.17.19)(rollup@3.26.2):
     resolution: {integrity: sha512-1cRIOHAPh8WQgdQQyyvFdeOdxuiyk+zB5zJ5+YOwrZP4cJ0MT3Fs48pQxrZeyZHcn+klFherytILVfE4aYrneg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     peerDependencies:
       esbuild: '>=0.10.1'
       rollup: ^1.20.0 || ^2.0.0 || ^3.0.0
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.20.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
       debug: 4.3.4
       es-module-lexer: 1.1.0
       esbuild: 0.17.19
       joycon: 3.1.1
       jsonc-parser: 3.2.0
-      rollup: 3.20.2
+      rollup: 3.26.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /rollup-plugin-polyfill-node@0.12.0(rollup@3.20.2):
+  /rollup-plugin-polyfill-node@0.12.0(rollup@3.26.2):
     resolution: {integrity: sha512-PWEVfDxLEKt8JX1nZ0NkUAgXpkZMTb85rO/Ru9AQ69wYW8VUCfDgP4CGRXXWYni5wDF0vIeR1UoF3Jmw/Lt3Ug==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0 || ^3.0.0
     dependencies:
-      '@rollup/plugin-inject': 5.0.3(rollup@3.20.2)
-      rollup: 3.20.2
-    dev: true
-
-  /rollup@3.20.2:
-    resolution: {integrity: sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
+      '@rollup/plugin-inject': 5.0.3(rollup@3.26.2)
+      rollup: 3.26.2
     dev: true
 
   /rollup@3.26.2:
@@ -5808,7 +5800,7 @@ packages:
       '@types/node': 16.18.38
       esbuild: 0.17.19
       postcss: 8.4.21
-      rollup: 3.20.2
+      rollup: 3.26.2
       terser: 5.18.2
     optionalDependencies:
       fsevents: 2.3.2


### PR DESCRIPTION
Rollup now supports marking a function as sied-effect free: 
- https://github.com/rollup/rollup/pull/5024

It's a common pitfall in tree-shaking component libraries. For example

```ts
export const RouterView = defineComponent(...)
 
export const RouterLink = defineComponent(...)
```

```ts
import { RouterView } from './my-route.ts
```

It seems `RouterLink` should be tree shaken, but in reality, because `defineComponent` is a bit complex that Rollup can't know whether it contains side-effects, causing it still remain in the bundle even if it's not been used.

A solution to that is to add the `__PURE__` comment to mark them as pure. But that requires to do so every single time, which can easily be forgotten.

```ts
export const RouterView = /*#__PURE__*/ defineComponent(...)
 
export const RouterLink = /*#__PURE__*/ defineComponent(...)
```

So, instead of asking every callee to add `__PURE__`, we mark the `defineComponent` function itself to be side-effect-free using `__NO_SIDE_EFFECTS__`. So they can always be safely tree-shaken.

In this PR, the following functions are marked side-effect free:

- `defineComponent`
- `defineAsyncComponet`
- `defineCustomElement`
- `defineSSRCustomElement`

> Side note: because we are using esbuild, which does not preserve comments. We need to use `/*!` to keep the controlling comment, before esbuild supports `__NO_SIDE_EFFECTS__` natively (https://github.com/evanw/esbuild/issues/3149)