### PR TITLE
fix(compiler-sfc): normalize windows paths when resolving types

### DIFF
--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -778,7 +778,7 @@ function importSourceToScope(
   if (!resolved) {
     if (source.startsWith('.')) {
       // relative import - fast path
-      const filename = joinPaths(scope.filename, '..', source)
+      const filename = joinPaths(normalizePath(scope.filename), '..', normalizePath(source))
       resolved = resolveExt(filename, fs)
     } else {
       // module or aliased import - use full TS resolution, only supported in Node


### PR DESCRIPTION
Getting error when using defineProps and importing a type from another files on Windows.

For more information and a reproduction repository, look at [this issue](https://github.com/vuejs/vue-loader/issues/2048.)
Similar to [this pull request](https://github.com/vuejs/core/pull/8136/commits)