### PR TITLE
fix(runtime-core): before cloneIfMounted, should first check if the object is a VNode (#8778)

### DIFF
--- a/packages/runtime-core/__tests__/rendererComponent.spec.ts
+++ b/packages/runtime-core/__tests__/rendererComponent.spec.ts
@@ -354,4 +354,41 @@ describe('renderer: component', () => {
     expect(serializeInner(root)).toBe(`<h1>1</h1>`)
     expect(spy).toHaveBeenCalledTimes(2)
   })
+
+  // #8778
+  describe('render return non-VNode', () => {
+    test('render return Object', async () => {
+      const root = nodeOps.createElement('div')
+      const App = {
+        render() {
+          return { info: 'hi' }
+        }
+      }
+      render(h(App), root)
+      expect(serializeInner(root)).toBe('[object Object]')
+    })
+
+    test('render return Proxy', async () => {
+      const root = nodeOps.createElement('div')
+      const App = {
+        render() {
+          return ref('hi')
+        }
+      }
+      render(h(App), root)
+      expect(serializeInner(root)).toBe('[object Object]')
+    })
+
+    test('render return Class', async () => {
+      const A = class {}
+      const root = nodeOps.createElement('div')
+      const App = {
+        render() {
+          return new A()
+        }
+      }
+      render(h(App), root)
+      expect(serializeInner(root)).toBe('[object Object]')
+    })
+  })
 })

--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -9,7 +9,8 @@ import {
   mergeProps,
   normalizeVNode,
   transformVNodeArgs,
-  isBlockTreeEnabled
+  isBlockTreeEnabled,
+  VNodeChild
 } from '../src/vnode'
 import { Data } from '../src/component'
 import { ShapeFlags, PatchFlags } from '@vue/shared'
@@ -201,6 +202,12 @@ describe('vnode', () => {
     // primitive types
     expect(normalizeVNode('foo')).toMatchObject({ type: Text, children: `foo` })
     expect(normalizeVNode(1)).toMatchObject({ type: Text, children: `1` })
+
+    // #8778 object from render function
+    expect(normalizeVNode({ key: '1' } as VNodeChild)).toMatchObject({
+      type: Text,
+      children: `[object Object]`
+    })
   })
 
   test('type shapeFlag inference', () => {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -743,12 +743,12 @@ export function normalizeVNode(child: VNodeChild): VNode {
       // #3666, avoid reference pollution when reusing vnode
       child.slice()
     )
-  } else if (typeof child === 'object') {
+  } else if (typeof child === 'object' && isVNode(child)) {
     // already vnode, this should be the most common since compiled templates
     // always produce all-vnode children arrays
     return cloneIfMounted(child)
   } else {
-    // strings and numbers
+    // strings and numbers or object that doesn't a vnode
     return createVNode(Text, null, String(child))
   }
 }


### PR DESCRIPTION
close #8778

In my opinion, it seems sufficient to directly check `isVNode`. However, should `VNodeChild` include the `object` type? For example, when using `render!.call`, it seems that we have no control over what it returns.