### PR TITLE
fix(compiler): ensure consistent treatment of comment nodes in default slots

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -29,6 +29,21 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: transform component slots > implicit default slot for comments 1`] = `
+"const { createCommentVNode: _createCommentVNode, resolveComponent: _resolveComponent, withCtx: _withCtx, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+return function render(_ctx, _cache) {
+  const _component_Comp = _resolveComponent(\\"Comp\\")
+
+  return (_openBlock(), _createBlock(_component_Comp, null, {
+    default: _withCtx(() => [
+      _createCommentVNode(\\"foo\\")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}"
+`;
+
 exports[`compiler: transform component slots > named slot with v-for w/ prefixIdentifiers: true 1`] = `
 "const { toDisplayString: _toDisplayString, resolveComponent: _resolveComponent, withCtx: _withCtx, renderList: _renderList, createSlots: _createSlots, openBlock: _openBlock, createBlock: _createBlock } = Vue
 
@@ -210,6 +225,22 @@ return function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_component_Comp, null, {
     one: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
     two: _withCtx(({ bar }) => [_toDisplayString(_ctx.foo), _toDisplayString(bar)]),
+    _: 1 /* STABLE */
+  }))
+}"
+`;
+
+exports[`compiler: transform component slots > template named slots and an implicit default slot for comments 1`] = `
+"const { createCommentVNode: _createCommentVNode, resolveComponent: _resolveComponent, withCtx: _withCtx, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+return function render(_ctx, _cache) {
+  const _component_Comp = _resolveComponent(\\"Comp\\")
+
+  return (_openBlock(), _createBlock(_component_Comp, null, {
+    one: _withCtx(() => []),
+    default: _withCtx(() => [
+      _createCommentVNode(\\"foo\\")
+    ]),
     _: 1 /* STABLE */
   }))
 }"

--- a/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
@@ -107,6 +107,27 @@ describe('compiler: transform component slots', () => {
     expect(generate(root, { prefixIdentifiers: true }).code).toMatchSnapshot()
   })
 
+  test('implicit default slot for comments', () => {
+    const { root, slots } = parseWithSlots(`<Comp><!--foo--></Comp>`, {
+      prefixIdentifiers: true
+    })
+    expect(slots).toMatchObject(
+      createSlotMatcher({
+        default: {
+          type: NodeTypes.JS_FUNCTION_EXPRESSION,
+          params: undefined,
+          returns: [
+            {
+              type: NodeTypes.COMMENT,
+              content: `foo`
+            }
+          ]
+        }
+      })
+    )
+    expect(generate(root, { prefixIdentifiers: true }).code).toMatchSnapshot()
+  })
+
   test('on-component default slot', () => {
     const { root, slots } = parseWithSlots(
       `<Comp v-slot="{ foo }">{{ foo }}{{ bar }}</Comp>`,
@@ -226,6 +247,36 @@ describe('compiler: transform component slots', () => {
               content: {
                 content: `bar`
               }
+            }
+          ]
+        }
+      })
+    )
+    expect(generate(root, { prefixIdentifiers: true }).code).toMatchSnapshot()
+  })
+
+  test('template named slots and an implicit default slot for comments', () => {
+    const { root, slots } = parseWithSlots(
+      `<Comp>
+        <!--foo-->
+        <template #one></template>
+      </Comp>`,
+      { prefixIdentifiers: true }
+    )
+    expect(slots).toMatchObject(
+      createSlotMatcher({
+        one: {
+          type: NodeTypes.JS_FUNCTION_EXPRESSION,
+          params: undefined,
+          returns: []
+        },
+        default: {
+          type: NodeTypes.JS_FUNCTION_EXPRESSION,
+          params: undefined,
+          returns: [
+            {
+              type: NodeTypes.COMMENT,
+              content: `foo`
             }
           ]
         }

--- a/packages/compiler-core/src/transforms/vSlot.ts
+++ b/packages/compiler-core/src/transforms/vSlot.ts
@@ -172,9 +172,7 @@ export function buildSlots(
       !(slotDir = findDir(slotElement, 'slot', true))
     ) {
       // not a <template v-slot>, skip.
-      if (slotElement.type !== NodeTypes.COMMENT) {
-        implicitDefaultChildren.push(slotElement)
-      }
+      implicitDefaultChildren.push(slotElement)
       continue
     }
 


### PR DESCRIPTION
This pr resolves an inconsistency in the logic for handling default slots in `packages/compiler-core/src/transforms/vSlot.ts`. Previously, when `<template v-slot>` was used in any component slot, comment nodes were inadvertently filtered out. Conversely, in the absence of `<template v-slot>`, comment nodes were retained in the default slot. [Minimal Reproduction](https://play.vuejs.org/#eNp9kTFPwzAQhf9KONYmGbpVUSRAHWAABIxejHsNLo5t2ecSqcp/x3aUUCTodvfed6d39glurK2OAWEDjRdOWio8UrBtU09tyzTTDWFvFSeMXVE0d6a3uYr1VVnujSnLuZ/J4ppz3r5z19S/h+tl+vKuBTxbACsgL4zey646eKNj6lPeBCKyUqF7siSN9gw2RXaSx5UyXw9ZIxdwNeviA8XnH/rBD0lj8OzQozsig8Uj7jqkyd6+PuIQ68XszS6oSF8wX9AbFVLGCbsNehdjn3E57X1vjSOpuze/HQi1n49KQRM5Zp5B/Lr0TP+d/hN3Xa3zHNMjjN9fB6Fd).

The behavior is now unified to consistently retain comment nodes in the default slot, regardless of the presence of `<template v-slot>`.

Additionally, new unit tests have been added to cover scenarios involving comment nodes in default slots.

Relates to #9655