### PR TITLE
feat(compiler-sfc): support use global style in nested css

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -142,6 +142,12 @@ describe('SFC scoped CSS', () => {
       ".foo .bar { color: red;
       }"
     `)
+    // #10403
+    expect(compileScoped(`::v-global(.foo) .bar { color: red; }`))
+      .toMatchInlineSnapshot(`
+      ".foo .bar { color: red;
+      }"
+    `)
   })
 
   test(':is() and :where() with multiple selectors', () => {

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -164,6 +164,10 @@ function rewriteSelector(
       // global: replace with inner selector and do not inject [id].
       // ::v-global(.foo) -> .foo
       if (value === ':global' || value === '::v-global') {
+        // ::v-global(.foo) .bar -> .foo .bar
+        for (let i = selector.index(n) + 1; i < selector.length; i++) {
+          n.nodes[0].nodes.push(selector.at(i))
+        }
         selectorRoot.insertAfter(selector, n.nodes[0])
         selectorRoot.removeChild(selector)
         return false


### PR DESCRIPTION
close #10403 

```scss
// scss
:global(.foo) {
    color: red;
    .bar {
        color: blue;
    }
}
```

The above scss code will be compiled to:
```css
// css
:global(.foo) {
  color: red;
}
:global(.foo) .bar {
  color: blue;
}
```

So we should support transforming `:global(.foo) .bar` to `.foo .bar`