### PR TITLE
test: replace deprecated `SpyInstance` with `MockInstance`

### DIFF
--- a/packages/runtime-dom/__tests__/customizedBuiltIn.spec.ts
+++ b/packages/runtime-dom/__tests__/customizedBuiltIn.spec.ts
@@ -1,8 +1,8 @@
-import { type SpyInstance } from 'vitest'
+import { type MockInstance } from 'vitest'
 import { render, h } from '@vue/runtime-dom'
 
 describe('customized built-in elements support', () => {
-  let createElement: SpyInstance
+  let createElement: MockInstance
   afterEach(() => {
     createElement.mockRestore()
   })

--- a/scripts/setupVitest.ts
+++ b/scripts/setupVitest.ts
@@ -1,4 +1,4 @@
-import { type SpyInstance } from 'vitest'
+import { type MockInstance } from 'vitest'
 
 expect.extend({
   toHaveBeenWarned(received: string) {
@@ -65,7 +65,7 @@ expect.extend({
   }
 })
 
-let warn: SpyInstance
+let warn: MockInstance
 const asserted: Set<string> = new Set()
 
 beforeEach(() => {


### PR DESCRIPTION
The `SpyInstance` type has been deprecated in vitest and is now marked as obsolete. According to the documentation, should replace it with `MockInstance`.


https://github.com/vitest-dev/vitest/blob/039814bd0eb9ed7b7f6e649a1c3def38d5174a5d/packages/spy/src/index.ts#L107-L110