### PR TITLE
feat(reactivity): add `toShallowRef`

### DIFF
--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -9,6 +9,7 @@ export {
   proxyRefs,
   customRef,
   triggerRef,
+  toShallowRef,
   type Ref,
   type MaybeRef,
   type MaybeRefOrGetter,
@@ -18,7 +19,8 @@ export {
   type ShallowRef,
   type ShallowUnwrapRef,
   type RefUnwrapBailTypes,
-  type CustomRefFactory
+  type CustomRefFactory,
+  type ToShallowRef
 } from './ref'
 export {
   reactive,

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -488,19 +488,21 @@ export type ToShallowRef<T> = IfAny<
  * @example
  * ```js
  * const state = reactive({
- *   foo: 1,
- *   bar: 2
+ *   nested: {
+ *    foo: 1
+ *   }
  * })
  *
- * const fooRef = toRef(state, 'foo')
+ * const nestedShallowRef = toShallowRef(state, 'nested')
+ * const doubleFoo = computed(() => nestedShallowRef.value.foo * 2)
  *
- * // mutating the ref updates the original
- * fooRef.value++
- * console.log(state.foo) // 2
+ * // mutating the shallow ref does NOT update the original state
+ * nestedShallowRef.value.nested.foo = 4
+ * console.log(doubleFoo.value) // 2
  *
- * // mutating the original also updates the ref
- * state.foo++
- * console.log(fooRef.value) // 3
+ * // manual trigger is needed to "sync" the ref
+ * triggerRef(nestedShallowRef)
+ * console.log(doubleFoo.value) // 8
  * ```
  *
  * @param source - A getter, an existing ref, a non-function value, or a


### PR DESCRIPTION
This introduces `toShallowRef` which act like `toRef` but to produce `shallowRef` instead of `ref`

```ts
// convert ref/reactive to shallowRef
toShallowRef(ref('Hello World')) // ShallowRef<string>
toShallowRef(reactive({ foo: 1 })) // ShallowRef<{ foo: number }>

// convert object keys like toRef
toShallowRef({ nested: { foo: 1 }}, 'nested') // ShallowRef<{ foo: number }>

// accept computed getter
toShallowRef(() => 'Hello World') // Readonly<ShallowRef<string>>

// act like shallowRef on raw values
toShallowRef('Hello World') // ShallowRef<string>

// preserve shallowRef
const shallow = shallowRef('Hello World')
toShallowRef(shallow) === shallow // true
```
