### PR TITLE
fix(runtime-dom): update type definition for jsx

### DIFF
--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -393,7 +393,7 @@ function hydrateTeleport(
 // Force-casted public typing for h and TSX props inference
 export const Teleport = TeleportImpl as unknown as {
   __isTeleport: true
-  new (): {
+  new(): {
     $props: VNodeProps & TeleportProps
     $slots: {
       default(): VNode[]

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -393,7 +393,7 @@ function hydrateTeleport(
 // Force-casted public typing for h and TSX props inference
 export const Teleport = TeleportImpl as unknown as {
   __isTeleport: true
-  new(): {
+  new (): {
     $props: VNodeProps & TeleportProps
     $slots: {
       default(): VNode[]

--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -366,7 +366,7 @@ export interface ButtonHTMLAttributes extends HTMLAttributes {
   formtarget?: string
   name?: string
   type?: 'submit' | 'reset' | 'button'
-  value?: string | string[] | number
+  value?: string | ReadonlyArray<string> | number
 }
 
 export interface CanvasHTMLAttributes extends HTMLAttributes {
@@ -384,11 +384,12 @@ export interface ColgroupHTMLAttributes extends HTMLAttributes {
 }
 
 export interface DataHTMLAttributes extends HTMLAttributes {
-  value?: string | string[] | number
+  value?: string | ReadonlyArray<string> | number
 }
 
 export interface DetailsHTMLAttributes extends HTMLAttributes {
   open?: Booleanish
+  onToggle?: Event
 }
 
 export interface DelHTMLAttributes extends HTMLAttributes {
@@ -451,6 +452,7 @@ export interface ImgHTMLAttributes extends HTMLAttributes {
   crossorigin?: 'anonymous' | 'use-credentials' | ''
   decoding?: 'async' | 'auto' | 'sync'
   height?: Numberish
+  loading?: 'eager' | 'lazy'
   referrerpolicy?: HTMLAttributeReferrerPolicy
   sizes?: string
   src?: string
@@ -473,6 +475,14 @@ export interface InputHTMLAttributes extends HTMLAttributes {
   checked?: Booleanish | any[] | Set<any> // for IDE v-model multi-checkbox support
   crossorigin?: string
   disabled?: Booleanish
+  enterKeyHint?:
+    | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send'
   form?: string
   formaction?: string
   formenctype?: string
@@ -516,7 +526,7 @@ export interface LabelHTMLAttributes extends HTMLAttributes {
 }
 
 export interface LiHTMLAttributes extends HTMLAttributes {
-  value?: string | string[] | number
+  value?: string | ReadonlyArray<string> | number
 }
 
 export interface LinkHTMLAttributes extends HTMLAttributes {
@@ -530,6 +540,7 @@ export interface LinkHTMLAttributes extends HTMLAttributes {
   rel?: string
   sizes?: string
   type?: string
+  charset?: string
 }
 
 export interface MapHTMLAttributes extends HTMLAttributes {
@@ -567,7 +578,7 @@ export interface MeterHTMLAttributes extends HTMLAttributes {
   max?: Numberish
   min?: Numberish
   optimum?: Numberish
-  value?: string | string[] | number
+  value?: string | ReadonlyArray<string> | number
 }
 
 export interface QuoteHTMLAttributes extends HTMLAttributes {
@@ -612,12 +623,12 @@ export interface OutputHTMLAttributes extends HTMLAttributes {
 
 export interface ParamHTMLAttributes extends HTMLAttributes {
   name?: string
-  value?: string | string[] | number
+  value?: string | ReadonlyArray<string> | number
 }
 
 export interface ProgressHTMLAttributes extends HTMLAttributes {
   max?: Numberish
-  value?: string | string[] | number
+  value?: string | ReadonlyArray<string> | number
 }
 
 export interface ScriptHTMLAttributes extends HTMLAttributes {
@@ -664,6 +675,7 @@ export interface TableHTMLAttributes extends HTMLAttributes {
   cellpadding?: Numberish
   cellspacing?: Numberish
   summary?: string
+  width?: Numberish
 }
 
 export interface TextareaHTMLAttributes extends HTMLAttributes {
@@ -680,7 +692,7 @@ export interface TextareaHTMLAttributes extends HTMLAttributes {
   readonly?: boolean
   required?: Booleanish
   rows?: Numberish
-  value?: string | string[] | number
+  value?: string | ReadonlyArray<string> | number
   wrap?: string
 }
 
@@ -690,6 +702,9 @@ export interface TdHTMLAttributes extends HTMLAttributes {
   headers?: string
   rowspan?: Numberish
   scope?: string
+  abbr?: string
+  height?: Numberish
+  width?: Numberish
   valign?: 'top' | 'middle' | 'bottom' | 'baseline'
 }
 
@@ -699,6 +714,7 @@ export interface ThHTMLAttributes extends HTMLAttributes {
   headers?: string
   rowspan?: Numberish
   scope?: string
+  abbr?: string
 }
 
 export interface TimeHTMLAttributes extends HTMLAttributes {
@@ -719,6 +735,7 @@ export interface VideoHTMLAttributes extends MediaHTMLAttributes {
   poster?: string
   width?: Numberish
   disablePictureInPicture?: Booleanish
+  disableRemotePlayback?: Booleanish
 }
 
 export interface WebViewHTMLAttributes extends HTMLAttributes {
@@ -767,6 +784,7 @@ export interface SVGAttributes extends AriaAttributes, EventHandlers<Events> {
   // Other HTML properties supported by SVG elements in browsers
   role?: string
   tabindex?: Numberish
+  crossOrigin?: 'anonymous' | 'use-credentials' | ''
 
   // SVG Specific attributes
   'accent-height'?: Numberish

--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -433,13 +433,17 @@ export interface IframeHTMLAttributes extends HTMLAttributes {
   allow?: string
   allowfullscreen?: Booleanish
   allowtransparency?: Booleanish
+  /** @deprecated */
   frameborder?: Numberish
   height?: Numberish
+  /** @deprecated */
   marginheight?: Numberish
+  /** @deprecated */
   marginwidth?: Numberish
   name?: string
   referrerpolicy?: HTMLAttributeReferrerPolicy
   sandbox?: string
+  /** @deprecated */
   scrolling?: string
   seamless?: Booleanish
   src?: string
@@ -633,6 +637,7 @@ export interface ProgressHTMLAttributes extends HTMLAttributes {
 
 export interface ScriptHTMLAttributes extends HTMLAttributes {
   async?: Booleanish
+  /** @deprecated */
   charset?: string
   crossorigin?: string
   defer?: Booleanish


### PR DESCRIPTION
`ImgHTMLAttributes` missing the `loading` attribute, more see [MDN](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading#images_and_iframes).
Also I sync some new properties from latest `@types/react`.

<img width="830" alt="image" src="https://github.com/vuejs/core/assets/39730999/e2cb49f5-b544-41c5-aef7-62e17cbda9cf">
