### PR TITLE
chore(eslint): eslint ignore .gitignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "size-esm-runtime": "node scripts/build.js vue -f esm-bundler-runtime",
     "size-esm": "node scripts/build.js runtime-dom runtime-core reactivity shared -f esm-bundler",
     "check": "tsc --incremental --noEmit",
-    "lint": "eslint --cache --ext .js,.ts,.tsx .",
+    "lint": "eslint --cache --ext .js,.ts,.tsx . --ignore-path .gitignore",
     "format": "prettier --write --cache .",
     "format-check": "prettier --check --cache .",
     "test": "vitest",


### PR DESCRIPTION
The current lint script checks all files, causing errors when checking files in directories like dist and temp. In this PR, I have added "--ignore-path .gitignore" to exclude these files from the linting process.

![image](https://github.com/vuejs/core/assets/55641773/c9c308f6-4b7b-4679-8271-63c44f8f1461)
