### PR TITLE
chore(compiler-sfc): explicitly annotate parseCache to fix TS 5.3

### DIFF
--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -39,6 +39,7 @@
     "@vue/reactivity-transform": "3.3.7",
     "@vue/shared": "3.3.7",
     "estree-walker": "^2.0.2",
+    "lru-cache": "^10.0.1",
     "magic-string": "^0.30.5",
     "postcss": "^8.4.31",
     "source-map-js": "^1.0.2"
@@ -47,7 +48,6 @@
     "@babel/types": "^7.23.0",
     "@vue/consolidate": "^0.17.3",
     "hash-sum": "^2.0.0",
-    "lru-cache": "^10.0.1",
     "merge-source-map": "^1.1.0",
     "minimatch": "^9.0.3",
     "postcss-modules": "^4.3.1",

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -7,6 +7,7 @@ import {
   BindingMetadata
 } from '@vue/compiler-core'
 import * as CompilerDOM from '@vue/compiler-dom'
+import { LRUCache } from 'lru-cache'
 import { RawSourceMap, SourceMapGenerator } from 'source-map-js'
 import { TemplateCompiler } from './compileTemplate'
 import { parseCssVars } from './style/cssVars'
@@ -93,7 +94,9 @@ export interface SFCParseResult {
   errors: (CompilerError | SyntaxError)[]
 }
 
-export const parseCache = createCache<SFCParseResult>()
+export const parseCache:
+  | Map<string, SFCParseResult>
+  | LRUCache<string, SFCParseResult> = createCache<SFCParseResult>()
 
 export function parse(
   source: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       estree-walker:
         specifier: ^2.0.2
         version: 2.0.2
+      lru-cache:
+        specifier: ^10.0.1
+        version: 10.0.1
       magic-string:
         specifier: ^0.30.5
         version: 0.30.5
@@ -226,9 +229,6 @@ importers:
       hash-sum:
         specifier: ^2.0.0
         version: 2.0.0
-      lru-cache:
-        specifier: ^10.0.1
-        version: 10.0.1
       merge-source-map:
         specifier: ^1.1.0
         version: 1.1.0
@@ -4046,7 +4046,6 @@ packages:
   /lru-cache@10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}


### PR DESCRIPTION
Without this, the build fails. See also https://github.com/microsoft/TypeScript/issues/56261.