### PR TITLE
types(withDefaults): improve the type of boolean attribute value

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -134,6 +134,26 @@ describe('defineProps w/ generic type declaration + withDefaults', <T extends nu
   expectType<boolean>(res.bool)
 })
 
+describe('withDefaults w/ boolean type', () => {
+  const res1 = withDefaults(
+    defineProps<{
+      bool?: boolean
+    }>(),
+    { bool: false }
+  )
+  expectType<boolean>(res1.bool)
+
+  const res2 = withDefaults(
+    defineProps<{
+      bool?: boolean
+    }>(),
+    {
+      bool: undefined
+    }
+  )
+  expectType<boolean | undefined>(res2.bool)
+})
+
 describe('defineProps w/ runtime declaration', () => {
   // runtime declaration
   const props = defineProps({

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -303,7 +303,13 @@ type PropsWithDefaults<
       ? T[K]
       : NotUndefined<T[K]>
     : never
-} & { readonly [K in BKeys]-?: boolean }
+} & {
+  readonly [K in BKeys]-?: K extends keyof Defaults
+    ? Defaults[K] extends undefined
+      ? boolean | undefined
+      : boolean
+    : boolean
+}
 
 /**
  * Vue `<script setup>` compiler macro for providing props default values when


### PR DESCRIPTION
Before:

```ts
const props = withDefaults(defineProps<{ active?: boolean }>(), {
  active: undefined
})
props.active // boolean
props.active.toString() // error!
```

After:

```ts
const props = withDefaults(defineProps<{ active?: boolean }>(), {})
props.active // boolean

const props = withDefaults(defineProps<{ active?: boolean }>(), {
  active: undefined
})
props.active // boolean | undefined
```

Also matches the following usages:

```ts
export default defineComponent({
  props: {
    active: {
      type: Boolean,
      required: false,
      default: undefined
    }
  },

  setup(props) {
    props.active // boolean | undefined
  }
})
```

---

Related to: https://github.com/vuejs/core/issues/8576