### PR TITLE
feat(reactivity): strictMode option for readonly and shallowReadonly

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -90,6 +90,38 @@ describe('reactivity/readonly', () => {
       ).toHaveBeenWarnedLast()
     })
 
+    describe('warn/error', () => {
+      it('should throw an error when strict mode is true', () => {
+        const original = readonly({ foo: 1 }, { strict: true })
+        expect(() => {
+          // @ts-expect-error
+          original.foo = 2
+        }).toThrowError(
+          `Set operation on key "foo" failed: target is readonly.`
+        )
+        expect(() => {
+          // @ts-expect-error
+          delete original.foo
+        }).toThrowError(
+          `Delete operation on key "foo" failed: target is readonly`
+        )
+      })
+      it('should warn error when strict mode is false', () => {
+        const original = readonly({ foo: 1 })
+        // @ts-expect-error
+        original.foo = 2
+        expect(original.foo).toBe(1)
+        expect(
+          `Set operation on key "foo" failed: target is readonly.`
+        ).toHaveBeenWarned()
+        // @ts-expect-error
+        delete original.foo
+        expect(
+          `Delete operation on key "foo" failed: target is readonly.`
+        ).toHaveBeenWarnedLast()
+      })
+    })
+
     it('should not trigger effects', () => {
       const wrapped: any = readonly({ a: 1 })
       let dummy

--- a/packages/reactivity/__tests__/shallowReadonly.spec.ts
+++ b/packages/reactivity/__tests__/shallowReadonly.spec.ts
@@ -37,6 +37,36 @@ describe('reactivity/shallowReadonly', () => {
     expect(isReadonly(reactiveProxy.foo)).toBe(true)
   })
 
+  describe('warn/error', () => {
+    it('should throw an error when strict mode is true and property is readonly', () => {
+      const original = shallowReadonly({ foo: 1 }, { strict: true })
+      expect(() => {
+        // @ts-expect-error
+        original.foo = 2
+      }).toThrowError(`Set operation on key "foo" failed: target is readonly.`)
+      expect(() => {
+        // @ts-expect-error
+        delete original.foo
+      }).toThrowError(
+        `Delete operation on key "foo" failed: target is readonly`
+      )
+    })
+    it('should warn error when strict mode is false and property is readonly', () => {
+      const original = shallowReadonly({ foo: 1 })
+      // @ts-expect-error
+      original.foo = 2
+      expect(original.foo).toBe(1)
+      expect(
+        `Set operation on key "foo" failed: target is readonly.`
+      ).toHaveBeenWarned()
+      // @ts-expect-error
+      delete original.foo
+      expect(
+        `Delete operation on key "foo" failed: target is readonly.`
+      ).toHaveBeenWarnedLast()
+    })
+  })
+
   describe('collection/Map', () => {
     ;[Map, WeakMap].forEach(Collection => {
       test('should make the map/weak-map readonly', () => {

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -40,6 +40,10 @@ const enum TargetType {
   COLLECTION = 2
 }
 
+export interface StrictMode {
+  strict: boolean
+}
+
 function targetTypeMap(rawType: string) {
   switch (rawType) {
     case 'Object':
@@ -194,12 +198,13 @@ export type DeepReadonly<T> = T extends Builtin
  * @see {@link https://vuejs.org/api/reactivity-core.html#readonly}
  */
 export function readonly<T extends object>(
-  target: T
+  target: T,
+  strictMode?: StrictMode
 ): DeepReadonly<UnwrapNestedRefs<T>> {
   return createReactiveObject(
     target,
     true,
-    readonlyHandlers,
+    readonlyHandlers(strictMode),
     readonlyCollectionHandlers,
     readonlyMap
   )
@@ -235,11 +240,14 @@ export function readonly<T extends object>(
  * @param target - The source object.
  * @see {@link https://vuejs.org/api/reactivity-advanced.html#shallowreadonly}
  */
-export function shallowReadonly<T extends object>(target: T): Readonly<T> {
+export function shallowReadonly<T extends object>(
+  target: T,
+  strictMode?: StrictMode
+): Readonly<T> {
   return createReactiveObject(
     target,
     true,
-    shallowReadonlyHandlers,
+    shallowReadonlyHandlers(strictMode),
     shallowReadonlyCollectionHandlers,
     shallowReadonlyMap
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
## Strict Mode Option to readonly and shallowReadonly

This PR introduces a strictMode option to the readonly and shallowReadonly functionalities, enhancing safety when handling readonly variables. With strict mode enabled, attempting to mutate a readonly variable will result in an error, providing immediate feedback to developers instead of a console warning. 

### Motivation:

Enabling strict mode in readonly and shallowReadonly it will be beneficial for large projects with complex data structures, it ensures data integrity and boosts code predictability, reducing the risk of subtle bugs caused by mutable readonly variables. Additionally, by throwing an error, this will help advanced debugging tools to track and analyse these attempted mutations.

## Changes
The readonly and shallowReadonly functions have been updated to include a new parameter:

```ts
export function readonly<T extends object>(
  target: T,
  strictMode?: StrictMode
): DeepReadonly<UnwrapNestedRefs<T>> {
  return createReactiveObject(
    target,
    true,
    readonlyHandlers(strictMode),
    readonlyCollectionHandlers,
    readonlyMap
  )
}

```
## Usage Example
```ts

const state = readonly({ count: 0 }, {strict: true}); // Enabling strict mode

try {
  state.count = 10; // Throws an error in strict mode, preventing accidental mutation
} catch (error) {
  console.error('Error:', error.message); // Output: "Error: Cannot assign to read-only property 'count' of object '#<Object>'"
}

```

The strictMode parameter is optional and can be set to one of the following values:

- true: In strict mode, any attempt to mutate a readonly variable will throw an error. This helps explicitly track all mutation intents, making debugging more straightforward.

- false (default): If strictMode is not provided or set to false, the previous behavior without strict mode will be maintained.

## Related Issues

[Closes #8919] (if applicable)

Thank you! 😄