### PR TITLE
refactor(shared): respect Promise A+ specification

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -519,7 +519,7 @@ export function withAsyncContext(getAwaitable: () => any) {
   let awaitable = getAwaitable()
   unsetCurrentInstance()
   if (isPromise(awaitable)) {
-    awaitable = awaitable.catch(e => {
+    awaitable = awaitable.then(null, e => {
       setCurrentInstance(ctx)
       throw e
     })

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -392,7 +392,7 @@ export interface ComponentInternalInstance {
   /**
    * @internal
    */
-  asyncDep: Promise<any> | null
+  asyncDep: PromiseLike<any> | null
   /**
    * @internal
    */
@@ -732,13 +732,14 @@ function setupStatefulComponent(
       setupResult.then(unsetCurrentInstance, unsetCurrentInstance)
       if (isSSR) {
         // return the promise so server-renderer can wait on it
-        return setupResult
-          .then((resolvedResult: unknown) => {
+        return setupResult.then(
+          (resolvedResult: unknown) => {
             handleSetupResult(instance, resolvedResult, isSSR)
-          })
-          .catch(e => {
+          },
+          e => {
             handleError(e, instance, ErrorCodes.SETUP_FUNCTION)
-          })
+          }
+        )
       } else if (__FEATURE_SUSPENSE__) {
         // async setup returned Promise.
         // bail here and wait for re-entry.

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -630,7 +630,7 @@ function createSuspenseBoundary(
       }
       const hydratedEl = instance.vnode.el
       instance
-        .asyncDep!.catch(err => {
+        .asyncDep!.then(null, err => {
           handleError(err, instance, ErrorCodes.SETUP_FUNCTION)
         })
         .then(asyncSetupResult => {

--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -84,7 +84,7 @@ export function callWithAsyncErrorHandling(
   if (isFunction(fn)) {
     const res = callWithErrorHandling(fn, instance, type, args)
     if (res && isPromise(res)) {
-      res.catch(err => {
+      res.then(null, err => {
         handleError(err, instance, type)
       })
     }

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -100,12 +100,14 @@ export function renderComponentVNode(
       ? (res as Promise<void>)
       : Promise.resolve()
     if (prefetches) {
-      p = p
-        .then(() =>
-          Promise.all(prefetches.map(prefetch => prefetch.call(instance.proxy)))
-        )
+      p = p.then(
+        () =>
+          Promise.all(
+            prefetches.map(prefetch => prefetch.call(instance.proxy))
+          ),
         // Note: error display is already done by the wrapped lifecycle hook function.
-        .catch(() => {})
+        NOOP
+      )
     }
     return p.then(() => renderComponentSubTree(instance, slotScopeId))
   } else {

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -49,12 +49,8 @@ export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
 export const isObject = (val: unknown): val is Record<any, any> =>
   val !== null && typeof val === 'object'
 
-export const isPromise = <T = any>(val: unknown): val is Promise<T> => {
-  return (
-    (isObject(val) || isFunction(val)) &&
-    isFunction((val as any).then) &&
-    isFunction((val as any).catch)
-  )
+export const isPromise = <T = any>(val: unknown): val is PromiseLike<T> => {
+  return !!val && isFunction((val as any).then)
 }
 
 export const objectToString = Object.prototype.toString


### PR DESCRIPTION
According to the [Promise A+ specification](https://promisesaplus.com/#the-then-method), we cannot guarantee that a Promise will necessarily have the `catch` method. Therefore, we need to use the second argument of the [`then` method](https://promisesaplus.com/#the-then-method) to capture errors, instead of using the `catch` method.


from

```ts
p.catch((err) => {
  console.log(err)
})
```
to

```ts
p.then(null, (err) => {
  console.log(err)
})
```
