### PR TITLE
fix(reactivity): infinite loops when pushing a variable to a custom proxy of reactive array

### DIFF
--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -217,7 +217,6 @@ describe('reactivity/reactive/Array', () => {
       expect(proxyArray.includes(1)).toBe(true)
     })
 
-    
     test('toRaw on array using reactive as prototype', () => {
       const original = reactive([])
       const obj = Object.create(original)

--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -209,7 +209,7 @@ describe('reactivity/reactive/Array', () => {
       expect(index).toBe(2)
       expect(observed.lastSearched).toBe(6)
     })
-    
+
     test('add a proxy to a reactive array', () => {
       const reactiveArray: number[] = reactive([])
       const proxyArray = new Proxy(reactiveArray, {})

--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -216,5 +216,14 @@ describe('reactivity/reactive/Array', () => {
       proxyArray.push(1)
       expect(proxyArray.includes(1)).toBe(true)
     })
+
+    
+    test('toRaw on array using reactive as prototype', () => {
+      const original = reactive([])
+      const obj = Object.create(original)
+      const raw = toRaw(obj)
+      expect(raw).toBe(obj)
+      expect(raw).not.toBe(toRaw(original))
+    })
   })
 })

--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -209,5 +209,12 @@ describe('reactivity/reactive/Array', () => {
       expect(index).toBe(2)
       expect(observed.lastSearched).toBe(6)
     })
+    
+    test('add a proxy to a reactive array', () => {
+      const reactiveArray: number[] = reactive([])
+      const proxyArray = new Proxy(reactiveArray, {})
+      proxyArray.push(1)
+      expect(proxyArray.includes(1)).toBe(true)
+    })
   })
 })

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -33,7 +33,7 @@ import { warn } from './warning'
 
 const isNonTrackableKeys = /*#__PURE__*/ makeMap(`__proto__,__v_isRef,__isVue`)
 
-// skip the compare bwtween receiver and proxy of the target
+// skip the comparsion bwtween receiver and proxy of the target
 // which leads to infinite loops in some cases (#9742)
 let forceToRaw = false
 

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -33,7 +33,7 @@ import { warn } from './warning'
 
 const isNonTrackableKeys = /*#__PURE__*/ makeMap(`__proto__,__v_isRef,__isVue`)
 
-// skip the comparsion bwtween receiver and proxy of the target
+// skip the comparsion between receiver and proxy of the target
 // which leads to infinite loops in some cases (#9742)
 let forceToRaw = false
 


### PR DESCRIPTION
fix #9742 

When user add a proxy to a reactive array and use motheds of Array such as `push/pop/shift/unshift/includes/indexOf/lastIndexOf/splice`, the result of `toRaw(proxy)` will always return proxy and infinitely trigger `toRaw` because `receiver` isn't the origin proxy(created by vue) of `target`.

So I think when we use the above methods, it should skip the comparsion between `receiver` and the origin proxy(created by vue) of `target`.

```js
// Create a reactive array
const originalArray = reactive([]);

// Create a Proxy around the reactive array
const proxyArray = new Proxy(originalArray, {});

// Pushing elements to the Proxy array
proxyArray.push(1); // this will trigger toRaw infinitely
```