### PR TITLE
fix(compiler-core): compilation of slot v-if/else when preserve whitespace

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -215,6 +215,34 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: transform component slots > template named v-if/else and whitespace preserve 1`] = `
+"const { toDisplayString: _toDisplayString, createTextVNode: _createTextVNode, resolveComponent: _resolveComponent, withCtx: _withCtx, createSlots: _createSlots, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+return function render(_ctx, _cache) {
+  const _component_Comp = _resolveComponent(\\"Comp\\")
+
+  return (_openBlock(), _createBlock(_component_Comp, null, _createSlots({ _: 2 /* DYNAMIC */ }, [
+    true
+      ? {
+          name: \\"one\\",
+          fn: _withCtx(() => [
+            _createTextVNode(_toDisplayString(_ctx.foo) + _toDisplayString(_ctx.bar), 1 /* TEXT */)
+          ]),
+          key: \\"0\\"
+        }
+      : true
+        ? {
+            name: \\"one\\",
+            fn: _withCtx(() => [
+              _createTextVNode(_toDisplayString(_ctx.foo) + _toDisplayString(_ctx.bar), 1 /* TEXT */)
+            ]),
+            key: \\"1\\"
+          }
+        : undefined
+  ]), 1024 /* DYNAMIC_SLOTS */))
+}"
+`;
+
 exports[`compiler: transform component slots > with whitespace: 'preserve' > implicit default slot 1`] = `
 "const { createElementVNode: _createElementVNode, resolveComponent: _resolveComponent, withCtx: _withCtx, openBlock: _openBlock, createBlock: _createBlock } = Vue
 

--- a/packages/compiler-core/src/transforms/vSlot.ts
+++ b/packages/compiler-core/src/transforms/vSlot.ts
@@ -223,6 +223,13 @@ export function buildSlots(
       let prev
       while (j--) {
         prev = children[j]
+        if (
+          prev.type === NodeTypes.TEXT_CALL &&
+          prev.content.type === NodeTypes.TEXT &&
+          prev.content.content === ' '
+        ) {
+          continue
+        }
         if (prev.type !== NodeTypes.COMMENT) {
           break
         }


### PR DESCRIPTION
closes #6063
based on https://github.com/vuejs/core/pull/6124

Not exposing the `whitespace` option to the context because I don't think 
```
// pseudo-node
SlotNode(vIf)
TextNode('')
SlotNode(vElse)
```
Is possible without the whitespace preserve, since it check for text content to be empty