### PR TITLE
fix(reactivity): mark the effect as recursive if there's updates during the run

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -72,6 +72,21 @@ describe('reactivity/computed', () => {
     expect(c1.value).toBe(1)
   })
 
+  it('should work when chained(ref+computed)', () => {
+    const value = ref(0)
+    const provider = computed(() => value.value + consumer.value)
+    const consumer = computed(() => {
+      value.value++
+      return 'foo'
+    })
+    expect(provider.value).toBe('1foo')
+
+    value.value += 1
+    expect(provider.value).toBe('3foo')
+    value.value += 1
+    expect(provider.value).toBe('5foo')
+  })
+
   it('should trigger effect when chained', () => {
     const value = reactive({ foo: 0 })
     const getter1 = vi.fn(() => value.foo)


### PR DESCRIPTION
close https://github.com/vuejs/core/issues/10082

The test that fixes https://github.com/vuejs/core/issues/2043 is contradicting this PR, not sure if the https://github.com/vuejs/core/issues/2043 should be handle differently
