### PR TITLE
fix(Suspense): mount runs too early when used in Transition

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -491,10 +491,12 @@ function createSuspenseBoundary(
         container
       } = suspense
 
+      // if there's a transition happening we need to wait it to finish.
+      let delayEnter: boolean | null = false
       if (suspense.isHydrating) {
         suspense.isHydrating = false
       } else if (!resume) {
-        const delayEnter =
+        delayEnter =
           activeBranch &&
           pendingBranch!.transition &&
           pendingBranch!.transition.mode === 'out-in'
@@ -502,6 +504,7 @@ function createSuspenseBoundary(
           activeBranch!.transition!.afterLeave = () => {
             if (pendingId === suspense.pendingId) {
               move(pendingBranch!, container, anchor, MoveType.ENTER)
+              queuePostFlushCb(effects)
             }
           }
         }
@@ -538,8 +541,8 @@ function createSuspenseBoundary(
         }
         parent = parent.parent
       }
-      // no pending parent suspense, flush all jobs
-      if (!hasUnresolvedAncestor) {
+      // no pending parent suspense nor transition, flush all jobs
+      if (!hasUnresolvedAncestor && !delayEnter) {
         queuePostFlushCb(effects)
       }
       suspense.effects = []


### PR DESCRIPTION
closes #5844 , #5952

`Suspense` was executing `effects` before the Transition ended.

