### PR TITLE
feat: Implement a configuration parameter to enable strict `readonly` (proposal)

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -252,6 +252,34 @@ export const readonlyHandlers: ProxyHandler<object> = {
   }
 }
 
+export const strictReadonlyHandlers: ProxyHandler<object> = {
+  get: readonlyGet,
+  set(target, key) {
+    if (__DEV__) {
+      warn(
+        `Set operation on key "${String(key)}" failed: target is readonly.`,
+        target
+      )
+      throw new Error(
+        `Set operation on key "${String(key)}" failed: target is readonly.`,
+      )
+    }
+    return true
+  },
+  deleteProperty(target, key) {
+    if (__DEV__) {
+      warn(
+        `Delete operation on key "${String(key)}" failed: target is readonly.`,
+        target
+      )
+      throw new Error(
+        `Delete operation on key "${String(key)}" failed: target is readonly.`,
+      )
+    }
+    return true
+  }
+}
+
 export const shallowReactiveHandlers = /*#__PURE__*/ extend(
   {},
   mutableHandlers,

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -260,11 +260,10 @@ export const strictReadonlyHandlers: ProxyHandler<object> = {
         `Set operation on key "${String(key)}" failed: target is readonly.`,
         target
       )
-      throw new Error(
-        `Set operation on key "${String(key)}" failed: target is readonly.`,
-      )
     }
-    return true
+    throw new Error(
+      `Set operation on key "${String(key)}" failed: target is readonly.`,
+    )
   },
   deleteProperty(target, key) {
     if (__DEV__) {
@@ -272,11 +271,10 @@ export const strictReadonlyHandlers: ProxyHandler<object> = {
         `Delete operation on key "${String(key)}" failed: target is readonly.`,
         target
       )
-      throw new Error(
-        `Delete operation on key "${String(key)}" failed: target is readonly.`,
-      )
     }
-    return true
+    throw new Error(
+      `Delete operation on key "${String(key)}" failed: target is readonly.`,
+    )
   }
 }
 

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -2,6 +2,7 @@ import { isObject, toRawType, def } from '@vue/shared'
 import {
   mutableHandlers,
   readonlyHandlers,
+  strictReadonlyHandlers,
   shallowReactiveHandlers,
   shallowReadonlyHandlers
 } from './baseHandlers'
@@ -163,7 +164,10 @@ export type DeepReadonly<T> = T extends Builtin
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
   : Readonly<T>
-
+interface ReadonlyOptions { 
+  strict?: boolean 
+}
+  
 /**
  * Takes an object (reactive or plain) or a ref and returns a readonly proxy to
  * the original.
@@ -194,12 +198,13 @@ export type DeepReadonly<T> = T extends Builtin
  * @see {@link https://vuejs.org/api/reactivity-core.html#readonly}
  */
 export function readonly<T extends object>(
-  target: T
+  target: T,
+  options: ReadonlyOptions = {}
 ): DeepReadonly<UnwrapNestedRefs<T>> {
   return createReactiveObject(
     target,
     true,
-    readonlyHandlers,
+    options.strict ? strictReadonlyHandlers : readonlyHandlers,
     readonlyCollectionHandlers,
     readonlyMap
   )


### PR DESCRIPTION
This PR represents a proposal to enable strict `readonly()` , where additionally to the console `warn` an `Error` is also thrown.

Usage: 
```typescript
const myStrictReadonlyObj = readonly( {foo: 123} , {strict: true} } )

myStrictReadonlyObj.foo = 456
// Console warn +  error : `Set operation on key "foo" failed: target is readonly.`
```

