### PR TITLE
fix(runtime-core): inject supports number type parameters.

### DIFF
--- a/packages/dts-test/inject.test-d.ts
+++ b/packages/dts-test/inject.test-d.ts
@@ -40,3 +40,6 @@ provide<Cube>(injectionKeyRef, { size: 123 })
 provide<Cube>('cube', { size: 'foo' })
 // @ts-expect-error
 provide<Cube>(123, { size: 'foo' })
+
+// inject supports numeric type parameters
+inject(123)

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -31,19 +31,19 @@ export function provide<T, K = InjectionKey<T> | string | number>(
   }
 }
 
-export function inject<T>(key: InjectionKey<T> | string): T | undefined
+export function inject<T>(key: InjectionKey<T> | string | number): T | undefined
 export function inject<T>(
-  key: InjectionKey<T> | string,
+  key: InjectionKey<T> | string | number,
   defaultValue: T,
   treatDefaultAsFactory?: false
 ): T
 export function inject<T>(
-  key: InjectionKey<T> | string,
+  key: InjectionKey<T> | string | number,
   defaultValue: T | (() => T),
   treatDefaultAsFactory: true
 ): T
 export function inject(
-  key: InjectionKey<any> | string,
+  key: InjectionKey<any> | string | number,
   defaultValue?: unknown,
   treatDefaultAsFactory = false
 ) {


### PR DESCRIPTION
closes #9439 
The implementation of  `provide` is based on `Object`.  However, if the key is a `number`, it will be converted to a `string`. Therefore, there is no good way to distinguish between `number` and `string`. 
For example:
```
provide(1, 1)
provide('1', 2)

inject(1)  // 1
inject('1')  // 2
```

So, this commit only modifies the type hints.