### PR TITLE
chore: Simplify setupComponent condition check in mountComponent

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1217,7 +1217,7 @@ function baseCreateRenderer(
     }
 
     // resolve props and slots for setup context
-    if (!(__COMPAT__ && compatMountInstance)) {
+    if (!compatMountInstance) {
       if (__DEV__) {
         startMeasure(instance, `init`)
       }


### PR DESCRIPTION
This PR simplifies the condition check in the `mountComponent` function in `packages/runtime-core/src/renderer.ts`. 

The `__COMPAT__` check in `if (!(__COMPAT__ && compatMountInstance))` is redundant because `compatMountInstance` is already based on `__COMPAT__`. 

This change makes the code cleaner and easier to understand.