### PR TITLE
chore(compiler): merge-redundant-code

### DIFF
--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -117,16 +117,7 @@ function createParserContext(
   content: string,
   rawOptions: ParserOptions
 ): ParserContext {
-  const options = extend({}, defaultParserOptions)
-
-  let key: keyof ParserOptions
-  for (key in rawOptions) {
-    // @ts-ignore
-    options[key] =
-      rawOptions[key] === undefined
-        ? defaultParserOptions[key]
-        : rawOptions[key]
-  }
+  const options = extend({}, defaultParserOptions, rawOptions)
   return {
     options,
     column: 1,


### PR DESCRIPTION
Use extend's default behavior to merge options without having to go through them again.