### PR TITLE
fix(hydration): css vars should only be added to expected on component root dom

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1554,5 +1554,21 @@ describe('SSR hydration', () => {
       app.mount(container)
       expect(`Hydration style mismatch`).not.toHaveBeenWarned()
     })
+
+    test('css vars should only be added to expected on component root dom', () => {
+      const container = document.createElement('div')
+      container.innerHTML = `<div style="--foo:red;"><div style="color:var(--foo);" /></div>`
+      const app = createSSRApp({
+        setup() {
+          useCssVars(() => ({
+            foo: 'red',
+          }))
+          return () =>
+            h('div', null, [h('div', { style: { color: 'var(--foo)' } })])
+        },
+      })
+      app.mount(container)
+      expect(`Hydration style mismatch`).not.toHaveBeenWarned()
+    })
   })
 })

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -753,7 +753,7 @@ function propHasMismatch(
       }
     }
 
-    if (instance && isElementWithVars(instance.subTree, el)) {
+    if (instance && isInstanceRootEl(instance.subTree, el)) {
       const cssVars = instance?.getCssVars?.()
       for (const key in cssVars) {
         expectedMap.set(`--${key}`, String(cssVars[key]))
@@ -855,7 +855,7 @@ function isMapEqual(a: Map<string, string>, b: Map<string, string>): boolean {
   return true
 }
 
-function isElementWithVars(vnode: VNode, element: Element): boolean {
+function isInstanceRootEl(vnode: VNode, element: Element): boolean {
   while (vnode.component) {
     vnode = vnode.component.subTree
   }
@@ -863,7 +863,7 @@ function isElementWithVars(vnode: VNode, element: Element): boolean {
   if (vnode.shapeFlag & ShapeFlags.ELEMENT && vnode.el) {
     return element === vnode.el
   } else if (vnode.type === Fragment) {
-    return (vnode.children as VNode[]).some(c => isElementWithVars(c, element))
+    return (vnode.children as VNode[]).some(c => isInstanceRootEl(c, element))
   } else if (vnode.type === Static) {
     let { el, anchor } = vnode
     while (el) {

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -753,9 +753,11 @@ function propHasMismatch(
       }
     }
 
-    const cssVars = instance?.getCssVars?.()
-    for (const key in cssVars) {
-      expectedMap.set(`--${key}`, String(cssVars[key]))
+    if (el === instance?.subTree?.el) {
+      const cssVars = instance?.getCssVars?.()
+      for (const key in cssVars) {
+        expectedMap.set(`--${key}`, String(cssVars[key]))
+      }
     }
 
     if (!isMapEqual(actualMap, expectedMap)) {

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -753,7 +753,7 @@ function propHasMismatch(
       }
     }
 
-    if (el === instance?.subTree?.el) {
+    if (instance && isElementWithVars(instance.subTree, el)) {
       const cssVars = instance?.getCssVars?.()
       for (const key in cssVars) {
         expectedMap.set(`--${key}`, String(cssVars[key]))
@@ -853,4 +853,26 @@ function isMapEqual(a: Map<string, string>, b: Map<string, string>): boolean {
     }
   }
   return true
+}
+
+function isElementWithVars(vnode: VNode, element: Element): boolean {
+  while (vnode.component) {
+    vnode = vnode.component.subTree
+  }
+
+  if (vnode.shapeFlag & ShapeFlags.ELEMENT && vnode.el) {
+    return element === vnode.el
+  } else if (vnode.type === Fragment) {
+    return (vnode.children as VNode[]).some(c => isElementWithVars(c, element))
+  } else if (vnode.type === Static) {
+    let { el, anchor } = vnode
+    while (el) {
+      if (el === element) {
+        return true
+      }
+      if (el === anchor) break
+      el = el.nextSibling
+    }
+  }
+  return false
 }


### PR DESCRIPTION
close #10317 

Css vars are only added to root node, so when matches expect and actual on hydration phase, only the root node of the instance should set css vars.