### PR TITLE
transition is breaking/flickering when enter is canceled (fix #2482, #10677)

### DIFF
--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -239,9 +239,11 @@ export function resolveTransitionProps(
       if (__COMPAT__ && legacyClassEnabled && legacyLeaveFromClass) {
         addTransitionClass(el, legacyLeaveFromClass)
       }
+      // add *-leave-active class before reflow so in the case of a cancelled enter transition
+      // the css will not get the final state (#10677)
+      addTransitionClass(el, leaveActiveClass)
       // force reflow so *-leave-from classes immediately take effect (#2593)
       forceReflow()
-      addTransitionClass(el, leaveActiveClass)
       nextFrame(() => {
         if (!el._isLeaving) {
           // cancelled


### PR DESCRIPTION
When the transition's enter is canceled final CSS styles are applied and all transition's *-active styles are removed for a short period so the element is flickering, getting its final state(no transition classes applied) 

https://github.com/vuejs/core/assets/49036220/988c02bd-a9c4-4b25-831f-f155fd0b91c7

