### PR TITLE
feat(compiler-core): add current filename to TransformContext

### DIFF
--- a/packages/compiler-core/__tests__/transform.spec.ts
+++ b/packages/compiler-core/__tests__/transform.spec.ts
@@ -200,6 +200,25 @@ describe('compiler: transform', () => {
     expect((ast as any).children[0].props[0].exp.content).toBe(`_hoisted_1`)
     expect((ast as any).children[1].props[0].exp.content).toBe(`_hoisted_2`)
   })
+  
+  test('context.filename', () => {
+    const ast = baseParse(`<div />`)
+    
+    const calls: any[] = []
+    const plugin: NodeTransform = (node, context) => {
+      calls.push({ ...context })
+    }
+    
+    transform(ast, {
+      filename: '/the/filename.vue',
+      nodeTransforms: [plugin]
+    })
+    
+    expect(calls.length).toBe(2)
+    expect(calls[1]).toMatchObject({
+      filename: '/the/filename.vue'
+    })
+  })
 
   test('onError option', () => {
     const ast = baseParse(`<div/>`)

--- a/packages/compiler-core/__tests__/transform.spec.ts
+++ b/packages/compiler-core/__tests__/transform.spec.ts
@@ -201,7 +201,7 @@ describe('compiler: transform', () => {
     expect((ast as any).children[1].props[0].exp.content).toBe(`_hoisted_2`)
   })
   
-  test('context.filename', () => {
+  test('context.filename and selfName', () => {
     const ast = baseParse(`<div />`)
     
     const calls: any[] = []
@@ -210,13 +210,14 @@ describe('compiler: transform', () => {
     }
     
     transform(ast, {
-      filename: '/the/filename.vue',
+      filename: '/the/fileName.vue',
       nodeTransforms: [plugin]
     })
     
     expect(calls.length).toBe(2)
     expect(calls[1]).toMatchObject({
-      filename: '/the/filename.vue'
+      filename: '/the/fileName.vue',
+      selfName: 'FileName'
     })
   })
 

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -84,7 +84,7 @@ export interface ImportItem {
 
 export interface TransformContext
   extends Required<
-      Omit<TransformOptions, 'filename' | keyof CompilerCompatOptions>
+      Omit<TransformOptions, keyof CompilerCompatOptions>
     >,
     CompilerCompatOptions {
   selfName: string | null
@@ -152,6 +152,7 @@ export function createTransformContext(
   const nameMatch = filename.replace(/\?.*$/, '').match(/([^/\\]+)\.\w+$/)
   const context: TransformContext = {
     // options
+    filename,
     selfName: nameMatch && capitalize(camelize(nameMatch[1])),
     prefixIdentifiers,
     hoistStatic,


### PR DESCRIPTION
When using `nodeTransform`, I have found myself needing the absolute path in which the component is to do filesystem operations, which well cannot be done without that and I don't think a fork of the compiler is warranted for just that ;)

Since we already have this available to infer the component name, why not just pass it in the context to make it available to hooks?

This has no effect to the core and just allows plugins to use the current filename in hooks like `nodeTransforms` and `directiveTransforms`