### PR TITLE
fix(runtime-dom): fix option selected update failed

### DIFF
--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -3,7 +3,6 @@ import {
   type DirectiveHook,
   type ObjectDirective,
   type VNode,
-  isReactive,
   nextTick,
   warn,
 } from '@vue/runtime-core'

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -3,6 +3,7 @@ import {
   type DirectiveHook,
   type ObjectDirective,
   type VNode,
+  isReactive,
   nextTick,
   warn,
 } from '@vue/runtime-core'
@@ -236,11 +237,6 @@ function setSelected(
         `<select multiple v-model> expects an Array or Set value for its binding, ` +
           `but got ${Object.prototype.toString.call(value).slice(8, -1)}.`,
       )
-    return
-  }
-
-  // fast path for updates triggered by other changes
-  if (isArrayValue && looseEqual(value, oldValue)) {
     return
   }
 


### PR DESCRIPTION
These codes are introduced by https://github.com/vuejs/core/commit/2ffb956efe692da059f4895669084c5278871351 and it's the edge perf.
So I think it's ok to delete it to prevent the options from skipping updates.

close #10194