### PR TITLE
fix(event): addEventListener set passive option to false by default

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -74,7 +74,6 @@ function parseName(name: string): [string, AddEventListenerOptions] {
     passive: false,
   }
   if (optionsModifierRE.test(name)) {
-    options = {}
     let m
     while ((m = name.match(optionsModifierRE))) {
       name = name.slice(0, name.length - m[0].length)

--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -70,7 +70,7 @@ export function patchEvent(
 const optionsModifierRE = /(?:Once|Passive|Capture)$/
 
 function parseName(name: string): [string, AddEventListenerOptions] {
-  let options: AddEventListenerOptions = {
+  const options: AddEventListenerOptions = {
     passive: false,
   }
   if (optionsModifierRE.test(name)) {

--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -69,8 +69,10 @@ export function patchEvent(
 
 const optionsModifierRE = /(?:Once|Passive|Capture)$/
 
-function parseName(name: string): [string, EventListenerOptions | undefined] {
-  let options: EventListenerOptions | undefined
+function parseName(name: string): [string, AddEventListenerOptions] {
+  let options: AddEventListenerOptions = {
+    passive: false,
+  }
   if (optionsModifierRE.test(name)) {
     options = {}
     let m


### PR DESCRIPTION
When I bind the `wheel` event to the input, and then call `e.preventDefault()` to prevent the default event under certain circumstances, a warning message will appear on the console.

![image](https://github.com/vuejs/core/assets/24516654/fcbb8d4d-1361-4af7-a15c-f3e069c758f9)

[example](https://play.vuejs.org/#eNp9Uk1v1DAQ/SuDL7srlWQrOC3Jiq+VgAMgQOLiS5RMEhfHtuxxuijKf2fiKKWHqpIPfh+y3xt7Eu+cy8aI4iSKUHvlCAJSdGdp1OCsJ5jAYwsztN4OsGPrThppamsCwRA6KBd9v/uEWlv4bb1uXuwOm6GqWN/jAcozTNIAqBb2ja3jgIayqiY14kXjgqAsS8CMKt8hHVY3MOE8jix/xLaKmvZ8NMAsDa8iXxNzVgaEg9MVISOAor89T1PKN89FziixyrhIML4cbIO6lIJ1KeDtfY8JVhUjyFdvo0YI9FcjCz2qrqcT3B6PR3d9I8W5yFlnY5E/ulfcCApcvFVddhes4aGmGlLUdnBKo//mSPFgpDhtBflWHtz9l8SRj3iz8XWP9Z8n+LtwXTgpvnsM6EeU4kFbp7fKl59f8cr7B5FbR83uZ8QfGKyOS8bV9j6ahmM/8qW0n9PXUKb7FS5XQhO2UkvQ9EDJLwV/lw/PVP8f91X2entYMf8DrXrZgw==)