### PR TITLE
fix(parser): skip compat mode check for SFC root `<template>` tags

### DIFF
--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -692,6 +692,7 @@ function onCloseTag(el: ElementNode, end: number, isImplied = false) {
     }
 
     if (
+      !tokenizer.inSFCRoot &&
       isCompatEnabled(
         CompilerDeprecationTypes.COMPILER_NATIVE_TEMPLATE,
         currentOptions,


### PR DESCRIPTION
Fixes https://github.com/vitejs/vite-plugin-vue/issues/330

I didn't include a test here because I think this case is more like an integration issue, it makes more sense to test that in the `vite-plugin-vue` repository.