### PR TITLE
fix(compat): return value of vue compat set()

### DIFF
--- a/packages/runtime-core/src/compat/instance.ts
+++ b/packages/runtime-core/src/compat/instance.ts
@@ -58,6 +58,7 @@ export interface LegacyPublicProperties {
 export function installCompatInstanceProperties(map: PublicPropertiesMap) {
   const set = (target: any, key: any, val: any) => {
     target[key] = val
+    return target[key]
   }
 
   const del = (target: any, key: any) => {


### PR DESCRIPTION
According to https://v2.vuejs.org/v2/api/#Vue-set, the expected behavior is:

> Returns: the set value.