### PR TITLE
feat(runtime-core): return onUnmounted in onMounted

### DIFF
--- a/packages/runtime-core/__tests__/apiLifecycle.spec.ts
+++ b/packages/runtime-core/__tests__/apiLifecycle.spec.ts
@@ -183,6 +183,36 @@ describe('api: lifecycle hooks', () => {
     expect(fn).toHaveBeenCalledTimes(1)
   })
 
+  it('onMounted return onUnmounted', async () => {
+    const toggle = ref(true)
+    const root = nodeOps.createElement('div')
+    const fn1 = vi.fn(() => fn2)
+    const fn2 = vi.fn()
+
+    const Comp = {
+      setup() {
+        return () => (toggle.value ? h(Child) : null)
+      }
+    }
+
+    const Child = {
+      setup() {
+        onMounted(fn1)
+        return () => h('div')
+      }
+    }
+
+    render(h(Comp), root)
+
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(0)
+
+    toggle.value = false
+
+    await nextTick()
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+
   it('onBeforeUnmount in onMounted', async () => {
     const toggle = ref(true)
     const root = nodeOps.createElement('div')

--- a/packages/runtime-core/src/apiLifecycle.ts
+++ b/packages/runtime-core/src/apiLifecycle.ts
@@ -75,7 +75,9 @@ export const createHook =
         if (lifecycle === LifecycleHooks.MOUNTED) {
           // In the mounted hook, if a function is returned, it will be called in the unmounted hook.
           if (isPromise(res)) {
-            res.then(_res => isFunction(_res) && onUnmounted(_res, target))
+            res
+              .then(_res => isFunction(_res) && onUnmounted(_res, target))
+              .catch(() => {})
           } else if (isFunction(res)) {
             onUnmounted(res)
           }


### PR DESCRIPTION
Return a function in onMounted that will be executed in onUnmounted.

[RFC](https://github.com/vuejs/rfcs/discussions/593)

```ts

onMounted(() => {
  console.log('onMounted')
  return () => {
    console.log('onUnmounted')
  }
})

```