### PR TITLE
fix(compiler-core): properly rewrite identifier of for

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/transformExpressions.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/transformExpressions.spec.ts.snap
@@ -13,3 +13,17 @@ return function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock(\\"div\\", null, _toDisplayString($props.props) + \\" \\" + _toDisplayString($setup.setup) + \\" \\" + _toDisplayString($data.data) + \\" \\" + _toDisplayString($options.options), 1 /* TEXT */))
 }"
 `;
+
+exports[`compiler: expression transform > bindingMetadata > should not prefix temp variable of for 1`] = `
+"const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+return function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\\"div\\", {
+    onClick: () => {
+          for (let i = 0; i < 10; i++) {
+            _ctx.log(i,_ctx.arr[i])
+          }         
+        }
+  }, null, 8 /* PROPS */, [\\"onClick\\"]))
+}"
+`;

--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -574,5 +574,17 @@ describe('compiler: expression transform', () => {
         `${PatchFlags.TEXT} /* ${PatchFlagNames[PatchFlags.TEXT]} */`
       )
     })
+
+    test('should not prefix temp variable of for', () => {
+      const { code } = compileWithBindingMetadata(
+        `<div @click="() => {
+          for (let i = 0; i < 10; i++) {
+            log(i,arr[i])
+          }         
+        }"/>`
+      )
+      expect(code).not.toMatch(`_ctx.i`)
+      expect(code).toMatchSnapshot()
+    })
   })
 })

--- a/packages/compiler-core/src/babelUtils.ts
+++ b/packages/compiler-core/src/babelUtils.ts
@@ -165,6 +165,14 @@ export function walkBlockDeclarations(
     ) {
       if (stmt.declare || !stmt.id) continue
       onIdent(stmt.id)
+    } else if (stmt.type === 'ForStatement') {
+      if (stmt.init?.type === 'VariableDeclaration') {
+        for (const decl of stmt.init.declarations) {
+          for (const id of extractIdentifiers(decl.id)) {
+            onIdent(id)
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I think #7245  should take into account the case of for loop

example:
~~~html
<div @click = "() => {
	for(let i = 0; i < 10; i++){
		console.log(i,arr[i])
	}
}"/>
~~~

i think the for loop should compiler to:
~~~text
	for (let i = 0; i < 10; i++) {
            _ctx.log(i,_ctx.arr[i])
    }
~~~
but now it is:
~~~text
	for (let i = 0; _ctx.i < 10; _ctx.i++) {
      _ctx.log(_ctx.i,_ctx.arr[_ctx.i])
  	}
~~~
   