### PR TITLE
fix(runtime-dom): clear prev style with string and object

### DIFF
--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -106,6 +106,21 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.getPropertyValue('--custom')).toBe('100\\;')
   })
 
+  it('should clear prev style with string and object', () => {
+    let el = document.createElement('div')
+    patchProp(el, 'style', null, { color: 'red' })
+    expect(el.style.cssText.replace(/\s/g, '')).toBe('color:red;')
+    patchProp(el, 'style', { color: 'red' }, { fontSize: '12px' })
+    expect(el.style.cssText.replace(/\s/g, '')).toBe('font-size:12px;')
+
+    // reset el
+    el = document.createElement('div')
+    patchProp(el, 'style', null, 'color: red')
+    expect(el.style.cssText.replace(/\s/g, '')).toBe('color:red;')
+    patchProp(el, 'style', 'color: red', { fontSize: '12px' })
+    expect(el.style.cssText.replace(/\s/g, '')).toBe('font-size:12px;')
+  })
+
   it('shorthand properties', () => {
     const el = document.createElement('div')
     patchProp(


### PR DESCRIPTION
1. use this code, after click button, the text style will change to 'font-size: 12px'
``` vue
<script setup>
import { ref } from 'vue'

const style = ref({ color: 'red' })
function handleClick() {
  style.value = { fontSize: '12px' }
}
</script>

<template>
  <h1 :style="style">Hello World</h1>
  <button @click="handleClick">change style</button>
</template>

```
2. but this code, after click button, the text style will change to 'color: red; font-size: 12px'. the 'color: red' do not be removed
``` vue
<script setup>
import { ref } from 'vue'

const style = ref('color: red')
function handleClick() {
  style.value = { fontSize: '12px' }
}
</script>

<template>
  <h1 :style="style">Hello World</h1>
  <button @click="handleClick">change style</button>
</template>

```