### PR TITLE
feat: repalce Object.prototype.hasOwnProperty with Object.hasOwn

### DIFF
--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -25,12 +25,10 @@ export const remove = <T>(arr: T[], el: T) => {
     arr.splice(i, 1)
   }
 }
-
-const hasOwnProperty = Object.prototype.hasOwnProperty
 export const hasOwn = (
   val: object,
   key: string | symbol
-): key is keyof typeof val => hasOwnProperty.call(val, key)
+): key is keyof typeof val => Object.hasOwn(val, key)
 
 export const isArray = Array.isArray
 export const isMap = (val: unknown): val is Map<any, any> =>


### PR DESCRIPTION
MDN said
 > It is recommended over [Object.prototype.hasOwnProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) because it works for [null-prototype objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) and with objects that have overridden the inherited hasOwnProperty() method. While it is possible to workaround these problems by calling Object.prototype.hasOwnProperty() on an external object, Object.hasOwn() is more intuitive.



So i think `Object.hasOwn` is better. I will replace other place if the maintainer approved.