### PR TITLE
fix(types: compiler-core): specificity of type of ForIteratorExpression

### DIFF
--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -538,7 +538,7 @@ export interface ForRenderListExpression extends CallExpression {
 }
 
 export interface ForIteratorExpression extends FunctionExpression {
-  returns: BlockCodegenNode
+  returns: ForCodegenNode
 }
 
 // AST Utilities ---------------------------------------------------------------


### PR DESCRIPTION
The ForIteratorExpression `returns` can only be a `ForCodegenNode`