### PR TITLE
fix(runtime-core): expose type using generics

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -233,7 +233,9 @@ export type SetupContext<
       attrs: Data
       slots: UnwrapSlotsType<S>
       emit: EmitFn<E>
-      expose: (exposed?: Record<string, any>) => void
+      expose: <Exposed extends Record<string, any> = Record<string, any>>(
+        exposed?: Exposed,
+      ) => void
     }
   : never
 


### PR DESCRIPTION
Makes it consistent with the definition of [defineExpose](https://github.com/vuejs/core/blob/main/packages/runtime-core/src/apiSetupHelpers.ts#L171). Without this change, using the generic parameter on `defineExpose` throws a compilation error.