### PR TITLE
feat: add xmp/noembed/noframes tag as RAWTEXT

### DIFF
--- a/packages/compiler-dom/__tests__/parse.spec.ts
+++ b/packages/compiler-dom/__tests__/parse.spec.ts
@@ -478,4 +478,22 @@ describe('DOM parser', () => {
       expect(element.ns).toBe(DOMNamespaces.MATH_ML)
     })
   })
+
+  describe('RawText tag', () => {
+    test('xmp tag', () => {
+      const ast = parse('<xmp><li>this is li</li></xmp>', parserOptions)
+      const elementXMP = ast.children[0] as ElementNode
+      const elementText = elementXMP.children[0]
+
+      expect(elementText).toStrictEqual({
+        type: NodeTypes.TEXT,
+        content: '<li>this is li</li>',
+        loc: {
+          start: { offset: 5, line: 1, column: 6 },
+          end: { offset: 24, line: 1, column: 25 },
+          source: '<li>this is li</li>'
+        }
+      })
+    })
+  })
 })

--- a/packages/compiler-dom/src/parserOptions.ts
+++ b/packages/compiler-dom/src/parserOptions.ts
@@ -10,8 +10,9 @@ import { TRANSITION, TRANSITION_GROUP } from './runtimeHelpers'
 import { decodeHtml } from './decodeHtml'
 import { decodeHtmlBrowser } from './decodeHtmlBrowser'
 
+// https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
 const isRawTextContainer = /*#__PURE__*/ makeMap(
-  'style,iframe,script,noscript',
+  'style,iframe,script,noscript,xmp,noembed,noframes',
   true
 )
 

--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -1201,6 +1201,9 @@ export interface IntrinsicElementAttributes {
   video: VideoHTMLAttributes
   wbr: HTMLAttributes
   webview: WebViewHTMLAttributes
+  xmp: HTMLAttributes
+  noembed: HTMLAttributes
+  noframes: HTMLAttributes
 
   // SVG
   svg: SVGAttributes

--- a/packages/shared/src/domTagConfig.ts
+++ b/packages/shared/src/domTagConfig.ts
@@ -12,7 +12,7 @@ const HTML_TAGS =
   'canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,' +
   'th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,' +
   'option,output,progress,select,textarea,details,dialog,menu,' +
-  'summary,template,blockquote,iframe,tfoot'
+  'summary,template,blockquote,iframe,tfoot,xmp,noembed,noframes'
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element
 const SVG_TAGS =


### PR DESCRIPTION
close #9807 
https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
`xmg`、`noembed`、`noframes` should be handled as RAWTEXT tag