### PR TITLE
feat(compiler-core): export error message

### DIFF
--- a/packages/compiler-core/src/index.ts
+++ b/packages/compiler-core/src/index.ts
@@ -24,6 +24,7 @@ export {
 export { generate, type CodegenContext, type CodegenResult } from './codegen'
 export {
   ErrorCodes,
+  errorMessages,
   createCompilerError,
   type CoreCompilerError,
   type CompilerError
@@ -62,7 +63,6 @@ export {
 export { processSlotOutlet } from './transforms/transformSlotOutlet'
 export { getConstantType } from './transforms/hoistStatic'
 export { generateCodeFrame } from '@vue/shared'
-
 // v2 compat only
 export {
   checkCompatEnabled,

--- a/packages/compiler-core/src/index.ts
+++ b/packages/compiler-core/src/index.ts
@@ -63,6 +63,7 @@ export {
 export { processSlotOutlet } from './transforms/transformSlotOutlet'
 export { getConstantType } from './transforms/hoistStatic'
 export { generateCodeFrame } from '@vue/shared'
+
 // v2 compat only
 export {
   checkCompatEnabled,

--- a/packages/compiler-dom/src/index.ts
+++ b/packages/compiler-dom/src/index.ts
@@ -68,5 +68,9 @@ export function parse(template: string, options: ParserOptions = {}): RootNode {
 
 export * from './runtimeHelpers'
 export { transformStyle } from './transforms/transformStyle'
-export { createDOMCompilerError, DOMErrorCodes } from './errors'
+export {
+  createDOMCompilerError,
+  DOMErrorCodes,
+  DOMErrorMessages
+} from './errors'
 export * from '@vue/compiler-core'


### PR DESCRIPTION
#4537 

The dev environment has a more friendly error message when compiling a template that reports an error. But the prod environment has only one error code
```
SyntaxError: Element is missing end tag.  # dev
```

```
SyntaxError: 24  #prod
``` 

we can add error-messages export for better production bug and error report 

```
import {errorMessages, DOMErrorMessages} from '@vue/compiler-dom'

const errorLogProd = 'SyntaxError: 24'
const code = errorLogProd.split(':')[1].trim()
const message = errorMessages[code] || DOMErrorMessages[code]
sendErrorReport(message ...) // Invalid end tag.
...

```
