### PR TITLE
fix(runtime-core): optimize judgment

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -364,7 +364,7 @@ export function resolveTransitionHooks(
       if (
         leavingVNode &&
         isSameVNodeType(vnode, leavingVNode) &&
-        (leavingVNode.el as TransitionElement)[leaveCbKey]
+        (leavingVNode.el as TransitionElement)?.[leaveCbKey]
       ) {
         // force early removal (not cancelled)
         ;(leavingVNode.el as TransitionElement)[leaveCbKey]!()


### PR DESCRIPTION
When I use nuxt3 with pageTransition and there is await on the page, changing files triggers HMR to report an error. The leavingVNode.el value is not judged to be null, which can be seen in [my demo](https://codesandbox.io/p/devbox/hopeful-faraday-m5zvtr?file=%2Fpages%2Findex.vue%3A7%2C26&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522cltmwl6gw0007356kg08c226i%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522cltmwl6gw0002356kncdlgjvh%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522cltmwl6gw0004356khsujrdi8%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522cltmwl6gw0006356kvedzpmbd%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522cltmwl6gw0002356kncdlgjvh%2522%253A%257B%2522id%2522%253A%2522cltmwl6gw0002356kncdlgjvh%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltmwmcrf004x356k0yjjgm04%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A9%252C%2522startColumn%2522%253A5%252C%2522endLineNumber%2522%253A9%252C%2522endColumn%2522%253A5%257D%255D%252C%2522filepath%2522%253A%2522%252Fnuxt.config.ts%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522activeTabId%2522%253A%2522cltmwmcrf004x356k0yjjgm04%2522%257D%252C%2522cltmwl6gw0006356kvedzpmbd%2522%253A%257B%2522id%2522%253A%2522cltmwl6gw0006356kvedzpmbd%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltmwl6gw0005356kuj756sn4%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A3000%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522activeTabId%2522%253A%2522cltmwl6gw0005356kuj756sn4%2522%257D%252C%2522cltmwl6gw0004356khsujrdi8%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltmwl6gw0003356komn0fdu5%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%257D%255D%252C%2522id%2522%253A%2522cltmwl6gw0004356khsujrdi8%2522%252C%2522activeTabId%2522%253A%2522cltmwl6gw0003356komn0fdu5%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D).

Uncaught (in promise) TypeError: Cannot read properties of null (reading 'Symbol(_leaveCb)')
![image](https://github.com/vuejs/core/assets/18730979/d4bf4926-460e-4822-a9b2-fe618ad3d49f)

# https://github.com/vuejs/router/issues/341