### PR TITLE
fix(runtime-dom): TransitionGroup children el may be null

### DIFF
--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -112,7 +112,7 @@ const TransitionGroupImpl: ComponentOptions = {
         tag = 'span'
       }
 
-      prevChildren = children
+      prevChildren = children.filter((c: VNode) => c.el?.getBoundingClientRect)
       children = slots.default ? getTransitionRawChildren(slots.default()) : []
 
       for (let i = 0; i < children.length; i++) {

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -112,7 +112,7 @@ const TransitionGroupImpl: ComponentOptions = {
         tag = 'span'
       }
 
-      prevChildren = children.filter((c: VNode) => c.el?.getBoundingClientRect)
+      prevChildren = children?.filter((c: VNode) => c.el?.getBoundingClientRect)
       children = slots.default ? getTransitionRawChildren(slots.default()) : []
 
       for (let i = 0; i < children.length; i++) {

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -112,7 +112,9 @@ const TransitionGroupImpl: ComponentOptions = {
         tag = 'span'
       }
 
-      prevChildren = children?.filter((c: VNode) => c.el?.getBoundingClientRect)
+      prevChildren =
+        children &&
+        children.filter((c: VNode) => c.el && c.el.getBoundingClientRect)
       children = slots.default ? getTransitionRawChildren(slots.default()) : []
 
       for (let i = 0; i < children.length; i++) {

--- a/packages/vue/__tests__/e2e/TransitionGroup.spec.ts
+++ b/packages/vue/__tests__/e2e/TransitionGroup.spec.ts
@@ -515,13 +515,13 @@ describe('e2e: TransitionGroup', () => {
       const { createApp, ref } = (window as any).Vue
       createApp({
         template: `
-              <div id="container">
-								<transition-group name="group">
-									<Comp v-for="item in items" :key="item"></Comp>
-								</transition-group>
-							</div>
-              <button id="toggleBtn" @click="click">button</button>
-              <button id="pushBtn" @click="change">button</button>
+        <div id="container">
+          <transition-group name="group">
+            <Comp v-for="item in items" :key="item"></Comp>
+          </transition-group>
+        </div>
+        <button id="toggleBtn" @click="click">button</button>
+        <button id="pushBtn" @click="change">button</button>
             `,
         components: {
           Comp: {

--- a/packages/vue/__tests__/e2e/TransitionGroup.spec.ts
+++ b/packages/vue/__tests__/e2e/TransitionGroup.spec.ts
@@ -521,7 +521,7 @@ describe('e2e: TransitionGroup', () => {
 								</transition-group>
 							</div>
               <button id="toggleBtn" @click="click">button</button>
-              <button id="pushwBtn" @click="change">button</button>
+              <button id="pushBtn" @click="change">button</button>
             `,
         components: {
           Comp: {
@@ -550,7 +550,7 @@ describe('e2e: TransitionGroup', () => {
     expect(await html('#container')).toBe(`<!--v-if-->`)
     // push back
     await page().evaluate(() => {
-      ;(document.querySelector('#pushwBtn') as any)!.click()
+      ;(document.querySelector('#pushBtn') as any)!.click()
     })
     await transitionFinish()
     expect(await html('#container')).toBe('<!--v-if--><!--v-if-->')


### PR DESCRIPTION
close: #9067 
When the children of TransitionGroup are components, first set the elements inside the component to empty through v-if. Afterwards, an error will be reported when TransitionGroup executes the end animation.


