### PR TITLE
refactor: change condition for invoking propertyToRef to check for un…

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -436,8 +436,8 @@ export function toRef(
     return source
   } else if (isFunction(source)) {
     return new GetterRefImpl(source) as any
-  } else if (isObject(source) && arguments.length > 1) {
-    return propertyToRef(source, key!, defaultValue)
+  } else if (isObject(source) && key !== undefined) {
+    return propertyToRef(source, key, defaultValue)
   } else {
     return ref(source)
   }


### PR DESCRIPTION
I think changing `arguments.length > 1` to`key !== undefined` will improve the readability of the code. It also prevents the user from explicitly passing `undefined` parameters, causing `arguments.length ` to be 2, causing the code to enter the`propertyToRef` function. (Although this is unlikely to happen).