### PR TITLE
feat(types): expose `DefineProps` type

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -93,7 +93,7 @@ export function defineProps() {
   return null as any
 }
 
-type DefineProps<T, BKeys extends keyof T> = Readonly<T> & {
+export type DefineProps<T, BKeys extends keyof T> = Readonly<T> & {
   readonly [K in BKeys]-?: boolean
 }
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -60,7 +60,7 @@ export { provide, inject, hasInjectionContext } from './apiInject'
 export { nextTick } from './scheduler'
 export { defineComponent } from './apiDefineComponent'
 export { defineAsyncComponent } from './apiAsyncComponent'
-export { useAttrs, useSlots } from './apiSetupHelpers'
+export { useAttrs, useSlots, type DefineProps } from './apiSetupHelpers'
 
 // <script setup> API ----------------------------------------------------------
 


### PR DESCRIPTION
Consider the code below:
```ts
declare const props: DefineProps<{ foo?: boolean | undefined }, 'foo'>
declare const props2: Readonly<{ foo?: boolean | undefined }> & {
  readonly foo: boolean
}
// They're the same.
expectTypeOf(props).toEqualTypeOf(props2)

withDefaults(props, { foo: true })
withDefaults(props2, { foo: true })
//                     ^ Type 'boolean' is not assignable to type '(props: { foo: unknown; }) => {}'.ts(2322)
```

So without `DefineProps` type, `withDefaults` cannot infer the props type.

