### PR TITLE
fix: the value of display is sometimes incorrect with v-show

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vShow.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vShow.spec.ts
@@ -276,4 +276,37 @@ describe('runtime-dom: v-show directive', () => {
     await nextTick()
     expect($div.style.display).toEqual('')
   })
+
+  // #10294
+  test('should record display by vShowOldKey only when display exists in style', async () => {
+    const isVisible = ref(false)
+    const style = ref({
+      margin: '10px',
+    })
+
+    const Component = {
+      setup() {
+        return () => {
+          return withVShow(
+            h('div', {
+              style: style.value,
+            }),
+            isVisible.value,
+          )
+        }
+      },
+    }
+    render(h(Component), root)
+    const $div = root.children[0]
+
+    expect($div.style.display).toEqual('none')
+
+    style.value.margin = '20px'
+    await nextTick()
+    expect($div.style.display).toEqual('none')
+
+    isVisible.value = true
+    await nextTick()
+    expect($div.style.display).toEqual('')
+  })
 })

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -50,7 +50,6 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
         el[vShowOldKey] = style.display
       }
     }
-
     style.display = currentDisplay
   }
 }

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -38,7 +38,19 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   // so we always keep the current `display` value regardless of the `style`
   // value, thus handing over control to `v-show`.
   if (vShowOldKey in el) {
-    el[vShowOldKey] = style.display
+    el[vShowOldKey] = ''
+    if (next) {
+      if (
+        (!isCssString && next.display != null) ||
+        (isCssString &&
+          next
+            .split(';')
+            .some(item => item.split(':')[0]?.trim() === 'display'))
+      ) {
+        el[vShowOldKey] = style.display
+      }
+    }
+
     style.display = currentDisplay
   }
 }

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -5,10 +5,13 @@ import { CSS_VAR_TEXT } from '../helpers/useCssVars'
 
 type Style = string | Record<string, string | string[]> | null
 
+const displayRE = /(^|;)\s*display\s*:/
+
 export function patchStyle(el: Element, prev: Style, next: Style) {
   const style = (el as HTMLElement).style
-  const currentDisplay = style.display
   const isCssString = isString(next)
+  const currentDisplay = style.display
+  let hasControlledDisplay = false
   if (next && !isCssString) {
     if (prev && !isString(prev)) {
       for (const key in prev) {
@@ -18,6 +21,9 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
       }
     }
     for (const key in next) {
+      if (key === 'display') {
+        hasControlledDisplay = true
+      }
       setStyle(style, key, next[key])
     }
   } else {
@@ -29,6 +35,7 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
           ;(next as string) += ';' + cssVarText
         }
         style.cssText = next as string
+        hasControlledDisplay = displayRE.test(next)
       }
     } else if (prev) {
       el.removeAttribute('style')
@@ -38,18 +45,7 @@ export function patchStyle(el: Element, prev: Style, next: Style) {
   // so we always keep the current `display` value regardless of the `style`
   // value, thus handing over control to `v-show`.
   if (vShowOldKey in el) {
-    el[vShowOldKey] = ''
-    if (next) {
-      if (
-        (!isCssString && next.display != null) ||
-        (isCssString &&
-          next
-            .split(';')
-            .some(item => item.split(':')[0]?.trim() === 'display'))
-      ) {
-        el[vShowOldKey] = style.display
-      }
-    }
+    el[vShowOldKey] = hasControlledDisplay ? style.display : ''
     style.display = currentDisplay
   }
 }


### PR DESCRIPTION
a optimize about #10161，close #10151 and won't lead to the issue in #10294

For an element with `v-show`, when its `style` changes, `el[vShowOldKey]` is assigned as `style.display`, regardless of whether display exists in the style. If `v-show === false` and there is no `display` in `style`, the value of `style.display` is `'none'` at this time, so `el[vShowOldKey]` will also be incorrectly assigned as 'none'.

The correct logic should be: `el[vShowOldKey] = style.display` only when display exists in the next style; otherwise, `el[vShowOldKey] = ''`.