### PR TITLE
fix(compiler-sfc): fix the incorrect behavior of UnknownType encountered in defineModel in non-production mode

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineModel.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineModel.spec.ts.snap
@@ -123,6 +123,26 @@ return { modelValue }
 })"
 `;
 
+exports[`defineModel() > w/ UnknownType, non-production mode 1`] = `
+"import { useModel as _useModel, defineComponent as _defineComponent } from 'vue'
+
+export default /*#__PURE__*/_defineComponent({
+  props: {
+    "modelValue": { type: [Array, String], skipCheck: true },
+    "modelModifiers": {},
+  },
+  emits: ["update:modelValue"],
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      const modelValue = _useModel<unknownType | Array<int> | string>(__props, "modelValue")
+      
+return { modelValue }
+}
+
+})"
+`;
+
 exports[`defineModel() > w/ array props 1`] = `
 "import { useModel as _useModel, mergeModels as _mergeModels } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript/defineModel.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineModel.spec.ts
@@ -241,4 +241,25 @@ describe('defineModel()', () => {
       modelValue: BindingTypes.SETUP_REF,
     })
   })
+
+  test('w/ UnknownType, non-production mode', () => {
+    const { content, bindings } = compile(
+      `
+      <script setup lang="ts">
+      const modelValue = defineModel<unknownType | Array<int> | string>()
+      </script>
+      `,
+    )
+    assertCode(content)
+    expect(content).toMatch(
+      '"modelValue": { type: [Array, String], skipCheck: true }',
+    )
+    expect(content).toMatch('emits: ["update:modelValue"]')
+    expect(content).toMatch(
+      `const modelValue = _useModel<unknownType | Array<int> | string>(__props, "modelValue")`,
+    )
+    expect(bindings).toStrictEqual({
+      modelValue: BindingTypes.SETUP_REF,
+    })
+  })
 })

--- a/packages/compiler-sfc/src/script/defineModel.ts
+++ b/packages/compiler-sfc/src/script/defineModel.ts
@@ -133,12 +133,17 @@ export function genModelProps(ctx: ScriptCompileContext) {
       const hasUnknownType = runtimeTypes.includes(UNKNOWN_TYPE)
 
       if (isProd || hasUnknownType) {
-        runtimeTypes = runtimeTypes.filter(
-          t =>
-            t === 'Boolean' ||
-            (hasBoolean && t === 'String') ||
-            (t === 'Function' && options),
-        )
+        runtimeTypes = runtimeTypes.filter(t => {
+          if (isProd) {
+            return (
+              t === 'Boolean' ||
+              (hasBoolean && t === 'String') ||
+              (t === 'Function' && options)
+            )
+          }
+
+          return t !== UNKNOWN_TYPE
+        })
 
         skipCheck = !isProd && hasUnknownType && runtimeTypes.length > 0
       }


### PR DESCRIPTION
```typescript
const modelValue = defineModel<unknownType | Array<int> | string>()
```

In non-production mode, `defineModel` incorrectly filters out certain types, such as Array and String, when encountering UnknownType.