### PR TITLE
fix(defineModel): support kebab-case/camelCase mismatches

### DIFF
--- a/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
+++ b/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
@@ -314,6 +314,84 @@ describe('SFC <script setup> helpers', () => {
       expect(serializeInner(root)).toBe('bar')
     })
 
+    test('kebab-case v-model (should not be local)', async () => {
+      let foo: any
+
+      const compRender = vi.fn()
+      const Comp = defineComponent({
+        props: ['fooBar'],
+        emits: ['update:fooBar'],
+        setup(props) {
+          foo = useModel(props, 'fooBar')
+          return () => {
+            compRender()
+            return foo.value
+          }
+        },
+      })
+
+      const updateFooBar = vi.fn()
+      const root = nodeOps.createElement('div')
+      // v-model:foo-bar compiles to foo-bar and onUpdate:fooBar
+      render(
+        h(Comp, { 'foo-bar': 'initial', 'onUpdate:fooBar': updateFooBar }),
+        root,
+      )
+      expect(compRender).toBeCalledTimes(1)
+      expect(serializeInner(root)).toBe('initial')
+
+      expect(foo.value).toBe('initial')
+      foo.value = 'bar'
+      // should not be using local mode, so nothing should actually change
+      expect(foo.value).toBe('initial')
+
+      await nextTick()
+      expect(compRender).toBeCalledTimes(1)
+      expect(updateFooBar).toBeCalledTimes(1)
+      expect(updateFooBar).toHaveBeenCalledWith('bar')
+      expect(foo.value).toBe('initial')
+      expect(serializeInner(root)).toBe('initial')
+    })
+
+    test('kebab-case update listener (should not be local)', async () => {
+      let foo: any
+
+      const compRender = vi.fn()
+      const Comp = defineComponent({
+        props: ['fooBar'],
+        emits: ['update:fooBar'],
+        setup(props) {
+          foo = useModel(props, 'fooBar')
+          return () => {
+            compRender()
+            return foo.value
+          }
+        },
+      })
+
+      const updateFooBar = vi.fn()
+      const root = nodeOps.createElement('div')
+      // The template compiler won't create hyphenated listeners, but it could have been passed manually
+      render(
+        h(Comp, { 'foo-bar': 'initial', 'onUpdate:foo-bar': updateFooBar }),
+        root,
+      )
+      expect(compRender).toBeCalledTimes(1)
+      expect(serializeInner(root)).toBe('initial')
+
+      expect(foo.value).toBe('initial')
+      foo.value = 'bar'
+      // should not be using local mode, so nothing should actually change
+      expect(foo.value).toBe('initial')
+
+      await nextTick()
+      expect(compRender).toBeCalledTimes(1)
+      expect(updateFooBar).toBeCalledTimes(1)
+      expect(updateFooBar).toHaveBeenCalledWith('bar')
+      expect(foo.value).toBe('initial')
+      expect(serializeInner(root)).toBe('initial')
+    })
+
     test('default value', async () => {
       let count: any
       const inc = () => {

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -6,6 +6,7 @@ import {
   camelize,
   extend,
   hasChanged,
+  hyphenate,
   isArray,
   isFunction,
   isPromise,
@@ -382,6 +383,7 @@ export function useModel(
   }
 
   const camelizedName = camelize(name)
+  const hyphenatedName = hyphenate(name)
 
   const res = customRef((track, trigger) => {
     let localValue: any
@@ -403,9 +405,12 @@ export function useModel(
           !(
             rawProps &&
             // check if parent has passed v-model
-            (name in rawProps || camelizedName in rawProps) &&
+            (name in rawProps ||
+              camelizedName in rawProps ||
+              hyphenatedName in rawProps) &&
             (`onUpdate:${name}` in rawProps ||
-              `onUpdate:${camelizedName}` in rawProps)
+              `onUpdate:${camelizedName}` in rawProps ||
+              `onUpdate:${hyphenatedName}` in rawProps)
           ) &&
           hasChanged(value, localValue)
         ) {


### PR DESCRIPTION
This PR attempts to fix a problem with the logic for detecting local mode. The problem occurs when the parent uses kebab-case and the child uses camelCase.

Here's an example illustrating the problem I'm trying to fix with 3.4.3:

- [SFC Playground](https://play.vuejs.org/#eNp9Uk2PmzAQ/SsjX0K0BHa1t4hE7W730Eppq37cfGFhCN41NrINSYX47x0bkqZSlJvnvTfDG94M7GPbJn2HbM0yWxjROrDounbLlWhabRwMYLCK4ZC7ooYRKqMbWFDH4qzY/XmuhSxnKknn2o8lEVeFVtZBoTvlYOOnRQ9Lj4eRUcBjiPolbLYwcAXQk2yXuzpp8mN0H89voaI+hof7JTXDNC7pc9khqXuuRoKzdNqB3FPhsGll7pAqgGGYHYyjL7PaBDg7me9XjS5RriutV6+52XAW5JxBSsIsPQ9jMXOWVqrEPnmzWtGfC6Z9Q9MKieZb6wStzNl6WsdzuZT68CVgznQYn/CixuL9Cv5mjx7j7LtBi6ZHzs6cy80eyZmnX35+xSO9zyRt0UlS3yB/oNWy8x4n2VOnSrJ9oQtuP4d0hdr/si9Hh8qelvJGvXIMes4o5+cbq/+z+5g8hj4Ki/7ixZlcub7paEImlG+JlVC481W0oIiecrO4nXdWij48QvTTnCl64l4757SCD4UUxTtFHejVirPtJ32gqRM/t19X392R+nf7nzZLp49eXAtXbPwLa8UhUg==)

The value is supposed to be restricted to the range 0-10, but clicking the buttons allows the child to drift out of that range.

This is because the parent uses `v-model:foo-bar`, with a hyphenated prop name, whereas the child is using `defineModel('fooBar')`. It incorrectly uses local mode in that scenario.

The example above works correctly if it is changed to `v-model:fooBar` instead, but that isn't an option if the parent uses an in-DOM template. Attempting to work around the problem in the child using `defineModel('foo-bar')` results in an error. This PR does not address that error, it just tries to allow the parent template to use kebab-case.

The key change is to check for `hyphenatedName in rawProps`. I've also added a check for `` `onUpdate:${hyphenatedName}` in rawProps``, though that is less important as the template compiler doesn't generate kebab-case listener names. I still thought it was worth including, both for consistency and because listeners can be passed in other ways without going through the compiler.

Here's the same example above, but using this PR:

- [Fixed Playground](https://deploy-preview-9950--vue-sfc-playground.netlify.app/#eNp9Uk2PmzAQ/SsjX0K0BHa1t4hE7W730Eppq37cfGFhCN41NrINSYX47x0bkqZSlJvnvTfDG94M7GPbJn2HbM0yWxjROrDounbLlWhabRwMYLCK4ZC7ooYRKqMbWFDH4qzY/XmuhSxnKknn2o8lEVeFVtZBoTvlYOOnRQ9Lj4eRUcBjiPolbLYwcAXQk2yXuzpp8mN0H89voaI+hof7JTXDNC7pc9khqXuuRoKzdNqB3FPhsGll7pAqgGGYHYyjL7PaBDg7me9XjS5RriutV6+52XAW5JxBSsIsPQ9jMXOWVqrEPnmzWtGfC6Z9Q9MKieZb6wStzNl6WsdzuZT68CVgznQYn/CixuL9Cv5mjx7j7LtBi6ZHzs6cy80eyZmnX35+xSO9zyRt0UlS3yB/oNWy8x4n2VOnSrJ9oQtuP4d0hdr/si9Hh8qelvJGvXIMes4o5+cbq/+z+5g8hj4Ki/7ixZlcub7paEImlG+JlVC481W0oIiecrO4nXdWij48QvTTnCl64l4757SCD4UUxTtFHejVirPtJ32gqRM/t19X392R+nf7nzZLp49eXAtXbPwLa8UhUg==)