### PR TITLE
types(hooks): Remove onVnode* and add onVue:* hooks

### DIFF
--- a/packages/dts-test/defineComponent.test-d.tsx
+++ b/packages/dts-test/defineComponent.test-d.tsx
@@ -1472,6 +1472,37 @@ describe('slots', () => {
   expectType<Slots | undefined>(new comp2().$slots)
 })
 
+// Not exposed by vue
+type VueMountHook = (vnode: VNode) => void
+type VueUpdateHook = (vnode: VNode, vnodeOld: VNode) => void
+
+type VueMountHooks = VueMountHook | VueMountHook[]
+type VueUpdateHooks = VueUpdateHook | VueUpdateHook[]
+
+describe('@vue:* events', () => {
+  const Comp = new (defineComponent({}))()
+  expectType<VueMountHooks | undefined>(Comp.$props['onVue:BeforeMount'])
+  expectType<VueMountHooks | undefined>(Comp.$props['onVue:Mounted'])
+  expectType<VueUpdateHooks | undefined>(Comp.$props['onVue:BeforeUpdate'])
+  expectType<VueUpdateHooks | undefined>(Comp.$props['onVue:Updated'])
+  expectType<VueMountHooks | undefined>(Comp.$props['onVue:BeforeUnmount'])
+  expectType<VueMountHooks | undefined>(Comp.$props['onVue:Unmounted'])
+
+  // NOTE These Should have been removed :/
+  // // @ts-expect-error not valid anymore
+  // Comp.$props.onVnodeBeforeMount
+  // // @ts-expect-error not valid anymore
+  // Comp.$props.onVnodeMounted
+  // // @ts-expect-error not valid anymore
+  // Comp.$props.onVnodeBeforeUpdate
+  // // @ts-expect-error not valid anymore
+  // Comp.$props.onVnodeUpdated
+  // // @ts-expect-error not valid anymore
+  // Comp.$props.onVnodeBeforeUnmount
+  // // @ts-expect-error not valid anymore
+  // Comp.$props.onVnodeUnmounted
+})
+
 import {
   DefineComponent,
   ComponentOptionsMixin,

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -103,12 +103,50 @@ export type VNodeProps = {
   ref_for?: boolean
   ref_key?: string
 
+  // vue hooks
+  ['onVue:BeforeMount']?: VNodeMountHook | VNodeMountHook[]
+  ['onVue:Mounted']?: VNodeMountHook | VNodeMountHook[]
+  ['onVue:BeforeUpdate']?: VNodeUpdateHook | VNodeUpdateHook[]
+  ['onVue:Updated']?: VNodeUpdateHook | VNodeUpdateHook[]
+  ['onVue:BeforeUnmount']?: VNodeMountHook | VNodeMountHook[]
+  ['onVue:Unmounted']?: VNodeMountHook | VNodeMountHook[]
+
   // vnode hooks
+  /**
+   * Please use onVue:beforeMount
+   * @deprecated
+   * @internal
+   */
   onVnodeBeforeMount?: VNodeMountHook | VNodeMountHook[]
+  /**
+   * Please use onVue:mounted
+   * @deprecated
+   * @internal
+   */
   onVnodeMounted?: VNodeMountHook | VNodeMountHook[]
+  /**
+   * Please use onVue:beforeUpdate
+   * @deprecated
+   * @internal
+   */
   onVnodeBeforeUpdate?: VNodeUpdateHook | VNodeUpdateHook[]
+  /**
+   * Please use onVue:updated
+   * @deprecated
+   * @internal
+   */
   onVnodeUpdated?: VNodeUpdateHook | VNodeUpdateHook[]
+  /**
+   * Please use onVue:beforeUnmount
+   * @deprecated
+   * @internal
+   */
   onVnodeBeforeUnmount?: VNodeMountHook | VNodeMountHook[]
+  /**
+   * Please use onVue:unmounted
+   * @deprecated
+   * @internal
+   */
   onVnodeUnmounted?: VNodeMountHook | VNodeMountHook[]
 }
 


### PR DESCRIPTION
Adding the new recommended `@vue:*` hooks to the type.

Internally the vnode hooks are still heavily used, so I'm not too sure about how to handle those.