### PR TITLE
fix: issue where `c` type is `any`

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -1055,7 +1055,7 @@ export function getExposeProxy(instance: ComponentInternalInstance) {
 
 const classifyRE = /(?:^|[-_])(\w)/g
 const classify = (str: string): string =>
-  str.replace(classifyRE, c => c.toUpperCase()).replace(/[-_]/g, '')
+  str.replace(classifyRE, c => c.toString().toUpperCase()).replace(/[-_]/g, '')
 
 export function getComponentName(
   Component: ConcreteComponent,

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -100,7 +100,7 @@ const camelizeRE = /-(\w)/g
  * @private
  */
 export const camelize = cacheStringFunction((str: string): string => {
-  return str.replace(camelizeRE, (_, c) => (c ? c.toUpperCase() : ''))
+  return str.replace(camelizeRE, (_, c) => (c ? c.toString().toUpperCase() : ''))
 })
 
 const hyphenateRE = /\B([A-Z])/g

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -100,7 +100,9 @@ const camelizeRE = /-(\w)/g
  * @private
  */
 export const camelize = cacheStringFunction((str: string): string => {
-  return str.replace(camelizeRE, (_, c) => (c ? c.toString().toUpperCase() : ''))
+  return str.replace(camelizeRE, (_, c) =>
+    c ? c.toString().toUpperCase() : ''
+  )
 })
 
 const hyphenateRE = /\B([A-Z])/g


### PR DESCRIPTION
While running nuxt app, I was getting the error `c.toUpperCase is not a function`, after digging in the vite builds, found out that these functions `classify` & `camelize` are the root cause.

- [x] This PR fixes the issue (we have `c` which is of type `any` & [`toUpperString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase) only works on String prototype.

Issue Repro – 

1. Clone – https://github.com/geoql/expenses
2. npm ci
3. npm run dev

<img width="1421" alt="Screenshot 2023-07-29 at 12 56 51 AM" src="https://github.com/vuejs/core/assets/19776877/770e6f48-bded-47a1-a00c-89f398c82a2e">

For context, Nuxi info

```
------------------------------
- Operating System: Darwin
- Node Version:     v20.4.0
- Nuxt Version:     3.6.5
- Nitro Version:    2.5.2
- Package Manager:  npm@9.8.1
- Builder:          vite
- User Config:      app, components, css, devtools, experimental, vue, ssr, modules, nitro, plugins, routeRules, runtimeConfig, typescript
- Runtime Modules:  @pinia/nuxt@0.4.11, @vueuse/nuxt@10.2.1, @nuxtjs/plausible@0.2.1, @unocss/nuxt@0.53.6
- Build Modules:    -
------------------------------
```