### PR TITLE
dx(runtime-core): log the component object when warning about missing template/render function

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -993,7 +993,7 @@ export function finishComponentSetup(
                 : ``) /* should not happen */,
       )
     } else {
-      warn(`Component is missing template or render function.`)
+      warn(`Component is missing template or render function: `, Component)
     }
   }
 }


### PR DESCRIPTION
There's an existing warning that's shown when a component doesn't have a template or render function:

> Component is missing template or render function

A common cause of this warning is that the object being used as a component is not actually a component. This typically happens when there's a mistake with the `import`/`export` from a library. The 'component' might actually be a plugin, or an object with a `default` property.

This PR adds the component object to the warning, saving a bit of time trying to debug the problem.