### PR TITLE
fix: correctly resolve types from relative paths on Windows

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1,3 +1,4 @@
+import { normalize } from 'node:path'
 import { Identifier } from '@babel/types'
 import { SFCScriptCompileOptions, parse } from '../../src'
 import { ScriptCompileContext } from '../../src/script/context'
@@ -933,10 +934,10 @@ function resolve(
     id: 'test',
     fs: {
       fileExists(file) {
-        return !!files[file]
+        return !!(files[file] ?? files[normalize(file)])
       },
       readFile(file) {
-        return files[file]
+        return files[file] ?? files[normalize(file)]
       }
     },
     ...options

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -501,7 +501,9 @@ describe('resolveType', () => {
         foo: ['Number'],
         bar: ['String']
       })
-      expect(deps && [...deps]).toStrictEqual(Object.keys(files))
+      expect(deps && [...deps].map(normalize)).toStrictEqual(
+        Object.keys(files).map(normalize)
+      )
     })
 
     // #8244

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -778,7 +778,7 @@ function importSourceToScope(
   if (!resolved) {
     if (source.startsWith('.')) {
       // relative import - fast path
-      const filename = joinPaths(scope.filename, '..', source)
+      const filename = joinPaths(dirname(scope.filename), source)
       resolved = resolveExt(filename, fs)
     } else {
       // module or aliased import - use full TS resolution, only supported in Node


### PR DESCRIPTION
Closes #8671
Closes https://github.com/vuejs/vue-loader/issues/2048

`dirname` is the safest way to get a directory name from a path string.

As for this specific bug, it's because
`path.posix.join(AnyWindowsPathUsingBackSlashes, '..')` returns `.`.

I'm not sure whether there will be unexpected regression if I modify the `joinPaths` utility, so I changed the smallest possible bit of code to fix this.