### PR TITLE
fix(runtime-core): v-model modifiers trim and number when cases don't match

### DIFF
--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -361,7 +361,7 @@ describe('component: emit', () => {
       render() {},
       created() {
         this.$emit('update:firstName', ' one ')
-      }
+      },
     })
 
     const fn1 = vi.fn()
@@ -370,7 +370,7 @@ describe('component: emit', () => {
       h(Foo, {
         'first-name': null,
         'first-nameModifiers': { trim: true },
-        'onUpdate:first-name': fn1
+        'onUpdate:first-name': fn1,
       })
 
     render(h(Comp), nodeOps.createElement('div'))
@@ -385,7 +385,7 @@ describe('component: emit', () => {
       created() {
         this.$emit('update:model-value', ' one ')
         this.$emit('update:first-name', ' two ')
-      }
+      },
     })
 
     const fn1 = vi.fn()
@@ -399,7 +399,7 @@ describe('component: emit', () => {
 
         firstName: null,
         firstNameModifiers: { trim: true },
-        'onUpdate:firstName': fn2
+        'onUpdate:firstName': fn2,
       })
 
     render(h(Comp), nodeOps.createElement('div'))
@@ -415,7 +415,7 @@ describe('component: emit', () => {
       render() {},
       created() {
         this.$emit('update:base-URL', ' one ')
-      }
+      },
     })
 
     const fn1 = vi.fn()
@@ -424,7 +424,7 @@ describe('component: emit', () => {
       h(Foo, {
         'base-URL': null,
         'base-URLModifiers': { trim: true },
-        'onUpdate:base-URL': fn1
+        'onUpdate:base-URL': fn1,
       })
 
     render(h(Comp), nodeOps.createElement('div'))

--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -355,6 +355,54 @@ describe('component: emit', () => {
     expect(fn2).toHaveBeenCalledTimes(1)
     expect(fn2).toHaveBeenCalledWith('two')
   })
+  // for hyphenate props and camelize emit
+  test('.trim modifier should work with v-model on component for hyphenate props and camelize emit', () => {
+    const Foo = defineComponent({
+      render() {},
+      created() {
+        this.$emit('update:firstName', ' one ')
+      }
+    })
+
+    const fn1 = jest.fn()
+
+    const Comp = () =>
+      h(Foo, {
+        'first-name': null,
+        'first-nameModifiers': { trim: true },
+        'onUpdate:first-name': fn1,
+      })
+
+    render(h(Comp), nodeOps.createElement('div'))
+
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn1).toHaveBeenCalledWith('one')
+  })
+
+  // for camelize props and hyphenate emit
+  test('.trim modifier should work with v-model on component for camelize props and hyphenate emit', () => {
+    const Foo = defineComponent({
+      render() {},
+      created() {
+        this.$emit('update:first-name', ' one ')
+      }
+    })
+
+    const fn1 = jest.fn()
+
+    const Comp = () =>
+      h(Foo, {
+        firstName: null,
+        firstNameModifiers: { trim: true },
+        'onUpdate:firstName': fn1,
+
+      })
+
+    render(h(Comp), nodeOps.createElement('div'))
+
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn1).toHaveBeenCalledWith('one')
+  })
 
   test('.trim and .number modifiers should work with v-model on component', () => {
     const Foo = defineComponent({

--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -355,8 +355,8 @@ describe('component: emit', () => {
     expect(fn2).toHaveBeenCalledTimes(1)
     expect(fn2).toHaveBeenCalledWith('two')
   })
-  // for hyphenate props and camelize emit
-  test('.trim modifier should work with v-model on component for hyphenate props and camelize emit', () => {
+
+  test('.trim modifier should work with v-model on component for kebab-cased props and camelCased emit', () => {
     const Foo = defineComponent({
       render() {},
       created() {
@@ -364,13 +364,13 @@ describe('component: emit', () => {
       }
     })
 
-    const fn1 = jest.fn()
+    const fn1 = vi.fn()
 
     const Comp = () =>
       h(Foo, {
         'first-name': null,
         'first-nameModifiers': { trim: true },
-        'onUpdate:first-name': fn1,
+        'onUpdate:first-name': fn1
       })
 
     render(h(Comp), nodeOps.createElement('div'))
@@ -379,23 +379,52 @@ describe('component: emit', () => {
     expect(fn1).toHaveBeenCalledWith('one')
   })
 
-  // for camelize props and hyphenate emit
-  test('.trim modifier should work with v-model on component for camelize props and hyphenate emit', () => {
+  test('.trim modifier should work with v-model on component for camelCased props and kebab-cased emit', () => {
     const Foo = defineComponent({
       render() {},
       created() {
-        this.$emit('update:first-name', ' one ')
+        this.$emit('update:model-value', ' one ')
+        this.$emit('update:first-name', ' two ')
       }
     })
 
-    const fn1 = jest.fn()
+    const fn1 = vi.fn()
+    const fn2 = vi.fn()
 
     const Comp = () =>
       h(Foo, {
+        modelValue: null,
+        modelModifiers: { trim: true },
+        'onUpdate:modelValue': fn1,
+
         firstName: null,
         firstNameModifiers: { trim: true },
-        'onUpdate:firstName': fn1,
+        'onUpdate:firstName': fn2
+      })
 
+    render(h(Comp), nodeOps.createElement('div'))
+
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn1).toHaveBeenCalledWith('one')
+    expect(fn2).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledWith('two')
+  })
+
+  test('.trim modifier should work with v-model on component for mixed cased props and emit', () => {
+    const Foo = defineComponent({
+      render() {},
+      created() {
+        this.$emit('update:base-URL', ' one ')
+      }
+    })
+
+    const fn1 = vi.fn()
+
+    const Comp = () =>
+      h(Foo, {
+        'base-URL': null,
+        'base-URLModifiers': { trim: true },
+        'onUpdate:base-URL': fn1
       })
 
     render(h(Comp), nodeOps.createElement('div'))

--- a/packages/runtime-core/src/helpers/useModel.ts
+++ b/packages/runtime-core/src/helpers/useModel.ts
@@ -108,5 +108,10 @@ export function useModel(
 export const getModelModifiers = (
   props: Record<string, any>,
   modelName: string,
-): Record<string, boolean> | undefined =>
-  props[`${modelName === 'modelValue' ? 'model' : modelName}Modifiers`]
+): Record<string, boolean> | undefined => {
+  return modelName === 'modelValue'
+    ? props.modelModifiers
+    : props[`${modelName}Modifiers`] ||
+        props[`${camelize(modelName)}Modifiers`] ||
+        props[`${hyphenate(modelName)}Modifiers`]
+}

--- a/packages/runtime-core/src/helpers/useModel.ts
+++ b/packages/runtime-core/src/helpers/useModel.ts
@@ -109,7 +109,7 @@ export const getModelModifiers = (
   props: Record<string, any>,
   modelName: string,
 ): Record<string, boolean> | undefined => {
-  return modelName === 'modelValue'
+  return modelName === 'modelValue' || modelName === 'model-value'
     ? props.modelModifiers
     : props[`${modelName}Modifiers`] ||
         props[`${camelize(modelName)}Modifiers`] ||


### PR DESCRIPTION
Closes #4848.

There is an existing PR for this, #4850. This PR includes the commits from that PR, but I thought there was another edge case that needed addressing, otherwise it would cause a regression.

The original PR assumed that the prop would always be written in either kebab-case or camelCase. While this is usually true, it doesn't take account of the possibility that the prop name could be written in neither case convention. In that scenario, an exact match should still work, which is what I've tried to handle here.

I've also switched the new tests from `jest` to `vi`  and added some extra tests.