### PR TITLE
build: add production/development export conditions

### DIFF
--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -9,6 +9,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/compiler-core.d.ts",
+      "node": {
+        "production": "./dist/compiler-core.cjs.prod.js",
+        "development": "./dist/compiler-core.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/compiler-core.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "buildOptions": {
     "name": "VueCompilerCore",
     "compat": true,

--- a/packages/compiler-dom/package.json
+++ b/packages/compiler-dom/package.json
@@ -11,6 +11,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/compiler-dom.d.ts",
+      "node": {
+        "production": "./dist/compiler-dom.cjs.prod.js",
+        "development": "./dist/compiler-dom.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/compiler-dom.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "sideEffects": false,
   "buildOptions": {
     "name": "VueCompilerDOM",

--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -8,6 +8,15 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/compiler-sfc.d.ts",
+      "node": "./dist/compiler-sfc.cjs.js",
+      "import": "./dist/compiler-sfc.esm-browser.js",
+      "require": "./dist/compiler-sfc.cjs.js"
+    },
+    "./*": "./*"
+  },
   "buildOptions": {
     "name": "VueCompilerSFC",
     "formats": [

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -11,6 +11,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/reactivity.d.ts",
+      "node": {
+        "production": "./dist/reactivity.cjs.prod.js",
+        "development": "./dist/reactivity.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/reactivity.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -9,6 +9,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/runtime-core.d.ts",
+      "node": {
+        "production": "./dist/runtime-core.cjs.prod.js",
+        "development": "./dist/runtime-core.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/runtime-core.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "buildOptions": {
     "name": "VueRuntimeCore",
     "formats": [

--- a/packages/runtime-dom/package.json
+++ b/packages/runtime-dom/package.json
@@ -10,6 +10,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/runtime-dom.d.ts",
+      "node": {
+        "production": "./dist/runtime-dom.cjs.prod.js",
+        "development": "./dist/runtime-dom.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/runtime-dom.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "sideEffects": false,
   "buildOptions": {
     "name": "VueRuntimeDOM",

--- a/packages/server-renderer/package.json
+++ b/packages/server-renderer/package.json
@@ -9,6 +9,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/server-renderer.d.ts",
+      "node": {
+        "production": "./dist/server-renderer.cjs.prod.js",
+        "development": "./dist/server-renderer.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/server-renderer.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "buildOptions": {
     "name": "VueServerRenderer",
     "formats": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/shared.d.ts",
+      "node": {
+        "production": "./dist/shared.cjs.prod.js",
+        "development": "./dist/shared.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/shared.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "sideEffects": false,
   "buildOptions": {
     "formats": [

--- a/packages/vue-compat/package.json
+++ b/packages/vue-compat/package.json
@@ -10,6 +10,19 @@
     "index.js",
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/vue.d.ts",
+      "node": {
+        "production": "./dist/vue.cjs.prod.js",
+        "development": "./dist/vue.cjs.js",
+        "default": "./index.js"
+      },
+      "import": "./dist/vue.esm-bundler.js",
+      "require": "./index.js"
+    },
+    "./*": "./*"
+  },
   "buildOptions": {
     "name": "Vue",
     "filename": "vue",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -20,7 +20,11 @@
     ".": {
       "import": {
         "types": "./dist/vue.d.mts",
-        "node": "./index.mjs",
+        "node": {
+          "production": "./dist/vue.cjs.prod.js",
+          "development": "./dist/vue.cjs.js",
+          "default": "./index.mjs"
+        },
         "default": "./dist/vue.runtime.esm-bundler.js"
       },
       "require": {


### PR DESCRIPTION
In [Nitro](https://nitro.unjs.io/), we create a minimal `node_modules/` just for our final output. This traces the files that are used, respecting the correct export conditions.

At the moment, `NODE_ENV` governs whether we load the prod/dev CJS versions of the Vue packages. However, we can support custom export conditions like `production` and `development` (see [nodejs reference](https://nodejs.org/api/packages.html#community-conditions-definitions)). These have broad community support and can be used on the CLI (for example, with `node --conditions=development index.js`) and by bundlers like Nitro which have support for them.

This PR adds production/development conditions for the Node/CJS bundles. To make it backwards compatible it:

1. adds `./*` as a subpath export so any file that was previously fully specified can continue to be fully specified (e.g. `@vue/compiler-core/package.json`
2. Adds a `default` condition that falls back the previous behaviour (e.g. if no production/development condition is explicitly specified)

I've tested this with Nuxt ([see repo](https://github.com/danielroe/vue-subpath-conditions) and [Stackblitz](https://stackblitz.com/github/danielroe/vue-subpath-conditions)). It enables us to reduce the output bundle by 1.2Mb.

Related https://github.com/unjs/nitro/issues/2046