### PR TITLE
fix: #10192  When passing a Vnode to the 'is' prop of a <component>, the page does not refresh upon changes in the Vnode

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -547,7 +547,7 @@ function _createVNode(
         currentBlock.push(cloned)
       }
     }
-    cloned.patchFlag |= PatchFlags.BAIL
+    cloned.patchFlag = PatchFlags.BAIL
     return cloned
   }
 


### PR DESCRIPTION
This is a proposal I submitted for bug [#10192](https://github.com/vuejs/core/issues/10192).


在  [minimal reproduction](https://play.vuejs.org/#eNqNVF1v0zAU/StXGdJasabdOqYqZB0f2gM8AAK0F8JDZt8k3hw7sp22qOp/59puu44B2pvvOcfX9+Mk6+Rt16WLHpMsyS0zonNg0fXdvFCi7bRx8F63HVRGt3Ccjn3g5cd7eg0GK9hsFZFiWlkHgq/g0rODybBQO5Q1parxRmmOxA6GcDmHdaHAy9NFKXsPP5xfwmmhNoXKx7E6qosCh20nS4cUAeS3vXNawRsmBbu/LJKDJ4pkLhQzlOc0H0ddvBO6am1N8hvh/Ds3vVd7kmguFvP1OrSw2eRjH4ZrYQB0zMcHJVBo3S+JYJnukBOSSl3r2FaDom5cBhfYvvZxV3IuVJ3BafpqCy2FlKNYdAaVkA5NwJ0plRVOaLWDYTqZtJZImkh4I2v0guDwUpRkwI3uRrYpuV4OJjCBM2zh6OL8glVVWQ4PLvtFPjvB+dntbDbdJ6B9+Jap1+QkcdS4qkSd3lmtyEkhG+2BZiUkms+d78EWSRbf8VwppV5+DJgzPZ7scNYgu/8LfmdXHiuSLwYtmgXtas+50tToIn397ROu6LwnW817Ser/kF/Ratn7GqPsXa84lX2gC9V+CIan3X231yuHtJptU75Qr9wEfZHQWL1N/tX6Q7nTdBru0URpirtvy3+Kjw2+sx8d/Uy1QuUgE5bM+8JK7WzKsSp76a7SwfAq/TH5WSQATJbWS1YrGh3M8/H+7tbLMe0TKx/8BUCSKSlFmH6kH32Hf9reYMlHrsER18zGjpmWmjx1NJvNnjhn8xvFd4Ep)中  

The VNode generated by the slot possesses a pathFlag value of 1（TEXT）, which, when subjected to a bitwise OR operation with PatchFlags.BAIL (-2), yields PatchFlags.HOISTED (-1). As a consequence, this results in the diff process omitting the update of the VDom. I am uncertain as to the rationale behind employing a bitwise OR operation in this context and am eager to learn if there exists a superior alternative solution.