### PR TITLE
fix(runtime-core): uncomment assertion in hydration test

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1207,7 +1207,7 @@ describe('SSR hydration', () => {
       </div>
     `)
     expect(vnode.el).toBe(container.firstChild)
-    // expect(`mismatch`).not.toHaveBeenWarned()
+    expect(`mismatch`).not.toHaveBeenWarned()
   })
 
   test('transition appear with v-if', () => {


### PR DESCRIPTION
The comment has been introduced in 2ffc1e8cfdc6ec9c45c4a4dd8e3081b2aa138f1e