### PR TITLE
fix: hydration `__vnode` missing

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -111,6 +111,17 @@ export function createHydrationFunctions(
     let domType = node.nodeType
     vnode.el = node
 
+    if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
+      Object.defineProperty(node, '__vnode', {
+        value: vnode,
+        enumerable: false
+      })
+      Object.defineProperty(node, '__vueParentComponent', {
+        value: parentComponent,
+        enumerable: false
+      })
+    }
+
     if (patchFlag === PatchFlags.BAIL) {
       optimized = false
       vnode.dynamicChildren = null

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -112,14 +112,18 @@ export function createHydrationFunctions(
     vnode.el = node
 
     if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
-      Object.defineProperty(node, '__vnode', {
-        value: vnode,
-        enumerable: false
-      })
-      Object.defineProperty(node, '__vueParentComponent', {
-        value: parentComponent,
-        enumerable: false
-      })
+      if (!('__vnode' in node)) {
+        Object.defineProperty(node, '__vnode', {
+          value: vnode,
+          enumerable: false
+        })
+      }
+      if (!('__vueParentComponent' in node)) {
+        Object.defineProperty(node, '__vueParentComponent', {
+          value: parentComponent,
+          enumerable: false
+        })
+      }
     }
 
     if (patchFlag === PatchFlags.BAIL) {


### PR DESCRIPTION
In the basic renderer, we inject `__vnode` on dev for devtools to grab it. We missing that information in SSR as we didn't do so in hydration.

https://github.com/vuejs/core/blob/a6ae876c54cc218479b8ff3bc09b59070d9b72a6/packages/runtime-core/src/renderer.ts#L689-L698