### PR TITLE
types: support typecheck --isolatedModules flag is provided (vite-vue-ts-template by default)

### DIFF
--- a/packages/reactivity/src/operations.ts
+++ b/packages/reactivity/src/operations.ts
@@ -1,13 +1,13 @@
 // using literal strings instead of numbers so that it's easier to inspect
 // debugger events
 
-export const enum TrackOpTypes {
+export enum TrackOpTypes {
   GET = 'get',
   HAS = 'has',
   ITERATE = 'iterate'
 }
 
-export const enum TriggerOpTypes {
+export enum TriggerOpTypes {
   SET = 'set',
   ADD = 'add',
   DELETE = 'delete',

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -13,7 +13,7 @@ import {
 } from './collectionHandlers'
 import type { UnwrapRefSimple, Ref, RawSymbol } from './ref'
 
-export const enum ReactiveFlags {
+export enum ReactiveFlags {
   SKIP = '__v_skip',
   IS_REACTIVE = '__v_isReactive',
   IS_READONLY = '__v_isReadonly',

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -164,7 +164,7 @@ export type ExtractPublicPropTypes<O> = {
   [K in keyof Pick<O, PublicOptionalKeys<O>>]?: InferPropType<O[K]>
 }
 
-const enum BooleanFlags {
+enum BooleanFlags {
   shouldCast,
   shouldCastTrue
 }


### PR DESCRIPTION
 #1228, 

instead of setting "skipLibCheck": true