### PR TITLE
feat(reactivity): expose last result for computed getter

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -16,8 +16,8 @@ export interface WritableComputedRef<T> extends Ref<T> {
   readonly effect: ReactiveEffect<T>
 }
 
-export type ComputedGetter<T> = (...args: any[]) => T
-export type ComputedSetter<T> = (v: T) => void
+export type ComputedGetter<T> = (oldValue?: T) => T
+export type ComputedSetter<T> = (newValue: T) => void
 
 export interface WritableComputedOptions<T> {
   get: ComputedGetter<T>
@@ -41,9 +41,10 @@ export class ComputedRefImpl<T> {
     isReadonly: boolean,
     isSSR: boolean
   ) {
-    this.effect = new ReactiveEffect(getter, () => {
-      triggerRefValue(this, DirtyLevels.ComputedValueMaybeDirty)
-    })
+    this.effect = new ReactiveEffect(
+      () => getter(this._value),
+      () => triggerRefValue(this, DirtyLevels.ComputedValueMaybeDirty)
+    )
     this.effect.computed = this
     this.effect.active = this._cacheable = !isSSR
     this[ReactiveFlags.IS_READONLY] = isReadonly


### PR DESCRIPTION
`computed` internally uses `Object.is` to compare whether the old and new values ​​have changed. This is valid for primitives, but cannot compare objects (this is the correct behavior).

We can expose the `computed` last value for getter, so the user can decide whether to return the last value for object to pass `Object.is`.

```ts
const a = ref(1);
const b = ref(2);
const c = computed(oldValue => {
	if (oldValue && oldValue[0] === a.value && oldValue[1] === b.value) {
		return oldValue;
	}
	return [a.value, b.value];
});
```

```ts
import isEqual from 'lodash.isequal';

const a = ref(1);
const b = ref(2);
const c = computed(oldValue => {
	const newValue = { a: a.value, b: b.value };
	return isEqual(oldValue, newValue) ? oldValue : newValue;
});
```

Another alternative is to provide `isEqual` option, but I don't recommend this approach. This requires always fully executing the getter and returning a new object, which I think limits performance and GC pitfalls that the user should be able to avoid.

- getter cannot exit early on equal to avoid possible expensive operations
- getter may be executed frequently and return object to execute `isEqual` that needs to GC