### PR TITLE
fix: should not remove \t to single whitespace

### DIFF
--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -259,7 +259,7 @@ function parseChildren(
       const node = nodes[i]
       if (node.type === NodeTypes.TEXT) {
         if (!context.inPre) {
-          if (!/[^\t\r\n\f ]/.test(node.content)) {
+          if (!/[^\r\n\f ]/.test(node.content)) {
             const prev = nodes[i - 1]
             const next = nodes[i + 1]
             // Remove if:
@@ -290,7 +290,7 @@ function parseChildren(
           } else if (shouldCondense) {
             // in condense mode, consecutive whitespaces in text are condensed
             // down to a single space.
-            node.content = node.content.replace(/[\t\r\n\f ]+/g, ' ')
+            node.content = node.content.replace(/[\r\n\f ]+/g, ' ')
           }
         } else {
           // #6410 normalize windows newlines in <pre>:

--- a/packages/compiler-dom/__tests__/parse.spec.ts
+++ b/packages/compiler-dom/__tests__/parse.spec.ts
@@ -477,5 +477,21 @@ describe('DOM parser', () => {
       expect(elementHtml.ns).toBe(DOMNamespaces.HTML)
       expect(element.ns).toBe(DOMNamespaces.MATH_ML)
     })
+
+    test('should convert \t to single whitespace', () => {
+      const ast = parse('<div>1&#0009;234</div>', parserOptions)
+      const element = ast.children[0] as ElementNode
+      const text = element.children[0] as TextNode
+
+      expect(text).toStrictEqual({
+        type: NodeTypes.TEXT,
+        content: '1\t234',
+        loc: {
+          start: { offset: 5, line: 1, column: 6 },
+          end: { offset: 16, line: 1, column: 17 },
+          source: '1&#0009;234'
+        }
+      })
+    })
   })
 })


### PR DESCRIPTION
close #9793 
\t should always preserve and leave it to the browser to handle