### PR TITLE
fix(runtime-dom): fix vShow not respect passing display

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vShow.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vShow.spec.ts
@@ -255,6 +255,14 @@ describe('runtime-dom: v-show directive', () => {
     await nextTick()
     expect($div.style.display).toEqual('inline-block')
 
+    isVisible.value = false
+    await nextTick()
+    expect($div.style.display).toEqual('none')
+
+    isVisible.value = true
+    await nextTick()
+    expect($div.style.display).toEqual('inline-block')
+
     useDisplayStyle.value = false
     await nextTick()
     expect($div.style.display).toEqual('')
@@ -263,5 +271,9 @@ describe('runtime-dom: v-show directive', () => {
     isVisible.value = false
     await nextTick()
     expect($div.style.display).toEqual('none')
+
+    isVisible.value = true
+    await nextTick()
+    expect($div.style.display).toEqual('')
   })
 })

--- a/packages/runtime-dom/__tests__/directives/vShow.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vShow.spec.ts
@@ -215,15 +215,23 @@ describe('runtime-dom: v-show directive', () => {
   // #10151
   test('should respect the display value when v-show value is true', async () => {
     const isVisible = ref(false)
+    const useDisplayStyle = ref(true)
     const compStyle = ref({
       display: 'none',
     })
+    const withoutDisplayStyle = {
+      margin: '10px',
+    }
 
     const Component = {
       setup() {
         return () => {
           return withVShow(
-            h('div', { style: compStyle.value }),
+            h('div', {
+              style: useDisplayStyle.value
+                ? compStyle.value
+                : withoutDisplayStyle,
+            }),
             isVisible.value,
           )
         }
@@ -246,6 +254,11 @@ describe('runtime-dom: v-show directive', () => {
     compStyle.value.display = 'inline-block'
     await nextTick()
     expect($div.style.display).toEqual('inline-block')
+
+    useDisplayStyle.value = false
+    await nextTick()
+    expect($div.style.display).toEqual('')
+    expect(getComputedStyle($div).display).toEqual('block')
 
     isVisible.value = false
     await nextTick()

--- a/packages/runtime-dom/__tests__/directives/vShow.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vShow.spec.ts
@@ -211,4 +211,44 @@ describe('runtime-dom: v-show directive', () => {
     await nextTick()
     expect($div.style.display).toEqual('')
   })
+
+  // #10151
+  test('should respect the display value when v-show value is true', async () => {
+    const isVisible = ref(false)
+    const compStyle = ref({
+      display: 'none',
+    })
+
+    const Component = {
+      setup() {
+        return () => {
+          return withVShow(
+            h('div', { style: compStyle.value }),
+            isVisible.value,
+          )
+        }
+      },
+    }
+    render(h(Component), root)
+
+    const $div = root.children[0]
+
+    expect($div.style.display).toEqual('none')
+
+    isVisible.value = true
+    await nextTick()
+    expect($div.style.display).toEqual('none')
+
+    compStyle.value.display = 'block'
+    await nextTick()
+    expect($div.style.display).toEqual('block')
+
+    compStyle.value.display = 'inline-block'
+    await nextTick()
+    expect($div.style.display).toEqual('inline-block')
+
+    isVisible.value = false
+    await nextTick()
+    expect($div.style.display).toEqual('none')
+  })
 })

--- a/packages/runtime-dom/src/directives/vShow.ts
+++ b/packages/runtime-dom/src/directives/vShow.ts
@@ -22,7 +22,7 @@ export const vShow: ObjectDirective<VShowElement> & { name?: 'show' } = {
     }
   },
   updated(el, { value, oldValue }, { transition }) {
-    if (!value === !oldValue) return
+    if (!value === !oldValue && el.style.display === el[vShowOldKey]) return
     if (transition) {
       if (value) {
         transition.beforeEnter(el)

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -38,6 +38,7 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   // so we always keep the current `display` value regardless of the `style`
   // value, thus handing over control to `v-show`.
   if (vShowOldKey in el) {
+    el[vShowOldKey] = style.display
     style.display = currentDisplay
   }
 }


### PR DESCRIPTION
According to the [doc](https://vuejs.org/api/built-in-directives.html#v-show). In this [case](https://play.vuejs.org/#eNqNVMtu2zAQ/JUtL0oAR2rqmyC7bYwcWiBp0QQ96SLLa5kxRQoipTgQ9O9dUrYeRR6+UTOzw9klqYZ9Lwq/rpCFLNJpyQsDGk1VLGPJ80KVBhoocTuDHbSwLVUOHqm9WMYyVVIb4Pov13wtEBZWeLFNhMbLE5urTSIezEtPN1RpNlwXInkJwZNKojeLJUCelBmXBF1/Lg4WasnkZEORboRK92RycQmLJZANlfTmfp2ICv2jL6m8tZVTzHZick/bne/hwk0sjMoygXe2ZmrTT6FzIfLTf9DEJ90lMsPjXM5L8za16NuFr+BxKbjEqyNA8xxNIgq6I6bDpQ+DORkYpC+Aphk2aG1SE2147agoOK36lsKm6ddvqqN1ZYyS8C0VPN0vYjaaXsyWK4vCHUZBp7OhzrIZDY9srARg5TDoQFf+geljmUjNDXcS69CLuiWE2nrRdsNcYgb1ld6pZ0L79imCUwCdrEFphj3ISBeJXF5/mdPg7eqIDimCSYwoGB0JmzGjyXPLM/9JK0kP1F0R6l/lBRdY/ipsnY5Z2F0eyyVCqOefDjNlhe5luZodpvtX8Cd9sFjMfpeosaypnZ4z9CLRdPTtwz0eaN2T1HNlm3+H/INaicpm7GQ3ldxQ7JHOpf3hfjNcZo/69kAT1KembFCrbJ0+ZvTfWb3T+hB37s9dHd151v4DpSaoBg==), I think the correct behavior is when isVisible is false, modal content should not show no matter the display value is, and when isVisible is true, should switch style when click on Change Style button.

One **different behavior** is that if the `vShow` value is true but the user explicitly passes in `display: none`, then the PR change will follow the `display: none` passed in by the user instead of ignoring the user input like the current version. I think this is intuitive though.

close #10151