### PR TITLE
fix(runtime-core): remove prod checks from warn

### DIFF
--- a/packages/runtime-core/src/warning.ts
+++ b/packages/runtime-core/src/warning.ts
@@ -31,8 +31,6 @@ export function popWarningContext() {
 }
 
 export function warn(msg: string, ...args: any[]) {
-  if (!__DEV__) return
-
   // avoid props formatting or warn handler tracking deps that might be mutated
   // during patch, leading to infinite recursion.
   pauseTracking()


### PR DESCRIPTION
All the `warn` calls are already scoped within `__DEV__`, so I don't think there's any need to keep that condition here. Also, currently conditionally enabling warnings in prod (like the hydration mismatch flag) doesn't work because of this.