### PR TITLE
fix(compiler-sfc): properly handle dynamic directive arguments usage check

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -696,14 +696,14 @@ return { get vMyDir() { return vMyDir } }
 
 exports[`SFC compile <script setup> > dev mode import usage check > dynamic arguments 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
-import { FooBar, foo, bar, unused } from './x'
+import { FooBar, foo, bar, unused, baz } from './x'
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose: __expose }) {
   __expose();
 
         
-return { get FooBar() { return FooBar }, get foo() { return foo }, get bar() { return bar } }
+return { get FooBar() { return FooBar }, get foo() { return foo }, get bar() { return bar }, get baz() { return baz } }
 }
 
 })"

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -383,7 +383,7 @@ describe('SFC compile <script setup>', () => {
           <FooBar #unused />
           <div :[bar.attrName]="15"></div>
           <div unused="unused"></div>
-          <div #[\`item\${item.key}\`]="{ value }"></div>
+          <div #[\`item:\${item.key}\`]="{ value }"></div>
         </template>
         `)
       expect(content).toMatch(

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -383,6 +383,7 @@ describe('SFC compile <script setup>', () => {
           <FooBar #unused />
           <div :[bar.attrName]="15"></div>
           <div unused="unused"></div>
+          <div #[\`item\${item.key}\`]="{ value }"></div>
         </template>
         `)
       expect(content).toMatch(

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -376,19 +376,19 @@ describe('SFC compile <script setup>', () => {
     test('dynamic arguments', () => {
       const { content } = compile(`
         <script setup lang="ts">
-        import { FooBar, foo, bar, unused } from './x'
+        import { FooBar, foo, bar, unused, baz } from './x'
         </script>
         <template>
           <FooBar #[foo.slotName] />
           <FooBar #unused />
           <div :[bar.attrName]="15"></div>
           <div unused="unused"></div>
-          <div #[\`item:\${item.key}\`]="{ value }"></div>
+          <div #[\`item:\${baz.key}\`]="{ value }"></div>
         </template>
         `)
       expect(content).toMatch(
         `return { get FooBar() { return FooBar }, get foo() { return foo }, ` +
-          `get bar() { return bar } }`
+          `get bar() { return bar }, get baz() { return baz } }`
       )
       assertCode(content)
     })

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -51,11 +51,10 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
                 code += `,v${capitalize(camelize(prop.name))}`
               }
 
-              //  process dynamic directive arguments as bind
+              // process dynamic directive arguments
               if (prop.arg && !(prop.arg as SimpleExpressionNode).isStatic) {
-                code += `,${processExp(
-                  (prop.arg as SimpleExpressionNode).content,
-                  'bind'
+                code += `,${stripStrings(
+                  (prop.arg as SimpleExpressionNode).content
                 )}`
               }
 

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -50,12 +50,15 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
               if (!isBuiltInDirective(prop.name)) {
                 code += `,v${capitalize(camelize(prop.name))}`
               }
+              
+              //  process dynamic directive arguments as bind
               if (prop.arg && !(prop.arg as SimpleExpressionNode).isStatic) {
                 code += `,${processExp(
                   (prop.arg as SimpleExpressionNode).content,
                   'bind'
                 )}`
               }
+              
               if (prop.exp) {
                 code += `,${processExp(
                   (prop.exp as SimpleExpressionNode).content,

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -53,7 +53,7 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
               if (prop.arg && !(prop.arg as SimpleExpressionNode).isStatic) {
                 code += `,${processExp(
                   (prop.arg as SimpleExpressionNode).content,
-                  prop.name
+                  'bind'
                 )}`
               }
               if (prop.exp) {

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -50,7 +50,7 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
               if (!isBuiltInDirective(prop.name)) {
                 code += `,v${capitalize(camelize(prop.name))}`
               }
-              
+
               //  process dynamic directive arguments as bind
               if (prop.arg && !(prop.arg as SimpleExpressionNode).isStatic) {
                 code += `,${processExp(
@@ -58,7 +58,7 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
                   'bind'
                 )}`
               }
-              
+
               if (prop.exp) {
                 code += `,${processExp(
                   (prop.exp as SimpleExpressionNode).content,


### PR DESCRIPTION
close #9493 

Due to the dynamic directive argument cannot contain spaces, this means it cannot be a possible TypeScript expression. I think it just need to strip out the string.