### PR TITLE
fix(helpers): useCssVars race condition (fix #9264)

### DIFF
--- a/packages/runtime-dom/src/helpers/useCssVars.ts
+++ b/packages/runtime-dom/src/helpers/useCssVars.ts
@@ -40,9 +40,11 @@ export function useCssVars(getter: (ctx: any) => Record<string, string>) {
   watchPostEffect(setVars)
 
   onMounted(() => {
-    const ob = new MutationObserver(setVars)
-    ob.observe(instance.subTree.el!.parentNode, { childList: true })
-    onUnmounted(() => ob.disconnect())
+    if (instance.subTree.el?.parentNode) {
+      const ob = new MutationObserver(setVars)
+      ob.observe(instance.subTree.el!.parentNode, { childList: true })
+      onUnmounted(() => ob.disconnect())
+    }
   })
 }
 


### PR DESCRIPTION
close #9264

**Observations**
It seems that the issue happens when there is a mount and directly unmount of the component
I noticed with the reproduction envs, that if I add an `onBeforeUnmount` hook, it's triggered before the `onMounted` which explains why the `parentNode` is `undefined` thus the error

I think checking the `parentNode` to be defined is enough, another solution might be to track the `beforeUnmount` hook and avoid plugging the observer