### PR TITLE
fix(runtime-dom): height and width of all elements should be set as attribute

### DIFF
--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -110,15 +110,9 @@ function shouldSetAsProp(
     return false
   }
 
-  // #8780 the width or height of embedded tags must be set as attribute
+  // #9762 width and height of all elements should be set as attribute
   if (key === 'width' || key === 'height') {
-    const tag = el.tagName
-    return !(
-      tag === 'IMG' ||
-      tag === 'VIDEO' ||
-      tag === 'CANVAS' ||
-      tag === 'SOURCE'
-    )
+    return false
   }
 
   // native onclick with string value, must be set as attribute


### PR DESCRIPTION
close #9762 

Height and width of all elements should be set as attribute.

When set width and height for a custom element with `width` and `height` as prop, the width and height should be set as attribute.

And for elements without `width` and `height` as prop such as `div`, it won't affect the real height and width of them, but should be displayed as an attribute on the dom in html. Just as the following image:

![image](https://github.com/vuejs/core/assets/73059627/54345cc8-2fcf-4261-b36e-eb8a1a181cb9)

