### PR TITLE
feat(runtime-core): add `once` option to watch 

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -32,7 +32,6 @@ import {
   effectScope,
   toRef
 } from '@vue/reactivity'
-import { expect } from 'vitest'
 
 // reference: https://vue-composition-api-rfc.netlify.com/api.html#watch
 
@@ -1244,5 +1243,4 @@ describe('api: watch', () => {
     expect(count.value).toBe(2)
     expect(cb).toHaveBeenCalledTimes(1)
   })
-  // watch once with immediate
 })

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -32,6 +32,7 @@ import {
   effectScope,
   toRef
 } from '@vue/reactivity'
+import { expect } from 'vitest'
 
 // reference: https://vue-composition-api-rfc.netlify.com/api.html#watch
 
@@ -1205,4 +1206,43 @@ describe('api: watch', () => {
     expect(countWE).toBe(3)
     expect(countW).toBe(2)
   })
+
+  const options = [
+    { name: 'only trigger once watch' },
+    {
+      deep: true,
+      name: 'only trigger once watch with deep'
+    },
+    {
+      flush: 'sync',
+      name: 'only trigger once watch with flush: sync'
+    },
+    {
+      flush: 'pre',
+      name: 'only trigger once watch with flush: pre'
+    },
+    {
+      immediate: true,
+      name: 'only trigger once watch with immediate'
+    }
+  ] as const
+  test.each(options)('$name', async option => {
+    const count = ref(0)
+    const cb = vi.fn()
+
+    watch(count, cb, { once: true, ...option })
+
+    count.value++
+    await nextTick()
+
+    expect(count.value).toBe(1)
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    count.value++
+    await nextTick()
+
+    expect(count.value).toBe(2)
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+  // watch once with immediate
 })

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -198,7 +198,7 @@ function doWatch(
     }
     if (once !== undefined) {
       warn(
-        `watch() "deep" option is only respected when using the ` +
+        `watch() "once" option is only respected when using the ` +
           `watch(source, callback, options?) signature.`
       )
     }

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -75,6 +75,7 @@ export interface WatchOptionsBase extends DebuggerOptions {
 export interface WatchOptions<Immediate = boolean> extends WatchOptionsBase {
   immediate?: Immediate
   deep?: boolean
+  once?: boolean
 }
 
 export type WatchStopHandle = () => void
@@ -172,8 +173,16 @@ export function watch<T = any, Immediate extends Readonly<boolean> = false>(
 function doWatch(
   source: WatchSource | WatchSource[] | WatchEffect | object,
   cb: WatchCallback | null,
-  { immediate, deep, flush, onTrack, onTrigger }: WatchOptions = EMPTY_OBJ
+  { immediate, deep, flush, once, onTrack, onTrigger }: WatchOptions = EMPTY_OBJ
 ): WatchStopHandle {
+  if (cb && once) {
+    const _cb = cb
+    cb = (...args) => {
+      _cb(...args)
+      unwatch()
+    }
+  }
+
   if (__DEV__ && !cb) {
     if (immediate !== undefined) {
       warn(
@@ -182,6 +191,12 @@ function doWatch(
       )
     }
     if (deep !== undefined) {
+      warn(
+        `watch() "deep" option is only respected when using the ` +
+          `watch(source, callback, options?) signature.`
+      )
+    }
+    if (once !== undefined) {
       warn(
         `watch() "deep" option is only respected when using the ` +
           `watch(source, callback, options?) signature.`
@@ -363,6 +378,13 @@ function doWatch(
 
   const effect = new ReactiveEffect(getter, scheduler)
 
+  const unwatch = () => {
+    effect.stop()
+    if (instance && instance.scope) {
+      remove(instance.scope.effects!, effect)
+    }
+  }
+
   if (__DEV__) {
     effect.onTrack = onTrack
     effect.onTrigger = onTrigger
@@ -382,13 +404,6 @@ function doWatch(
     )
   } else {
     effect.run()
-  }
-
-  const unwatch = () => {
-    effect.stop()
-    if (instance && instance.scope) {
-      remove(instance.scope.effects!, effect)
-    }
   }
 
   if (__SSR__ && ssrCleanup) ssrCleanup.push(unwatch)


### PR DESCRIPTION
In certain scenarios, there are instances when I only need to use the `watch` function to monitor data changes once. For example, when detecting duplicate submissions of a form. Currently, my approach involves calling the `stop` function within the callback, but this method lacks elegance. Hence, I have introduced an `once` parameter to the `watch` function. When the `once` parameter is set to `true`, it automatically stops monitoring after the initial change is detected.

Now:
```ts
const formData = ref({
  name: 'John',
  age: 18
})

const stop = watch(formData, (newVal, oldVal) => {
  console.log(newVal, oldVal)
  stop()
})

```

Expect: 
```ts
const formData = ref({
  name: 'John',
  age: 18
})

watch(formData, (newVal, oldVal) => {
  console.log(newVal, oldVal)
}, { once: true })

```