### PR TITLE
fix: do not render class when it is undefined or null

### DIFF
--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -26,6 +26,7 @@ import {
   toDisplayString,
   normalizeClass,
   normalizeStyle,
+  stringifyClass,
   stringifyStyle,
   makeMap,
   isKnownSvgAttr,
@@ -311,7 +312,7 @@ function stringifyElement(
         if (evaluated != null) {
           const arg = p.arg && (p.arg as SimpleExpressionNode).content
           if (arg === 'class') {
-            evaluated = normalizeClass(evaluated)
+            evaluated = stringifyClass(normalizeClass(evaluated))
           } else if (arg === 'style') {
             evaluated = stringifyStyle(normalizeStyle(evaluated))
           }

--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -17,6 +17,12 @@ describe('normalizeClass', () => {
     )
   })
 
+  // #3173
+  test('handles null and undefined correctly', () => {
+    expect(normalizeClass(undefined)).toEqual(undefined)
+    expect(normalizeClass(null)).toEqual(undefined)
+  })
+
   // #6777
   test('parse multi-line inline style', () => {
     expect(

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -60,7 +60,13 @@ export function stringifyStyle(
   return ret
 }
 
-export function normalizeClass(value: unknown): string {
+export function stringifyClass(klass: string | undefined): string {
+  return klass || ''
+}
+
+export function normalizeClass(value: unknown): string | undefined {
+  // #3173
+  if (value == null) return undefined
   let res = ''
   if (isString(value)) {
     res = value


### PR DESCRIPTION
This PR is related to #3173.

Since `normalizeStyle` method can return `undefined`, I was just thinking why not make `normalizeClass` also able to return `undefined`? In my personal opinion, this seems more consistent.

With this PR, the props in the example in #3173 should be rendered consistently as below:

`string`
<img width="1388" alt="image" src="https://github.com/vuejs/core/assets/55378595/b27991aa-1900-418d-b6c3-5525016d22cc">
`undefined`
<img width="1440" alt="image" src="https://github.com/vuejs/core/assets/55378595/7b05039a-d17b-4c8b-804a-78c8d4d6efaf">
`null`
<img width="1440" alt="image" src="https://github.com/vuejs/core/assets/55378595/517fcfb3-5679-4cc9-8adb-624645f6b6bc">
