### PR TITLE
fix(hydration): improve comment node hydration

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -75,6 +75,16 @@ describe('SSR hydration', () => {
     expect(vnode.el.nodeType).toBe(8) // comment
   })
 
+  test('comment (left square bracket)', () => {
+    const { vnode, container } = mountWithHydration(
+      `<div><span>foo</span><!--[--></div>`,
+      () => h('div', [h('span', 'foo'), createCommentVNode('[')])
+    )
+    expect(vnode.el).toBe(container.firstChild)
+    expect(container.innerHTML).toBe('<div><span>foo</span><!--[--></div>')
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+  })
+
   test('static', () => {
     const html = '<div><span>hello</span></div>'
     const { vnode, container } = mountWithHydration(html, () =>

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -146,7 +146,7 @@ export function createHydrationFunctions(
         break
       case Comment:
         if (domType !== DOMNodeTypes.COMMENT || isFragmentStart) {
-          if ((node as Element).tagName.toLowerCase() === 'template') {
+          if (isTemplateNode(node as Element)) {
             const content = (vnode.el! as HTMLTemplateElement).content
               .firstChild!
 

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -154,6 +154,10 @@ export function createHydrationFunctions(
             replaceNode(content, node, parentComponent)
             vnode.el = node = content
             nextNode = nextSibling(node)
+          }
+          // real left square bracket comment node
+          else if (isFragmentStart && vnode.children === '[') {
+            nextNode = nextSibling(node)
           } else {
             nextNode = onMismatch()
           }


### PR DESCRIPTION
close #9531 
The root cause is that the `node` is a `<!--[-->`. 
```html
<template>
  <div><span>foo</span><!--[--></div>
</template>
```
[see](https://play.vuejs.org/#__SSR__eNp9kDFPwzAQhf+K8dKlaYdulRUJUAcYAAEbXqLkElwc2/KdQ6Qo/x3bUQMD6nb33nendzfxW+d2QwB+5AJrrxwxBAqulEb1znpiE/PQspm13vZsE9GNNGK/sJGKDUHvdEUQO8ZEo4ZSoKtM2VobwVSJm6L4KIpS7JOb5tcZvuWEtTWt6nZntCYGmdIeyWvbO6XBPztS1qDkR5ad5FVa2+/HrJEPsL3o9SfUX//oZxyTJvmLBwQ/gOSrR5XvgBb79PYEY6xXs7dN0JG+Yr4CWh1SxgW7C6aJsf9wOe1Dfqcy3TueRgKDl6NS0ETOmZc8vvj+yum/cQ+7Q56TZubzD7pClq0=)
BTW, support hydrate left square bracket comment node