### PR TITLE
chore(apiWatch): constraint deep passes boolean

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -191,11 +191,9 @@ function doWatch(
   }
 
   // TODO remove in 3.5
-  if (__DEV__ && deep !== void 0 && typeof deep !== 'boolean') {
+  if (__DEV__ && deep !== void 0 && typeof deep === 'number') {
     warn(
-      `watch() "deep" option now only accepts boolean values. Please update your code accordingly.` +
-        `\n Expected: watch(source, callback, { deep: ${!!deep} }) ` +
-        `\n Received: watch(source, callback, { deep: ${deep} })`,
+      `watch() "deep" option passing "number" type will be considered as watch depth in future versions.`,
     )
   }
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -193,7 +193,8 @@ function doWatch(
   // TODO remove in 3.5
   if (__DEV__ && deep !== void 0 && typeof deep === 'number') {
     warn(
-      `watch() "deep" option passing "number" type will be considered as watch depth in future versions.`,
+      `watch() "deep" option with number value will be used as watch depth in future versions.` +
+      `Please use a boolean instead to avoid potential breakage.",
     )
   }
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -194,7 +194,7 @@ function doWatch(
   if (__DEV__ && deep !== void 0 && typeof deep === 'number') {
     warn(
       `watch() "deep" option with number value will be used as watch depth in future versions. ` +
-      `Please use a boolean instead to avoid potential breakage.",
+        `Please use a boolean instead to avoid potential breakage.`,
     )
   }
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -193,7 +193,7 @@ function doWatch(
   // TODO remove in 3.5
   if (__DEV__ && deep !== void 0 && typeof deep === 'number') {
     warn(
-      `watch() "deep" option with number value will be used as watch depth in future versions.` +
+      `watch() "deep" option with number value will be used as watch depth in future versions. ` +
       `Please use a boolean instead to avoid potential breakage.",
     )
   }

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -190,6 +190,15 @@ function doWatch(
     }
   }
 
+  // TODO remove in 3.5
+  if (__DEV__ && deep !== void 0 && typeof deep !== 'boolean') {
+    warn(
+      `watch() "deep" option now only accepts boolean values. Please update your code accordingly.` +
+        `\n Expected: watch(source, callback, { deep: ${!!deep} }) ` +
+        `\n Received: watch(source, callback, { deep: ${deep} })`,
+    )
+  }
+
   if (__DEV__ && !cb) {
     if (immediate !== undefined) {
       warn(


### PR DESCRIPTION
relate #9572

In #9572, modify `deep` to accept `number` type, allowing control of the depth of the watching object. To prevent users from inadvertently passing other types in previous versions, In the current version, add a warning message.


