### PR TITLE
chore(pnpm-workspace.yaml): packages/* in the pnpm-workspace.yaml is vague, it would be better to list specific package names

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,17 @@
 packages:
-  - 'packages/*'
+  - packages/compiler-core
+  - packages/compiler-dom
+  - packages/compiler-sfc
+  - packages/compiler-ssr
+  - packages/dts-built-test
+  - packages/dts-test
+  - packages/reactivity
+  - packages/runtime-core
+  - packages/runtime-dom
+  - packages/runtime-test
+  - packages/server-renderer
+  - packages/sfc-playground
+  - packages/shared
+  - packages/template-explorer
+  - packages/vue
+  - packages/vue-compat


### PR DESCRIPTION
### Purpose: Better for managing packages of vuejs/core

As vuejs/core project grows, it would be better to list specific package names, which can be more clear to see how many packages in the project when using pnpm as package manager.

### Why this commit ?

An error shown when running pnpm build:
../packages/reactivity-transform/package.json is not found

Above error gave me a confusing for a short time, and after comparing the remote vuejs/core code repo with local code base, making sure this empty folder should not be appear in the project.

### Benefits

If the specific package name listed in the pnpm-workspace.yaml, there would be 2 benefits apparently

1. More clear when adding package

Adding package would be more clear in the project, as it must be handled by pnpm in the pnpm-workspace.yaml

2. Packages reference 

As packages reference for folders in the packages, which holding so many packages in the vuejs/core project that pnpm-workspace.yaml file can be compared with existed packages in the packages folder.
