### PR TITLE
fix(runtime-core): clean scopeIds when leave node

### DIFF
--- a/packages/compiler-core/src/babelUtils.ts
+++ b/packages/compiler-core/src/babelUtils.ts
@@ -72,6 +72,7 @@ export function walkIdentifiers(
           knownIds[id]--
           if (knownIds[id] === 0) {
             delete knownIds[id]
+            node.scopeIds = undefined
           }
         }
       }

--- a/packages/compiler-core/src/babelUtils.ts
+++ b/packages/compiler-core/src/babelUtils.ts
@@ -72,7 +72,7 @@ export function walkIdentifiers(
           knownIds[id]--
           if (knownIds[id] === 0) {
             delete knownIds[id]
-            node.scopeIds = undefined
+            node.scopeIds.delete(id)
           }
         }
       }


### PR DESCRIPTION
close #9853

Another solution is to reuse `node.scopeIds` for better performance. see https://github.com/vuejs/core/pull/9867
