### PR TITLE
chore(eslint): update eslint `no-unused-vars` rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,12 +9,6 @@ module.exports = {
   plugins: ['jest'],
   rules: {
     'no-debugger': 'error',
-    'no-unused-vars': [
-      'error',
-      // we are only using this rule to check for unused arguments since TS
-      // catches unused variables but not args.
-      { varsIgnorePattern: '.*', args: 'none' }
-    ],
     // most of the codebase are expected to be env agnostic
     'no-restricted-globals': ['error', ...DOMGlobals, ...NodeGlobals],
 
@@ -70,6 +64,13 @@ module.exports = {
       rules: {
         'no-restricted-globals': ['error', ...NodeGlobals],
         'no-restricted-syntax': 'off'
+      }
+    },
+    // JavaScript files
+    {
+      files: ['*.js'],
+      rules: {
+        'no-unused-vars': ['error', { vars: 'all', args: 'none' }]
       }
     },
     // Node scripts

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -70,6 +70,7 @@ module.exports = {
     {
       files: ['*.js'],
       rules: {
+        // We only do `no-unused-vars` checks for js files, TS files are checked by TypeScript itself.
         'no-unused-vars': ['error', { vars: 'all', args: 'none' }]
       }
     },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-globals */
+
 const DOMGlobals = ['window', 'document']
 const NodeGlobals = ['module', 'require']
 
@@ -68,7 +70,7 @@ module.exports = {
     },
     // JavaScript files
     {
-      files: ['*.js'],
+      files: ['*.js', '*.cjs'],
       rules: {
         // We only do `no-unused-vars` checks for js files, TS files are checked by TypeScript itself.
         'no-unused-vars': ['error', { vars: 'all', args: 'none' }]

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,7 +17,7 @@ nr build core --formats cjs
 */
 
 import fs from 'node:fs/promises'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 import minimist from 'minimist'
 import { gzipSync, brotliCompressSync } from 'node:zlib'


### PR DESCRIPTION
We have excluded the `no-unused-vars` rule for TypeScript (`.ts`) files in our existing ESLint configuration, as TypeScript inherently checks for unused variables. However, if we don't configure this rule, ESLint won't perform the `no-unused-vars` check for TypeScript files. Nevertheless, we do need to enable this rule for JavaScript (`.js`) files to ensure that variables defined in JavaScript files are also being utilized.

```diff
-    'no-unused-vars': [
-      'error',
-      // we are only using this rule to check for unused arguments since TS
-      // catches unused variables but not args.
-      { varsIgnorePattern: '.*', args: 'none' }
-    ],

+    {
+      files: ['*.js'],
+      rules: {
+        // We only do `no-unused-vars` checks for js files, TS files are checked by TypeScript itself.
+        'no-unused-vars': ['error', { vars: 'all', args: 'none' }]
+      }
+    },
```