### PR TITLE
feat(compiler-sfc): analyze import usage in template via AST

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2174,6 +2174,7 @@ describe('compiler: parse', () => {
   describe('expression parsing', () => {
     test('interpolation', () => {
       const ast = baseParse(`{{ a + b }}`, { prefixIdentifiers: true })
+      // @ts-ignore
       expect((ast.children[0] as InterpolationNode).content.ast?.type).toBe(
         'BinaryExpression'
       )
@@ -2184,7 +2185,9 @@ describe('compiler: parse', () => {
         prefixIdentifiers: true
       })
       const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
+      // @ts-ignore
       expect(dir.arg?.ast?.type).toBe('BinaryExpression')
+      // @ts-ignore
       expect(dir.exp?.ast?.type).toBe('CallExpression')
     })
 
@@ -2193,6 +2196,7 @@ describe('compiler: parse', () => {
         prefixIdentifiers: true
       })
       const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
+      // @ts-ignore
       expect(dir.exp?.ast?.type).toBe('Program')
       expect((dir.exp?.ast as Program).body).toMatchObject([
         { type: 'ExpressionStatement' },
@@ -2205,6 +2209,7 @@ describe('compiler: parse', () => {
         prefixIdentifiers: true
       })
       const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
+      // @ts-ignore
       expect(dir.exp?.ast?.type).toBe('ArrowFunctionExpression')
     })
 
@@ -2214,10 +2219,12 @@ describe('compiler: parse', () => {
       })
       const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
       const { source, value, key, index } = dir.forParseResult!
+      // @ts-ignore
       expect(source.ast?.type).toBe('MemberExpression')
+      // @ts-ignore
       expect(value?.ast?.type).toBe('ArrowFunctionExpression')
-      expect(key?.ast).toBeUndefined() // simple ident
-      expect(index?.ast).toBeUndefined() // simple ident
+      expect(key?.ast).toBeNull() // simple ident
+      expect(index?.ast).toBeNull() // simple ident
     })
   })
 

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '../src/ast'
 
 import { baseParse } from '../src/parser'
+import { Program } from '@babel/types'
 
 /* eslint jest/no-disabled-tests: "off" */
 
@@ -2167,6 +2168,56 @@ describe('compiler: parse', () => {
       const content = `   foo  \n    bar     baz     `
       const ast = parse(content)
       expect((ast.children[0] as TextNode).content).toBe(content)
+    })
+  })
+
+  describe('expression parsing', () => {
+    test('interpolation', () => {
+      const ast = baseParse(`{{ a + b }}`, { prefixIdentifiers: true })
+      expect((ast.children[0] as InterpolationNode).content.ast?.type).toBe(
+        'BinaryExpression'
+      )
+    })
+
+    test('v-bind', () => {
+      const ast = baseParse(`<div :[key+1]="foo()" />`, {
+        prefixIdentifiers: true
+      })
+      const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
+      expect(dir.arg?.ast?.type).toBe('BinaryExpression')
+      expect(dir.exp?.ast?.type).toBe('CallExpression')
+    })
+
+    test('v-on multi statements', () => {
+      const ast = baseParse(`<div @click="a++;b++" />`, {
+        prefixIdentifiers: true
+      })
+      const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
+      expect(dir.exp?.ast?.type).toBe('Program')
+      expect((dir.exp?.ast as Program).body).toMatchObject([
+        { type: 'ExpressionStatement' },
+        { type: 'ExpressionStatement' }
+      ])
+    })
+
+    test('v-slot', () => {
+      const ast = baseParse(`<Comp #foo="{ a, b }" />`, {
+        prefixIdentifiers: true
+      })
+      const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
+      expect(dir.exp?.ast?.type).toBe('ArrowFunctionExpression')
+    })
+
+    test('v-for', () => {
+      const ast = baseParse(`<div v-for="({ a, b }, key, index) of a.b" />`, {
+        prefixIdentifiers: true
+      })
+      const dir = (ast.children[0] as ElementNode).props[0] as DirectiveNode
+      const { source, value, key, index } = dir.forParseResult!
+      expect(source.ast?.type).toBe('MemberExpression')
+      expect(value?.ast?.type).toBe('ArrowFunctionExpression')
+      expect(key?.ast).toBeUndefined() // simple ident
+      expect(index?.ast).toBeUndefined() // simple ident
     })
   })
 

--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -18,7 +18,7 @@ function parseWithExpressionTransform(
   template: string,
   options: CompilerOptions = {}
 ) {
-  const ast = parse(template)
+  const ast = parse(template, options)
   transform(ast, {
     prefixIdentifiers: true,
     nodeTransforms: [transformIf, transformExpression],

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -227,7 +227,12 @@ export interface SimpleExpressionNode extends Node {
   content: string
   isStatic: boolean
   constType: ConstantTypes
-  ast?: BabelNode | null
+  /**
+   * - `null` means the expression is a simple identifier that doesn't need
+   *    parsing
+   * - `false` means there was a parsing error
+   */
+  ast?: BabelNode | null | false
   /**
    * Indicates this is an identifier for a hoist vnode call and points to the
    * hoisted node.
@@ -248,7 +253,12 @@ export interface InterpolationNode extends Node {
 
 export interface CompoundExpressionNode extends Node {
   type: NodeTypes.COMPOUND_EXPRESSION
-  ast?: BabelNode | null
+  /**
+   * - `null` means the expression is a simple identifier that doesn't need
+   *    parsing
+   * - `false` means there was a parsing error
+   */
+  ast?: BabelNode | null | false
   children: (
     | SimpleExpressionNode
     | CompoundExpressionNode

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -14,6 +14,7 @@ import {
 } from './runtimeHelpers'
 import { PropsExpression } from './transforms/transformElement'
 import { ImportItem, TransformContext } from './transform'
+import { Node as BabelNode } from '@babel/types'
 
 // Vue template is a platform-agnostic superset of HTML (syntax only).
 // More namespaces can be declared by platform specific compilers.
@@ -226,6 +227,7 @@ export interface SimpleExpressionNode extends Node {
   content: string
   isStatic: boolean
   constType: ConstantTypes
+  ast?: BabelNode | null
   /**
    * Indicates this is an identifier for a hoist vnode call and points to the
    * hoisted node.
@@ -246,6 +248,7 @@ export interface InterpolationNode extends Node {
 
 export interface CompoundExpressionNode extends Node {
   type: NodeTypes.COMPOUND_EXPRESSION
+  ast?: BabelNode | null
   children: (
     | SimpleExpressionNode
     | CompoundExpressionNode

--- a/packages/compiler-core/src/babelUtils.ts
+++ b/packages/compiler-core/src/babelUtils.ts
@@ -28,9 +28,9 @@ export function walkIdentifiers(
   }
 
   const rootExp =
-    root.type === 'Program' &&
-    root.body[0].type === 'ExpressionStatement' &&
-    root.body[0].expression
+    root.type === 'Program'
+      ? root.body[0].type === 'ExpressionStatement' && root.body[0].expression
+      : root
 
   walk(root, {
     enter(node: Node & { scopeIds?: Set<string> }, parent: Node | undefined) {

--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -86,6 +86,17 @@ export interface ParserOptions
    * This defaults to `true` in development and `false` in production builds.
    */
   comments?: boolean
+  /**
+   * Parse JavaScript expressions with Babel.
+   * @default false
+   */
+  prefixIdentifiers?: boolean
+  /**
+   * A list of parser plugins to enable for `@babel/parser`, which is used to
+   * parse expressions in bindings and interpolations.
+   * https://babeljs.io/docs/en/next/babel-parser#plugins
+   */
+  expressionPlugins?: ParserPlugin[]
 }
 
 export type HoistTransform = (

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -990,6 +990,12 @@ function createExp(
       const options = {
         plugins: currentOptions.expressionPlugins
       }
+      if (/ as\s+\w|<.*>|:/.test(content)) {
+        options.plugins = [
+          ...(currentOptions.expressionPlugins || []),
+          'typescript'
+        ]
+      }
       if (parseMode === ExpParseMode.Statements) {
         // v-on with multi-inline-statements, pad 1 char
         exp.ast = parse(` ${content} `, options).program

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -223,7 +223,14 @@ export function processExpression(
   // bail constant on parens (function invocation) and dot (member access)
   const bailConstant = constantBailRE.test(rawExp)
 
-  if (isSimpleIdentifier(rawExp)) {
+  let ast = node.ast
+
+  if (ast === false) {
+    // ast being false means it has caused an error already during parse phase
+    return node
+  }
+
+  if (ast === null || (!ast && isSimpleIdentifier(rawExp))) {
     const isScopeVarReference = context.identifiers[rawExp]
     const isAllowedGlobal = isGloballyAllowed(rawExp)
     const isLiteral = isLiteralWhitelisted(rawExp)
@@ -249,11 +256,6 @@ export function processExpression(
     return node
   }
 
-  let ast = node.ast
-  if (ast === null) {
-    // ast being null means it has caused an error already during parse phase
-    return node
-  }
   if (!ast) {
     // exp needs to be parsed differently:
     // 1. Multiple inline statements (v-on, with presence of `;`): parse as raw

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -249,29 +249,35 @@ export function processExpression(
     return node
   }
 
-  let ast: any
-  // exp needs to be parsed differently:
-  // 1. Multiple inline statements (v-on, with presence of `;`): parse as raw
-  //    exp, but make sure to pad with spaces for consistent ranges
-  // 2. Expressions: wrap with parens (for e.g. object expressions)
-  // 3. Function arguments (v-for, v-slot): place in a function argument position
-  const source = asRawStatements
-    ? ` ${rawExp} `
-    : `(${rawExp})${asParams ? `=>{}` : ``}`
-  try {
-    ast = parse(source, {
-      plugins: context.expressionPlugins
-    }).program
-  } catch (e: any) {
-    context.onError(
-      createCompilerError(
-        ErrorCodes.X_INVALID_EXPRESSION,
-        node.loc,
-        undefined,
-        e.message
-      )
-    )
+  let ast = node.ast
+  if (ast === null) {
+    // ast being null means it has caused an error already during parse phase
     return node
+  }
+  if (!ast) {
+    // exp needs to be parsed differently:
+    // 1. Multiple inline statements (v-on, with presence of `;`): parse as raw
+    //    exp, but make sure to pad with spaces for consistent ranges
+    // 2. Expressions: wrap with parens (for e.g. object expressions)
+    // 3. Function arguments (v-for, v-slot): place in a function argument position
+    const source = asRawStatements
+      ? ` ${rawExp} `
+      : `(${rawExp})${asParams ? `=>{}` : ``}`
+    try {
+      ast = parse(source, {
+        plugins: context.expressionPlugins
+      }).program
+    } catch (e: any) {
+      context.onError(
+        createCompilerError(
+          ErrorCodes.X_INVALID_EXPRESSION,
+          node.loc,
+          undefined,
+          e.message
+        )
+      )
+      return node
+    }
   }
 
   type QualifiedId = Identifier & PrefixMeta
@@ -351,6 +357,7 @@ export function processExpression(
   let ret
   if (children.length) {
     ret = createCompoundExpression(children, node.loc)
+    ret.ast = ast
   } else {
     ret = node
     ret.constType = bailConstant

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -748,6 +748,51 @@ return { get FooBaz() { return FooBaz }, get Last() { return Last } }
 })"
 `;
 
+exports[`SFC compile <script setup> > dev mode import usage check > property access (whitespace) 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { Foo, Bar, Baz } from './foo'
+        
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+          
+return { get Foo() { return Foo } }
+}
+
+})"
+`;
+
+exports[`SFC compile <script setup> > dev mode import usage check > property access 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { Foo, Bar, Baz } from './foo'
+        
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+          
+return { get Foo() { return Foo } }
+}
+
+})"
+`;
+
+exports[`SFC compile <script setup> > dev mode import usage check > spread operator 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { Foo, Bar, Baz } from './foo'
+        
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+          
+return { get Foo() { return Foo } }
+}
+
+})"
+`;
+
 exports[`SFC compile <script setup> > dev mode import usage check > template ref 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 import { foo, bar, Baz } from './foo'

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -243,7 +243,7 @@ describe('SFC compile <script setup>', () => {
       import { useCssVars, ref } from 'vue'
       const msg = ref()
       </script>
-      
+
       <style>
       .foo {
         color: v-bind(msg)
@@ -516,6 +516,46 @@ describe('SFC compile <script setup>', () => {
       expect(content).toMatch(
         'return { get foo() { return foo }, get bar() { return bar }, get Baz() { return Baz } }'
       )
+      assertCode(content)
+    })
+
+    // https://github.com/nuxt/nuxt/issues/22416
+    test('property access', () => {
+      const { content } = compile(`
+        <script setup lang="ts">
+          import { Foo, Bar, Baz } from './foo'
+        </script>
+        <template>
+          <div>{{ Foo.Bar.Baz }}</div>
+        </template>
+        `)
+      expect(content).toMatch('return { get Foo() { return Foo } }')
+      assertCode(content)
+    })
+
+    test('spread operator', () => {
+      const { content } = compile(`
+        <script setup lang="ts">
+          import { Foo, Bar, Baz } from './foo'
+        </script>
+        <template>
+          <div v-bind="{ ...Foo.Bar.Baz }"></div>
+        </template>
+        `)
+      expect(content).toMatch('return { get Foo() { return Foo } }')
+      assertCode(content)
+    })
+
+    test('property access (whitespace)', () => {
+      const { content } = compile(`
+        <script setup lang="ts">
+          import { Foo, Bar, Baz } from './foo'
+        </script>
+        <template>
+          <div>{{ Foo . Bar . Baz }}</div>
+        </template>
+        `)
+      expect(content).toMatch('return { get Foo() { return Foo } }')
       assertCode(content)
     })
   })

--- a/packages/compiler-sfc/__tests__/utils.ts
+++ b/packages/compiler-sfc/__tests__/utils.ts
@@ -13,7 +13,10 @@ export function compileSFCScript(
   options?: Partial<SFCScriptCompileOptions>,
   parseOptions?: SFCParseOptions
 ) {
-  const { descriptor } = parse(src, parseOptions)
+  const { descriptor, errors } = parse(src, parseOptions)
+  if (errors.length) {
+    console.warn(errors[0])
+  }
   return compileScript(descriptor, {
     ...options,
     id: mockId

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -24,6 +24,7 @@ export interface SFCParseOptions {
   pad?: boolean | 'line' | 'space'
   ignoreEmpty?: boolean
   compiler?: TemplateCompiler
+  parseExpressions?: boolean
 }
 
 export interface SFCBlock {
@@ -104,7 +105,8 @@ export function parse(
     sourceRoot = '',
     pad = false,
     ignoreEmpty = true,
-    compiler = CompilerDOM
+    compiler = CompilerDOM,
+    parseExpressions = true
   }: SFCParseOptions = {}
 ): SFCParseResult {
   const sourceKey =
@@ -130,6 +132,7 @@ export function parse(
   const errors: (CompilerError | SyntaxError)[] = []
   const ast = compiler.parse(source, {
     parseMode: 'sfc',
+    prefixIdentifiers: parseExpressions,
     onError: e => {
       errors.push(e)
     }

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -81,9 +81,9 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
 }
 
 function extractIdentifiers(ids: Set<string>, node: ExpressionNode) {
-  if (!node.ast) {
+  if (node.ast) {
+    walkIdentifiers(node.ast, n => ids.add(n.name))
+  } else if (node.ast === null) {
     ids.add((node as SimpleExpressionNode).content)
-    return
   }
-  walkIdentifiers(node.ast, n => ids.add(n.name))
 }


### PR DESCRIPTION
Use proper AST analysis to perform import usage check.

close #8897
close https://github.com/nuxt/nuxt/issues/22416

This PR also adds two new parser options (both are already transform options, they just now also apply to the parser):
-  `prefixIdentifiers`
- `expressionPlugins`

When enabled, `SimpleExpression` and `CompoundExpression` nodes now also has an `ast` property attached, which is the Babel AST parsed from the original JS expression. During the transform phase, `transformExpression` will reuse the ASTs if they are already present on expression nodes.

`SFCParseOptions` from `@vue/compiler-sfc` now also gets a new `parseExpressions: boolean` option. Since this is required for the new import usage check to work, it is enabled by default. The only case where you'd want to disable it is when you are using the `parse` method from `@vue/compiler-sfc` for non-compilation purposes (e.g. just to get the blocks of the SFC) and want to avoid the Babel parse overhead.