### PR TITLE
fix(useCssVars): fix the loss of CSS variables during updates

### DIFF
--- a/packages/runtime-dom/__tests__/helpers/useCssVars.spec.ts
+++ b/packages/runtime-dom/__tests__/helpers/useCssVars.spec.ts
@@ -293,4 +293,35 @@ describe('useCssVars', () => {
     await nextTick()
     expect(target.children.length).toBe(0)
   })
+
+  test('with string style', async () => {
+    document.body.innerHTML = ''
+    const state = reactive({ color: 'red' })
+    const root = document.createElement('div')
+    const disabled = ref(false)
+
+    const App = {
+      setup() {
+        useCssVars(() => state)
+        return () => [
+          h(
+            'div',
+            { style: disabled.value ? 'pointer-events: none' : undefined },
+            'foo'
+          )
+        ]
+      }
+    }
+    render(h(App), root)
+    await nextTick()
+    for (const c of [].slice.call(root.children as any)) {
+      expect((c as HTMLElement).style.getPropertyValue(`--color`)).toBe('red')
+    }
+    disabled.value = true
+    await nextTick()
+
+    for (const c of [].slice.call(root.children as any)) {
+      expect((c as HTMLElement).style.getPropertyValue(`--color`)).toBe('red')
+    }
+  })
 })

--- a/packages/runtime-dom/src/helpers/useCssVars.ts
+++ b/packages/runtime-dom/src/helpers/useCssVars.ts
@@ -10,6 +10,7 @@ import {
 } from '@vue/runtime-core'
 import { ShapeFlags } from '@vue/shared'
 
+export const CSS_VAR_TEXT = Symbol(__DEV__ ? 'CSS_VAR_TEXT' : '')
 /**
  * Runtime helper for SFC's CSS variable injection feature.
  * @private
@@ -79,8 +80,11 @@ function setVarsOnVNode(vnode: VNode, vars: Record<string, string>) {
 function setVarsOnNode(el: Node, vars: Record<string, string>) {
   if (el.nodeType === 1) {
     const style = (el as HTMLElement).style
+    let cssText = ''
     for (const key in vars) {
       style.setProperty(`--${key}`, vars[key])
+      cssText += `--${key}: ${vars[key]};`
     }
+    ;(style as any)[CSS_VAR_TEXT] = cssText
   }
 }

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -24,7 +24,7 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
     if (isCssString) {
       if (prev !== next) {
         // #9821
-        let cssVarText = (style as any)[CSS_VAR_TEXT]
+        const cssVarText = (style as any)[CSS_VAR_TEXT]
         if (cssVarText) {
           ;(next as string) += ';' + cssVarText
         }

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -1,6 +1,7 @@
 import { isString, hyphenate, capitalize, isArray } from '@vue/shared'
 import { camelize, warn } from '@vue/runtime-core'
 import { vShowOldKey } from '../directives/vShow'
+import { CSS_VAR_TEXT } from '../helpers/useCssVars'
 
 type Style = string | Record<string, string | string[]> | null
 
@@ -22,6 +23,10 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
     const currentDisplay = style.display
     if (isCssString) {
       if (prev !== next) {
+        const _cssVarText = (style as any)[CSS_VAR_TEXT]
+        if (_cssVarText) {
+          ;(next as string) += `; ${_cssVarText}`
+        }
         style.cssText = next as string
       }
     } else if (prev) {

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -23,9 +23,11 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
     const currentDisplay = style.display
     if (isCssString) {
       if (prev !== next) {
-        const _cssVarText = (style as any)[CSS_VAR_TEXT]
-        if (_cssVarText) {
-          ;(next as string) += `; ${_cssVarText}`
+        // #9821
+        let cssVarText = (style as any)[CSS_VAR_TEXT]
+        if (cssVarText) {
+          cssVarText = (next.endsWith(';') ? '' : '; ') + cssVarText
+          ;(next as string) += cssVarText
         }
         style.cssText = next as string
       }

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -26,8 +26,7 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
         // #9821
         let cssVarText = (style as any)[CSS_VAR_TEXT]
         if (cssVarText) {
-          cssVarText = (next.endsWith(';') ? '' : '; ') + cssVarText
-          ;(next as string) += cssVarText
+          ;(next as string) += ';' + cssVarText
         }
         style.cssText = next as string
       }


### PR DESCRIPTION
fixed #9821

During the `patchStyle` process, if a string type is passed, it will overwrite the entire `cssText`, leading to the loss of the `useCssVars` variable. In `useCssVars`, I store CSS variables in a private property of the style, which is then collectively set to `cssText` during the `patchStyle` process.

I attempted to use a `MutationObserver` to monitor style changes in all child elements. However, in the scenario where we also need to listen to the `childList` of the `parentNode`, I had to add another `MutationObserver` within the `parentNode`'s observer to simultaneously monitor newly added child elements. This approach introduces complexity to the logic, so I opted for the current solution.