### PR TITLE
chore: lock closed issues after 14 days

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,0 +1,20 @@
+name: Lock Closed Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    if: github.repository == 'vuejs/core'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-inactive-days: '14'
+          issue-lock-reason: ''
+          process-only: 'issues'


### PR DESCRIPTION
Check issues closed for more than 14 days, and lock them.

Refer to https://github.com/vitejs/vite/pull/4195.