### PR TITLE
fix(compiler-core): add isTemplateFor to ast of For nodes

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vFor.spec.ts
@@ -202,6 +202,17 @@ describe('compiler: v-for', () => {
       expect(forNode.valueAlias).toBeUndefined()
       expect((forNode.source as SimpleExpressionNode).content).toBe('items')
     })
+
+    test('is template property', () => {
+      const { node: spanForNode } = parseWithForTransform(
+          '<span v-for="index in 5" />'
+      )
+      const { node: templateForNode } = parseWithForTransform(
+          '<template v-for="index in 5" />'
+      )
+      expect(spanForNode.isTemplateFor).toBe(false)
+      expect(templateForNode.isTemplateFor).toBe(true)
+    })
   })
 
   describe('errors', () => {

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -274,6 +274,7 @@ export interface ForNode extends Node {
   parseResult: ForParseResult
   children: TemplateChildNode[]
   codegenNode?: ForCodegenNode
+  isTemplateFor?: boolean
 }
 
 export interface TextCallNode extends Node {

--- a/packages/compiler-core/src/transforms/vFor.ts
+++ b/packages/compiler-core/src/transforms/vFor.ts
@@ -271,6 +271,7 @@ export function processFor(
 
   const { addIdentifiers, removeIdentifiers, scopes } = context
   const { source, value, key, index } = parseResult
+  const isTemplate = isTemplateNode(node)
 
   const forNode: ForNode = {
     type: NodeTypes.FOR,
@@ -280,7 +281,8 @@ export function processFor(
     keyAlias: key,
     objectIndexAlias: index,
     parseResult,
-    children: isTemplateNode(node) ? node.children : [node]
+    children: isTemplate ? node.children : [node],
+    isTemplateFor: isTemplate
   }
 
   context.replaceNode(forNode)


### PR DESCRIPTION
There is an inconsistency in the generated ast between `v-for` and `v-if`, the `v-for` only returns one root node and then the children, the `v-if` returns one node and branch nodes

Here is a demonstration https://codesandbox.io/p/sandbox/priceless-cache-t7zwzg

While we can work around this inconsistency for the most part, the original node properties on the `v-for` are entirely lost, there is just no way to know if the node is a template or an element by looking at it to reverse engineer the ast

Even the `loc.source` does not give this information like the `v-if` does (unless looking into the `codeGen.loc.source`)

Here is the difference in `loc` between a v-for
```js
{
    start: { column: 3, line: 3, offset: 13 },
    end: { column: 24, line: 3, offset: 34 },
    source: 'v-for="test in test2"'
  }
```
and a v-if
```js
{
    start: { column: 1, line: 2, offset: 1 },
    end: { column: 12, line: 5, offset: 55 },
    source: '<template\n    v-if="test">\n    <div></div>\n</template>'
}
```

As we can see the v-for completely drops it's parent information and uses the information of the directive, while the v-if uses the information of the `Element` on which it was found

This PR aims to aleviate a bit the trouble by adding a `isTemplateFor` to the `ForNode` to indicate whether the original is a template or an element to know how to interpret the children nodes properly when we reverse engineer the AST