### PR TITLE
refactor: remove const enum

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -7,9 +7,7 @@ import {
   isReadonly,
   DebuggerEvent,
   toRaw,
-  TrackOpTypes,
-  ITERATE_KEY,
-  TriggerOpTypes
+  ITERATE_KEY
 } from '../src'
 
 describe('reactivity/computed', () => {
@@ -236,19 +234,19 @@ describe('reactivity/computed', () => {
       {
         effect: c.effect,
         target: toRaw(obj),
-        type: TrackOpTypes.GET,
+        type: 'get',
         key: 'foo'
       },
       {
         effect: c.effect,
         target: toRaw(obj),
-        type: TrackOpTypes.HAS,
+        type: 'has',
         key: 'bar'
       },
       {
         effect: c.effect,
         target: toRaw(obj),
-        type: TrackOpTypes.ITERATE,
+        type: 'iterate',
         key: ITERATE_KEY
       }
     ])
@@ -271,7 +269,7 @@ describe('reactivity/computed', () => {
     expect(events[0]).toEqual({
       effect: c.effect,
       target: toRaw(obj),
-      type: TriggerOpTypes.SET,
+      type: 'set',
       key: 'foo',
       oldValue: 1,
       newValue: 2
@@ -283,7 +281,7 @@ describe('reactivity/computed', () => {
     expect(events[1]).toEqual({
       effect: c.effect,
       target: toRaw(obj),
-      type: TriggerOpTypes.DELETE,
+      type: 'delete',
       key: 'foo',
       oldValue: 2
     })

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -4,8 +4,6 @@ import {
   effect,
   stop,
   toRaw,
-  TrackOpTypes,
-  TriggerOpTypes,
   DebuggerEvent,
   markRaw,
   shallowReactive,
@@ -732,19 +730,19 @@ describe('reactivity/effect', () => {
       {
         effect: runner.effect,
         target: toRaw(obj),
-        type: TrackOpTypes.GET,
+        type: 'get',
         key: 'foo'
       },
       {
         effect: runner.effect,
         target: toRaw(obj),
-        type: TrackOpTypes.HAS,
+        type: 'has',
         key: 'bar'
       },
       {
         effect: runner.effect,
         target: toRaw(obj),
-        type: TrackOpTypes.ITERATE,
+        type: 'iterate',
         key: ITERATE_KEY
       }
     ])
@@ -770,7 +768,7 @@ describe('reactivity/effect', () => {
     expect(events[0]).toEqual({
       effect: runner.effect,
       target: toRaw(obj),
-      type: TriggerOpTypes.SET,
+      type: 'set',
       key: 'foo',
       oldValue: 1,
       newValue: 2
@@ -782,7 +780,7 @@ describe('reactivity/effect', () => {
     expect(events[1]).toEqual({
       effect: runner.effect,
       target: toRaw(obj),
-      type: TriggerOpTypes.DELETE,
+      type: 'delete',
       key: 'foo',
       oldValue: 2
     })

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,7 +1,7 @@
 import { DebuggerOptions, ReactiveEffect } from './effect'
 import { Ref, trackRefValue, triggerRefValue } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
-import { ReactiveFlags, toRaw } from './reactive'
+import { toRaw } from './reactive'
 import { Dep } from './dep'
 
 declare const ComputedRefSymbol: unique symbol
@@ -30,7 +30,7 @@ export class ComputedRefImpl<T> {
   public readonly effect: ReactiveEffect<T>
 
   public readonly __v_isRef = true
-  public readonly [ReactiveFlags.IS_READONLY]: boolean = false
+  public readonly __v_isReadonly: boolean = false
 
   public _dirty = true
   public _cacheable: boolean
@@ -49,7 +49,7 @@ export class ComputedRefImpl<T> {
     })
     this.effect.computed = this
     this.effect.active = this._cacheable = !isSSR
-    this[ReactiveFlags.IS_READONLY] = isReadonly
+    this.__v_isReadonly = isReadonly
   }
 
   get value() {

--- a/packages/reactivity/src/deferredComputed.ts
+++ b/packages/reactivity/src/deferredComputed.ts
@@ -1,7 +1,7 @@
 import { Dep } from './dep'
 import { ReactiveEffect } from './effect'
 import { ComputedGetter, ComputedRef } from './computed'
-import { ReactiveFlags, toRaw } from './reactive'
+import { toRaw } from './reactive'
 import { trackRefValue, triggerRefValue } from './ref'
 
 const tick = /*#__PURE__*/ Promise.resolve()
@@ -32,7 +32,7 @@ class DeferredComputedRefImpl<T> {
   public readonly effect: ReactiveEffect<T>
 
   public readonly __v_isRef = true
-  public readonly [ReactiveFlags.IS_READONLY] = true
+  public readonly __v_isReadonly = true
 
   constructor(getter: ComputedGetter<T>) {
     let compareTarget: any

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -1,4 +1,4 @@
-import { TrackOpTypes, TriggerOpTypes } from './operations'
+import { TrackOpTypesUnion, TriggerOpTypesUnion } from './operations'
 import { extend, isArray, isIntegerKey, isMap } from '@vue/shared'
 import { EffectScope, recordEffectScope } from './effectScope'
 import {
@@ -38,7 +38,7 @@ export type DebuggerEvent = {
 
 export type DebuggerEventExtraInfo = {
   target: object
-  type: TrackOpTypes | TriggerOpTypes
+  type: TrackOpTypesUnion | TriggerOpTypesUnion
   key: any
   newValue?: any
   oldValue?: any
@@ -244,7 +244,7 @@ export function resetTracking() {
  * @param type - Defines the type of access to the reactive property.
  * @param key - Identifier of the reactive property to track.
  */
-export function track(target: object, type: TrackOpTypes, key: unknown) {
+export function track(target: object, type: TrackOpTypesUnion, key: unknown) {
   if (shouldTrack && activeEffect) {
     let depsMap = targetMap.get(target)
     if (!depsMap) {
@@ -304,7 +304,7 @@ export function trackEffects(
  */
 export function trigger(
   target: object,
-  type: TriggerOpTypes,
+  type: TriggerOpTypesUnion,
   key?: unknown,
   newValue?: unknown,
   oldValue?: unknown,
@@ -317,7 +317,7 @@ export function trigger(
   }
 
   let deps: (Dep | undefined)[] = []
-  if (type === TriggerOpTypes.CLEAR) {
+  if (type === 'clear') {
     // collection being cleared
     // trigger all effects for target
     deps = [...depsMap.values()]
@@ -336,7 +336,7 @@ export function trigger(
 
     // also run for iteration key on ADD | DELETE | Map.SET
     switch (type) {
-      case TriggerOpTypes.ADD:
+      case 'add':
         if (!isArray(target)) {
           deps.push(depsMap.get(ITERATE_KEY))
           if (isMap(target)) {
@@ -347,7 +347,7 @@ export function trigger(
           deps.push(depsMap.get('length'))
         }
         break
-      case TriggerOpTypes.DELETE:
+      case 'delete':
         if (!isArray(target)) {
           deps.push(depsMap.get(ITERATE_KEY))
           if (isMap(target)) {
@@ -355,7 +355,7 @@ export function trigger(
           }
         }
         break
-      case TriggerOpTypes.SET:
+      case 'set':
         if (isMap(target)) {
           deps.push(depsMap.get(ITERATE_KEY))
         }

--- a/packages/reactivity/src/operations.ts
+++ b/packages/reactivity/src/operations.ts
@@ -1,15 +1,23 @@
 // using literal strings instead of numbers so that it's easier to inspect
 // debugger events
 
+/**
+ * @deprecated use string literal instead.
+ */
 export const enum TrackOpTypes {
   GET = 'get',
   HAS = 'has',
   ITERATE = 'iterate'
 }
+export type TrackOpTypesUnion = 'get' | 'has' | 'iterate'
 
+/**
+ * @deprecated use string literal instead.
+ */
 export const enum TriggerOpTypes {
   SET = 'set',
   ADD = 'add',
   DELETE = 'delete',
   CLEAR = 'clear'
 }
+export type TriggerOpTypesUnion = 'set' | 'add' | 'delete' | 'clear'

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -5,7 +5,6 @@ import {
   trackEffects,
   triggerEffects
 } from './effect'
-import { TrackOpTypes, TriggerOpTypes } from './operations'
 import { isArray, hasChanged, IfAny, isFunction, isObject } from '@vue/shared'
 import {
   isProxy,
@@ -43,7 +42,7 @@ export function trackRefValue(ref: RefBase<any>) {
     if (__DEV__) {
       trackEffects(ref.dep || (ref.dep = createDep()), {
         target: ref,
-        type: TrackOpTypes.GET,
+        type: 'get',
         key: 'value'
       })
     } else {
@@ -59,7 +58,7 @@ export function triggerRefValue(ref: RefBase<any>, newVal?: any) {
     if (__DEV__) {
       triggerEffects(dep, {
         target: ref,
-        type: TriggerOpTypes.SET,
+        type: 'set',
         key: 'value',
         newValue: newVal
       })

--- a/packages/runtime-core/__tests__/apiLifecycle.spec.ts
+++ b/packages/runtime-core/__tests__/apiLifecycle.spec.ts
@@ -13,10 +13,9 @@ import {
   onUnmounted,
   onRenderTracked,
   reactive,
-  TrackOpTypes,
   onRenderTriggered
 } from '@vue/runtime-test'
-import { ITERATE_KEY, DebuggerEvent, TriggerOpTypes } from '@vue/reactivity'
+import { ITERATE_KEY, DebuggerEvent } from '@vue/reactivity'
 
 // reference: https://vue-composition-api-rfc.netlify.com/api.html#lifecycle-hooks
 
@@ -315,17 +314,17 @@ describe('api: lifecycle hooks', () => {
     expect(events).toMatchObject([
       {
         target: obj,
-        type: TrackOpTypes.GET,
+        type: 'get',
         key: 'foo'
       },
       {
         target: obj,
-        type: TrackOpTypes.HAS,
+        type: 'has',
         key: 'bar'
       },
       {
         target: obj,
-        type: TrackOpTypes.ITERATE,
+        type: 'iterate',
         key: ITERATE_KEY
       }
     ])
@@ -355,7 +354,7 @@ describe('api: lifecycle hooks', () => {
     await nextTick()
     expect(onTrigger).toHaveBeenCalledTimes(1)
     expect(events[0]).toMatchObject({
-      type: TriggerOpTypes.SET,
+      type: 'set',
       key: 'foo',
       oldValue: 1,
       newValue: 2
@@ -365,7 +364,7 @@ describe('api: lifecycle hooks', () => {
     await nextTick()
     expect(onTrigger).toHaveBeenCalledTimes(2)
     expect(events[1]).toMatchObject({
-      type: TriggerOpTypes.DELETE,
+      type: 'delete',
       key: 'bar',
       oldValue: 2
     })
@@ -373,7 +372,7 @@ describe('api: lifecycle hooks', () => {
     await nextTick()
     expect(onTrigger).toHaveBeenCalledTimes(3)
     expect(events[2]).toMatchObject({
-      type: TriggerOpTypes.ADD,
+      type: 'add',
       key: 'baz',
       newValue: 3
     })

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -24,8 +24,6 @@ import {
 import {
   ITERATE_KEY,
   DebuggerEvent,
-  TrackOpTypes,
-  TriggerOpTypes,
   triggerRef,
   shallowRef,
   Ref,
@@ -815,17 +813,17 @@ describe('api: watch', () => {
     expect(events).toMatchObject([
       {
         target: obj,
-        type: TrackOpTypes.GET,
+        type: 'get',
         key: 'foo'
       },
       {
         target: obj,
-        type: TrackOpTypes.HAS,
+        type: 'has',
         key: 'bar'
       },
       {
         target: obj,
-        type: TrackOpTypes.ITERATE,
+        type: 'iterate',
         key: ITERATE_KEY
       }
     ])
@@ -852,7 +850,7 @@ describe('api: watch', () => {
     expect(dummy).toBe(2)
     expect(onTrigger).toHaveBeenCalledTimes(1)
     expect(events[0]).toMatchObject({
-      type: TriggerOpTypes.SET,
+      type: 'set',
       key: 'foo',
       oldValue: 1,
       newValue: 2
@@ -863,7 +861,7 @@ describe('api: watch', () => {
     expect(dummy).toBeUndefined()
     expect(onTrigger).toHaveBeenCalledTimes(2)
     expect(events[1]).toMatchObject({
-      type: TriggerOpTypes.DELETE,
+      type: 'delete',
       key: 'foo',
       oldValue: 2
     })

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -5,7 +5,6 @@ import {
   ComputedRef,
   ReactiveEffect,
   isReactive,
-  ReactiveFlags,
   EffectScheduler,
   DebuggerOptions,
   getCurrentScope
@@ -438,7 +437,7 @@ export function createPathGetter(ctx: any, path: string) {
 }
 
 export function traverse(value: unknown, seen?: Set<unknown>) {
-  if (!isObject(value) || (value as any)[ReactiveFlags.SKIP]) {
+  if (!isObject(value) || (value as any).__v_skip) {
     return value
   }
   seen = seen || new Set()

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -1,11 +1,4 @@
-import {
-  isReactive,
-  reactive,
-  track,
-  TrackOpTypes,
-  trigger,
-  TriggerOpTypes
-} from '@vue/reactivity'
+import { isReactive, reactive, track, trigger } from '@vue/reactivity'
 import {
   isFunction,
   extend,
@@ -643,12 +636,12 @@ function defineReactiveSimple(obj: any, key: string, val: any) {
     enumerable: true,
     configurable: true,
     get() {
-      track(obj, TrackOpTypes.GET, key)
+      track(obj, 'get', key)
       return val
     },
     set(newVal) {
       val = isObject(newVal) ? reactive(newVal) : newVal
-      trigger(obj, TriggerOpTypes.SET, key, newVal)
+      trigger(obj, 'set', key, newVal)
     }
   })
 }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -8,7 +8,6 @@ import {
   EffectScope,
   markRaw,
   track,
-  TrackOpTypes,
   ReactiveEffect
 } from '@vue/reactivity'
 import {
@@ -942,7 +941,7 @@ function getAttrsProxy(instance: ComponentInternalInstance): Data {
         ? {
             get(target, key: string) {
               markAttrsAccessed()
-              track(instance, TrackOpTypes.GET, '$attrs')
+              track(instance, 'get', '$attrs')
               return target[key]
             },
             set() {
@@ -956,7 +955,7 @@ function getAttrsProxy(instance: ComponentInternalInstance): Data {
           }
         : {
             get(target, key: string) {
-              track(instance, TrackOpTypes.GET, '$attrs')
+              track(instance, 'get', '$attrs')
               return target[key]
             }
           }
@@ -972,7 +971,7 @@ function getSlotsProxy(instance: ComponentInternalInstance): Slots {
     instance.slotsProxy ||
     (instance.slotsProxy = new Proxy(instance.slots, {
       get(target, key: string) {
-        track(instance, TrackOpTypes.GET, '$slots')
+        track(instance, 'get', '$slots')
         return target[key]
       }
     }))

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -1,9 +1,4 @@
-import {
-  toRaw,
-  shallowReactive,
-  trigger,
-  TriggerOpTypes
-} from '@vue/reactivity'
+import { toRaw, shallowReactive, trigger } from '@vue/reactivity'
 import {
   EMPTY_OBJ,
   camelize,
@@ -361,7 +356,7 @@ export function updateProps(
 
   // trigger updates for $attrs in case it's used in component slots
   if (hasAttrsChanged) {
-    trigger(instance, TriggerOpTypes.SET, '$attrs')
+    trigger(instance, 'set', '$attrs')
   }
 
   if (__DEV__) {

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -21,7 +21,6 @@ import {
   toRaw,
   shallowReadonly,
   track,
-  TrackOpTypes,
   ShallowUnwrapRef,
   UnwrapNestedRefs
 } from '@vue/reactivity'
@@ -354,10 +353,10 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     // public $xxx properties
     if (publicGetter) {
       if (key === '$attrs') {
-        track(instance, TrackOpTypes.GET, key)
+        track(instance, 'get', key)
         __DEV__ && markAttrsAccessed()
       } else if (__DEV__ && key === '$slots') {
-        track(instance, TrackOpTypes.GET, key)
+        track(instance, 'get', key)
       }
       return publicGetter(instance)
     } else if (

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -24,7 +24,6 @@ import { isHmrUpdating } from './hmr'
 import { DeprecationTypes, isCompatEnabled } from './compat/compatConfig'
 import { toRaw } from '@vue/reactivity'
 import { trigger } from '@vue/reactivity'
-import { TriggerOpTypes } from '@vue/reactivity'
 
 export type Slot<T extends any = any> = (
   ...args: IfAny<T, any[], [T] | (T extends undefined ? [] : never)>
@@ -203,7 +202,7 @@ export const updateSlots = (
         // Parent was HMR updated so slot content may have changed.
         // force update slots and mark instance for hmr as well
         extend(slots, children as Slots)
-        trigger(instance, TriggerOpTypes.SET, '$slots')
+        trigger(instance, 'set', '$slots')
       } else if (optimized && type === SlotFlags.STABLE) {
         // compiled AND stable.
         // no need to update, and skip stale slots removal.

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -21,7 +21,7 @@ import {
   isClassComponent
 } from './component'
 import { RawSlots } from './componentSlots'
-import { isProxy, Ref, toRaw, ReactiveFlags, isRef } from '@vue/reactivity'
+import { isProxy, Ref, toRaw, isRef } from '@vue/reactivity'
 import { AppContext } from './apiCreateApp'
 import {
   Suspense,
@@ -144,7 +144,7 @@ export interface VNode<
   /**
    * @internal
    */
-  [ReactiveFlags.SKIP]: true
+  __v_skip: true
 
   type: VNodeTypes
   props: (VNodeProps & ExtraProps) | null


### PR DESCRIPTION
`const enum` caused many trouble for both user (#1228) and [Vue itself](https://github.com/vuejs/core/blob/main/scripts/const-enum.js). So this PR is trying to remove all the `const enum` in Vue codebase, with non-breaking way of course.

For types I will use `union` type to replace `const enum`, for runtime I will replace `const enum` with literal value. It's not a breaking change because `const enum` is compatible with `union` type, so the code below can continue to work:
```ts
const enum TrackOpTypes {
  GET = 'get',
  HAS = 'has',
  ITERATE = 'iterate'
}

type TrackOpTypesUnion = 'get' | 'has' | 'iterate'

function track(target: object, type: TrackOpTypesUnion, key: unknown) {
  // ...
}

track(rawTarget, TrackOpTypes.GET, key) // NO ERROR!
```

Currently I only refactored the `@vue/reactivity` package as an example, and it works. I kept the `const enum` declaration and its exports for compatibility.

Do you think this is worth a try? If so, please let me know so I can continue. Or if you don't think this is the right path, I'll stop there.