### PR TITLE
types(withDefaults): enhance read-only type

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -107,6 +107,7 @@ describe('defineProps w/ generic type declaration + withDefaults', <T extends nu
     defineProps<{
       n?: number
       bool?: boolean
+      s?: string
 
       generic1?: T[] | { x: T }
       generic2?: { x: T }
@@ -125,6 +126,10 @@ describe('defineProps w/ generic type declaration + withDefaults', <T extends nu
   )
 
   res.n + 1
+  // @ts-expect-error should be readonly
+  res.n++
+  // @ts-expect-error should be readonly
+  res.s = ''
 
   expectType<T[] | { x: T }>(res.generic1)
   expectType<{ x: T }>(res.generic2)

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -297,8 +297,8 @@ type PropsWithDefaults<
   T,
   Defaults extends InferDefaults<T>,
   BKeys extends keyof T
-> = Omit<T, keyof Defaults> & {
-  [K in keyof Defaults]-?: K extends keyof T
+> = Readonly<Omit<T, keyof Defaults>> & {
+  readonly [K in keyof Defaults]-?: K extends keyof T
     ? Defaults[K] extends undefined
       ? T[K]
       : NotUndefined<T[K]>


### PR DESCRIPTION
Props should also be read-only in the following two cases:

```ts
const props = withDefaults(defineProps<{ name?: string }>(), {})
props.name // readonly
```

```ts
const props = withDefaults(defineProps<{ name?: string }>(), {
  name: ''
})
props.name // readonly
```