### PR TITLE
refactor(reactivity): priority check if the object is invalid

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -302,4 +302,19 @@ describe('reactivity/reactive', () => {
     const observed = reactive(original)
     expect(isReactive(observed)).toBe(false)
   })
+
+  test('should not check cache', () => {
+    const foo = {}
+    Object.freeze(foo)
+    const noObserved = reactive(foo)
+    expect(noObserved).toBe(foo)
+
+    const bar = {}
+    // put in cache
+    reactive(bar)
+    Object.freeze(bar)
+    // do not check cache
+    const observed = reactive(bar)
+    expect(observed).toBe(bar)
+  })
 })

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -252,23 +252,15 @@ function createReactiveObject(
     }
     return target
   }
-  // target is already a Proxy, return it.
-  // exception: calling readonly() on a reactive object
-  if (
-    target[ReactiveFlags.RAW] &&
-    !(isReadonly && target[ReactiveFlags.IS_REACTIVE])
-  ) {
+  const targetType = getTargetType(target)
+  const isBaseOnReactiveTarget = isReadonly && target[ReactiveFlags.IS_REACTIVE]
+  const isInvalid = targetType === TargetType.INVALID
+  if ((target[ReactiveFlags.RAW] && !isBaseOnReactiveTarget) || isInvalid) {
     return target
   }
-  // target already has corresponding Proxy
   const existingProxy = proxyMap.get(target)
   if (existingProxy) {
     return existingProxy
-  }
-  // only specific value types can be observed.
-  const targetType = getTargetType(target)
-  if (targetType === TargetType.INVALID) {
-    return target
   }
   const proxy = new Proxy(
     target,


### PR DESCRIPTION
- If the object is non-extensible from the beginning, return the original object directly, without the need to check the cache first.
- If the original object has already been proxied and subsequently becomes non-extensible, when attempting to proxy it again, it should return the original object directly.

- Removed comments and used variable names instead.