### PR TITLE
feat(sfc-playground): init custom formatter when preview

### DIFF
--- a/packages/sfc-playground/src/App.vue
+++ b/packages/sfc-playground/src/App.vue
@@ -134,6 +134,12 @@ onMounted(() => {
     :autoResize="true"
     :sfcOptions="sfcOptions"
     :clearConsole="false"
+    :preview-options="{
+      customCode: {
+        importCode: `import { initCustomFormatter } from 'vue'`,
+        useCode: `initCustomFormatter()`
+      }
+    }"
   />
 </template>
 


### PR DESCRIPTION
Fix #9957

In this PR, I modified the `<Repl>` in `App.vue` of the `sfc-playground` package, adding an automatic execution of `initCustomFormatter()` to `preview-options`.

However, I'm uncertain whether this setting should be applied within `sfc-playground` or if I should directly modify [`Preview.vue`](https://github.com/vuejs/repl/blob/main/src/output/Preview.vue) in [`@vue/repl`](https://github.com/vuejs/repl) to make it the default value.

I would appreciate any opinions on this.