### PR TITLE
fix(custom-element): boolean type error in customElement

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -172,17 +172,19 @@ describe('defineCustomElement', () => {
 
       e.setAttribute('bar', '')
       await nextTick()
-      expect(e.shadowRoot!.innerHTML).toBe(`1 number true boolean 12345 string`)
+      expect(e.shadowRoot!.innerHTML).toBe(
+        `1 number false boolean 12345 string`
+      )
 
       e.setAttribute('foo-bar', '2e1')
       await nextTick()
       expect(e.shadowRoot!.innerHTML).toBe(
-        `20 number true boolean 12345 string`
+        `20 number false boolean 12345 string`
       )
 
       e.setAttribute('baz', '2e1')
       await nextTick()
-      expect(e.shadowRoot!.innerHTML).toBe(`20 number true boolean 2e1 string`)
+      expect(e.shadowRoot!.innerHTML).toBe(`20 number false boolean 2e1 string`)
     })
 
     // #4772

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -330,7 +330,7 @@ export class VueElement extends BaseClass {
   }
 
   protected _setAttr(key: string) {
-    let value = this.getAttribute(key) as any
+    let value: boolean | string | number = this.getAttribute(key)!
     const camelKey = camelize(key)
     if (this._numberProps && this._numberProps[camelKey]) {
       value = toNumber(value)

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -162,6 +162,20 @@ export const toNumber = (val: any): any => {
   return isNaN(n) ? val : n
 }
 
+/**
+ * Converts a value to a boolean. If the input value is the string 'false', the result will be `false`. Otherwise, the result will be the boolean representation of the input value using the double negation (`!!`) to coerce the value to a boolean.
+ *
+ * @example
+ * toBoolean('false') // false
+ *
+ * toBoolean(1) // true
+ *
+ * toBoolean(null) // false
+ */
+export const toBoolean = (val: any): boolean => {
+  return val === 'false' ? false : !!val
+}
+
 let _globalThis: any
 export const getGlobalThis = (): any => {
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
fixed #9697
fixed #7401

When using `defineCustomElement` to define a custom element, if we use `setAttribute` to set attributes for the custom element, the values will be converted to string type. This conversion can lead to type errors when using number or boolean types as props in the component. Currently, we have already handled the conversion for number types in the code. In this PR, I have extended the conversion to boolean types as well. This ensures that boolean type props can be used seamlessly in the CustomElement.
