### PR TITLE
fix(compat): use LegacyPublicInstance for $root

### DIFF
--- a/packages/runtime-core/src/compat/instance.ts
+++ b/packages/runtime-core/src/compat/instance.ts
@@ -43,6 +43,7 @@ export type LegacyPublicInstance = ComponentPublicInstance &
   LegacyPublicProperties
 
 export interface LegacyPublicProperties {
+  $root: LegacyPublicInstance
   $set(target: object, key: string, value: any): void
   $delete(target: object, key: string): void
   $mount(el?: string | Element): this


### PR DESCRIPTION
With `@vue/compat`, `$root` should also contain the legacy properties from Vue 2 (found in `LegacyPublicProperties`).