### PR TITLE
fix: add hydration mismatch checks for attrs can't be get with hasAtt…

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1454,6 +1454,9 @@ describe('SSR hydration', () => {
       mountWithHydration(`<textarea>foo</textarea>`, () =>
         h('textarea', { value: 'foo' }),
       )
+      mountWithHydration(`<textarea></textarea>`, () =>
+        h('textarea', { value: '' }),
+      )
       expect(`Hydration attribute mismatch`).not.toHaveBeenWarned()
 
       mountWithHydration(`<div></div>`, () => h('div', { id: 'foo' }))

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1451,6 +1451,9 @@ describe('SSR hydration', () => {
       mountWithHydration(`<select multiple></div>`, () =>
         h('select', { multiple: 'multiple' }),
       )
+      mountWithHydration(`<textarea>foo</textarea>`, () =>
+        h('textarea', { value: 'foo' }),
+      )
       expect(`Hydration attribute mismatch`).not.toHaveBeenWarned()
 
       mountWithHydration(`<div></div>`, () => h('div', { id: 'foo' }))

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -739,15 +739,15 @@ function propHasMismatch(el: Element, key: string, clientValue: any): boolean {
   ) {
     actual = el.hasAttribute(key)
       ? el.getAttribute(key)
-      : el[key as keyof typeof el]
+      : key in el
         ? el[key as keyof typeof el]
-        : false
+        : ''
     expected = isBooleanAttr(key)
       ? includeBooleanAttr(clientValue)
         ? ''
         : false
       : clientValue == null
-        ? false
+        ? ''
         : String(clientValue)
     if (actual !== expected) {
       mismatchType = `attribute`

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -737,7 +737,11 @@ function propHasMismatch(el: Element, key: string, clientValue: any): boolean {
     (el instanceof SVGElement && isKnownSvgAttr(key)) ||
     (el instanceof HTMLElement && (isBooleanAttr(key) || isKnownHtmlAttr(key)))
   ) {
-    actual = el.hasAttribute(key) && el.getAttribute(key)
+    actual = el.hasAttribute(key)
+      ? el.getAttribute(key)
+      : el[key as keyof typeof el]
+        ? el[key as keyof typeof el]
+        : false
     expected = isBooleanAttr(key)
       ? includeBooleanAttr(clientValue)
         ? ''


### PR DESCRIPTION
close #10000 
Some attributes of element can't be gotten by `el.hasAttribute(key)` such as `value` of `textarea`. So we should add checks by `el[key]` to validate.