### PR TITLE
feat: add types when creating global directives

### DIFF
--- a/packages/dts-test/appDirective.test-d.ts
+++ b/packages/dts-test/appDirective.test-d.ts
@@ -1,0 +1,14 @@
+import { createApp } from 'vue'
+import { expectType } from './utils'
+
+const app = createApp({})
+
+app.directive<HTMLElement, string>('custom', {
+  mounted(el, binding) {
+    expectType<HTMLElement>(el)
+    expectType<string>(binding.value)
+
+    // @ts-expect-error not any
+    expectType<number>(binding.value)
+  }
+})

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -43,7 +43,7 @@ export interface App<HostElement = any> {
   component(name: string): Component | undefined
   component(name: string, component: Component | DefineComponent): this
   directive(name: string): Directive | undefined
-  directive(name: string, directive: Directive): this
+  directive<T = any, V = any>(name: string, directive: Directive<T, V>): this
   mount(
     rootContainer: HostElement | string,
     isHydrate?: boolean,

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -42,7 +42,7 @@ export interface App<HostElement = any> {
   mixin(mixin: ComponentOptions): this
   component(name: string): Component | undefined
   component(name: string, component: Component | DefineComponent): this
-  directive(name: string): Directive | undefined
+  directive<T = any, V = any>(name: string): Directive<T, V> | undefined
   directive<T = any, V = any>(name: string, directive: Directive<T, V>): this
   mount(
     rootContainer: HostElement | string,

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -83,7 +83,10 @@ export type CompatVue = Pick<App, 'version' | 'component' | 'directive'> & {
   component(name: string): Component | undefined
   component(name: string, component: Component): CompatVue
   directive(name: string): Directive | undefined
-  directive(name: string, directive: Directive): CompatVue
+  directive<T = any, V = any>(
+    name: string,
+    directive: Directive<T, V>
+  ): CompatVue
 
   compile(template: string): RenderFunction
 

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -82,7 +82,7 @@ export type CompatVue = Pick<App, 'version' | 'component' | 'directive'> & {
 
   component(name: string): Component | undefined
   component(name: string, component: Component): CompatVue
-  directive(name: string): Directive | undefined
+  directive<T = any, V = any>(name: string): Directive<T, V> | undefined
   directive<T = any, V = any>(
     name: string,
     directive: Directive<T, V>


### PR DESCRIPTION
Right now, when you want to create a typed global directive you have to:

```typescript
import { createApp, type Directive } from 'vue'

const app = createApp(App);

app.directive('custom', <Directive<HTMLElement, string>>{
  mounted(element, { value }) {
    // `element` has type `HtmlElement`
    // `value` has type `string`
  }
});
```

Also, if you want to create a `FunctionDirective`, you will have to provide the typings outside, if not, TS will complain:

```typescript
const custom: Directive<HTMLElement, string> = (element, { value }) => {
  // `element` has type `HtmlElement`
  // `value` has type `string`
};

app.directive('custom', custom);
```

With this PR, you will be able to provide Directive typings without having to import `type Directive` and without having to cast the object/function inline:

```typescript
// Global directive
app.directive<HTMLElement, string>('custom', {
  mounted(element, { value }) {
    // `element` has type `HtmlElement`
    // `value` has type `string`
  }
});

// Function directive
app.directive<HTMLElement, string>('custom', (element, { value }) => {
  // `element` has type `HtmlElement`
  // `value` has type `string`
});
```