### PR TITLE
fix(ssr): Using teleport disabled causes mismatch

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1083,5 +1083,29 @@ describe('SSR hydration', () => {
       expect(teleportContainer.innerHTML).toBe(`<span>value</span>`)
       expect(`Hydration children mismatch`).toHaveBeenWarned()
     })
+    // #6152
+    test('Teleport is disabled', () => {
+      const { container } = mountWithHydration(
+        '<!--[--><div>Parent fragment</div><!--teleport start--><div>Teleport content</div><!--teleport end--><!--]-->',
+        () => [
+          h('div', 'Parent fragment'),
+          h(
+            defineComponent(
+              () => () =>
+                h(Teleport, { to: 'body', disabled: true }, [
+                  h('div', 'Teleport content')
+                ])
+            )
+          )
+        ]
+      )
+      expect(document.body.innerHTML).toBe('')
+      expect(container.innerHTML).toBe(
+        '<!--[--><div>Parent fragment</div><!--teleport start--><div>Teleport content</div><!--teleport end--><!--]-->'
+      )
+      expect(
+        `Hydration completed but contains mismatches.`
+      ).not.toHaveBeenWarned()
+    })
   })
 })

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -393,6 +393,28 @@ describe('SSR hydration', () => {
     )
   })
 
+  // #6152
+  test('Teleport (disabled + as component root)', () => {
+    const { container } = mountWithHydration(
+      '<!--[--><div>Parent fragment</div><!--teleport start--><div>Teleport content</div><!--teleport end--><!--]-->',
+      () => [
+        h('div', 'Parent fragment'),
+        h(() =>
+          h(Teleport, { to: 'body', disabled: true }, [
+            h('div', 'Teleport content')
+          ])
+        )
+      ]
+    )
+    expect(document.body.innerHTML).toBe('')
+    expect(container.innerHTML).toBe(
+      '<!--[--><div>Parent fragment</div><!--teleport start--><div>Teleport content</div><!--teleport end--><!--]-->'
+    )
+    expect(
+      `Hydration completed but contains mismatches.`
+    ).not.toHaveBeenWarned()
+  })
+
   test('Teleport (as component root)', () => {
     const teleportContainer = document.createElement('div')
     teleportContainer.id = 'teleport4'
@@ -1082,30 +1104,6 @@ describe('SSR hydration', () => {
       )
       expect(teleportContainer.innerHTML).toBe(`<span>value</span>`)
       expect(`Hydration children mismatch`).toHaveBeenWarned()
-    })
-    // #6152
-    test('Teleport is disabled', () => {
-      const { container } = mountWithHydration(
-        '<!--[--><div>Parent fragment</div><!--teleport start--><div>Teleport content</div><!--teleport end--><!--]-->',
-        () => [
-          h('div', 'Parent fragment'),
-          h(
-            defineComponent(
-              () => () =>
-                h(Teleport, { to: 'body', disabled: true }, [
-                  h('div', 'Teleport content')
-                ])
-            )
-          )
-        ]
-      )
-      expect(document.body.innerHTML).toBe('')
-      expect(container.innerHTML).toBe(
-        '<!--[--><div>Parent fragment</div><!--teleport start--><div>Teleport content</div><!--teleport end--><!--]-->'
-      )
-      expect(
-        `Hydration completed but contains mismatches.`
-      ).not.toHaveBeenWarned()
     })
   })
 })


### PR DESCRIPTION
closes #6152

When hydrating a teleport inside a component will cause the warning `Hydration completed but contains mismatches.`, caused because the lookhead of teleport start was based on being always the next sibling when teleport is disabled the next sibling is the content. 
