### PR TITLE
fix(script): an error is reported if package.json does not exist

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -6,7 +6,10 @@ import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
 
 export const targets = fs.readdirSync('packages').filter(f => {
-  if (!fs.statSync(`packages/${f}`).isDirectory()) {
+  if (
+    !fs.statSync(`packages/${f}`).isDirectory() ||
+    !fs.existsSync(`packages/${f}/package.json`)
+  ) {
     return false
   }
   const pkg = require(`../packages/${f}/package.json`)


### PR DESCRIPTION
Some packages do not have a package.json, so an error will be reported when you run `build-all-cjs`
![image](https://github.com/vuejs/core/assets/91084928/9ad405c1-ae66-4340-bcdd-88ae6f32e91d)
