### PR TITLE
fix: don't register typescript in browsers

### DIFF
--- a/packages/vue/compiler-sfc/index.browser.js
+++ b/packages/vue/compiler-sfc/index.browser.js
@@ -1,0 +1,1 @@
+module.exports = require('@vue/compiler-sfc')

--- a/packages/vue/compiler-sfc/index.browser.mjs
+++ b/packages/vue/compiler-sfc/index.browser.mjs
@@ -1,0 +1,1 @@
+export * from '@vue/compiler-sfc'

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -44,10 +44,12 @@
     "./compiler-sfc": {
       "import": {
         "types": "./compiler-sfc/index.d.mts",
+        "browser": "./compiler-sfc/index.browser.mjs",
         "default": "./compiler-sfc/index.mjs"
       },
       "require": {
         "types": "./compiler-sfc/index.d.ts",
+        "browser": "./compiler-sfc/index.browser.js",
         "default": "./compiler-sfc/index.js"
       }
     },
@@ -99,5 +101,13 @@
     "@vue/runtime-dom": "3.3.4",
     "@vue/compiler-sfc": "3.3.4",
     "@vue/server-renderer": "3.3.4"
+  },
+  "peerDependencies": {
+    "typescript": "*"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       '@vue/shared':
         specifier: 3.3.4
         version: link:../shared
+      typescript:
+        specifier: '*'
+        version: 5.0.2
 
   packages/vue-compat:
     dependencies:
@@ -5410,7 +5413,6 @@ packages:
     resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
     engines: {node: '>=12.20'}
     hasBin: true
-    dev: true
 
   /ufo@1.1.1:
     resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}


### PR DESCRIPTION
- Don't require `typescript` and call `registerTS` function in browsers.
  - Reduce the bundle size used in browsers.
- Add `typescript` as a peer dep.