### PR TITLE
fix(runtime-core): stringify Map and Set in hydration warning

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -24,6 +24,7 @@ import {
   isOn,
   isRenderableAttrValue,
   isReservedProp,
+  isSet,
   isString,
   normalizeClass,
   normalizeStyle,
@@ -791,8 +792,12 @@ function propHasMismatch(
   }
 
   if (mismatchType) {
-    const format = (v: any) =>
-      v === false ? `(not rendered)` : `${mismatchKey}="${v}"`
+    const format = (v: any) => {
+      if (isSet(v)) {
+        v = Array.from(v).join(' ')
+      }
+      return v === false ? `(not rendered)` : `${mismatchKey}="${v}"`
+    }
     const preSegment = `Hydration ${mismatchType} mismatch on`
     const postSegment =
       `\n  - rendered on server: ${format(actual)}` +

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -21,6 +21,7 @@ import {
   isBooleanAttr,
   isKnownHtmlAttr,
   isKnownSvgAttr,
+  isMap,
   isOn,
   isRenderableAttrValue,
   isReservedProp,
@@ -795,6 +796,10 @@ function propHasMismatch(
     const format = (v: any) => {
       if (isSet(v)) {
         v = Array.from(v).join(' ')
+      } else if (isMap(v)) {
+        v = Array.from(v)
+          .map(([k, v]) => `${k}:${v}`)
+          .join('; ')
       }
       return v === false ? `(not rendered)` : `${mismatchKey}="${v}"`
     }


### PR DESCRIPTION
Class and style mismatches are currently reported as

```
[Vue warn]: Hydration class mismatch on <element> 
  - rendered on server: class="[object Set]"
  - expected on client: class="[object Set]"

Hydration style mismatch on <element> 
  - rendered on server: style="[object Map]"
  - expected on client: style="[object Map]"
```