### PR TITLE
fix(runtime-core): don't inline isShallow

### DIFF
--- a/packages/runtime-core/src/customFormatter.ts
+++ b/packages/runtime-core/src/customFormatter.ts
@@ -1,6 +1,12 @@
-import { type Ref, isReactive, isReadonly, isRef, toRaw } from '@vue/reactivity'
+import {
+  type Ref,
+  isReactive,
+  isReadonly,
+  isRef,
+  isShallow,
+  toRaw,
+} from '@vue/reactivity'
 import { EMPTY_OBJ, extend, isArray, isFunction, isObject } from '@vue/shared'
-import { isShallow } from '../../reactivity/src/reactive'
 import type { ComponentInternalInstance, ComponentOptions } from './component'
 import type { ComponentPublicInstance } from './componentPublicInstance'
 


### PR DESCRIPTION
`isShallow` is inline-imported in [runtime-core.esm-bundler.js](https://unpkg.com/browse/@vue/runtime-core@3.4.15/dist/runtime-core.esm-bundler.js), line 7937