### PR TITLE
types(reactivity): respect readonly on `toRefs` and `reactive`

### DIFF
--- a/packages/dts-test/reactivity.test-d.ts
+++ b/packages/dts-test/reactivity.test-d.ts
@@ -1,4 +1,12 @@
-import { ref, readonly, shallowReadonly, Ref, reactive, markRaw } from 'vue'
+import {
+  ref,
+  readonly,
+  shallowReadonly,
+  Ref,
+  reactive,
+  markRaw,
+  computed
+} from 'vue'
 import { describe, expectType } from './utils'
 
 describe('should support DeepReadonly', () => {
@@ -61,4 +69,27 @@ describe('should unwrap tuple correctly', () => {
   const tuple: [Ref<number>] = [ref(0)]
   const reactiveTuple = reactive(tuple)
   expectType<Ref<number>>(reactiveTuple[0])
+})
+
+describe('should add readonly', () => {
+  test('readonly ref', () => {
+    const r = reactive({ foo: readonly(ref('foo')), bar: 3 })
+    // @ts-expect-error readonly
+    r.foo = 'bar'
+    r.bar = 42
+  })
+  test('computed ', () => {
+    // #5159
+    const r = reactive({ foo: computed(() => 'foo'), bar: 3 })
+    // @ts-expect-error readonly
+    r.foo = 'bar'
+    r.bar = 42
+  })
+
+  test('readonly property', () => {
+    const r = reactive({} as { foo: { readonly bar: number }; bar: number })
+    // @ts-expect-error readonly
+    r.foo.bar = 2
+    r.bar = 42
+  })
 })

--- a/packages/dts-test/reactivity.test-d.ts
+++ b/packages/dts-test/reactivity.test-d.ts
@@ -100,13 +100,13 @@ describe('should unwrap Set correctly', () => {
 })
 
 describe('should add readonly', () => {
-  test('readonly ref', () => {
+  describe('readonly ref', () => {
     const r = reactive({ foo: readonly(ref('foo')), bar: 3 })
     // @ts-expect-error readonly
     r.foo = 'bar'
     r.bar = 42
   })
-  test('computed ', () => {
+  describe('computed ', () => {
     // #5159
     const r = reactive({ foo: computed(() => 'foo'), bar: 3 })
     // @ts-expect-error readonly
@@ -114,7 +114,7 @@ describe('should add readonly', () => {
     r.bar = 42
   })
 
-  test('readonly property', () => {
+  describe('readonly property', () => {
     const r = reactive({} as { foo: { readonly bar: number }; bar: number })
     // @ts-expect-error readonly
     r.foo.bar = 2

--- a/packages/dts-test/ref.test-d.ts
+++ b/packages/dts-test/ref.test-d.ts
@@ -273,6 +273,49 @@ expectType<Ref<string>>(p2.obj.k)
   expectType<Ref<number>>(x)
 }
 
+// #5159 toRef readonly
+{
+  const withReadonly = toRefs(readonly(reactive({ foo: 'foo' })))
+  // @ts-expect-error readonly
+  withReadonly.foo.value = 'bar'
+
+  const obj = toRefs({
+    foo: 'test'
+  } as const)
+  // @ts-expect-error readonly
+  obj.foo.value = 'bar'
+
+  const multiple = toRefs(
+    {} as {
+      foo: string
+      readonly bar: string
+    }
+  )
+  // @ts-expect-error readonly
+  multiple.bar.value = 'bar'
+  multiple.foo.value = 'bar'
+
+  const deep = toRefs(
+    {} as {
+      foo: string
+      obj: {
+        readonly bar: string
+      }
+      readonly deep: { baz: string; readonly qux: string }
+    }
+  )
+
+  deep.foo.value = 'bar'
+  // @ts-expect-error readonly
+  deep.obj.value.bar = 'bar'
+
+  // @ts-expect-error readonly
+  deep.deep.value = { baz: 'test', qux: 'test' }
+  deep.deep.value.baz = 'test'
+  // @ts-expect-error readonly
+  deep.deep.value.qux = 'test'
+}
+
 // readonly() + ref()
 expectType<Readonly<Ref<number>>>(readonly(ref(1)))
 

--- a/packages/dts-test/utils.d.ts
+++ b/packages/dts-test/utils.d.ts
@@ -16,10 +16,6 @@ export type IsUnion<T, U extends T = T> = (
   ? false
   : true
 
-/**
- * IfEquals<X, Y, A, B> is a conditional type that checks if types X and Y are equal.
- * If they are, it results in type A, otherwise in type B.
- */
 export type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X
   ? 1
   : 2) extends <T>() => T extends Y ? 1 : 2

--- a/packages/dts-test/utils.d.ts
+++ b/packages/dts-test/utils.d.ts
@@ -16,6 +16,16 @@ export type IsUnion<T, U extends T = T> = (
   ? false
   : true
 
+/**
+ * IfEquals<X, Y, A, B> is a conditional type that checks if types X and Y are equal.
+ * If they are, it results in type A, otherwise in type B.
+ */
+export type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X
+  ? 1
+  : 2) extends <T>() => T extends Y ? 1 : 2
+  ? A
+  : B
+
 export type IsAny<T> = 0 extends 1 & T ? true : false
 
 export type Prettify<T> = { [K in keyof T]: T[K] } & {}

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -141,6 +141,7 @@ describe('reactivity/effect', () => {
     expect(dummy).toBe(4)
     // this doesn't work, should it?
     // expect(parentDummy).toBe(4)
+    // @ts-expect-error readonly
     parent.prop = 2
     expect(dummy).toBe(2)
     expect(parentDummy).toBe(2)

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -497,6 +497,7 @@ describe('reactivity/readonly', () => {
     const ror = readonly(r)
     const obj = reactive({ ror })
     expect(() => {
+      // @ts-expect-error readonly
       obj.ror = true
     }).toThrow()
     expect(obj.ror).toBe(false)
@@ -506,6 +507,8 @@ describe('reactivity/readonly', () => {
     const r = ref(false)
     const ror = readonly(r)
     const obj = reactive({ ror })
+    // @ts-expect-error this type is tecnically `readonly` if boolean is used, since
+    // we are overriding the ref... might be an edge case
     obj.ror = ref(true) as unknown as boolean
     expect(obj.ror).toBe(true)
     expect(toRaw(obj).ror).not.toBe(ror) // ref successfully replaced

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -318,9 +318,6 @@ export function customRef<T>(factory: CustomRefFactory<T>): Ref<T> {
   return new CustomRefImpl(factory) as any
 }
 
-// export type ToRefs<T = any> = {
-//   [K in keyof T]: ToRef<T[K]>
-// }
 export type ToRefs<T> = {
   [P in keyof T]: IfEquals<
     { [Q in P]: T[P] },

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -13,6 +13,16 @@ export type LooseRequired<T> = { [P in keyof (T & Required<T>)]: T[P] }
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
 
+/**
+ * IfEquals<X, Y, A, B> is a conditional type that checks if types X and Y are equal.
+ * If they are, it results in type A, otherwise in type B.
+ */
+export type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X
+  ? 1
+  : 2) extends <T>() => T extends Y ? 1 : 2
+  ? A
+  : B
+
 // To prevent users with TypeScript versions lower than 4.5 from encountering unsupported Awaited<T> type, a copy has been made here.
 export type Awaited<T> = T extends null | undefined
   ? T // special case for `null | undefined` when not in `--strictNullChecks` mode


### PR DESCRIPTION
closes #5159

decided to type the readonly Ref as:
```ts
Omit<Ref<T>, 'value'> & { readonly value: T }
// instead of 
ComputedRef<T>
```

Because `ComputedRef` contains the `symbol` for Computed, if someone is relying on it to extract actual computed, might give a false positive. 


Based on:  https://github.com/vuejs/core/pull/7073