### PR TITLE
fix(runtime-dom): should not trigger transition when the old value and the new value of `v-show` are both `false`

### DIFF
--- a/packages/runtime-dom/src/directives/vShow.ts
+++ b/packages/runtime-dom/src/directives/vShow.ts
@@ -22,7 +22,11 @@ export const vShow: ObjectDirective<VShowElement> & { name?: 'show' } = {
     }
   },
   updated(el, { value, oldValue }, { transition }) {
-    if (!value === !oldValue && el.style.display === el[vShowOldKey]) return
+    if (
+      !value === !oldValue &&
+      (el.style.display === el[vShowOldKey] || !value)
+    )
+      return
     if (transition) {
       if (value) {
         transition.beforeEnter(el)


### PR DESCRIPTION
Re-fix #10294 

Should not trigger transition when the old value and the new value of `v-show` are both `false`.

For this case in vuetify:
https://play.vuetifyjs.com/#eNq9VU1vGjEQ/SsjXwCJhVS0PawIUtQeeumlVU7AwbUHYtW7tmwvTYX47xkv2WU/AKFEysn2+M28N/O03uWeeSemD9ZOdgWylM0DZlbzgItVDjDfJYI7CUJz7+9XLHtOeBHMisE/JcMTRWZ3dytWYku0Vj7ALsmMRJ0aizlKAsVNjapxiSIusA7pViZKmDwySJU8mQyJIqigkUI/yuNiPm2kUa1uta0zhYUd10VMevTofIOTcFVnpM9rE1IugtrxYBzB96TDWA+HVkpbajMOVOSPymNzZeKKtW/PdMWFMEUeEqGc0NRQO6Fq9lV387LXeS1u2jCrET47kAeZqaYJbx5Jx7/uHOpOKsJL6i/qvz71TSluuCxpxhAHvKZlBCoHHil7XqR/8T+lqF68UlquvduOhXHpYarhnqlwxbWmP7c4R6aY2NYHeldTfqB7whXydvOujP791t5u3pVwFTy+pHSITykdOoObe+GUPaLw2RoXQOKGFzrA/lhI8sBTGI7gfgHD1xhAfFRTWA7KF2OwHlfx40dANyfVy8FPnvMtZpiHwRgGzecoIyJlNSamCFrl2KgUE39jCCrf+ipNmO0Z5GlXmtgh/+aQmq0qWF34C2S/kMsKtlEXNT1amkhdrzie2pDvqPEEoZ9RPPX1Hkbl5hBNqW1ghzGbTT5PPn1lcfNlMmPrF6+2HfE=