### PR TITLE
fix(runtime-core): expose events to props for functional components

### DIFF
--- a/packages/dts-test/functionalComponent.test-d.tsx
+++ b/packages/dts-test/functionalComponent.test-d.tsx
@@ -45,7 +45,7 @@ Bar.emits = {
 Bar.emits = { baz: () => void 0 }
 
 // TSX
-expectType<JSX.Element>(<Bar foo={1} />)
+expectType<JSX.Element>(<Bar foo={1} onUpdate={() => {}} />)
 //  @ts-expect-error
 ;<Foo />
 //  @ts-expect-error

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -50,7 +50,8 @@ import {
   ObjectEmitsOptions,
   EmitFn,
   emit,
-  normalizeEmitsOptions
+  normalizeEmitsOptions,
+  EmitsToProps
 } from './componentEmits'
 import {
   EMPTY_OBJ,
@@ -131,7 +132,7 @@ export interface FunctionalComponent<
 > extends ComponentInternalOptions {
   // use of any here is intentional so it can be a valid JSX Element constructor
   (
-    props: P,
+    props: P & EmitsToProps<E>,
     ctx: Omit<SetupContext<E, IfAny<S, {}, SlotsType<S>>>, 'expose'>
   ): any
   props?: ComponentPropsOptions<P>


### PR DESCRIPTION
Expose events to props for consumer of components to be correctly typed, `onX` handlers where not exposed as such the interface for functional components is incorrect for consuming FunctionalComponents in parent components.

Before:
```tsx

const Foo: FunctionalComponent<{}, { change(): void }> = () => {}
// type error: Property 'onChange' does not exist on type '...'
<Foo onChange={() => {}} />
```

After: 

```tsx
const Foo: FunctionalComponent<{}, { change(): void }> = () => {}

// No type error:
<Foo onChange={() => {}} />
```

