### PR TITLE
fix(compiler-sfc): error generating CSS sourcemap when using SCSS

### DIFF
--- a/packages/compiler-sfc/src/style/preprocessors.ts
+++ b/packages/compiler-sfc/src/style/preprocessors.ts
@@ -40,7 +40,7 @@ const scss: StylePreprocessor = (source, map, options, load = require) => {
         code: result.css.toString(),
         map: merge(
           map,
-          result.map.toJSON
+          !(result.map instanceof Buffer) && result.map.toJSON
             ? result.map.toJSON()
             : JSON.parse(result.map.toString()),
         ),


### PR DESCRIPTION
This is an attempt to fix #9969. See the issue for details.