### PR TITLE
fix(types): inference for generic object types

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -41,7 +41,7 @@ describe('defineProps w/ generics', () => {
   test()
 })
 
-//github.com/vuejs/core/issues/9277
+// #9277
 describe('defineProps w/ generic object type', <T>() => {
   type Props<T> = {
     modelValue: T

--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -8,7 +8,8 @@ import {
   defineSlots,
   VNode,
   Ref,
-  defineModel
+  defineModel,
+  PropType
 } from 'vue'
 import { describe, expectType } from './utils'
 import { defineComponent } from 'vue'
@@ -38,6 +39,22 @@ describe('defineProps w/ generics', () => {
     expectType<boolean>(props.x)
   }
   test()
+})
+
+//github.com/vuejs/core/issues/9277
+describe('defineProps w/ generic object type', <T>() => {
+  type Props<T> = {
+    modelValue: T
+  }
+
+  const props = defineProps({
+    modelValue: {
+      type: Object as PropType<Props<T>['modelValue']>,
+      required: true
+    }
+  })
+
+  expectType<T>(props.modelValue)
 })
 
 describe('defineProps w/ type declaration + withDefaults', () => {

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -21,8 +21,7 @@ import {
   EMPTY_ARR,
   def,
   extend,
-  isOn,
-  IfAny
+  isOn
 } from '@vue/shared'
 import { warn } from './warning'
 import {
@@ -122,10 +121,20 @@ type InferPropType<T> = [T] extends [null]
   ? U extends DateConstructor
     ? Date | InferPropType<U>
     : InferPropType<U>
-  : [T] extends [Prop<infer V, infer D>]
-  ? unknown extends V
-    ? IfAny<V, V, D>
-    : V
+  : [T] extends [{ type: infer U; default: infer D }]
+  ? [T] extends [PropOptions<infer V, infer E>]
+    ? V
+    : D
+  : [T] extends [{ type: infer U }]
+  ? [T] extends [PropOptions<infer V>]
+    ? V
+    : U
+  : [T] extends [{ default: infer U }]
+  ? [T] extends [PropOptions<infer V, infer D>]
+    ? D
+    : U
+  : [T] extends [PropType<infer V>]
+  ? V
   : T
 
 /**


### PR DESCRIPTION
This one fixes
* https://github.com/vuejs/core/issues/9277 

Possibly related:
* https://github.com/vuejs/language-tools/issues/2192#issuecomment-1518672899
* https://github.com/vuejs/core/issues/8144

I've used this rather verbose notation because TypeScript doesn't let us assume anything (unknown extends T etc.) about the generic type `T`. Not sure if it's the best way to work around this limitation - let me know if you have a better idea.