### PR TITLE
perf(apiWatch): avoid unnecessary traverse

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -231,10 +231,12 @@ function doWatch(
     getter = () => source.value
     forceTrigger = isShallow(source)
   } else if (isReactive(source)) {
-    getter =
-      isShallow(source) || deep === false
-        ? () => traverse(source, 1)
-        : () => traverse(source)
+    if (isShallow(source) || deep === false) {
+      getter = () => traverse(source, 1)
+    } else {
+      getter = () => source
+      deep = true
+    }
     forceTrigger = true
   } else if (isArray(source)) {
     isMultiSource = true


### PR DESCRIPTION
In the modification at #9928, if the `reactive` parameter is passed, a traverse action will be performed regardless of the circumstances. However, when the user manually passes `deep:true`, it results in two traverse actions, leading to unnecessary execution of traverse.

https://github.com/vuejs/core/blob/8f85b6da442cec326c22418ead6486e914245656/packages/runtime-core/src/apiWatch.ts#L296-L299