### PR TITLE
feat: support space contained in the filename for asset

### DIFF
--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -181,4 +181,19 @@ describe('compiler sfc: transform asset url', () => {
     expect(code).toMatch(`_createElementVNode`)
     expect(code).toContain(`import _imports_0 from '/foo bar.png'`)
   })
+
+  test('transform with stringify with space in relative filename', () => {
+    const { code } = compileWithAssetUrls(
+      `<div><img src="./foo bar.png"/></div>`,
+      {
+        includeAbsolute: true
+      },
+      {
+        hoistStatic: true,
+        transformHoist: stringifyStatic
+      }
+    )
+    expect(code).toMatch(`_createElementVNode`)
+    expect(code).toContain(`import _imports_0 from './foo bar.png'`)
+  })
 })

--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -166,4 +166,19 @@ describe('compiler sfc: transform asset url', () => {
     expect(code).toMatch(`_createStaticVNode`)
     expect(code).toMatchSnapshot()
   })
+
+  test('transform with stringify with space in absolute filename', () => {
+    const { code } = compileWithAssetUrls(
+      `<div>` + `<img src="/foo bar.png"/>` + `</div>`,
+      {
+        includeAbsolute: true
+      },
+      {
+        hoistStatic: true,
+        transformHoist: stringifyStatic
+      }
+    )
+    expect(code).toMatch(`_createElementVNode`)
+    expect(code).toContain(`import _imports_0 from '/foo bar.png'`)
+  })
 })

--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -169,7 +169,7 @@ describe('compiler sfc: transform asset url', () => {
 
   test('transform with stringify with space in absolute filename', () => {
     const { code } = compileWithAssetUrls(
-      `<div>` + `<img src="/foo bar.png"/>` + `</div>`,
+      `<div><img src="/foo bar.png"/></div>`,
       {
         includeAbsolute: true
       },

--- a/packages/compiler-sfc/src/template/transformAssetUrl.ts
+++ b/packages/compiler-sfc/src/template/transformAssetUrl.ts
@@ -168,12 +168,12 @@ function getImportsExpressionExp(
         loc,
         ConstantTypes.CAN_STRINGIFY
       )
-      // When path starts with /, for example, /foo/bar.png, it is an absolute file path
-      // In this case we need to ensure the path is not encoded (to %2F),
+
+      // We need to ensure the path is not encoded (to %2F),
       // so we decode it back in case it is encoded
       context.imports.push({
         exp,
-        path: isRelativeUrl(path) ? path : decodeURIComponent(path)
+        path: decodeURIComponent(path)
       })
     }
 

--- a/packages/compiler-sfc/src/template/transformAssetUrl.ts
+++ b/packages/compiler-sfc/src/template/transformAssetUrl.ts
@@ -169,10 +169,11 @@ function getImportsExpressionExp(
         ConstantTypes.CAN_STRINGIFY
       )
       // When path starts with /, for example, /foo/bar.png, it is an absolute file path
-      // In this case we need to ensure the path is not encoded
+      // In this case we need to ensure the path is not encoded (to %2F),
+      // so we decode it back in case it is encoded
       context.imports.push({
         exp,
-        path: path && path[0] === '/' ? decodeURIComponent(path) : path
+        path: isRelativeUrl(path) ? path : decodeURIComponent(path)
       })
     }
 

--- a/packages/compiler-sfc/src/template/transformAssetUrl.ts
+++ b/packages/compiler-sfc/src/template/transformAssetUrl.ts
@@ -168,7 +168,12 @@ function getImportsExpressionExp(
         loc,
         ConstantTypes.CAN_STRINGIFY
       )
-      context.imports.push({ exp, path })
+      // When path starts with /, for example, /foo/bar.png, it is an absolute file path
+      // In this case we need to ensure the path is not encoded
+      context.imports.push({
+        exp,
+        path: path && path[0] === '/' ? decodeURIComponent(path) : path
+      })
     }
 
     if (!hash) {

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -1363,13 +1363,13 @@ describe('function syntax w/ runtime props', () => {
     }
   )
 
+  // @ts-expect-error prop keys don't match
   defineComponent(
     (_props: { msg: string }) => {
       return () => {}
     },
     {
       props: {
-        // @ts-expect-error prop type mismatch
         msg: Number
       }
     }

--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -1363,13 +1363,13 @@ describe('function syntax w/ runtime props', () => {
     }
   )
 
-  // @ts-expect-error prop keys don't match
   defineComponent(
     (_props: { msg: string }) => {
       return () => {}
     },
     {
       props: {
+        // @ts-expect-error prop type mismatch
         msg: Number
       }
     }


### PR DESCRIPTION
See https://github.com/vuejs/vitepress/issues/2596. 

When including an image into a markdown file, most tools must encode the space to render the image in preview mode.

But the encoded space will fail the vitepress building process due to the `import` statement containing the encoded path. So we need to decode it back when it's an absolute path.

> Using space in the filename is a bad idea, but the operating system allows it, and many automatic processes will generate a filename with space, so I hope we can support it!

## More information

The `transformAssetUrl` will use `parseUrl` to the asset path, which encodes the path. 