### PR TITLE
chore(playground): save `tsconfig.json` to the root directory; update Node.js version requirement

### DIFF
--- a/packages/sfc-playground/src/download/download.ts
+++ b/packages/sfc-playground/src/download/download.ts
@@ -27,8 +27,7 @@ export async function downloadProject(store: ReplStore) {
 
   const files = store.getFiles()
   for (const file in files) {
-    if (file === 'tsconfig.json') continue
-    if (file !== 'import-map.json') {
+    if (file !== 'import-map.json' && file !== 'tsconfig.json') {
       src.file(file, files[file])
     } else {
       zip.file(file, files[file])

--- a/packages/sfc-playground/src/download/download.ts
+++ b/packages/sfc-playground/src/download/download.ts
@@ -27,6 +27,7 @@ export async function downloadProject(store: ReplStore) {
 
   const files = store.getFiles()
   for (const file in files) {
+    if (file === 'tsconfig.json') continue
     if (file !== 'import-map.json') {
       src.file(file, files[file])
     } else {

--- a/packages/sfc-playground/src/download/template/README.md
+++ b/packages/sfc-playground/src/download/template/README.md
@@ -1,6 +1,6 @@
 # Vite Vue Starter
 
-This is a project template using [Vite](https://vitejs.dev/). It requires [Node.js](https://nodejs.org) version 14.18+, 16+.
+This is a project template using [Vite](https://vitejs.dev/). It requires [Node.js](https://nodejs.org) version 18+, 20+.
 
 To start:
 

--- a/packages/sfc-playground/src/download/template/README.md
+++ b/packages/sfc-playground/src/download/template/README.md
@@ -1,6 +1,6 @@
 # Vite Vue Starter
 
-This is a project template using [Vite](https://vitejs.dev/). It requires [Node.js](https://nodejs.org) v12+.
+This is a project template using [Vite](https://vitejs.dev/). It requires [Node.js](https://nodejs.org) version 14.18+, 16+.
 
 To start:
 


### PR DESCRIPTION
When using `download` to download a project in the sfc-playground, the `tsconfig.json` file is being downloaded into the `src` directory. Since the downloaded project is a JavaScript project, I overlooked the `tsconfig.json` file in this PR. vite@4.3.0 requires [Node.js version 14.18+, 16+](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) updated README.md for this.