### PR TITLE
fix(runtime-core) better typing for direct setup

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -89,6 +89,30 @@ export type DefineComponent<
   > &
   PP
 
+type DirectSetupComponent<
+  P extends Record<string, any>,
+  E extends EmitsOptions = {},
+  S extends SlotsType = SlotsType,
+  Props = P & EmitsToProps<E>,
+  PP = PublicProps,
+> = new (
+  props: Props & PP,
+) => CreateComponentPublicInstance<
+  Props,
+  {},
+  {},
+  {},
+  {},
+  ComponentOptionsMixin,
+  ComponentOptionsMixin,
+  E,
+  PP,
+  {},
+  false,
+  {},
+  S
+>
+
 // defineComponent is a utility that is primarily used for type inference
 // when declaring components. Type inference is provided in the component
 // options (provided as the argument). The returned value has artificial types
@@ -111,7 +135,7 @@ export function defineComponent<
     emits?: E | EE[]
     slots?: S
   },
-): (props: Props & EmitsToProps<E>) => any
+): DirectSetupComponent<Props, E, S>
 export function defineComponent<
   Props extends Record<string, any>,
   E extends EmitsOptions = {},
@@ -127,7 +151,7 @@ export function defineComponent<
     emits?: E | EE[]
     slots?: S
   },
-): (props: Props & EmitsToProps<E>) => any
+): DirectSetupComponent<Props, E, S>
 
 // overload 2: object format with no props
 // (uses user defined props interface)


### PR DESCRIPTION
Component declared using the direct setup syntax now have better support in `.tsx` and `.vue` files.

- PublicProps added and merge with the Props
- vue-language-server will now properly infer generic. The previous behavior of returning `any` caused the language-server to fail to infer the props.

Fixes: 
- #8604
- #8855
- https://github.com/vuejs/language-tools/issues/3745
- https://github.com/vuejs/language-tools/issues/3309
- Maybe more?

It's an alternative to this #9127 PR, but I belive it is more complete here.