### PR TITLE
chore: acceptable color in dark mode for custom formatter

### DIFF
--- a/packages/runtime-core/src/customFormatter.ts
+++ b/packages/runtime-core/src/customFormatter.ts
@@ -11,9 +11,9 @@ export function initCustomFormatter() {
   }
 
   const vueStyle = { style: 'color:#3ba776' }
-  const numberStyle = { style: 'color:#0b1bc9' }
-  const stringStyle = { style: 'color:#b62e24' }
-  const keywordStyle = { style: 'color:#9d288c' }
+  const numberStyle = { style: 'color:#1677ff' }
+  const stringStyle = { style: 'color:#f5222d' }
+  const keywordStyle = { style: 'color:#eb2f96' }
 
   // custom formatter for Chrome
   // https://www.mattzeunert.com/2016/02/19/custom-chrome-devtools-object-formatters.html


### PR DESCRIPTION
#5502 ,  may not it's not the best color, but at least it's a bit clearer

before:
<img width="614" alt="image" src="https://github.com/vuejs/core/assets/1905176/9f9fc4e3-3a72-4d36-86cc-5726488edb98">

after:
<img width="588" alt="image" src="https://github.com/vuejs/core/assets/1905176/48dffd87-fcae-489f-a46d-0cd8f7d252ee">

