### PR TITLE
feat(reactivity): enhance type inference for context-sensitive inputs

### DIFF
--- a/packages/dts-test/reactivity.test-d.ts
+++ b/packages/dts-test/reactivity.test-d.ts
@@ -1,4 +1,13 @@
-import { ref, readonly, shallowReadonly, Ref, reactive, markRaw } from 'vue'
+import {
+  ref,
+  readonly,
+  shallowReadonly,
+  Ref,
+  reactive,
+  markRaw,
+  ComputedRef,
+  computed
+} from 'vue'
 import { describe, expectType } from './utils'
 
 describe('should support DeepReadonly', () => {
@@ -61,4 +70,24 @@ describe('should unwrap tuple correctly', () => {
   const tuple: [Ref<number>] = [ref(0)]
   const reactiveTuple = reactive(tuple)
   expectType<Ref<number>>(reactiveTuple[0])
+})
+
+// #1930
+describe('should unwrap the computed type', () => {
+  interface Bar {
+    a: number
+    b: (_: any) => void
+  }
+
+  const computedA: ComputedRef<number> = computed(() => 1)
+
+  expectType<{ a: number }>(reactive({ a: computedA }))
+
+  expectType<Bar>(
+    reactive({
+      a: computedA, // issue happens here, but is should be okay
+      // @ts-expect-error
+      b: _ => {} // error depending on --noImplicitAny
+    })
+  )
 })

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -64,6 +64,8 @@ function getTargetType(value: Target) {
 // only unwrap nested ref
 export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>
 
+type NoInfer<T> = [T][T extends any ? 0 : never]
+
 /**
  * Returns a reactive proxy of the object.
  *
@@ -80,6 +82,9 @@ export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>
  * @see {@link https://vuejs.org/api/reactivity-core.html#reactive}
  */
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
+export function reactive<T extends object>(
+  target: T
+): NoInfer<UnwrapNestedRefs<T>>
 export function reactive(target: object) {
   // if trying to observe a readonly proxy, return the readonly version.
   if (isReadonly(target)) {


### PR DESCRIPTION
Close #1930.

---

Based on the issue description, I simplified the problem with the following code:

```ts
declare function reactive<T extends object>(target: T): UnwrapNestedRefs<T>;

interface Bar {
  a: number;
  b: (v: any) => void;
}

const a: ComputedRef<number> = computed(() => 1);

const bar: Bar = reactive({
  // issue happens here: `Type 'ComputedRef<number>' is not assignable to type 'number'`
  a,
  b: (v) => {}, // error depending on --noImplicitAny
});
```

The error occurs due to _context-sensitive_ type inference, specifically with the `b` property. The compiler defers type inference for the `v` callback parameter until after inferring the generic type parameter `T`. This leads to a fallback to infer `T` from the expected return type of `Bar`, a behavior introduced in [microsoft/TypeScript#16072](https://github.com/microsoft/TypeScript/pull/16072)

The use of a homomorphic mapped type `UnwrapNestedRefs<T>` further complicates inference, causing `T` to be inferred from `Bar`. This check succeeds for the return type but fails for the `target` argument, resulting in an error.

---

On the other hand, in this PR, the following code is provided:

```ts
type NoInfer<T> = [T][T extends any ? 0 : never];

declare function reactive<T extends object>(target: T): UnwrapNestedRefs<T>;
declare function reactive<T extends object>(
  target: T
): NoInfer<UnwrapNestedRefs<T>>;

interface Bar {
  a: number;
  b: (v: any) => void;
}

const a: ComputedRef<number> = computed(() => 1);

const bar: Bar = reactive({
  a, // okay
  b: (v) => {}, // error depending on --noImplicitAny
});
```

In this case, the return type of `reactive` is still contextually typed from `Bar`, but `T` can now only be inferred from the value passed in as `target`. There was an old feature request at [microsoft/TypeScript#7234](https://github.com/microsoft/TypeScript/issues/7234) that would have supported such inference, but it hasn't been implemented yet.

This behavior is sometimes used intentionally to block inference. There's an open feature request at [microsoft/TypeScript#14829](https://github.com/microsoft/TypeScript/issues/14829) asking for a way to prevent the use of a type parameter from being used as a generic type argument inference site. Although native support for this doesn't exist, one of the workarounds is to use `NoInfer`, as mentioned in this comment on [ms/TS#14829](https://github.com/microsoft/TypeScript/issues/14829#issuecomment-504042546).

With the added overload function, similar scenarios can ensure that `T` is inferred from the function argument.