### PR TITLE
types: fix `scroll` event type; add support for `scrollend`

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -1348,8 +1348,8 @@ export interface Events {
   // selection events
   onSelect: Event
 
-  // UI events
-  onScroll: UIEvent
+  // scroll events
+  onScroll: Event
 
   // touch events
   onTouchcancel: TouchEvent

--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -1350,6 +1350,7 @@ export interface Events {
 
   // scroll events
   onScroll: Event
+  onScrollend: Event
 
   // touch events
   onTouchcancel: TouchEvent


### PR DESCRIPTION
This PR fixes the [`scroll` event type](https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll_event#event_type) and adds support for the new [scrollend](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event) event.