### PR TITLE
feat(compiler-sfc): Hoist leading comment of `defineOptions` to `export default`

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineOptions.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineOptions.spec.ts.snap
@@ -25,3 +25,51 @@ return {  }
 
 }"
 `;
+
+exports[`defineOptions() > should hoist comments even when called with no arguments 1`] = `
+"/** Script docstring. */
+const __default__ = {}
+
+/** Script setup docstring 1 */
+// Script setup docstring 2
+/**
+ * Script setup docstring 3
+ */
+export default /*#__PURE__*/Object.assign(__default__, {
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+
+
+
+
+
+return {  }
+}
+
+})"
+`;
+
+exports[`defineOptions() > should hoist leading comments up to export default 1`] = `
+"/** Script docstring. */
+const __default__ = {}
+
+/** Script setup docstring 1 */
+// Script setup docstring 2
+/**
+ * Script setup docstring 3
+ */
+export default /*#__PURE__*/Object.assign(__default__, {}, {
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+
+
+
+
+
+return {  }
+}
+
+})"
+`;

--- a/packages/compiler-sfc/src/script/context.ts
+++ b/packages/compiler-sfc/src/script/context.ts
@@ -1,4 +1,10 @@
-import { CallExpression, Node, ObjectPattern, Program } from '@babel/types'
+import {
+  CallExpression,
+  Comment,
+  Node,
+  ObjectPattern,
+  Program
+} from '@babel/types'
 import { SFCDescriptor } from '../parse'
 import { generateCodeFrame } from '@vue/shared'
 import { parse as babelParse, ParserPlugin } from '@babel/parser'
@@ -56,6 +62,7 @@ export class ScriptCompileContext {
   modelDecls: Record<string, ModelDecl> = {}
 
   // defineOptions
+  optionsLeadingComments: Comment[] = []
   optionsRuntimeDecl: Node | undefined
 
   // codegen

--- a/packages/compiler-sfc/src/script/defineOptions.ts
+++ b/packages/compiler-sfc/src/script/defineOptions.ts
@@ -1,4 +1,4 @@
-import { Node } from '@babel/types'
+import { Node, Comment } from '@babel/types'
 import { ScriptCompileContext } from './context'
 import { isCallOf, unwrapTSNode } from './utils'
 import { DEFINE_PROPS } from './defineProps'
@@ -10,7 +10,8 @@ export const DEFINE_OPTIONS = 'defineOptions'
 
 export function processDefineOptions(
   ctx: ScriptCompileContext,
-  node: Node
+  node: Node,
+  leadingComments: Comment[] = []
 ): boolean {
   if (!isCallOf(node, DEFINE_OPTIONS)) {
     return false
@@ -21,6 +22,10 @@ export function processDefineOptions(
   if (node.typeParameters) {
     ctx.error(`${DEFINE_OPTIONS}() cannot accept type arguments`, node)
   }
+
+  // Always setting leadingComments, even when called with no arguments.
+  ctx.optionsLeadingComments = leadingComments
+
   if (!node.arguments[0]) return true
 
   ctx.hasDefineOptionsCall = true


### PR DESCRIPTION
See also: https://github.com/vue-styleguidist/vue-styleguidist/issues/1399, https://github.com/vuejs/language-tools/issues/1894.

This PR allows to document components made in composition-api style:
```vue
<script setup lang="ts">
/**
 * Component documentation comment.
 * @version 12.5.7
 * @beta
 */
defineOptions();
</script>
```