### PR TITLE
perf(runtime-core): memoize getType

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -594,19 +594,26 @@ function validatePropName(key: string) {
   return false
 }
 
+const typeMap = new WeakMap<PropConstructor, string>()
+
 // use function string name to check type constructors
 // so that it works across vms / iframes.
-function getType(ctor: Prop<any>): string {
+function getType(ctor: PropConstructor): string {
+  if (typeMap.has(ctor)) {
+    return typeMap.get(ctor)!
+  }
   const match = ctor && ctor.toString().match(/^\s*(function|class) (\w+)/)
-  return match ? match[2] : ctor === null ? 'null' : ''
+  const type = match ? match[2] : ctor === null ? 'null' : ''
+  if (match) typeMap.set(ctor, type)
+  return type
 }
 
-function isSameType(a: Prop<any>, b: Prop<any>): boolean {
+function isSameType(a: PropConstructor, b: PropConstructor): boolean {
   return getType(a) === getType(b)
 }
 
 function getTypeIndex(
-  type: Prop<any>,
+  type: PropConstructor,
   expectedTypes: PropType<any> | void | null | true
 ): number {
   if (isArray(expectedTypes)) {


### PR DESCRIPTION
This function takes ~10-15% of the time when rendering a large number of components with lots of defined props.

Side note, is there a reason normalizePropsOptions is called for every vnode instead of just once in defineComponent?