### PR TITLE
fix(runtime-core): correctly assign suspenseId to avoid conflicts with the default id

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -24,12 +24,14 @@ import {
 } from '@vue/runtime-test'
 import { createApp, defineComponent } from 'vue'
 import type { RawSlots } from 'packages/runtime-core/src/componentSlots'
+import { resetSuspenseId } from '../../src/components/Suspense'
 
 describe('Suspense', () => {
   const deps: Promise<any>[] = []
 
   beforeEach(() => {
     deps.length = 0
+    resetSuspenseId()
   })
 
   // a simple async factory for testing purposes only.

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -253,7 +253,7 @@ function patchSuspense(
     } else {
       // toggled before pending tree is resolved
       // increment pending ID. this is used to invalidate async callbacks
-      suspense.pendingId = ++suspenseId
+      suspense.pendingId = suspenseId++
       if (isHydrating) {
         // if toggled before hydration is finished, the current DOM tree is
         // no longer valid. set it as the active branch so it will be unmounted
@@ -356,7 +356,7 @@ function patchSuspense(
       if (newBranch.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
         suspense.pendingId = newBranch.component!.suspenseId!
       } else {
-        suspense.pendingId = ++suspenseId
+        suspense.pendingId = suspenseId++
       }
       patch(
         null,
@@ -476,7 +476,7 @@ function createSuspenseBoundary(
     hiddenContainer,
     anchor,
     deps: 0,
-    pendingId: 0,
+    pendingId: suspenseId++,
     timeout: typeof timeout === 'number' ? timeout : -1,
     activeBranch: null,
     pendingBranch: null,

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -253,7 +253,7 @@ function patchSuspense(
     } else {
       // toggled before pending tree is resolved
       // increment pending ID. this is used to invalidate async callbacks
-      suspense.pendingId = suspenseId++
+      suspense.pendingId = ++suspenseId
       if (isHydrating) {
         // if toggled before hydration is finished, the current DOM tree is
         // no longer valid. set it as the active branch so it will be unmounted
@@ -356,7 +356,7 @@ function patchSuspense(
       if (newBranch.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
         suspense.pendingId = newBranch.component!.suspenseId!
       } else {
-        suspense.pendingId = suspenseId++
+        suspense.pendingId = ++suspenseId
       }
       patch(
         null,

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -50,6 +50,11 @@ export const isSuspense = (type: any): boolean => type.__isSuspense
 // incrementing unique id for every pending branch
 let suspenseId = 0
 
+/**
+ * For testing only
+ */
+export const resetSuspenseId = () => (suspenseId = 0)
+
 // Suspense exposes a component-like API, and is treated like a component
 // in the compiler, but internally it's a special built-in type that hooks
 // directly into the renderer.

--- a/packages/sfc-playground/src/App.vue
+++ b/packages/sfc-playground/src/App.vue
@@ -137,6 +137,12 @@ onMounted(() => {
     :autoResize="true"
     :sfcOptions="sfcOptions"
     :clearConsole="false"
+    :preview-options="{
+      customCode: {
+        importCode: `import { initCustomFormatter } from 'vue'`,
+        useCode: `initCustomFormatter()`,
+      },
+    }"
   />
 </template>
 


### PR DESCRIPTION
fix #9944 