### PR TITLE
feat(compiler-core): enhance `fnExpRE`

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -437,6 +437,135 @@ describe('compiler: transform v-on', () => {
     })
   })
 
+  test('should handle inline arrow function expression wrapped in parentheses', () => {
+    const { node } = parseWithVOn(`<div @click="(foo => bar = foo)" />`)
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: '(foo => bar = foo)'
+    })
+  })
+
+  test('should handle inline arrow function expression wrapped in parentheses (with Typescript)', () => {
+    const { node } = parseWithVOn(
+      `<div @click="((foo: any): any => bar = foo)" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: '((foo: any): any => bar = foo)'
+    })
+  })
+
+  test('should handle inline function expression wrapped in parentheses', () => {
+    const { node } = parseWithVOn(
+      `<div @click="(function (foo) { bar = foo })" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: '(function (foo) { bar = foo })'
+    })
+  })
+
+  test('should handle inline function expression wrapped in parentheses (with Typescript)', () => {
+    const { node } = parseWithVOn(
+      `<div @click="(function (foo: any): any { bar = foo })" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: '(function (foo: any): any { bar = foo })'
+    })
+  })
+
+  test('should handle inline async arrow function expression with parameters', () => {
+    const { node } = parseWithVOn(
+      `<div @click="async foo => await fetch(foo)" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: 'async foo => await fetch(foo)'
+    })
+  })
+
+  test('should handle inline async arrow function expression with parameters (with Typescript)', () => {
+    const { node } = parseWithVOn(
+      `<div @click="async (foo: any): Promise<any> => await fetch(foo)" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: 'async (foo: any): Promise<any> => await fetch(foo)'
+    })
+  })
+
+  test('should handle inline async arrow function expression with parameters wrapped in parentheses', () => {
+    const { node } = parseWithVOn(
+      `<div @click="(async foo => await fetch(foo))" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: '(async foo => await fetch(foo))'
+    })
+  })
+
+  test('should handle inline async arrow function expression with parameters wrapped in parentheses (with Typescript)', () => {
+    const { node } = parseWithVOn(
+      `<div @click="(async (foo: any): Promise<any> => await fetch(foo))" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: '(async (foo: any): Promise<any> => await fetch(foo))'
+    })
+  })
+
+  test('should handle inline async arrow function expression with parameters wrapped in parentheses', () => {
+    const { node } = parseWithVOn(
+      `<div @click="(async function (foo) {\nawait fetch(foo)\nbar = foo\n})" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: '(async function (foo) {\nawait fetch(foo)\nbar = foo\n})'
+    })
+  })
+
+  test('should handle inline async arrow function expression with parameters wrapped in parentheses (with Typescript)', () => {
+    const { node } = parseWithVOn(
+      `<div @click="(async function (foo: any): Promise<any> {\nawait fetch(foo)\nbar = foo\n}})" />`
+    )
+    const vnodeCall = node.codegenNode as VNodeCall
+    expect(
+      (vnodeCall.props as ObjectExpression).properties[0].value
+    ).toMatchObject({
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content:
+        '(async function (foo: any): Promise<any> {\nawait fetch(foo)\nbar = foo\n}})'
+    })
+  })
+
   // TODO remove in 3.4
   test('case conversion for vnode hooks', () => {
     const { node } = parseWithVOn(`<div v-on:vnode-mounted="onMount"/>`)

--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -17,7 +17,7 @@ import { hasScopeRef, isMemberExpression } from '../utils'
 import { TO_HANDLER_KEY } from '../runtimeHelpers'
 
 const fnExpRE =
-  /(^[\s\(]*((async\s*)?([\w$_]+|\([^)]*?\))\s*(:[^=]+)?=>|(async\s+)?function(?:\s*[\w$_]*)\s*\([^)]*?\)\s*(:[^=]+)?{))[\s\S]+\)*/
+  /(?:^[\s\(]*(?:(?:async\s*)?(?:[\w$_]+|\([^)]*?\))\s*(?::[^=]+)?=>|(?:async\s+)?function(?:\s+[\w$_]+)?\s*\([^)]*?\)\s*(?::[^=]+)?{))[\s\S]+\)*/
 
 export interface VOnDirectiveNode extends DirectiveNode {
   // v-on without arg is handled directly in ./transformElements.ts due to it affecting

--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -17,7 +17,7 @@ import { hasScopeRef, isMemberExpression } from '../utils'
 import { TO_HANDLER_KEY } from '../runtimeHelpers'
 
 const fnExpRE =
-  /^\s*([\w$_]+|(async\s*)?\([^)]*?\))\s*(:[^=]+)?=>|^\s*(async\s+)?function(?:\s+[\w$]+)?\s*\(/
+  /(^[\s\(]*((async\s*)?([\w$_]+|\([^)]*?\))\s*(:[^=]+)?=>|(async\s+)?function(?:\s*[\w$_]*)\s*\([^)]*?\)\s*(:[^=]+)?{))[\s\S]+\)*/
 
 export interface VOnDirectiveNode extends DirectiveNode {
   // v-on without arg is handled directly in ./transformElements.ts due to it affecting


### PR DESCRIPTION
I found that some syntactically valid function expressions were not handled correctly by the `v-on`.

[Playground](https://play.vuejs.org/#eNqVVE1v2zAM/SucL3GA2sbWAQMCN8g+OmA7bMO2ow9NbCZRY0mGRCUdAv/3UXLquk2ToqeEH3p8JB+9jz42Tbp1GE2i3JZGNAQWyTXTQgnZaEOwB4NLaGFptIQRp4760Gctm4M/zbzhkThcqFIrSyDtCq788/jmq1MWFljrHdi1dhWU67laIdBaWCC8I1g4AqUpvRkXKs86LsyCDULZ1HNCtgDy9dvpfh+g2zbP2PI57A9kZiukROndVRHF/ANX0wMJNsZFND125oF4B30EES+dKklo5d+NeRT9O2jHAe98xjnwuf2nypA45MOYzweGUG+SBHbabCwkyYPnRIUzBH0DLybdN9HXOprS84TDeE6Ezg79ZUav4u3V1Csouog67SZy3qS3VisW/t7zKA4BW0QTCB7vYz17u4jWRI2dZJlTzWaVllpmM45lxikSEpNKy9ll+i59/yGrhKWhP0Urk4XRO4uGKxbRxQA8Y+cWTWJQVWjQnC32JPdRwSexo6K+Zluolgdwf6iDk6/5Fnn0vvn+/LsTRinI8kgrXAqF197K9xDjBEaHlY0uYDsB5eQCzXgCWy0qaKfxuSsuKOdrJ61gVtai3HDpUCceYH7h1JT/xuHOupHlttYEWaebrIOY5gvjPY+XTJbpL8XqyYp5lI2o0fxsvGger3pe88fpe/CRcdhvqVxjuXnGf2vvum39MhimP9gszQ130oWv//zgz9sgKHXl6oOsTgR/o9W18xy7tE9OVUx7kBfYfguKFWr1117fESp735QnGjYe8oPS/NZPtf5A9zK97JXS/gdl1gap).

