### PR TITLE
fix(reactivity): `allowRecurse` effects's `dirtyLevel` unreliable

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -466,11 +466,19 @@ describe('reactivity/computed', () => {
     c2.effect.allowRecurse = true
     c2.value
 
-    expect(DirtyLevels[c1.effect._dirtyLevel]).toBe(
-      DirtyLevels[DirtyLevels.NotDirty],
-    )
-    expect(DirtyLevels[c2.effect._dirtyLevel]).toBe(
-      DirtyLevels[DirtyLevels.NotDirty],
-    )
+    expect(c1.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
+    expect(c2.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
+  })
+
+  it('should work when chained(ref+computed)', () => {
+    const value = ref(0)
+    const consumer = computed(() => {
+      value.value++
+      return 'foo'
+    })
+    const provider = computed(() => value.value + consumer.value)
+    expect(provider.value).toBe('0foo')
+    expect(provider.effect._dirtyLevel).toBe(DirtyLevels.Dirty)
+    expect(provider.value).toBe('1foo')
   })
 })

--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -11,6 +11,7 @@ import {
   ref,
   toRaw,
 } from '../src'
+import { DirtyLevels } from '../src/constants'
 
 describe('reactivity/computed', () => {
   it('should return updated value', () => {
@@ -450,5 +451,26 @@ describe('reactivity/computed', () => {
     expect(fnSpy).toBeCalledTimes(1)
     v.value = 2
     expect(fnSpy).toBeCalledTimes(2)
+  })
+
+  it('...', () => {
+    const fnSpy = vi.fn()
+    const v = ref(1)
+    const c1 = computed(() => v.value)
+    const c2 = computed(() => {
+      fnSpy()
+      return c1.value
+    })
+
+    c1.effect.allowRecurse = true
+    c2.effect.allowRecurse = true
+    c2.value
+
+    expect(DirtyLevels[c1.effect._dirtyLevel]).toBe(
+      DirtyLevels[DirtyLevels.NotDirty],
+    )
+    expect(DirtyLevels[c2.effect._dirtyLevel]).toBe(
+      DirtyLevels[DirtyLevels.NotDirty],
+    )
   })
 })

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -53,12 +53,12 @@ export class ComputedRefImpl<T> {
   get value() {
     // the computed ref may get wrapped by other proxies e.g. readonly() #3376
     const self = toRaw(this)
-    trackRefValue(self)
     if (!self._cacheable || self.effect.dirty) {
       if (hasChanged(self._value, (self._value = self.effect.run()!))) {
         triggerRefValue(self, DirtyLevels.ComputedValueDirty)
       }
     }
+    trackRefValue(self)
     return self._value
   }
 

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -43,7 +43,7 @@ export class ComputedRefImpl<T> {
   ) {
     this.effect = new ReactiveEffect(
       () => getter(this._value),
-      () => triggerRefValue(this, DirtyLevels.ComputedValueMaybeDirty),
+      () => triggerRefValue(this, DirtyLevels.MaybeDirty),
     )
     this.effect.computed = this
     this.effect.active = this._cacheable = !isSSR
@@ -55,7 +55,7 @@ export class ComputedRefImpl<T> {
     const self = toRaw(this)
     if (!self._cacheable || self.effect.dirty) {
       if (hasChanged(self._value, (self._value = self.effect.run()!))) {
-        triggerRefValue(self, DirtyLevels.ComputedValueDirty)
+        triggerRefValue(self, DirtyLevels.Dirty)
       }
     }
     trackRefValue(self)

--- a/packages/reactivity/src/constants.ts
+++ b/packages/reactivity/src/constants.ts
@@ -24,7 +24,6 @@ export enum ReactiveFlags {
 
 export enum DirtyLevels {
   NotDirty = 0,
-  ComputedValueMaybeDirty = 1,
-  ComputedValueDirty = 2,
-  Dirty = 3,
+  MaybeDirty = 1,
+  Dirty = 2,
 }

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -293,12 +293,7 @@ export function triggerEffects(
     if (!effect.allowRecurse && effect._runnings) {
       continue
     }
-    if (
-      effect._dirtyLevel < dirtyLevel &&
-      (!effect._runnings ||
-        effect.allowRecurse ||
-        dirtyLevel !== DirtyLevels.ComputedValueDirty)
-    ) {
+    if (effect._dirtyLevel < dirtyLevel) {
       const lastDirtyLevel = effect._dirtyLevel
       effect._dirtyLevel = dirtyLevel
       if (

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -78,7 +78,8 @@ export class ReactiveEffect<T = any> {
   public get dirty() {
     if (this._dirtyLevel === DirtyLevels.MaybeDirty) {
       pauseTracking()
-      for (const dep of this.deps) {
+      for (let i = 0; i < this._depsLength; i++) {
+        const dep = this.deps[i]
         if (dep.computed) {
           triggerComputed(dep.computed)
           if (this._dirtyLevel >= DirtyLevels.Dirty) {
@@ -290,6 +291,10 @@ export function triggerEffects(
 ) {
   pauseScheduling()
   for (const effect of dep.keys()) {
+    if (dep.get(effect) !== effect._trackId) {
+      // when recurse effect is running, dep map could have outdated items
+      continue
+    }
     if (effect._dirtyLevel < dirtyLevel) {
       const lastDirtyLevel = effect._dirtyLevel
       effect._dirtyLevel = dirtyLevel


### PR DESCRIPTION
This resolves the regression introduced by #10091 and re-fix #10082.

Also fix a test of #10085, #10090.