### PR TITLE
types(reactivity): fix type error when passing `any` through `ref`

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -88,7 +88,6 @@ export function isRef(r: any): r is Ref {
  * @param value - The object to wrap in the ref.
  * @see {@link https://vuejs.org/api/reactivity-core.html#ref}
  */
-export function ref<T extends Ref>(value: T): T
 export function ref<T>(value: T): Ref<UnwrapRef<T>>
 export function ref<T = any>(): Ref<T | undefined>
 export function ref(value?: unknown) {


### PR DESCRIPTION


This function overload matches the `any` type, and it returns `any` instead of `Ref<any>`.

`export function ref<T extends Ref>(value: T): T`

```ts
const msg: any = 'hello'

const msgRef = ref(msg) // ===> any

// Expected `Ref<any>` for msgRef, but received type `any`.

```

In this PR, the function overload was removed because its outcome is identical to `export function ref<T>(value: T): Ref<UnwrapRef<T>>`.


