### PR TITLE
types(watch): support single usage of defineModel with watch

### DIFF
--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -9,6 +9,7 @@ import {
   toRefs,
   useAttrs,
   useSlots,
+  watch,
   withDefaults,
 } from 'vue'
 import { describe, expectType } from './utils'
@@ -349,6 +350,15 @@ describe('defineModel', () => {
   defineModel<string>({ default: 123 })
   // @ts-expect-error unknown props option
   defineModel({ foo: 123 })
+
+  // usage with watch
+  const model = defineModel<string>()
+  watch(model, val => {
+    expectType<string | undefined>(val)
+  })
+  watch([model], ([val]) => {
+    expectType<string | undefined>(val)
+  })
 })
 
 describe('useModel', () => {

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -43,6 +43,7 @@ import { DeprecationTypes } from './compat/compatConfig'
 import { checkCompatEnabled, isCompatEnabled } from './compat/compatConfig'
 import type { ObjectWatchOptionItem } from './componentOptions'
 import { useSSRContext } from '@vue/runtime-core'
+import type { ModelRef } from './apiSetupHelpers'
 
 export type WatchEffect = (onCleanup: OnCleanup) => void
 
@@ -114,6 +115,13 @@ export function watchSyncEffect(
 const INITIAL_WATCHER_VALUE = {}
 
 type MultiWatchSources = (WatchSource<unknown> | object)[]
+
+// overload: ModelRef
+export function watch<T, Immediate extends Readonly<boolean> = false>(
+  sources: ModelRef<T>,
+  cb: WatchCallback<MapSources<T, false>, MapSources<T, Immediate>>,
+  options?: WatchOptions<Immediate>,
+): WatchStopHandle
 
 // overload: array of multiple sources + cb
 export function watch<


### PR DESCRIPTION
closes https://github.com/vuejs/core/issues/9939

Because `ModelRef` is also an array it falls through the array sources, even tho it shouldn't be handled as an array in this case