### PR TITLE
fix(teleport): not throw warning when teleport is disabled

### DIFF
--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -47,7 +47,7 @@ const resolveTarget = <T = RendererElement>(
       return null
     } else {
       const target = select(targetSelector)
-      if (!target) {
+      if (!target && !isTeleportDisabled(props)) {
         __DEV__ &&
           warn(
             `Failed to locate Teleport target with selector "${targetSelector}". ` +

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -47,14 +47,13 @@ const resolveTarget = <T = RendererElement>(
       return null
     } else {
       const target = select(targetSelector)
-      if (!target && !isTeleportDisabled(props)) {
-        __DEV__ &&
-          warn(
-            `Failed to locate Teleport target with selector "${targetSelector}". ` +
-              `Note the target element must exist before the component is mounted - ` +
-              `i.e. the target cannot be rendered by the component itself, and ` +
-              `ideally should be outside of the entire Vue component tree.`,
-          )
+      if (__DEV__ && !target && !isTeleportDisabled(props)) {
+        warn(
+          `Failed to locate Teleport target with selector "${targetSelector}". ` +
+            `Note the target element must exist before the component is mounted - ` +
+            `i.e. the target cannot be rendered by the component itself, and ` +
+            `ideally should be outside of the entire Vue component tree.`,
+        )
       }
       return target as T
     }


### PR DESCRIPTION
This PR removes a warning when `Teleport` is disabled and its `to` target is not found. [Reproduction link](https://play.vuejs.org/#__DEV__eNqNUstOwzAQ/JXIXEmsqreqVAXUAxwAQY+5pPHSuvgle5NGqvrvrN0HaXmIWzyzuzM7my27da5oG2AjNkbQTlUIk9Jk2XgOCpz1mAkZqoUCkaG9KdkVwRoM5riqMBcWQm4s5tDJgCVLrdQsZDuprUEqHPP4SCP5cSY9x7wnx66Z1JHIdeWKdbCG/GxjT3kgQslGWUIiRobju2QrRBdGnNfCUJsAJVtfGEBunOZTKuO+MSg1kFM9HRbDYjAgPwH7eAFB5wtvNwE8TSnZdU+HE9iCzz0YAR78f3Uv2s60L7hv+lF+V5odxYKBYnyXy4tQaqudVOCfHUprzsOplLKbx4Shb+C0TL2C+uMHfB26/VIvHpKzXgBY+SXQXSM9e3uCjr5PpLaiUYdD/EK+QrCqiR73ZXeNEWS7V5fcPqQbS7Och1lHP004LhWNpjRSfTrI/R+rf9mluE8p7j4B9DP5Uw==).