### PR TITLE
fix(ssr): avoid rendering transition-group slot content as a fragment

### DIFF
--- a/packages/server-renderer/__tests__/ssrSlot.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSlot.spec.ts
@@ -145,12 +145,12 @@ describe('ssr: slot', () => {
         createApp({
           components: {
             one: {
-              template: `<transition><slot/></transition>`,
+              template: `<TransitionGroup tag="div"><slot/></TransitionGroup>`,
             },
           },
           template: `<one><p v-for="i in 2">{{i}}</p></one>`,
         }),
       ),
-    ).toBe(`<p>1</p><p>2</p>`)
+    ).toBe(`<div><p>1</p><p>2</p></div>`)
   })
 })

--- a/packages/server-renderer/__tests__/ssrSlot.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSlot.spec.ts
@@ -137,4 +137,20 @@ describe('ssr: slot', () => {
       ),
     ).toBe(`<div>foo</div>`)
   })
+
+  // #9933
+  test('transition-group slot', async () => {
+    expect(
+      await renderToString(
+        createApp({
+          components: {
+            one: {
+              template: `<transition><slot/></transition>`,
+            },
+          },
+          template: `<one><p v-for="i in 2">{{i}}</p></one>`,
+        }),
+      ),
+    ).toBe(`<p>1</p><p>2</p>`)
+  })
 })

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -83,6 +83,17 @@ export function ssrRenderSlotInner(
         }
       } else {
         for (let i = 0; i < slotBuffer.length; i++) {
+          // #9933
+          // Although we handle Transition/TransitionGroup in the transform stage
+          // without rendering them as fragments, the content passed into the slot
+          // may still be a fragment.
+          // Therefore, here we need to avoid rendering it as a fragment again.
+          if (
+            transition &&
+            (slotBuffer[i] === '<!--[-->' || slotBuffer[i] === '<!--]-->')
+          ) {
+            continue
+          }
           push(slotBuffer[i])
         }
       }

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -82,17 +82,22 @@ export function ssrRenderSlotInner(
           fallbackRenderFn()
         }
       } else {
+        // #9933
+        // Although we handle Transition/TransitionGroup in the transform stage
+        // without rendering it as a fragment, the content passed into the slot
+        // may still be a fragment.
+        // Therefore, here we need to avoid rendering it as a fragment again.
+        if (
+          transition &&
+          slotBuffer[0] === '<!--[-->' &&
+          slotBuffer[slotBuffer.length - 1] === '<!--]-->'
+        ) {
+          slotBuffer.shift()
+          slotBuffer.pop()
+        }
+
         for (let i = 0; i < slotBuffer.length; i++) {
-          const buffer = slotBuffer[i]
-          // #9933
-          // Although we handle Transition/TransitionGroup in the transform stage
-          // without rendering it as a fragment, the content passed into the slot
-          // may still be a fragment.
-          // Therefore, here we need to avoid rendering it as a fragment again.
-          if (transition && (buffer === '<!--[-->' || buffer === '<!--]-->')) {
-            continue
-          }
-          push(buffer)
+          push(slotBuffer[i])
         }
       }
     }

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -87,16 +87,18 @@ export function ssrRenderSlotInner(
         // without rendering it as a fragment, the content passed into the slot
         // may still be a fragment.
         // Therefore, here we need to avoid rendering it as a fragment again.
+        let start = 0
+        let end = slotBuffer.length
         if (
           transition &&
           slotBuffer[0] === '<!--[-->' &&
-          slotBuffer[slotBuffer.length - 1] === '<!--]-->'
+          slotBuffer[end - 1] === '<!--]-->'
         ) {
-          slotBuffer.shift()
-          slotBuffer.pop()
+          start++
+          end--
         }
 
-        for (let i = 0; i < slotBuffer.length; i++) {
+        for (let i = start; i < end; i++) {
           push(slotBuffer[i])
         }
       }

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -83,18 +83,16 @@ export function ssrRenderSlotInner(
         }
       } else {
         for (let i = 0; i < slotBuffer.length; i++) {
+          const buffer = slotBuffer[i]
           // #9933
           // Although we handle Transition/TransitionGroup in the transform stage
-          // without rendering them as fragments, the content passed into the slot
+          // without rendering it as a fragment, the content passed into the slot
           // may still be a fragment.
           // Therefore, here we need to avoid rendering it as a fragment again.
-          if (
-            transition &&
-            (slotBuffer[i] === '<!--[-->' || slotBuffer[i] === '<!--]-->')
-          ) {
+          if (transition && (buffer === '<!--[-->' || buffer === '<!--]-->')) {
             continue
           }
-          push(slotBuffer[i])
+          push(buffer)
         }
       }
     }

--- a/packages/sfc-playground/src/App.vue
+++ b/packages/sfc-playground/src/App.vue
@@ -69,6 +69,9 @@ const sfcOptions: SFCOptions = {
   },
   template: {
     isProd: useProdMode.value,
+    compilerOptions: {
+      isCustomElement: (tag: string) => tag === 'mjx-container',
+    },
   },
 }
 
@@ -134,6 +137,12 @@ onMounted(() => {
     :autoResize="true"
     :sfcOptions="sfcOptions"
     :clearConsole="false"
+    :preview-options="{
+      customCode: {
+        importCode: `import { initCustomFormatter } from 'vue'`,
+        useCode: `initCustomFormatter()`,
+      },
+    }"
   />
 </template>
 


### PR DESCRIPTION
close #9933 