### PR TITLE
fix(runtime-core): fix 'Maximum call stack size exceeded' caused by native event attrs

### DIFF
--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -1,7 +1,7 @@
 import { VNode } from './vnode'
 import { ComponentInternalInstance } from './component'
 import { warn, pushWarningContext, popWarningContext } from './warning'
-import { isPromise, isFunction } from '@vue/shared'
+import { isPromise, isFunction, isString } from '@vue/shared'
 import { LifecycleHooks } from './enums'
 
 // contexts where user provided function may be executed, in addition to
@@ -81,6 +81,9 @@ export function callWithAsyncErrorHandling(
   type: ErrorTypes,
   args?: unknown[]
 ): any[] {
+  if (isString(fn)) {
+    fn = new Function(fn)
+  }
   if (isFunction(fn)) {
     const res = callWithErrorHandling(fn, instance, type, args)
     if (res && isPromise(res)) {


### PR DESCRIPTION
This issue has been present in Vue 3 [for many years](https://stackoverflow.com/questions/66197624/vue-uncaught-rangeerror-maximum-call-stack-size-exceeded-callwithasyncerrorha), but Vue 2 has always been working fine. 

The following code snippet triggered this exception:

https://github.com/vuejs/core/blob/a3dddd62059f4a7a762046c1e7f01485b96e737d/packages/runtime-core/src/errorHandling.ts#L78-L83

Vue3 is developed using TypeScript, which defaults the type of `fn` to be a function or an array of functions. When we pass a string as an argument, it leads to an infinite loop.