### PR TITLE
feat(server-renderer): catch errors from all promises in unrollBuffer()

### DIFF
--- a/packages/server-renderer/src/index.ts
+++ b/packages/server-renderer/src/index.ts
@@ -14,6 +14,14 @@ export {
   // deprecated
   renderToStream,
 } from './renderToStream'
+export class MultipleErrors extends Error {
+  constructor(
+    message: string,
+    public errors: unknown[],
+  ) {
+    super(message)
+  }
+}
 
 // internal runtime helpers
 export * from './internal'


### PR DESCRIPTION
In server-renderer, a `SSRBuffer` may contain multiple promises.

Currently `unrollBuffer()` throws immediately when the first promise is rejected / throws an error 

In this case, the remaining promises will be ignored.

If any of these ignored promises also reject / throw an error, nodejs will throw an `unhandledRejection` event and shutdown / crash by default.

This pr tries to improve the situation by collecting the errors from all promises and, if more than one error has been thrown, return a `MultipleErrors` error, which contains these errors.

The same issue has been discusses here: https://github.com/vuejs/core/pull/7660/files, but instead of ignoring all erors, this pr keeps the existing behaviour for 0 or 1 errors, and returns all errors if multiple happened.
