### PR TITLE
fix(compiler-sfc): malformed filename on windows using path.join()

### DIFF
--- a/packages/compiler-sfc/src/script/utils.ts
+++ b/packages/compiler-sfc/src/script/utils.ts
@@ -107,7 +107,12 @@ export function normalizePath(p: string) {
   return normalize(p.replace(windowsSlashRE, '/'))
 }
 
-export const joinPaths = (path.posix || path).join
+/**
+ * On Windows OS
+ * "(path.posix || path)" still resolves to "path.posix"
+ * which leads to a malformed "join()" filename path
+ */
+export const joinPaths = (process.platform !== 'win32' && path.posix ? path.posix : path).join
 
 /**
  * key may contain symbols


### PR DESCRIPTION
On Windows OS
"(path.posix || path)" still resolves to "path.posix"
which leads to a malformed "join()" filename path


Related to https://github.com/vuejs/core/discussions/9473

Reproduce (on Windows):

```javascript
const path = require('path');

console.log({
    join: path.resolve(__filename, '..'), // ✅ >> "'C:\\code\\sandbox\\posix-path'"
    posixJoin: path.posix.join(__filename, '..'), // ❌ >> "."
    resolve: path.resolve(__filename, '..'), // ✅ >> "C:\\code\\sandbox\\posix-path"
    posixResolve: path.posix.resolve(__filename, '..'), // ✅ >> /code/sandbox/posix-path
})

```

Fix forces to use `path.join()` instead of `path.posix.join()` on Windows.  

