### PR TITLE
fix: support v-bind shorthand syntax for slotName

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformSlotOutlet.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformSlotOutlet.spec.ts
@@ -389,4 +389,20 @@ describe('compiler: transform <slot> outlets', () => {
       },
     })
   })
+
+  test('dynamically named slot outlet with v-bind shorthand', () => {
+    const ast = parseWithSlots(`<slot :name />`)
+    expect((ast.children[0] as ElementNode).codegenNode).toMatchObject({
+      type: NodeTypes.JS_CALL_EXPRESSION,
+      callee: RENDER_SLOT,
+      arguments: [
+        `$slots`,
+        {
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content: `name`,
+          isStatic: false,
+        },
+      ],
+    })
+  })
 })

--- a/packages/compiler-core/src/transforms/transformSlotOutlet.ts
+++ b/packages/compiler-core/src/transforms/transformSlotOutlet.ts
@@ -84,7 +84,7 @@ export function processSlotOutlet(
           const name = camelize(p.arg.content)
           slotName = p.exp = createSimpleExpression(name, false, p.arg.loc)
           if (!__BROWSER__) {
-            p.exp = processExpression(p.exp, context)
+            slotName = p.exp = processExpression(p.exp, context)
           }
         }
       } else {

--- a/packages/compiler-core/src/transforms/transformSlotOutlet.ts
+++ b/packages/compiler-core/src/transforms/transformSlotOutlet.ts
@@ -77,20 +77,16 @@ export function processSlotOutlet(
         }
       }
     } else {
-      // :name is replaced by :name="name"
-      if (
-        p.name === 'bind' &&
-        !p.exp &&
-        p.arg &&
-        p.arg.type === NodeTypes.SIMPLE_EXPRESSION
-      ) {
-        const name = camelize(p.arg.content)
-        slotName = p.exp = createSimpleExpression(name, false, p.arg.loc)
-        if (!__BROWSER__) {
-          p.exp = processExpression(p.exp, context)
+      if (p.name === 'bind' && isStaticArgOf(p.arg, 'name')) {
+        if (p.exp) {
+          slotName = p.exp
+        } else if (p.arg && p.arg.type === NodeTypes.SIMPLE_EXPRESSION) {
+          const name = camelize(p.arg.content)
+          slotName = p.exp = createSimpleExpression(name, false, p.arg.loc)
+          if (!__BROWSER__) {
+            p.exp = processExpression(p.exp, context)
+          }
         }
-      } else if (p.name === 'bind' && isStaticArgOf(p.arg, 'name')) {
-        if (p.exp) slotName = p.exp
       } else {
         if (p.name === 'bind' && p.arg && isStaticExp(p.arg)) {
           p.arg.content = camelize(p.arg.content)


### PR DESCRIPTION
close #10213 

support use v-bind shorthand syntax for slotName: `<slot :name />`