### PR TITLE
chore: fix dev-sfc-prepare command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dev-esm": "node scripts/dev.js -if esm-bundler-runtime",
     "dev-compiler": "run-p \"dev template-explorer\" serve",
     "dev-sfc": "run-s dev-sfc-prepare dev-sfc-run",
-    "dev-sfc-prepare": "node scripts/pre-dev-sfc.js || npm run build-compiler-cjs",
+    "dev-sfc-prepare": "node scripts/pre-dev-sfc.js || npm run build-all-cjs",
     "dev-sfc-serve": "vite packages/sfc-playground --host",
     "dev-sfc-run": "run-p \"dev compiler-sfc -f esm-browser\" \"dev vue -if esm-bundler-runtime\" \"dev server-renderer -if esm-bundler\" dev-sfc-serve",
     "serve": "serve",


### PR DESCRIPTION
This commit [chore: fix sfc-playground build](https://github.com/vuejs/core/commit/90588534110b929eabadcd88d98e1e9ec8569f1f) changed package script `build-compiler-cjs` to `build-all-cjs`, while that in dev-sfc-prepare was left out.