### PR TITLE
missing @babel/types (fix: #5625, #6891, #8917)

### DIFF
--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -47,12 +47,10 @@
   "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-core#readme",
   "dependencies": {
     "@babel/parser": "^7.24.0",
+    "@babel/types": "^7.24.0",
     "@vue/shared": "workspace:*",
     "entities": "^4.5.0",
     "estree-walker": "^2.0.2",
     "source-map-js": "^1.0.2"
-  },
-  "devDependencies": {
-    "@babel/types": "^7.24.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@babel/parser':
         specifier: ^7.24.0
         version: 7.24.0
+      '@babel/types':
+        specifier: ^7.24.0
+        version: 7.24.0
       '@vue/shared':
         specifier: workspace:*
         version: link:../shared
@@ -191,10 +194,6 @@ importers:
       source-map-js:
         specifier: ^1.0.2
         version: 1.0.2
-    devDependencies:
-      '@babel/types':
-        specifier: ^7.24.0
-        version: 7.24.0
 
   packages/compiler-dom:
     dependencies:


### PR DESCRIPTION
fixes: #5625, #6891, #8917

Moved `@babel/types` from dev dependencies to normal dependencies. In this case npm will correctly resolve dependency under configurations described in related issues.

Reproduction of issue in: #8917