### PR TITLE
fix(teleport): ensure correct rendering when target is empty

### DIFF
--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '@vue/runtime-test'
 import { createVNode, Fragment } from '../../src/vnode'
 import { compile, render as domRender } from 'vue'
+import {transform} from "@vue/reactivity-transform";
 
 describe('renderer: teleport', () => {
   test('should work', () => {
@@ -566,5 +567,7 @@ describe('renderer: teleport', () => {
     expect(serializeInner(root)).toMatchInlineSnapshot(
       `"<!--teleport start--><div>teleported</div><!--teleport end-->"`
     )
+    expect(`Invalid Teleport target: null`).toHaveBeenWarnedTimes(1)
+    expect(`Invalid Teleport target on mount`).toHaveBeenWarnedTimes(1)
   })
 })

--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -553,4 +553,18 @@ describe('renderer: teleport', () => {
       `"<div>teleported</div>"`
     )
   })
+  // 8146
+  test(`ensure correct rendering when target is empty`, async () => {
+    const root = nodeOps.createElement('div')
+    const App = {
+      setup() {
+        return () => h(Teleport, { to: null }, h('div', 'teleported'))
+      }
+    }
+    render(h(App), root)
+    await nextTick()
+    expect(serializeInner(root)).toMatchInlineSnapshot(
+      `"<!--teleport start--><div>teleported</div><!--teleport end-->"`
+    )
+  })
 })

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -131,7 +131,7 @@ export const TeleportImpl = {
         }
       }
 
-      if (disabled) {
+      if (disabled || !target) {
         mount(container, mainAnchor)
       } else if (target) {
         mount(target, targetAnchor)


### PR DESCRIPTION
close: #9782 