### PR TITLE
fix(compiler-core): append full tagEnd in generated `loc.source`

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2070,6 +2070,16 @@ describe('compiler: parse', () => {
       baseParse(`<Foo>`, { parseMode: 'sfc', onError() {} })
       expect(() => baseParse(`{ foo }`)).not.toThrow()
     })
+
+    test('correct loc when the closing > is foarmatted', () => {
+      const [span] = baseParse(`<span></span
+      
+      >`).children
+
+      expect(span.loc.source).toBe('<span></span\n      \n      >')
+      expect(span.loc.start.offset).toBe(0)
+      expect(span.loc.end.offset).toBe(27)
+    })
   })
 
   describe('decodeEntities option', () => {

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -152,7 +152,8 @@ const tokenizer = new Tokenizer(stack, {
   },
 
   onclosetag(start, end) {
-    const name = getSlice(start, end)
+    // trimming end because the tag can get formatted with newlines
+    const name = getSlice(start, end).trimEnd()
     if (!currentOptions.isVoidTag(name)) {
       let found = false
       for (let i = 0; i < stack.length; i++) {

--- a/packages/compiler-core/src/tokenizer.ts
+++ b/packages/compiler-core/src/tokenizer.ts
@@ -607,7 +607,7 @@ export default class Tokenizer {
     }
   }
   private stateInClosingTagName(c: number): void {
-    if (c === CharCodes.Gt || isWhitespace(c)) {
+    if (c === CharCodes.Gt) {
       this.cbs.onclosetag(this.sectionStart, this.index)
       this.sectionStart = -1
       this.state = State.AfterClosingTagName


### PR DESCRIPTION
fixes #10694

