### PR TITLE
types: replace undefined types with optional parameters

### DIFF
--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -291,16 +291,15 @@ export interface VNodeCall extends Node {
   type: NodeTypes.VNODE_CALL
   tag: string | symbol | CallExpression
   props: PropsExpression | undefined
-  children:
+  children?:
     | TemplateChildNode[] // multiple children
     | TemplateTextChildNode // single text child
     | SlotsExpression // component slots
     | ForRenderListExpression // v-for fragment call
     | SimpleExpressionNode // hoisted
-    | undefined
-  patchFlag: string | undefined
-  dynamicProps: string | SimpleExpressionNode | undefined
-  directives: DirectiveArguments | undefined
+  patchFlag?: string
+  dynamicProps?: string | SimpleExpressionNode
+  directives?: DirectiveArguments
   isBlock: boolean
   disableTracking: boolean
   isComponent: boolean

--- a/packages/compiler-dom/src/parserOptions.ts
+++ b/packages/compiler-dom/src/parserOptions.ts
@@ -36,7 +36,7 @@ export const parserOptions: ParserOptions = {
   },
 
   // https://html.spec.whatwg.org/multipage/parsing.html#tree-construction-dispatcher
-  getNamespace(tag: string, parent: ElementNode | undefined): DOMNamespaces {
+  getNamespace(tag: string, parent?: ElementNode): DOMNamespaces {
     let ns = parent ? parent.ns : DOMNamespaces.HTML
 
     if (parent && ns === DOMNamespaces.MATH_ML) {

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -53,7 +53,7 @@ export const MAP_KEY_ITERATE_KEY = Symbol(__DEV__ ? 'Map key iterate' : '')
 export class ReactiveEffect<T = any> {
   active = true
   deps: Dep[] = []
-  parent: ReactiveEffect | undefined = undefined
+  parent?: ReactiveEffect
 
   /**
    * Can be attached after creation

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -21,18 +21,18 @@ export class EffectScope {
    * only assigned by undetached scope
    * @internal
    */
-  parent: EffectScope | undefined
+  parent?: EffectScope
   /**
    * record undetached scopes
    * @internal
    */
-  scopes: EffectScope[] | undefined
+  scopes?: EffectScope[]
   /**
    * track a child scope's index in its parent's scopes array for optimized
    * removal
    * @internal
    */
-  private index: number | undefined
+  private index?: number
 
   constructor(public detached = false) {
     this.parent = activeEffectScope

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -1082,7 +1082,7 @@ export function formatComponentName(
 
   if (!name && instance && instance.parent) {
     // try to infer the name based on reverse resolution
-    const inferFromRegistry = (registry: Record<string, any> | undefined) => {
+    const inferFromRegistry = (registry?: Record<string, any>) => {
       for (const key in registry) {
         if (registry[key] === Component) {
           return key

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -1113,7 +1113,7 @@ function mergeInject(
 }
 
 function normalizeInject(
-  raw: ComponentInjectOptions | undefined
+  raw?: ComponentInjectOptions
 ): ObjectInjectOptions | undefined {
   if (isArray(raw)) {
     const res: ObjectInjectOptions = {}
@@ -1133,21 +1133,12 @@ function mergeObjectOptions(to: Object | undefined, from: Object | undefined) {
   return to ? extend(Object.create(null), to, from) : from
 }
 
-function mergeEmitsOrPropsOptions(
-  to: EmitsOptions | undefined,
-  from: EmitsOptions | undefined
-): EmitsOptions | undefined
-function mergeEmitsOrPropsOptions(
-  to: ComponentPropsOptions | undefined,
-  from: ComponentPropsOptions | undefined
-): ComponentPropsOptions | undefined
-function mergeEmitsOrPropsOptions(
-  to: ComponentPropsOptions | EmitsOptions | undefined,
-  from: ComponentPropsOptions | EmitsOptions | undefined
-) {
+function mergeEmitsOrPropsOptions<
+  T extends ComponentPropsOptions | EmitsOptions
+>(to?: T, from?: T): T | undefined {
   if (to) {
     if (isArray(to) && isArray(from)) {
-      return [...new Set([...to, ...from])]
+      return [...new Set([...to, ...from])] as T
     }
     return extend(
       Object.create(null),

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -1129,7 +1129,7 @@ function mergeAsArray<T = Function>(to: T[] | T | undefined, from: T | T[]) {
   return to ? [...new Set([].concat(to as any, from as any))] : from
 }
 
-function mergeObjectOptions(to: Object | undefined, from: Object | undefined) {
+function mergeObjectOptions(to?: Object, from?: Object) {
   return to ? extend(Object.create(null), to, from) : from
 }
 
@@ -1151,8 +1151,8 @@ function mergeEmitsOrPropsOptions<
 }
 
 function mergeWatchOptions(
-  to: ComponentWatchOptions | undefined,
-  from: ComponentWatchOptions | undefined
+  to?: ComponentWatchOptions,
+  from?: ComponentWatchOptions
 ) {
   if (!to) return from
   if (!from) return to

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -414,7 +414,7 @@ export class VueElement extends BaseClass {
     return vnode
   }
 
-  private _applyStyles(styles: string[] | undefined) {
+  private _applyStyles(styles?: string[]) {
     if (styles) {
       styles.forEach(css => {
         const s = document.createElement('style')

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -83,10 +83,7 @@ export const TransitionPropsValidators = (Transition.props =
  * #3227 Incoming hooks may be merged into arrays when wrapping Transition
  * with custom HOCs.
  */
-const callHook = (
-  hook: Function | Function[] | undefined,
-  args: any[] = []
-) => {
+const callHook = (hook?: Function | Function[], args: any[] = []) => {
   if (isArray(hook)) {
     hook.forEach(h => h(...args))
   } else if (hook) {
@@ -98,9 +95,7 @@ const callHook = (
  * Check if a hook expects a callback (2nd arg), which means the user
  * intends to explicitly control the end of the transition.
  */
-const hasExplicitCallback = (
-  hook: Function | Function[] | undefined
-): boolean => {
+const hasExplicitCallback = (hook?: Function | Function[]): boolean => {
   return hook
     ? isArray(hook)
       ? hook.some(h => h.length > 1)

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -272,7 +272,7 @@ export const vModelDynamic: ObjectDirective<
   }
 }
 
-function resolveDynamicModel(tagName: string, type: string | undefined) {
+function resolveDynamicModel(tagName: string, type?: string) {
   switch (tagName) {
     case 'SELECT':
       return vModelSelect

--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -59,7 +59,7 @@ export function patchEvent(
 
 const optionsModifierRE = /(?:Once|Passive|Capture)$/
 
-function parseName(name: string): [string, EventListenerOptions | undefined] {
+function parseName(name: string): [string, EventListenerOptions?] {
   let options: EventListenerOptions | undefined
   if (optionsModifierRE.test(name)) {
     options = {}

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -42,9 +42,7 @@ export function parseStringStyle(cssText: string): NormalizedStyle {
   return ret
 }
 
-export function stringifyStyle(
-  styles: NormalizedStyle | string | undefined
-): string {
+export function stringifyStyle(styles?: NormalizedStyle | string): string {
   let ret = ''
   if (!styles || isString(styles)) {
     return ret


### PR DESCRIPTION
Replace undefined types with optional parameters.

```ts
  function fn(value: string | undefined){
    // ...
  }
```

to:

```ts
  function fn(value?: string){
    // ...
  }
```