### PR TITLE
feat(compiler-sfc): introduce `defineRender` macro

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineRender.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineRender.spec.ts.snap
@@ -15,6 +15,21 @@ return () => <div />
 })"
 `;
 
+exports[`defineRender() > empty argument 1`] = `
+"const foo = 'bar'
+      
+export default {
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      
+      
+return { foo }
+}
+
+}"
+`;
+
 exports[`defineRender() > function 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineRender.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineRender.spec.ts.snap
@@ -1,0 +1,47 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`defineRender() > JSX Element 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      
+      
+return () => <div />
+}
+
+})"
+`;
+
+exports[`defineRender() > function 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      
+      
+return () => <div />
+}
+
+})"
+`;
+
+exports[`defineRender() > identifier 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { renderFn } from './ctx'
+      
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      
+      
+return renderFn
+}
+
+})"
+`;

--- a/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
@@ -44,6 +44,21 @@ describe('defineRender()', () => {
     expect(content).not.toMatch('defineRender')
   })
 
+  test('empty argument', () => {
+    const { content } = compile(
+      `
+      <script setup>
+      const foo = 'bar'
+      defineRender()
+      </script>
+    `,
+      { defineRender: true }
+    )
+    assertCode(content)
+    expect(content).toMatch(`return { foo }`)
+    expect(content).not.toMatch('defineRender')
+  })
+
   describe('errors', () => {
     test('w/ <template>', () => {
       expect(() =>

--- a/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
@@ -43,4 +43,22 @@ describe('defineRender()', () => {
     expect(content).toMatch(`return renderFn`)
     expect(content).not.toMatch('defineRender')
   })
+
+  describe('errors', () => {
+    test('w/ <template>', () => {
+      expect(() =>
+        compile(
+          `
+      <script setup lang="tsx">
+      defineRender(<div />)
+      </script>
+      <template>
+        <span>hello</span>
+      </template>
+    `,
+          { defineRender: true }
+        )
+      ).toThrow(`defineRender() cannot be used with <template>.`)
+    })
+  })
 })

--- a/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
@@ -1,0 +1,46 @@
+import { compileSFCScript as compile, assertCode } from '../utils'
+
+describe('defineRender()', () => {
+  test('JSX Element', () => {
+    const { content } = compile(
+      `
+      <script setup lang="tsx">
+      defineRender(<div />)
+      </script>
+    `,
+      { defineRender: true }
+    )
+    assertCode(content)
+    expect(content).toMatch(`return () => <div />`)
+    expect(content).not.toMatch('defineRender')
+  })
+
+  test('function', () => {
+    const { content } = compile(
+      `
+      <script setup lang="tsx">
+      defineRender(() => <div />)
+      </script>
+    `,
+      { defineRender: true }
+    )
+    assertCode(content)
+    expect(content).toMatch(`return () => <div />`)
+    expect(content).not.toMatch('defineRender')
+  })
+
+  test('identifier', () => {
+    const { content } = compile(
+      `
+      <script setup lang="ts">
+      import { renderFn } from './ctx'
+      defineRender(renderFn)
+      </script>
+    `,
+      { defineRender: true }
+    )
+    assertCode(content)
+    expect(content).toMatch(`return renderFn`)
+    expect(content).not.toMatch('defineRender')
+  })
+})

--- a/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineRender.spec.ts
@@ -1,4 +1,4 @@
-import { compileSFCScript as compile, assertCode } from '../utils'
+import { assertCode, compileSFCScript as compile } from '../utils'
 
 describe('defineRender()', () => {
   test('JSX Element', () => {
@@ -8,7 +8,7 @@ describe('defineRender()', () => {
       defineRender(<div />)
       </script>
     `,
-      { defineRender: true }
+      { defineRender: true },
     )
     assertCode(content)
     expect(content).toMatch(`return () => <div />`)
@@ -22,7 +22,7 @@ describe('defineRender()', () => {
       defineRender(() => <div />)
       </script>
     `,
-      { defineRender: true }
+      { defineRender: true },
     )
     assertCode(content)
     expect(content).toMatch(`return () => <div />`)
@@ -37,7 +37,7 @@ describe('defineRender()', () => {
       defineRender(renderFn)
       </script>
     `,
-      { defineRender: true }
+      { defineRender: true },
     )
     assertCode(content)
     expect(content).toMatch(`return renderFn`)
@@ -52,7 +52,7 @@ describe('defineRender()', () => {
       defineRender()
       </script>
     `,
-      { defineRender: true }
+      { defineRender: true },
     )
     assertCode(content)
     expect(content).toMatch(`return { foo }`)
@@ -71,8 +71,8 @@ describe('defineRender()', () => {
         <span>hello</span>
       </template>
     `,
-          { defineRender: true }
-        )
+          { defineRender: true },
+        ),
       ).toThrow(`defineRender() cannot be used with <template>.`)
     })
   })

--- a/packages/compiler-sfc/__tests__/utils.ts
+++ b/packages/compiler-sfc/__tests__/utils.ts
@@ -31,6 +31,7 @@ export function assertCode(code: string) {
       plugins: [
         'typescript',
         ['importAttributes', { deprecatedAssertSyntax: true }],
+        'jsx',
       ],
     })
   } catch (e: any) {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -808,7 +808,10 @@ export function compileScript(
   let returned = ''
   if (ctx.renderFunction) {
     if (sfc.template) {
-      warnOnce(`<template> is ignored when using ${DEFINE_RENDER}().`)
+      ctx.error(
+        `${DEFINE_RENDER}() cannot be used with <template>.`,
+        ctx.renderFunction
+      )
     }
     if (ctx.renderFunction.type === 'JSXElement') {
       returned = '() => '

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -810,7 +810,7 @@ export function compileScript(
     if (sfc.template) {
       ctx.error(
         `${DEFINE_RENDER}() cannot be used with <template>.`,
-        ctx.renderFunction
+        ctx.renderFunction,
       )
     }
     if (ctx.renderFunction.type === 'JSXElement') {
@@ -818,7 +818,7 @@ export function compileScript(
     }
     returned += scriptSetup.content.slice(
       ctx.renderFunction.start!,
-      ctx.renderFunction.end!
+      ctx.renderFunction.end!,
     )
   } else if (
     !options.inlineTemplate ||
@@ -868,7 +868,7 @@ export function compileScript(
     // inline it right here
     const { code, ast, preamble, tips, errors } = compileTemplate({
       filename,
-        ast: sfc.template.ast,
+      ast: sfc.template.ast,
       source: sfc.template.content,
       inMap: sfc.template.map,
       ...options.templateOptions,
@@ -895,7 +895,7 @@ export function compileScript(
           `\n\n` +
           sfc.filename +
           '\n' +
-          generateCodeFrame(source, err.loc.start.offset, err.loc.end.offset,) +
+          generateCodeFrame(source, err.loc.start.offset, err.loc.end.offset) +
           `\n`
       }
       throw err

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -856,66 +856,59 @@ export function compileScript(
       }
     }
     returned = returned.replace(/, $/, '') + ` }`
-  } else {
+  } else if (sfc.template && !sfc.template.src) {
     // inline mode
-    if (sfc.template && !sfc.template.src) {
-      if (options.templateOptions && options.templateOptions.ssr) {
-        hasInlinedSsrRenderFn = true
-      }
-      // inline render function mode - we are going to compile the template and
-      // inline it right here
-      const { code, ast, preamble, tips, errors } = compileTemplate({
-        filename,
-        ast: sfc.template.ast,
-        source: sfc.template.content,
-        inMap: sfc.template.map,
-        ...options.templateOptions,
-        id: scopeId,
-        scoped: sfc.styles.some(s => s.scoped),
-        isProd: options.isProd,
-        ssrCssVars: sfc.cssVars,
-        compilerOptions: {
-          ...(options.templateOptions &&
-            options.templateOptions.compilerOptions),
-          inline: true,
-          isTS: ctx.isTS,
-          bindingMetadata: ctx.bindingMetadata,
-        },
-      })
-      if (tips.length) {
-        tips.forEach(warnOnce)
-      }
-      const err = errors[0]
-      if (typeof err === 'string') {
-        throw new Error(err)
-      } else if (err) {
-        if (err.loc) {
-          err.message +=
-            `\n\n` +
-            sfc.filename +
-            '\n' +
-            generateCodeFrame(
-              source,
-              err.loc.start.offset,
-              err.loc.end.offset,
-            ) +
-            `\n`
-        }
-        throw err
-      }
-      if (preamble) {
-        ctx.s.prepend(preamble)
-      }
-      // avoid duplicated unref import
-      // as this may get injected by the render function preamble OR the
-      // css vars codegen
-      if (ast && ast.helpers.has(UNREF)) {
-        ctx.helperImports.delete('unref')
-      }
-      returned = code
-    } else {
-      returned = `() => {}`
+    if (options.templateOptions && options.templateOptions.ssr) {
+      hasInlinedSsrRenderFn = true
     }
+    // inline render function mode - we are going to compile the template and
+    // inline it right here
+    const { code, ast, preamble, tips, errors } = compileTemplate({
+      filename,
+        ast: sfc.template.ast,
+      source: sfc.template.content,
+      inMap: sfc.template.map,
+      ...options.templateOptions,
+      id: scopeId,
+      scoped: sfc.styles.some(s => s.scoped),
+      isProd: options.isProd,
+      ssrCssVars: sfc.cssVars,
+      compilerOptions: {
+        ...(options.templateOptions && options.templateOptions.compilerOptions),
+        inline: true,
+        isTS: ctx.isTS,
+        bindingMetadata: ctx.bindingMetadata,
+      },
+    })
+    if (tips.length) {
+      tips.forEach(warnOnce)
+    }
+    const err = errors[0]
+    if (typeof err === 'string') {
+      throw new Error(err)
+    } else if (err) {
+      if (err.loc) {
+        err.message +=
+          `\n\n` +
+          sfc.filename +
+          '\n' +
+          generateCodeFrame(source, err.loc.start.offset, err.loc.end.offset,) +
+          `\n`
+      }
+      throw err
+    }
+    if (preamble) {
+      ctx.s.prepend(preamble)
+    }
+    // avoid duplicated unref import
+    // as this may get injected by the render function preamble OR the
+    // css vars codegen
+    if (ast && ast.helpers.has(UNREF)) {
+      ctx.helperImports.delete('unref')
+    }
+    returned = code
+  } else {
+    returned = `() => {}`
   }
 
   if (!options.inlineTemplate && !__TEST__) {

--- a/packages/compiler-sfc/src/script/context.ts
+++ b/packages/compiler-sfc/src/script/context.ts
@@ -36,6 +36,7 @@ export class ScriptCompileContext {
   hasDefaultExportRender = false
   hasDefineOptionsCall = false
   hasDefineSlotsCall = false
+  hasDefineRenderCall = false
   hasDefineModelCall = false
 
   // defineProps
@@ -58,6 +59,9 @@ export class ScriptCompileContext {
 
   // defineOptions
   optionsRuntimeDecl: Node | undefined
+
+  // defineRender
+  renderFunction?: Node
 
   // codegen
   bindingMetadata: BindingMetadata = {}

--- a/packages/compiler-sfc/src/script/defineRender.ts
+++ b/packages/compiler-sfc/src/script/defineRender.ts
@@ -1,0 +1,34 @@
+import { Node } from '@babel/types'
+import { isCallOf } from './utils'
+import { ScriptCompileContext } from './context'
+import { warnOnce } from '../warn'
+
+export const DEFINE_RENDER = 'defineRender'
+
+export function processDefineRender(
+  ctx: ScriptCompileContext,
+  node: Node
+): boolean {
+  if (!isCallOf(node, DEFINE_RENDER)) {
+    return false
+  }
+
+  if (!ctx.options.defineRender) {
+    warnOnce(
+      `${DEFINE_RENDER}() is an experimental feature and disabled by default.\n` +
+        `To enable it, follow the RFC at https://github.com/vuejs/rfcs/discussions/TODO.`
+    )
+    return false
+  }
+
+  if (ctx.hasDefineRenderCall) {
+    ctx.error(`duplicate ${DEFINE_RENDER}() call`, node)
+  }
+
+  ctx.hasDefineRenderCall = true
+  if (node.arguments.length > 0) {
+    ctx.renderFunction = node.arguments[0]
+  }
+
+  return true
+}

--- a/packages/compiler-sfc/src/script/defineRender.ts
+++ b/packages/compiler-sfc/src/script/defineRender.ts
@@ -16,7 +16,7 @@ export function processDefineRender(
   if (!ctx.options.defineRender) {
     warnOnce(
       `${DEFINE_RENDER}() is an experimental feature and disabled by default.\n` +
-        `To enable it, follow the RFC at https://github.com/vuejs/rfcs/discussions/TODO.`
+        `To enable it, follow the RFC at https://github.com/vuejs/rfcs/discussions/585.`
     )
     return false
   }

--- a/packages/compiler-sfc/src/script/defineRender.ts
+++ b/packages/compiler-sfc/src/script/defineRender.ts
@@ -1,13 +1,13 @@
-import { Node } from '@babel/types'
+import type { Node } from '@babel/types'
 import { isCallOf } from './utils'
-import { ScriptCompileContext } from './context'
+import type { ScriptCompileContext } from './context'
 import { warnOnce } from '../warn'
 
 export const DEFINE_RENDER = 'defineRender'
 
 export function processDefineRender(
   ctx: ScriptCompileContext,
-  node: Node
+  node: Node,
 ): boolean {
   if (!isCallOf(node, DEFINE_RENDER)) {
     return false
@@ -16,7 +16,7 @@ export function processDefineRender(
   if (!ctx.options.defineRender) {
     warnOnce(
       `${DEFINE_RENDER}() is an experimental feature and disabled by default.\n` +
-        `To enable it, follow the RFC at https://github.com/vuejs/rfcs/discussions/585.`
+        `To enable it, follow the RFC at https://github.com/vuejs/rfcs/discussions/585.`,
     )
     return false
   }

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -31,6 +31,7 @@ import type {
 import { warn } from './warning'
 import type { SlotsType, StrictUnwrapSlotsType } from './componentSlots'
 import type { Ref } from '@vue/reactivity'
+import type { VNode } from './vnode'
 
 // dev only
 const warnRuntimeUsage = (method: string) =>
@@ -330,7 +331,7 @@ type PropsWithDefaults<
  * defineRender(() => h('div', 'hello'))
  * ```
  */
-export function defineRender(renderFn: JSX.Element | RenderFunction): void {
+export function defineRender(renderFn: VNode | RenderFunction): void {
   if (__DEV__) {
     warnRuntimeUsage('defineRender')
   }

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -20,6 +20,7 @@ import type {
   ComponentOptionsWithoutProps,
   ComputedOptions,
   MethodOptions,
+  RenderFunction,
 } from './componentOptions'
 import type {
   ComponentObjectPropsOptions,
@@ -311,6 +312,28 @@ type PropsWithDefaults<
       ? boolean | undefined
       : boolean
     : boolean
+}
+
+/**
+ * (**Experimental**) Vue `<script setup>` compiler macro for declaring
+ * the render function.
+ *
+ * The first argument can be a JSX element or a render function.
+ *
+ * @example
+ * ```ts
+ * // JSX element
+ * defineRender(<div>hello</div>)
+ *
+ * // Render function
+ * defineRender(() => <div>hello</div>)
+ * defineRender(() => h('div', 'hello'))
+ * ```
+ */
+export function defineRender(renderFn: JSX.Element | RenderFunction): void {
+  if (__DEV__) {
+    warnRuntimeUsage('defineRender')
+  }
 }
 
 /**

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -73,6 +73,7 @@ export {
   defineOptions,
   defineSlots,
   defineModel,
+  defineRender,
   withDefaults,
   type DefineProps,
   type ModelRef,


### PR DESCRIPTION
**⚠️ Status: Experimental**

# Summary

See the [RFC](https://github.com/vuejs/rfcs/discussions/585) for details.

This PR introduces a new macro called `defineRender` that allows for defining a render function in `<script setup>` with or without JSX, instead of template syntax.

This is an experimental feature. We introduced a new compiler script option `defineRender`, and it's disabled by default.

## Basic Usage

```vue
<script setup lang="jsx">
import { h } from 'vue'

defineRender(<div />)
defineRender(h('div'))
defineRender(() => {
  // ...
  return <div />
})
</script>
```

---


<details>

<summary>Prev Solution: return statement</summary>

Redundant return statements can be removed by bundlers (tested on both Rollup and esbuild)

Example: https://deploy-preview-9400--vue-sfc-playground.netlify.app/#eNp9kDFPwzAQhf/K4SWtVIWhW9VWAlQJGAABEouXKLmEFOdsne0QKcp/x3bUwoC6We99vvfuRnFjTN57FBuxtSW3xoFF581eUtsZzQ5GYKxhgpp1B1lAM0mlJuugsw3sorvI7lEpDR+aVXWVLSVxmMEEiyXs9pHL+0J5lLS9nkPCeLESzoZBddvkR6spNBglAUhR6s60CvnZuDYESbGB5ESvCDnfj0lz7HF10stPLL/+0Y92iJoUL4wWuUcpzp4ruEE324e3JxzC+2x2uvIq0BfMV7Ra+dhxxm49VaH2Hy61fUh3bKl5t4fBIdnTUrFoJKfESxFue3dh9d+663yd/kmaxPQDLeaULA==

<img width="718" alt="image" src="https://github.com/vuejs/core/assets/6481596/31ebcb1e-476b-41a3-ae4b-da2866838436">


</details>