### PR TITLE
Fix #10185, Re-evaluate effect immediately until it doesn't re-trigger itself

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -1,4 +1,11 @@
-import { h, nextTick, nodeOps, render, serializeInner } from '@vue/runtime-test'
+import {
+  h,
+  nextTick,
+  nodeOps,
+  render,
+  serializeInner,
+  shallowRef,
+} from '@vue/runtime-test'
 import {
   type DebuggerEvent,
   ITERATE_KEY,
@@ -480,9 +487,9 @@ describe('reactivity/computed', () => {
 
     c3.value
 
-    expect(c1.effect._dirtyLevel).toBe(DirtyLevels.Dirty)
-    expect(c2.effect._dirtyLevel).toBe(DirtyLevels.MaybeDirty)
-    expect(c3.effect._dirtyLevel).toBe(DirtyLevels.MaybeDirty)
+    expect(c1.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
+    expect(c2.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
+    expect(c3.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
   })
 
   it('should work when chained(ref+computed)', () => {
@@ -494,9 +501,8 @@ describe('reactivity/computed', () => {
       return 'foo'
     })
     const c2 = computed(() => v.value + c1.value)
-    expect(c2.value).toBe('0foo')
-    expect(c2.effect._dirtyLevel).toBe(DirtyLevels.Dirty)
     expect(c2.value).toBe('1foo')
+    expect(c2.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
   })
 
   it('should trigger effect even computed already dirty', () => {
@@ -515,10 +521,38 @@ describe('reactivity/computed', () => {
       c2.value
     })
     expect(fnSpy).toBeCalledTimes(1)
-    expect(c1.effect._dirtyLevel).toBe(DirtyLevels.Dirty)
-    expect(c2.effect._dirtyLevel).toBe(DirtyLevels.Dirty)
+    expect(c1.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
+    expect(c2.effect._dirtyLevel).toBe(DirtyLevels.NotDirty)
     v.value = 2
     expect(fnSpy).toBeCalledTimes(2)
+  })
+
+  it('should update deps when triggering itself', () => {
+    class Item {
+      v = ref(0)
+    }
+
+    const someRef = shallowRef()
+    const inner = computed(() => {
+      let c = someRef.value
+      if (!c) {
+        c = new Item()
+        someRef.value = c
+      }
+      return c.v.value
+    })
+    const loaded = ref(false)
+    const outer = computed(() => {
+      if (!loaded.value) return 'no'
+      return inner.value ? 'yes' : 'not yet'
+    })
+    const result = computed(() => outer.value)
+    expect(result.value).toBe('no')
+    loaded.value = true
+    expect(result.value).toBe('not yet')
+    const item = someRef.value
+    item.v.value = 1
+    expect(result.value).toBe('yes')
   })
 
   it('should be not dirty after deps mutate (mutate deps in computed)', async () => {

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -376,11 +376,13 @@ describe('reactivity/effect', () => {
 
     const counterSpy = vi.fn(() => counter.num++)
     effect(counterSpy)
-    expect(counter.num).toBe(1)
-    expect(counterSpy).toHaveBeenCalledTimes(1)
+    expect(`Effect is recursively triggering itself`).toHaveBeenWarned()
+    expect(counter.num).toBe(100)
+    expect(counterSpy).toHaveBeenCalledTimes(100)
     counter.num = 4
-    expect(counter.num).toBe(5)
-    expect(counterSpy).toHaveBeenCalledTimes(2)
+    expect(`Effect is recursively triggering itself`).toHaveBeenWarned()
+    expect(counter.num).toBe(104)
+    expect(counterSpy).toHaveBeenCalledTimes(200)
   })
 
   it('should avoid infinite recursive loops when use Array.prototype.push/unshift/pop/shift', () => {
@@ -415,8 +417,9 @@ describe('reactivity/effect', () => {
       }
     })
     effect(numSpy)
-    expect(counter.num).toEqual(10)
-    expect(numSpy).toHaveBeenCalledTimes(10)
+    expect(counter.num).toEqual(109)
+    expect(numSpy).toHaveBeenCalledTimes(109)
+    expect(`Effect is recursively triggering itself`).toHaveBeenWarned()
   })
 
   it('should avoid infinite loops with other effects', () => {

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,4 +1,4 @@
-import { type DebuggerOptions, ReactiveEffect, scheduleEffects } from './effect'
+import { type DebuggerOptions, ReactiveEffect } from './effect'
 import { type Ref, trackRefValue, triggerRefValue } from './ref'
 import { NOOP, hasChanged, isFunction } from '@vue/shared'
 import { toRaw } from './reactive'
@@ -44,7 +44,6 @@ export class ComputedRefImpl<T> {
     this.effect = new ReactiveEffect(
       () => getter(this._value),
       () => triggerRefValue(this, DirtyLevels.MaybeDirty),
-      () => this.dep && scheduleEffects(this.dep),
     )
     this.effect.computed = this
     this.effect.active = this._cacheable = !isSSR
@@ -60,9 +59,6 @@ export class ComputedRefImpl<T> {
       }
     }
     trackRefValue(self)
-    if (self.effect._dirtyLevel >= DirtyLevels.MaybeDirty) {
-      triggerRefValue(self, DirtyLevels.MaybeDirty)
-    }
     return self._value
   }
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -125,6 +125,8 @@ export class ReactiveEffect<T = any> {
       if (--maxRecursion == 0) {
         if (__DEV__) {
           console.warn('Effect is recursively triggering itself')
+          // We regard the computed as being done to avoid reactivity issues as in #10185.
+          this._dirtyLevel = DirtyLevels.NotDirty
         }
         return result
       }

--- a/packages/runtime-core/__tests__/rendererComponent.spec.ts
+++ b/packages/runtime-core/__tests__/rendererComponent.spec.ts
@@ -135,8 +135,6 @@ describe('renderer: component', () => {
 
     const root = nodeOps.createElement('div')
     render(h(App), root)
-    expect(serializeInner(root)).toBe(`<div>0</div><div>1</div>`)
-    await nextTick()
     expect(serializeInner(root)).toBe(`<div>1</div><div>1</div>`)
   })
 


### PR DESCRIPTION
This is a proposal, or at least something to think about.

The improved reactivity system now evaluates computeds lazily. This caused issues when the computed re-triggered itself (in)directly. See https://github.com/vuejs/core/issues/10185

Although I can follow the idea that direct recursive re-triggering is an antipattern, we must support this situation. Re-triggering may happen indirectly and in a not-so-obvious way to the user. Think of a sync watchers for example, which act immediately upon the change of a computed and may trigger other changes outside of the scope of the original computed. I think that we all agree that we need to support this.

The current solution leaves the computed 'dirty' after returning a value to the invoker (in the case of a recursive trigger). This value is already 'old' when it is being used. I think it would be more sane to re-evaluate the computed until it is no longer dirty, then return that value. This prevents the problems that [have](https://github.com/vuejs/core/issues/10114) been [found](https://github.com/vuejs/core/issues/10185) (so far), because, after executing the effect, it can *never* be dirty.

In the case of infinite recursion, we could detect this after X iterations mark the effect as `NotDirty` as normal but issue a warning.

I don't know if this is a better approach than fixing this issues one by one, as in the PR https://github.com/vuejs/core/pull/10187

The change did have impact on the unit tests, but nothing unexpected. The unit tests have been updated in this PR.

The PR may impact current deployments using vue, because recursion is handled differently and effects may be triggered in a different order. I tested it on our own application, which makes complex use of reactivity. I found that we received one warning for infinite recursion, which is most likely true positives that we should take a look at. Other than that everything seemed to work perfectly as before.

@johnsoncodehk @Doctor-wu @yyx990803 any considerations on this approach?