### PR TITLE
fix(runtime-core): incomplete type inferred by generic components

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -4,6 +4,7 @@ import {
   useAttrs,
   useSlots,
   withDefaults,
+  PropType,
   Slots,
   defineSlots,
   VNode,
@@ -191,6 +192,25 @@ describe('defineProps w/ runtime declaration', () => {
   props2.foo + props2.bar
   // @ts-expect-error
   props2.baz
+})
+
+describe('defineProps w/ generics and runtime declarations', () => {
+  function test<T extends Record<string, any>>() {
+    const props = defineProps({
+      foo: {
+        type: Object as PropType<T>,
+        required: false,
+        default: null
+      },
+      bar: {
+        type: Object as PropType<T>,
+        required: true
+      }
+    })
+    expectType<T | null>(props.foo)
+    expectType<T>(props.bar)
+  }
+  test()
 })
 
 describe('defineEmits w/ type declaration', () => {

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -122,11 +122,17 @@ type InferPropType<T> = [T] extends [null]
             ? U extends DateConstructor
               ? Date | InferPropType<U>
               : InferPropType<U>
-            : [T] extends [Prop<infer V, infer D>]
-              ? unknown extends V
-                ? IfAny<V, V, D>
-                : V
-              : T
+            : [T] extends [PropOptions<infer V, infer D>]
+              ? unknown extends D
+                ? V
+                : unknown extends V
+                  ? IfAny<V, V, D>
+                  : V
+              : [T] extends [Prop<infer V, infer D>]
+                ? unknown extends V
+                  ? IfAny<V, V, D>
+                  : V
+                : T
 
 /**
  * Extract prop types from a runtime props options object.


### PR DESCRIPTION
This fixes the wrong type inferred by `defineProps(...)` using generic components as outlined in #9610 (and related #9546, #9277)
