### PR TITLE
chore: follow the unused variable naming convention

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -170,7 +170,7 @@ type ShortEmits<T extends Record<string, any>> = UnionToIntersection<
  */
 export function defineExpose<
   Exposed extends Record<string, any> = Record<string, any>
->(exposed?: Exposed) {
+>(_exposed?: Exposed) {
   if (__DEV__) {
     warnRuntimeUsage(`defineExpose`)
   }
@@ -191,7 +191,7 @@ export function defineOptions<
   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin
 >(
-  options?: ComponentOptionsWithoutProps<
+  _options?: ComponentOptionsWithoutProps<
     {},
     RawBindings,
     D,
@@ -330,8 +330,8 @@ export function withDefaults<
   BKeys extends keyof T,
   Defaults extends InferDefaults<T>
 >(
-  props: DefineProps<T, BKeys>,
-  defaults: Defaults
+  _props: DefineProps<T, BKeys>,
+  _defaults: Defaults
 ): PropsWithDefaults<T, Defaults, BKeys> {
   if (__DEV__) {
     warnRuntimeUsage(`withDefaults`)


### PR DESCRIPTION
We should follow the underscore naming convention for unused variables to avoid editor prompts.

<img width="857" alt="截屏2023-07-03 21 09 27" src="https://github.com/vuejs/core/assets/55641773/5f7babfd-8fba-4c5b-aecc-7d4575df3f20">
