### PR TITLE
feat(compiler-sfc): `withDefaults` supports the use of local variables

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -338,6 +338,27 @@ return { props, get defaults() { return defaults } }
 })"
 `;
 
+exports[`defineProps > withDefaults (locally variable) 1`] = `
+"import { mergeDefaults as _mergeDefaults, defineComponent as _defineComponent } from 'vue'
+const defaults = { baz: false }
+    
+export default /*#__PURE__*/_defineComponent({
+  props: _mergeDefaults({
+    baz: { type: Boolean, required: true }
+  }, defaults),
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+const props = __props;
+
+    
+    
+return { defaults, props }
+}
+
+})"
+`;
+
 exports[`defineProps > withDefaults (reference) 1`] = `
 "import { mergeDefaults as _mergeDefaults, defineComponent as _defineComponent } from 'vue'
 import { defaults } from './foo'

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -470,6 +470,26 @@ const props = defineProps({ foo: String })
     )
   })
 
+  test('withDefaults (locally variable)', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+    const defaults = { baz: false }
+    const props = withDefaults(defineProps<{
+      baz: boolean
+    }>(), defaults)
+    </script>
+    `)
+
+    assertCode(content)
+    expect(content).toMatch(`import { mergeDefaults as _mergeDefaults`)
+    expect(content).toMatch(
+      `
+  _mergeDefaults({
+    baz: { type: Boolean, required: true }
+  }, defaults)`.trim()
+    )
+  })
+
   // #7111
   test('withDefaults (dynamic) w/ production mode', () => {
     const { content } = compile(


### PR DESCRIPTION
close: #8517