### PR TITLE
feat(computed): allow computed get/set to have different types

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -12,12 +12,11 @@ export interface ComputedRef<T = any> extends WritableComputedRef<T> {
 }
 
 export interface WritableComputedRef<T, S = T> extends Ref<T> {
+  // @ts-ignore
   get value(): T
-  set value(newValue: S | T)
+  set value(newValue: S)
   readonly effect: ReactiveEffect<T>
 }
-
-//The return type of a 'get' accessor must be assignable to its 'set' accessor type
 
 export type ComputedGetter<T> = (...args: any[]) => T
 export type ComputedSetter<T> = (v: T) => void

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -59,7 +59,7 @@ export class ReactiveEffect<T = any> {
    * Can be attached after creation
    * @internal
    */
-  computed?: ComputedRefImpl<T>
+  computed?: ComputedRefImpl<T, any>
   /**
    * @internal
    */


### PR DESCRIPTION
resolve #7271

In certain cases, we would like the `computed` property's getter and setter to have different types. This would provide added convenience in our usage, such as having the getter return a string while the setter accepts an object. In this PR, I have added a second generic parameter to the `computed` property to specify the type of the setter. With this enhancement, we can set different types for the getter and setter of `computed` using the following approach.

Examples:
```ts

const obj = ref({
  name: 'foo'
})

const newObj = computed<string, typeof obj.value>({
  get() {
    return JSON.stringify(obj.value)
  },
  set(val) {
    obj.value = val
  }
})
console.log(newObj.value) // string

newObj.value = { name: 'bar' } // object


```