### PR TITLE
fix(parser): properly location tag end index

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -986,7 +986,7 @@ describe('compiler: parse', () => {
 
     test('attribute value with >', () => {
       const ast = baseParse(
-        '<script setup lang="ts" generic="T extends Record<string>"></script>',
+        '<script setup lang="ts" generic="T extends Record<string,string>"></script>',
         { parseMode: 'sfc' }
       )
       const element = ast.children[0] as ElementNode
@@ -998,141 +998,69 @@ describe('compiler: parse', () => {
         codegenNode: undefined,
         children: [],
         innerLoc: {
-          end: {
-            column: 60,
-            line: 1,
-            offset: 59
-          },
-          start: {
-            column: 60,
-            line: 1,
-            offset: 59
-          }
+          start: { column: 67, line: 1, offset: 66 },
+          end: { column: 67, line: 1, offset: 66 }
         },
         props: [
           {
             loc: {
-              end: {
-                column: 14,
-                line: 1,
-                offset: 13
-              },
               source: 'setup',
-              start: {
-                column: 9,
-                line: 1,
-                offset: 8
-              }
+              end: { column: 14, line: 1, offset: 13 },
+              start: { column: 9, line: 1, offset: 8 }
             },
             name: 'setup',
             nameLoc: {
-              end: {
-                column: 14,
-                line: 1,
-                offset: 13
-              },
               source: 'setup',
-              start: {
-                column: 9,
-                line: 1,
-                offset: 8
-              }
+              end: { column: 14, line: 1, offset: 13 },
+              start: { column: 9, line: 1, offset: 8 }
             },
-            type: 6,
+            type: NodeTypes.ATTRIBUTE,
             value: undefined
           },
           {
             loc: {
-              end: {
-                column: 24,
-                line: 1,
-                offset: 23
-              },
               source: 'lang="ts"',
-              start: {
-                column: 15,
-                line: 1,
-                offset: 14
-              }
+              end: { column: 24, line: 1, offset: 23 },
+              start: { column: 15, line: 1, offset: 14 }
             },
             name: 'lang',
             nameLoc: {
-              end: {
-                column: 19,
-                line: 1,
-                offset: 18
-              },
               source: 'lang',
-              start: {
-                column: 15,
-                line: 1,
-                offset: 14
-              }
+              end: { column: 19, line: 1, offset: 18 },
+              start: { column: 15, line: 1, offset: 14 }
             },
-            type: 6,
+            type: NodeTypes.ATTRIBUTE,
             value: {
               content: 'ts',
               loc: {
-                end: {
-                  column: 24,
-                  line: 1,
-                  offset: 23
-                },
                 source: '"ts"',
-                start: {
-                  column: 20,
-                  line: 1,
-                  offset: 19
-                }
+                end: { column: 24, line: 1, offset: 23 },
+                start: { column: 20, line: 1, offset: 19 }
               },
-              type: 2
+              type: NodeTypes.TEXT
             }
           },
           {
             loc: {
-              end: {
-                column: 59,
-                line: 1,
-                offset: 58
-              },
-              source: 'generic="T extends Record<string>"',
-              start: {
-                column: 25,
-                line: 1,
-                offset: 24
-              }
+              source: 'generic="T extends Record<string,string>"',
+              end: { column: 66, line: 1, offset: 65 },
+              start: { column: 25, line: 1, offset: 24 }
             },
             name: 'generic',
             nameLoc: {
-              end: {
-                column: 32,
-                line: 1,
-                offset: 31
-              },
               source: 'generic',
-              start: {
-                column: 25,
-                line: 1,
-                offset: 24
-              }
+              end: { column: 32, line: 1, offset: 31 },
+              start: { column: 25, line: 1, offset: 24 }
             },
-            type: 6,
+            type: NodeTypes.ATTRIBUTE,
             value: {
-              content: 'T extends Record<string>',
+              content: 'T extends Record<string,string>',
               loc: {
-                end: {
-                  column: 59,
-                  line: 1,
-                  offset: 58
-                },
-                source: '"T extends Record<string>"',
-                start: {
-                  column: 33,
-                  line: 1,
-                  offset: 32
-                }
+                source: '"T extends Record<string,string>"',
+                end: { column: 66, line: 1, offset: 65 },
+                start: { column: 33, line: 1, offset: 32 }
               },
-              type: 2
+              type: NodeTypes.TEXT
             }
           }
         ]

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -984,6 +984,161 @@ describe('compiler: parse', () => {
       })
     })
 
+    test('attribute value with >', () => {
+      const ast = baseParse(
+        '<script setup lang="ts" generic="T extends Record<string>"></script>',
+        { parseMode: 'sfc' }
+      )
+      const element = ast.children[0] as ElementNode
+      expect(element).toMatchObject({
+        type: NodeTypes.ELEMENT,
+        ns: Namespaces.HTML,
+        tag: 'script',
+        tagType: ElementTypes.ELEMENT,
+        codegenNode: undefined,
+        children: [],
+        innerLoc: {
+          end: {
+            column: 60,
+            line: 1,
+            offset: 59
+          },
+          start: {
+            column: 60,
+            line: 1,
+            offset: 59
+          }
+        },
+        props: [
+          {
+            loc: {
+              end: {
+                column: 14,
+                line: 1,
+                offset: 13
+              },
+              source: 'setup',
+              start: {
+                column: 9,
+                line: 1,
+                offset: 8
+              }
+            },
+            name: 'setup',
+            nameLoc: {
+              end: {
+                column: 14,
+                line: 1,
+                offset: 13
+              },
+              source: 'setup',
+              start: {
+                column: 9,
+                line: 1,
+                offset: 8
+              }
+            },
+            type: 6,
+            value: undefined
+          },
+          {
+            loc: {
+              end: {
+                column: 24,
+                line: 1,
+                offset: 23
+              },
+              source: 'lang="ts"',
+              start: {
+                column: 15,
+                line: 1,
+                offset: 14
+              }
+            },
+            name: 'lang',
+            nameLoc: {
+              end: {
+                column: 19,
+                line: 1,
+                offset: 18
+              },
+              source: 'lang',
+              start: {
+                column: 15,
+                line: 1,
+                offset: 14
+              }
+            },
+            type: 6,
+            value: {
+              content: 'ts',
+              loc: {
+                end: {
+                  column: 24,
+                  line: 1,
+                  offset: 23
+                },
+                source: '"ts"',
+                start: {
+                  column: 20,
+                  line: 1,
+                  offset: 19
+                }
+              },
+              type: 2
+            }
+          },
+          {
+            loc: {
+              end: {
+                column: 59,
+                line: 1,
+                offset: 58
+              },
+              source: 'generic="T extends Record<string>"',
+              start: {
+                column: 25,
+                line: 1,
+                offset: 24
+              }
+            },
+            name: 'generic',
+            nameLoc: {
+              end: {
+                column: 32,
+                line: 1,
+                offset: 31
+              },
+              source: 'generic',
+              start: {
+                column: 25,
+                line: 1,
+                offset: 24
+              }
+            },
+            type: 6,
+            value: {
+              content: 'T extends Record<string>',
+              loc: {
+                end: {
+                  column: 59,
+                  line: 1,
+                  offset: 58
+                },
+                source: '"T extends Record<string>"',
+                start: {
+                  column: 33,
+                  line: 1,
+                  offset: 32
+                }
+              },
+              type: 2
+            }
+          }
+        ]
+      })
+    })
+
     test('multiple attributes', () => {
       const ast = baseParse('<div id=a class="c" inert style=\'\'></div>')
       const element = ast.children[0] as ElementNode

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1383,6 +1383,21 @@ return { D, C, B, Foo }
 })"
 `;
 
+exports[`SFC compile <script setup> > with TypeScript > with generic attribute 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+type Bar = {}
+      
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+        
+return {  }
+}
+
+})"
+`;
+
 exports[`SFC genDefaultAs > <script setup> only 1`] = `
 "const a = 1
       

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -938,6 +938,14 @@ describe('SFC compile <script setup>', () => {
       expect(content).toMatch(`return { get Baz() { return Baz } }`)
       assertCode(content)
     })
+
+    test('with generic attribute', () => {
+      const { content } = compile(`
+      <script setup lang="ts" generic="T extends Record<string,string>">
+        type Bar = {}
+      </script>`)
+      assertCode(content)
+    })
   })
 
   describe('async/await detection', () => {

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -876,7 +876,7 @@ describe('SFC compile <script setup>', () => {
   describe('with TypeScript', () => {
     test('hoist type declarations', () => {
       const { content } = compile(`
-      <script setup lang="ts" generic="T extends Record<string>">
+      <script setup lang="ts">
         export interface Foo {}
         type Bar = {}
       </script>`)

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -876,7 +876,7 @@ describe('SFC compile <script setup>', () => {
   describe('with TypeScript', () => {
     test('hoist type declarations', () => {
       const { content } = compile(`
-      <script setup lang="ts">
+      <script setup lang="ts" generic="T extends Record<string>">
         export interface Foo {}
         type Bar = {}
       </script>`)


### PR DESCRIPTION
close #9890
should skip the `>` in quotes when locating the tag end