### PR TITLE
refactor: improve handling of shallowRef and ref in createRef

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -442,4 +442,22 @@ describe('reactivity/ref', () => {
     expect(a.value).toBe(rr)
     expect(a.value).not.toBe(r)
   })
+
+  test('should return ref when ref receiving a shallowRef', () => {
+    const a = shallowRef({ name: 'a' })
+    const shouldRef = ref(a)
+
+    expect(shouldRef.value.name).toBe('a')
+    expect(isRef(shouldRef)).toBe(true)
+    expect(isShallow(shouldRef)).toBe(false)
+  })
+
+  test('should return shallowRef when shallowRef receiving a ref', () => {
+    const a = ref({ name: 'a' })
+    const shouldShallow = shallowRef(a)
+
+    expect(shouldShallow.value.name).toBe('a')
+    expect(isRef(shouldShallow)).toBe(true)
+    expect(isShallow(shouldShallow)).toBe(true)
+  })
 })

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -126,8 +126,21 @@ export function shallowRef(value?: unknown) {
 
 function createRef(rawValue: unknown, shallow: boolean) {
   if (isRef(rawValue)) {
-    return rawValue
+    if (
+      (isShallow(rawValue) && shallow) ||
+      (!isShallow(rawValue) && !shallow)
+    ) {
+      return rawValue
+    }
+    // const a = ref({}), b = shallowRef({}), c = ref(b), d = shallowRef(a)
+    if (
+      (isShallow(rawValue) && !shallow) ||
+      (!isShallow(rawValue) && shallow)
+    ) {
+      rawValue = toRaw(rawValue.value)
+    }
   }
+
   return new RefImpl(rawValue, shallow)
 }
 


### PR DESCRIPTION
When ref receives a shallowRef parameter, it will return shallowRef, and when shallowRef receives a Ref parameter, it will return ref. I feel that the current phenomenon is unreasonable.

- before
```js
const a = ref({})
const b = shallowRef({})
const c = ref(b)
const d = shallowRef(a)
console.log(isShallow(c), isShallow(d)) // true false
```
- after
```js
const a = ref({})
const b = shallowRef({})
const c = ref(b)
const d = shallowRef(a)
console.log(isShallow(c), isShallow(d)) // false true
```