### PR TITLE
fix(runtime-core): app.provide throws a warning when assigning the same value.

### DIFF
--- a/packages/runtime-core/__tests__/apiCreateApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiCreateApp.spec.ts
@@ -106,42 +106,16 @@ describe('api: createApp', () => {
     expect(serializeInner(root)).toBe(`3,2`)
     expect('[Vue warn]: injection "__proto__" not found.').toHaveBeenWarned()
 
+    app.provide('baz', 1)
+    app.provide('baz', 1)
+    expect(
+      `App already provides property with key "baz".`,
+    ).not.toHaveBeenWarned()
+
     const app2 = createApp(Root)
     app2.provide('bar', 1)
     app2.provide('bar', 2)
     expect(`App already provides property with key "bar".`).toHaveBeenWarned()
-  })
-
-  test('allow provide reassignment', () => {
-    const Root = {
-      setup() {
-        provide('foo', 3)
-        return () => h('div')
-      },
-    }
-
-    const original = {}
-    const app = createApp(Root)
-
-    app.provide('foo', 1)
-    app.provide('foo', 2)
-    expect(`App already provides property with key "foo".`).toHaveBeenWarned()
-
-    app.provide('bar', 1)
-    app.provide('bar', 1)
-    expect(
-      `App already provides property with key "bar".`,
-    ).not.toHaveBeenWarned()
-
-    app.provide('foo1', original)
-    app.provide('foo1', original)
-    expect(
-      `App already provides property with key "foo1".`,
-    ).not.toHaveBeenWarned()
-
-    app.provide('bar1', original)
-    app.provide('bar1', {})
-    expect(`App already provides property with key "bar1".`).toHaveBeenWarned()
   })
 
   test('runWithContext', () => {

--- a/packages/runtime-core/__tests__/apiCreateApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiCreateApp.spec.ts
@@ -112,6 +112,38 @@ describe('api: createApp', () => {
     expect(`App already provides property with key "bar".`).toHaveBeenWarned()
   })
 
+  test('allow provide reassignment', () => {
+    const Root = {
+      setup() {
+        provide('foo', 3)
+        return () => h('div')
+      },
+    }
+
+    const original = {}
+    const app = createApp(Root)
+
+    app.provide('foo', 1)
+    app.provide('foo', 2)
+    expect(`App already provides property with key "foo".`).toHaveBeenWarned()
+
+    app.provide('bar', 1)
+    app.provide('bar', 1)
+    expect(
+      `App already provides property with key "bar".`,
+    ).not.toHaveBeenWarned()
+
+    app.provide('foo1', original)
+    app.provide('foo1', original)
+    expect(
+      `App already provides property with key "foo1".`,
+    ).not.toHaveBeenWarned()
+
+    app.provide('bar1', original)
+    app.provide('bar1', {})
+    expect(`App already provides property with key "bar1".`).toHaveBeenWarned()
+  })
+
   test('runWithContext', () => {
     const app = createApp({
       setup() {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -373,15 +373,24 @@ export function createAppAPI<HostElement>(
         }
       },
 
-      provide(key, value) {
-        if (__DEV__ && (key as string | symbol) in context.provides) {
+      provide(key, newVal) {
+        const oldValue = context.provides[key as string | symbol]
+        const isEqual = oldValue === newVal
+
+        if (
+          __DEV__ &&
+          (key as string | symbol) in context.provides &&
+          !isEqual
+        ) {
           warn(
             `App already provides property with key "${String(key)}". ` +
               `It will be overwritten with the new value.`,
           )
         }
 
-        context.provides[key as string | symbol] = value
+        if (!isEqual) {
+          context.provides[key as string | symbol] = newVal
+        }
 
         return app
       },

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -22,7 +22,7 @@ import { warn } from './warning'
 import { type VNode, cloneVNode, createVNode } from './vnode'
 import type { RootHydrateFunction } from './hydration'
 import { devtoolsInitApp, devtoolsUnmountApp } from './devtools'
-import { NO, extend, isFunction, isObject } from '@vue/shared'
+import { NO, extend, hasChanged, isFunction, isObject } from '@vue/shared'
 import { version } from '.'
 import { installAppCompatProperties } from './compat/global'
 import type { NormalizedPropsOptions } from './componentProps'
@@ -375,12 +375,12 @@ export function createAppAPI<HostElement>(
 
       provide(key, newVal) {
         const oldValue = context.provides[key as string | symbol]
-        const isEqual = oldValue === newVal
+        const isValueChanged = hasChanged(oldValue, newVal)
 
         if (
           __DEV__ &&
           (key as string | symbol) in context.provides &&
-          !isEqual
+          isValueChanged
         ) {
           warn(
             `App already provides property with key "${String(key)}". ` +
@@ -388,7 +388,7 @@ export function createAppAPI<HostElement>(
           )
         }
 
-        if (!isEqual) {
+        if (isValueChanged) {
           context.provides[key as string | symbol] = newVal
         }
 

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -377,18 +377,14 @@ export function createAppAPI<HostElement>(
         const oldValue = context.provides[key as string | symbol]
         const isValueChanged = hasChanged(oldValue, newVal)
 
-        if (
-          __DEV__ &&
-          (key as string | symbol) in context.provides &&
-          isValueChanged
-        ) {
-          warn(
-            `App already provides property with key "${String(key)}". ` +
-              `It will be overwritten with the new value.`,
-          )
-        }
-
         if (isValueChanged) {
+          if (__DEV__ && (key as string | symbol) in context.provides) {
+            warn(
+              `App already provides property with key "${String(key)}". ` +
+                `It will be overwritten with the new value.`,
+            )
+          }
+
           context.provides[key as string | symbol] = newVal
         }
 


### PR DESCRIPTION
If providing the same value to app.provide, no warning should be thrown.