### PR TITLE
fix(compiler-core): fix `resolveParserPlugins` decorators check

### DIFF
--- a/packages/compiler-sfc/src/script/context.ts
+++ b/packages/compiler-sfc/src/script/context.ts
@@ -164,7 +164,7 @@ export function resolveParserPlugins(
   }
   if (lang === 'ts' || lang === 'tsx') {
     plugins.push(['typescript', { dts }])
-    if (!plugins.includes('decorators')) {
+    if (!userPlugins || !userPlugins.includes('decorators')) {
       plugins.push('decorators-legacy')
     }
   }


### PR DESCRIPTION
fixed #9560

In the `resolveParserPlugins` function, `plugins` is not initially configured to include the possibility of `decorators`. Therefore, we should check if `userPlugins` contains `decorators`.