### PR TITLE
fix(runtime-core): Revert to using InternalObjectKey for normalized slots (fix #10709)

### DIFF
--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -1,5 +1,6 @@
 import { type ComponentInternalInstance, currentInstance } from './component'
 import {
+  InternalObjectKey,
   type VNode,
   type VNodeChild,
   type VNodeNormalizedChildren,
@@ -187,6 +188,8 @@ export const initSlots = (
       normalizeVNodeSlots(instance, children)
     }
   }
+
+  def(instance.slots, InternalObjectKey, 1)
 }
 
 export const updateSlots = (

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -405,6 +405,8 @@ const createVNodeWithArgsTransform = (
   )
 }
 
+export const InternalObjectKey = `__vInternal`
+
 const normalizeKey = ({ key }: VNodeProps): VNode['key'] =>
   key != null ? key : null
 
@@ -791,7 +793,7 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
     } else {
       type = ShapeFlags.SLOTS_CHILDREN
       const slotFlag = (children as RawSlots)._
-      if (!slotFlag) {
+      if (!slotFlag  && !(InternalObjectKey in children!)) {
         // if slots are not normalized, attach context instance
         // (compiled / normalized slots already have context)
         ;(children as RawSlots)._ctx = currentRenderingInstance


### PR DESCRIPTION
After the commit [af733d](https://github.com/vuejs/core/commit/6af733d68eb400a3d2c5ef5f465fff32b72a324e), the normalization of slots has lost track, and the `vNode` is trying to reassign the `_ctx` property, which was already set in the `normalize` function. To address this issue, I have reverted the behavior to the state before the commit. Additionally, we could consider renaming the `InternalObjectKey` to a more clear and descriptive name. I'm looking forward to your feedback on these potential solutions.

Link to minimal reproduction

https://play.vuejs.org/#eNqNUsFuwjAM/RUrmtQiVUWDnRAgAeKwHbZp2zHSVFEDYW1SJS5DQv33OelgbBobt9jv2e/Zzl5Mqird1igGYugWVlUEDqmuxlKrsjKWYA8WlwnkuFQaZ4aTGjUlsIYGltaUEHF5JLXUC6MdgadMYPSzIN5LDaCzEgcQBU6U+IxFnaONOxBwH1NtNazjKFfbKAFaK5deucKQS7llVhcUdzqe20jd8ONUd3qB7vQf3eAtgX3zTfuc4uwCxdkFitNW8RMC39OPOoC4MxpDdN3r84o94A2cOBl226vxvTggLKsiI+QIYNj663Iw7J4gIhHkeIKlWqUbZzSfPshKseACVaB9qEjxhFIMDoakyIrCvN+FHNkaw0ShZo2Lt1/yG7fzOSkeLTq0W5TiiFFmV0gtPH++xx2/j2Bp8rpg9h/gEzpT1N5jS5vWOmfbJ7zg9jZ8YKVXL26+I9TuMJQ3GrYY+FLwB/a7Ojf6l91+enPYPm/xdYvW9+QFMpD2eqL5AIr6FP8=