### PR TITLE
types: support `app.component` to be `defineComponent`

### DIFF
--- a/packages/dts-test/appUse.test-d.ts
+++ b/packages/dts-test/appUse.test-d.ts
@@ -1,4 +1,4 @@
-import { createApp, App, Plugin } from 'vue'
+import { createApp, App, Plugin, defineComponent } from 'vue'
 
 const app = createApp({})
 
@@ -93,3 +93,15 @@ const PluginTyped: Plugin<PluginOptions> = (app, options) => {}
 // @ts-expect-error: needs options
 app.use(PluginTyped)
 app.use(PluginTyped, { option2: 2, option3: true })
+
+// vuetify usage
+const key: string = ''
+const aliases: Record<string, any> = {}
+app.component(
+  key,
+  defineComponent({
+    ...aliases[key],
+    name: key,
+    aliasName: aliases[key].name
+  })
+)

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -27,6 +27,7 @@ import { version } from '.'
 import { installAppCompatProperties } from './compat/global'
 import { NormalizedPropsOptions } from './componentProps'
 import { ObjectEmitsOptions } from './componentEmits'
+import { DefineComponent } from './apiDefineComponent'
 
 export interface App<HostElement = any> {
   version: string
@@ -40,7 +41,7 @@ export interface App<HostElement = any> {
 
   mixin(mixin: ComponentOptions): this
   component(name: string): Component | undefined
-  component(name: string, component: Component): this
+  component(name: string, component: Component | DefineComponent): this
   directive(name: string): Directive | undefined
   directive(name: string, directive: Directive): this
   mount(


### PR DESCRIPTION
fix CI issue https://github.com/vuejs/ecosystem-ci/actions/runs/6925726707/job/18836836250 

Probably because the type is just to complex to resolve as `Component`

I've seen this issue, other way to fix is to offload the component to a variable
```ts
// Too complex
awesomeFunction(defineComponent(/* ... */))

// works
const c = defineComponent(/* ... */)
awesomeFunction(c)
```