### PR TITLE
refactor: remove toRaw(ref) in triggerRefValue

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -53,7 +53,6 @@ export function trackRefValue(ref: RefBase<any>) {
 }
 
 export function triggerRefValue(ref: RefBase<any>, newVal?: any) {
-  ref = toRaw(ref)
   const dep = ref.dep
   if (dep) {
     if (__DEV__) {


### PR DESCRIPTION
It is not necessary to do `toRaw(ref)` for a `RefBase<any>` type