### PR TITLE
types(runtime-core): ComponentInstance accept ComponentPublicInstance with any props

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -99,7 +99,7 @@ export type Data = Record<string, unknown>
  * declare const instance: ComponentInstance<typeof MyComp>
  * ```
  */
-export type ComponentInstance<T> = T extends { new (): ComponentPublicInstance }
+export type ComponentInstance<T> = T extends { new (): ComponentPublicInstance<any, any, any> }
   ? InstanceType<T>
   : T extends FunctionalComponent<infer Props, infer Emits>
     ? ComponentPublicInstance<Props, {}, {}, {}, {}, ShortEmitsToObject<Emits>>


### PR DESCRIPTION
`ComponentInstance<ComponentPublicInstanceConstructor<CreateComponentPublicInstance<Props>>>` currently returns `{ $props: { $props: Props }}`