### PR TITLE
types: introduce `Arrayable` and `Awaitable` utility types

### DIFF
--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -1,4 +1,4 @@
-import { isString } from '@vue/shared'
+import { type Arrayable, isString } from '@vue/shared'
 import { ForParseResult } from './transforms/vFor'
 import {
   RENDER_SLOT,
@@ -356,7 +356,7 @@ export interface ArrayExpression extends Node {
 export interface FunctionExpression extends Node {
   type: NodeTypes.JS_FUNCTION_EXPRESSION
   params: ExpressionNode | string | (ExpressionNode | string)[] | undefined
-  returns?: TemplateChildNode | TemplateChildNode[] | JSChildNode
+  returns?: Arrayable<TemplateChildNode> | JSChildNode
   body?: BlockStatement | IfStatement
   newline: boolean
   /**
@@ -435,7 +435,7 @@ export interface SequenceExpression extends Node {
 
 export interface ReturnStatement extends Node {
   type: NodeTypes.JS_RETURN_STATEMENT
-  returns: TemplateChildNode | TemplateChildNode[] | JSChildNode
+  returns: Arrayable<TemplateChildNode> | JSChildNode
 }
 
 // Codegen Node Types ----------------------------------------------------------

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -1,5 +1,5 @@
 import { ErrorHandlingOptions, ParserOptions } from './options'
-import { NO, isArray, makeMap, extend } from '@vue/shared'
+import { NO, isArray, makeMap, extend, type Arrayable } from '@vue/shared'
 import {
   ErrorCodes,
   createCompilerError,
@@ -152,7 +152,7 @@ function parseChildren(
   while (!isEnd(context, mode, ancestors)) {
     __TEST__ && assert(context.source.length > 0)
     const s = context.source
-    let node: TemplateChildNode | TemplateChildNode[] | undefined = undefined
+    let node: Arrayable<TemplateChildNode> | undefined = undefined
 
     if (mode === TextModes.DATA || mode === TextModes.RCDATA) {
       if (!context.inVPre && startsWith(s, context.options.delimiters[0])) {

--- a/packages/compiler-sfc/src/compileStyle.ts
+++ b/packages/compiler-sfc/src/compileStyle.ts
@@ -1,3 +1,4 @@
+import { Awaitable } from '@vue/shared'
 import postcss, {
   ProcessOptions,
   Result,
@@ -88,7 +89,7 @@ export function compileStyleAsync(
 
 export function doCompileStyle(
   options: SFCAsyncStyleCompileOptions
-): SFCStyleCompileResults | Promise<SFCStyleCompileResults> {
+): Awaitable<SFCStyleCompileResults> {
   const {
     filename,
     id,

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -22,7 +22,7 @@ import {
   ComponentObjectPropsOptions
 } from './componentProps'
 import { EmitsOptions, EmitsToProps } from './componentEmits'
-import { extend, isFunction } from '@vue/shared'
+import { type Awaitable, extend, isFunction } from '@vue/shared'
 import { VNodeProps } from './vnode'
 import {
   CreateComponentPublicInstance,
@@ -103,10 +103,7 @@ export function defineComponent<
   EE extends string = string,
   S extends SlotsType = {}
 >(
-  setup: (
-    props: Props,
-    ctx: SetupContext<E, S>
-  ) => RenderFunction | Promise<RenderFunction>,
+  setup: (props: Props, ctx: SetupContext<E, S>) => Awaitable<RenderFunction>,
   options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
     props?: (keyof Props)[]
     emits?: E | EE[]
@@ -119,10 +116,7 @@ export function defineComponent<
   EE extends string = string,
   S extends SlotsType = {}
 >(
-  setup: (
-    props: Props,
-    ctx: SetupContext<E, S>
-  ) => RenderFunction | Promise<RenderFunction>,
+  setup: (props: Props, ctx: SetupContext<E, S>) => Awaitable<RenderFunction>,
   options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
     props?: ComponentObjectPropsOptions<Props>
     emits?: E | EE[]

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -23,7 +23,8 @@ import {
   isMap,
   isSet,
   isPlainObject,
-  extend
+  extend,
+  type Arrayable
 } from '@vue/shared'
 import {
   currentInstance,
@@ -170,7 +171,7 @@ export function watch<T = any, Immediate extends Readonly<boolean> = false>(
 }
 
 function doWatch(
-  source: WatchSource | WatchSource[] | WatchEffect | object,
+  source: Arrayable<WatchSource> | WatchEffect | object,
   cb: WatchCallback | null,
   { immediate, deep, flush, onTrack, onTrigger }: WatchOptions = EMPTY_OBJ
 ): WatchStopHandle {

--- a/packages/runtime-core/src/compat/customDirective.ts
+++ b/packages/runtime-core/src/compat/customDirective.ts
@@ -1,4 +1,4 @@
-import { isArray } from '@vue/shared'
+import { type Arrayable, isArray } from '@vue/shared'
 import { ComponentInternalInstance } from '../component'
 import { ObjectDirective, DirectiveHook } from '../directives'
 import { softAssertCompatEnabled, DeprecationTypes } from './compatConfig'
@@ -27,7 +27,7 @@ export function mapCompatDirectiveHook(
   name: keyof ObjectDirective,
   dir: ObjectDirective & LegacyDirective,
   instance: ComponentInternalInstance | null
-): DirectiveHook | DirectiveHook[] | undefined {
+): Arrayable<DirectiveHook> | undefined {
   const mappedName = legacyDirectiveHookMap[name]
   if (mappedName) {
     if (isArray(mappedName)) {

--- a/packages/runtime-core/src/compat/renderHelpers.ts
+++ b/packages/runtime-core/src/compat/renderHelpers.ts
@@ -1,4 +1,5 @@
 import {
+  type Arrayable,
   camelize,
   extend,
   hyphenate,
@@ -155,7 +156,7 @@ export function legacyCheckKeyCodes(
   }
 }
 
-function isKeyNotMatch<T>(expect: T | T[], actual: T): boolean {
+function isKeyNotMatch<T>(expect: Arrayable<T>, actual: T): boolean {
   if (isArray(expect)) {
     return !expect.includes(actual)
   } else {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -16,7 +16,9 @@ import {
   NOOP,
   isPromise,
   LooseRequired,
-  Prettify
+  Prettify,
+  type Arrayable,
+  type Awaitable
 } from '@vue/shared'
 import { isRef, Ref } from '@vue/reactivity'
 import { computed } from './apiComputed'
@@ -127,7 +129,7 @@ export interface ComponentOptionsBase<
         >
     >,
     ctx: SetupContext<E, S>
-  ) => Promise<RawBindings> | RawBindings | RenderFunction | void
+  ) => Awaitable<RawBindings> | RenderFunction | void
   name?: string
   template?: string | object // can be a direct DOM node
   // Note: we are intentionally using the signature-less `Function` type here
@@ -543,7 +545,7 @@ interface LegacyOptions<
   __differentiator?: keyof D | keyof C | keyof M
 }
 
-type MergedHook<T = () => void> = T | T[]
+type MergedHook<T = () => void> = Arrayable<T>
 
 export type MergedComponentOptions = ComponentOptions &
   MergedComponentOptionsOverride
@@ -1125,7 +1127,10 @@ function normalizeInject(
   return raw
 }
 
-function mergeAsArray<T = Function>(to: T[] | T | undefined, from: T | T[]) {
+function mergeAsArray<T = Function>(
+  to: Arrayable<T> | undefined,
+  from: Arrayable<T>
+) {
   return to ? [...new Set([].concat(to as any, from as any))] : from
 }
 

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -16,11 +16,11 @@ import { warn } from '../warning'
 import { isKeepAlive } from './KeepAlive'
 import { toRaw } from '@vue/reactivity'
 import { callWithAsyncErrorHandling, ErrorCodes } from '../errorHandling'
-import { ShapeFlags, PatchFlags, isArray } from '@vue/shared'
+import { ShapeFlags, PatchFlags, isArray, type Arrayable } from '@vue/shared'
 import { onBeforeUnmount, onMounted } from '../apiLifecycle'
 import { RendererElement } from '../renderer'
 
-type Hook<T = () => void> = T | T[]
+type Hook<T = () => void> = Arrayable<T>
 
 const leaveCbKey = Symbol('_leaveCb')
 const enterCbKey = Symbol('_enterCb')

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -8,7 +8,13 @@ import {
   compatUtils,
   DeprecationTypes
 } from '@vue/runtime-core'
-import { isObject, toNumber, extend, isArray } from '@vue/shared'
+import {
+  isObject,
+  toNumber,
+  extend,
+  isArray,
+  type Arrayable
+} from '@vue/shared'
 
 const TRANSITION = 'transition'
 const ANIMATION = 'animation'
@@ -85,10 +91,7 @@ export const TransitionPropsValidators = (Transition.props =
  * #3227 Incoming hooks may be merged into arrays when wrapping Transition
  * with custom HOCs.
  */
-const callHook = (
-  hook: Function | Function[] | undefined,
-  args: any[] = []
-) => {
+const callHook = (hook: Arrayable<Function> | undefined, args: any[] = []) => {
   if (isArray(hook)) {
     hook.forEach(h => h(...args))
   } else if (hook) {
@@ -101,7 +104,7 @@ const callHook = (
  * intends to explicitly control the end of the transition.
  */
 const hasExplicitCallback = (
-  hook: Function | Function[] | undefined
+  hook: Arrayable<Function> | undefined
 ): boolean => {
   return hook
     ? isArray(hook)

--- a/packages/server-renderer/src/helpers/ssrRenderComponent.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderComponent.ts
@@ -1,3 +1,4 @@
+import { type Awaitable } from '@vue/shared'
 import { Component, ComponentInternalInstance, createVNode, Slots } from 'vue'
 import { Props, renderComponentVNode, SSRBuffer } from '../render'
 import { SSRSlots } from './ssrRenderSlot'
@@ -8,7 +9,7 @@ export function ssrRenderComponent(
   children: Slots | SSRSlots | null = null,
   parentComponent: ComponentInternalInstance | null = null,
   slotScopeId?: string
-): SSRBuffer | Promise<SSRBuffer> {
+): Awaitable<SSRBuffer> {
   return renderComponentVNode(
     createVNode(comp, props, children),
     parentComponent,

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -23,7 +23,8 @@ import {
   isVoidTag,
   ShapeFlags,
   isArray,
-  NOOP
+  NOOP,
+  type Awaitable
 } from '@vue/shared'
 import { ssrRenderAttrs } from './helpers/ssrRenderAttrs'
 import { ssrCompile } from './helpers/ssrCompile'
@@ -38,7 +39,7 @@ const {
 } = ssrUtils
 
 export type SSRBuffer = SSRBufferItem[] & { hasAsync?: boolean }
-export type SSRBufferItem = string | SSRBuffer | Promise<SSRBuffer>
+export type SSRBufferItem = string | Awaitable<SSRBuffer>
 export type PushFn = (item: SSRBufferItem) => void
 export type Props = Record<string, unknown>
 
@@ -90,7 +91,7 @@ export function renderComponentVNode(
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null = null,
   slotScopeId?: string
-): SSRBuffer | Promise<SSRBuffer> {
+): Awaitable<SSRBuffer> {
   const instance = createComponentInstance(vnode, parentComponent, null)
   const res = setupComponent(instance, true /* isSSR */)
   const hasAsyncSetup = isPromise(res)
@@ -116,7 +117,7 @@ export function renderComponentVNode(
 function renderComponentSubTree(
   instance: ComponentInternalInstance,
   slotScopeId?: string
-): SSRBuffer | Promise<SSRBuffer> {
+): Awaitable<SSRBuffer> {
   const comp = instance.type as Component
   const { getBuffer, push } = createBuffer()
   if (isFunction(comp)) {

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -21,3 +21,7 @@ export type Awaited<T> = T extends null | undefined
     ? Awaited<V> // recursively unwrap the value
     : never // the argument to `then` was not callable
   : T // non-object or non-thenable
+
+export type Arrayable<T> = T[] | T
+
+export type Awaitable<T> = Promise<T> | T


### PR DESCRIPTION
Referring to [VueUse](https://github.com/vueuse/vueuse/blob/c4fa9bd2165bf53029563d1eebb61a3c87cdba70/packages/shared/utils/types.ts#L59C2-L59C2), the utility types `Arrayable` and `Awaitable` have been introduced.