### PR TITLE
chore: remove unnecessary imports from vitest

### DIFF
--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { vi, type Mock } from 'vitest'
+import { type Mock } from 'vitest'
 import {
   h,
   nodeOps,

--- a/packages/runtime-dom/__tests__/customizedBuiltIn.spec.ts
+++ b/packages/runtime-dom/__tests__/customizedBuiltIn.spec.ts
@@ -1,4 +1,4 @@
-import { vi, SpyInstance } from 'vitest'
+import { type SpyInstance } from 'vitest'
 import { render, h } from '@vue/runtime-dom'
 
 describe('customized built-in elements support', () => {

--- a/packages/vue-compat/__tests__/global.spec.ts
+++ b/packages/vue-compat/__tests__/global.spec.ts
@@ -1,4 +1,3 @@
-import { expect, vi } from 'vitest'
 import Vue from '@vue/compat'
 import { effect, isReactive } from '@vue/reactivity'
 import { h, nextTick } from '@vue/runtime-core'

--- a/packages/vue-compat/__tests__/instance.spec.ts
+++ b/packages/vue-compat/__tests__/instance.spec.ts
@@ -1,4 +1,4 @@
-import { vi, Mock } from 'vitest'
+import { type Mock } from 'vitest'
 import Vue from '@vue/compat'
 import { Slots } from '../../runtime-core/src/componentSlots'
 import { Text } from '../../runtime-core/src/vnode'

--- a/scripts/setupVitest.ts
+++ b/scripts/setupVitest.ts
@@ -1,4 +1,4 @@
-import { vi, type SpyInstance } from 'vitest'
+import { type SpyInstance } from 'vitest'
 
 expect.extend({
   toHaveBeenWarned(received: string) {


### PR DESCRIPTION
The commonly used APIs in vitest are global, so there is no need to import.