### PR TITLE
fix(runtime-core): attrs should be readonly in functional components

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -17,7 +17,6 @@ import {
   ref,
   render,
   serializeInner,
-  toRaw,
   toRefs,
   watch,
 } from '@vue/runtime-test'
@@ -129,12 +128,12 @@ describe('component props', () => {
     render(h(Comp, { foo: 1 }), root)
     expect(props).toEqual({ foo: 1 })
     expect(attrs).toEqual({ foo: 1 })
-    expect(toRaw(props)).toBe(attrs)
+    expect(props).toBe(attrs)
 
     render(h(Comp, { bar: 2 }), root)
     expect(props).toEqual({ bar: 2 })
     expect(attrs).toEqual({ bar: 2 })
-    expect(toRaw(props)).toBe(attrs)
+    expect(props).toBe(attrs)
   })
 
   test('boolean casting', () => {

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -116,7 +116,7 @@ export function renderComponentRoot(
                 ? {
                     get attrs() {
                       markAttrsAccessed()
-                      return attrs
+                      return shallowReadonly(attrs)
                     },
                     slots,
                     emit,


### PR DESCRIPTION
This is a follow up to changes made yesterday: b93f26464785de227b88c51a88328ae80e80d804 and a7cf74277ee57093656faaa7f65610ee7584a507.

Those changes fixed issues #8216 and #10736. There was an existing PR that fixed those issues at #8222. That PR also made `attrs` readonly for functional components. This PR just makes that extra change.

Making the `attrs` readonly allows the test expectation changes in a7cf74277ee57093656faaa7f65610ee7584a507 to be rolled back. The `props` and `attrs` will both be the same `shallowReadonly` proxy.

The `attrs` are already readonly in other places, I believe functional components are the only place where this isn't currently enforced.

Here's a Playground that illustrates the type of code that I'm hoping to prevent:

- [Playground - main](https://play.vuejs.org/#eNp9UsFOAjEQ/ZVJLwths8ToCYFECSZ6UKMee1lKgYVu27RTxJD9d2dbFziop7bvvWnfm+mR3Vlb7INkIzb2wlUWwUsMdsp1VVvjEI6wycHJFTSwcqaGjNQZ11wLoz2CgEnL9q76Z+xBz0xtiehZZ6zP6Y4S0Xlo+jCZwpFroBoMTsOmly0CotEZqVocwOiZqsSu1+8ASNWFUKX3MJhABovSkYdEimJfqiAHgwQ07dLkkMVbSDvoFOSQyPEw5aSEdEBZW1WipBPA+Md4fGjC2coYzmBI3Hh4IaSjxy/VbguSJJvCKONGFGt5G58hjkwmblGK3dqZoJcjWJCRpCAj8RaWM/TUuFW1LrbeaBpFrOJMkJlKSfdisaLGcjbqWsJZqZT5fIoYuiDzDhcbKXa/4Ft/aDHOXp300u0lZycOS7eWmOj5+7M80P5E1mYZFKn/Id+kNyq0HpPsnpKS7QtddPsYP1Sl1x9+fkCpfReqNZqmlnLTD2vn8Ff0s93r4ibWUT9Z8w0/auoP)
- [Playground - this PR](https://deploy-preview-10767--vue-sfc-playground.netlify.app/#eNp9UsFOAjEQ/ZVJLwths8ToCYFECSZ6UKMee1lKgYVu27RTxJD9d2dbFziop7bvvWnfm+mR3Vlb7INkIzb2wlUWwUsMdsp1VVvjEI6wycHJFTSwcqaGjNQZ11wLoz2CgEnL9q76Z+xBz0xtiehZZ6zP6Y4S0Xlo+jCZwpFroBoMTsOmly0CotEZqVocwOiZqsSu1+8ASNWFUKX3MJhABovSkYdEimJfqiAHgwQ07dLkkMVbSDvoFOSQyPEw5aSEdEBZW1WipBPA+Md4fGjC2coYzmBI3Hh4IaSjxy/VbguSJJvCKONGFGt5G58hjkwmblGK3dqZoJcjWJCRpCAj8RaWM/TUuFW1LrbeaBpFrOJMkJlKSfdisaLGcjbqWsJZqZT5fIoYuiDzDhcbKXa/4Ft/aDHOXp300u0lZycOS7eWmOj5+7M80P5E1mYZFKn/Id+kNyq0HpPsnpKS7QtddPsYP1Sl1x9+fkCpfReqNZqmlnLTD2vn8Ff0s93r4ibWUT9Z8w0/auoP)

This is essentially the same problem that `props` had prior to yesterday's fix.