### PR TITLE
fix(ssr): hydrate before `onBeforeMount`

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1308,25 +1308,6 @@ function baseCreateRenderer(
         const isAsyncWrapperVNode = isAsyncWrapper(initialVNode)
 
         toggleRecurse(instance, false)
-        // beforeMount hook
-        if (bm) {
-          invokeArrayFns(bm)
-        }
-        // onVnodeBeforeMount
-        if (
-          !isAsyncWrapperVNode &&
-          (vnodeHook = props && props.onVnodeBeforeMount)
-        ) {
-          invokeVNodeHook(vnodeHook, parent, initialVNode)
-        }
-        if (
-          __COMPAT__ &&
-          isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)
-        ) {
-          instance.emit('hook:beforeMount')
-        }
-        toggleRecurse(instance, true)
-
         if (el && hydrateNode) {
           // vnode has adopted host node - perform hydration instead of mount.
           const hydrateSubTree = () => {
@@ -1363,7 +1344,27 @@ function baseCreateRenderer(
           } else {
             hydrateSubTree()
           }
-        } else {
+        }
+        // beforeMount hook
+        if (bm) {
+          invokeArrayFns(bm)
+        }
+        // onVnodeBeforeMount
+        if (
+          !isAsyncWrapperVNode &&
+          (vnodeHook = props && props.onVnodeBeforeMount)
+        ) {
+          invokeVNodeHook(vnodeHook, parent, initialVNode)
+        }
+        if (
+          __COMPAT__ &&
+          isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)
+        ) {
+          instance.emit('hook:beforeMount')
+        }
+        toggleRecurse(instance, true)
+
+        if (!el || !hydrate) {
           if (__DEV__) {
             startMeasure(instance, `render`)
           }


### PR DESCRIPTION
fix https://github.com/vuejs/core/issues/9044

The hook function onBeforeMount is now executed before the hydrate, and some page content may be changed in that hook function, causing the hydrate to fail.

Therefore the hydrate is raised to before the onBeforeMount hook is executed.