### PR TITLE
fix(runtime-core): swap client/server debug labels

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -134,8 +134,8 @@ export function createHydrationFunctions(
             __DEV__ &&
               warn(
                 `Hydration text mismatch:` +
-                  `\n- Client: ${JSON.stringify((node as Text).data)}` +
-                  `\n- Server: ${JSON.stringify(vnode.children)}`
+                  `\n- Server: ${JSON.stringify((node as Text).data)}` +
+                  `\n- Client: ${JSON.stringify(vnode.children)}`
               )
             ;(node as Text).data = vnode.children as string
           }

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -134,8 +134,8 @@ export function createHydrationFunctions(
             __DEV__ &&
               warn(
                 `Hydration text mismatch:` +
-                  `\n- Server: ${JSON.stringify((node as Text).data)}` +
-                  `\n- Client: ${JSON.stringify(vnode.children)}`
+                  `\n- Server rendered: ${JSON.stringify((node as Text).data)}` +
+                  `\n- Client rendered: ${JSON.stringify(vnode.children)}`
               )
             ;(node as Text).data = vnode.children as string
           }
@@ -406,8 +406,8 @@ export function createHydrationFunctions(
               `Hydration text content mismatch in <${
                 vnode.type as string
               }>:\n` +
-                `- Server: ${el.textContent}\n` +
-                `- Client: ${vnode.children as string}`
+                `- Server rendered: ${el.textContent}\n` +
+                `- Client rendered: ${vnode.children as string}`
             )
           el.textContent = vnode.children as string
         }

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -406,8 +406,8 @@ export function createHydrationFunctions(
               `Hydration text content mismatch in <${
                 vnode.type as string
               }>:\n` +
-                `- Client: ${el.textContent}\n` +
-                `- Server: ${vnode.children as string}`
+                `- Server: ${el.textContent}\n` +
+                `- Client: ${vnode.children as string}`
             )
           el.textContent = vnode.children as string
         }


### PR DESCRIPTION
At the moment I think the console log is misleading.

<img width="454" alt="CleanShot 2023-08-30 at 22 24 40@2x" src="https://github.com/vuejs/core/assets/28706372/cf87c944-b412-450f-8399-0f37b028a3fc">

The text here labelled 'Client' is in fact the server rendered HTML. I think reversing these two labels might be better.