### PR TITLE
fix(runtime-code): warn using array created without ref as a ref inside v for in script setup (fix: #10655)

### DIFF
--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -573,8 +573,8 @@ describe('api: template refs', () => {
     render(h(App), root)
 
     expect(
-      'In production mode reactive ref array will not be filled. ' +
-        'Use ref() instead.',
+      'In production mode ref array will not be filled. ' +
+        'Use ref() instead. Ref name: reactiveRef',
     ).toHaveBeenWarned()
   })
 })

--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -539,4 +539,42 @@ describe('api: template refs', () => {
       '<div><div>[object Object],[object Object]</div><ul><li>2</li><li>3</li></ul></div>',
     )
   })
+
+  // #10655 warn if reactive array used as a ref inside v-for
+  test('string ref pointing to reactive() in v-for, should warn that it will not work in prod for scripSetup', () => {
+    const list = ref([1, 2, 3])
+    const reactiveRef = reactive([])
+    const App = {
+      setup() {
+        return {
+          reactiveRef,
+          __isScriptSetup: true,
+        }
+      },
+      render() {
+        return h('div', null, [
+          h(
+            'ul',
+            list.value.map(i =>
+              h(
+                'li',
+                {
+                  ref: 'reactiveRef',
+                  ref_for: true,
+                },
+                i,
+              ),
+            ),
+          ),
+        ])
+      },
+    }
+    const root = nodeOps.createElement('div')
+    render(h(App), root)
+
+    expect(
+      'In production mode reactive ref array will not be filled. ' +
+        'Use ref() instead.',
+    ).toHaveBeenWarned()
+  })
 })

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -12,7 +12,7 @@ import {
 import { isAsyncWrapper } from './apiAsyncComponent'
 import { getExposeProxy } from './component'
 import { warn } from './warning'
-import { isRef } from '@vue/reactivity'
+import { isReactive, isRef } from '@vue/reactivity'
 import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 import type { SchedulerJob } from './scheduler'
 import { queuePostRenderEffect } from './renderer'
@@ -103,6 +103,20 @@ export function setRef(
                 if (rawRef.k) refs[rawRef.k] = ref.value
               }
             } else if (!existing.includes(refValue)) {
+              // #10655 warn if reactive array used as a ref
+              if (
+                __DEV__ &&
+                _isString &&
+                hasOwn(owner.devtoolsRawSetupState, ref) &&
+                !isRef(owner.devtoolsRawSetupState[ref]) &&
+                isReactive(owner.devtoolsRawSetupState[ref]) &&
+                hasOwn(setupState, '__isScriptSetup')
+              ) {
+                warn(
+                  'In production mode reactive ref array will not be filled. ' +
+                    'Use ref() instead.',
+                )
+              }
               existing.push(refValue)
             }
           }

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -104,14 +104,14 @@ export function setRef(
               }
             } else if (!existing.includes(refValue)) {
               // #10655 warn if reactive array used as a ref
-              if (
+              const reactiveAsRef =
                 __DEV__ &&
                 _isString &&
                 hasOwn(owner.devtoolsRawSetupState, ref) &&
                 !isRef(owner.devtoolsRawSetupState[ref]) &&
                 isReactive(owner.devtoolsRawSetupState[ref]) &&
                 hasOwn(setupState, '__isScriptSetup')
-              ) {
+              if (reactiveAsRef) {
                 warn(
                   'In production mode reactive ref array will not be filled. ' +
                     'Use ref() instead.',

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -12,7 +12,7 @@ import {
 import { isAsyncWrapper } from './apiAsyncComponent'
 import { getExposeProxy } from './component'
 import { warn } from './warning'
-import { isReactive, isRef } from '@vue/reactivity'
+import { isRef } from '@vue/reactivity'
 import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 import type { SchedulerJob } from './scheduler'
 import { queuePostRenderEffect } from './renderer'
@@ -103,18 +103,18 @@ export function setRef(
                 if (rawRef.k) refs[rawRef.k] = ref.value
               }
             } else if (!existing.includes(refValue)) {
-              // #10655 warn if reactive array used as a ref
-              const reactiveAsRef =
+              // #10655 warn if not ref() array used as a string ref
+              const wrongRefType =
                 __DEV__ &&
                 _isString &&
                 hasOwn(owner.devtoolsRawSetupState, ref) &&
                 !isRef(owner.devtoolsRawSetupState[ref]) &&
-                isReactive(owner.devtoolsRawSetupState[ref]) &&
                 hasOwn(setupState, '__isScriptSetup')
-              if (reactiveAsRef) {
+              if (wrongRefType) {
                 warn(
-                  'In production mode reactive ref array will not be filled. ' +
-                    'Use ref() instead.',
+                  'In production mode ref array will not be filled. ' +
+                    'Use ref() instead. Ref name: ',
+                  ref,
                 )
               }
               existing.push(refValue)

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -113,8 +113,8 @@ export function setRef(
               if (wrongRefType) {
                 warn(
                   'In production mode ref array will not be filled. ' +
-                    'Use ref() instead. Ref name: ',
-                  ref,
+                    'Use ref() instead. Ref name: ' +
+                    ref,
                 )
               }
               existing.push(refValue)


### PR DESCRIPTION
Close #10655 

In production mode, after inlining the `<script setup>`, variables created are not exposed in the `setupResult` nor compiled to provide ref props with the actual reference, as it is for references created using `ref()`. This causes string refs to lose their reactivity in the `renderTemplateRef.ts` file. However, in development mode, all variables are exposed in the `setupResult`, and string refs with array values work as expected.

To address this issue, I have added a warning in the PR for this specific case. One potential solution could be to forbid the use of string refs other than those created with `ref()`, as other cases (e.g., reactive, ...) seem to be unhandled in `renderTemplateRef.ts`. We could introduce a compile-time error if anything other than `ref()` is used as a string ref for `<script setup>`.

Implementation details: I could not use setupResults as it unrefs the ref, and reactive and ref are indistinguishable, so I used `devtoolsRawSetupState`. However, there might be a better way or a need to introduce another `rawSetupState` variable specifically for the development mode. I'm open to suggestions on how to handle this more effectively.

I'm looking forward to the team's input and suggestions on how to best resolve this issue. Please share your thoughts and insights to help us find an optimal solution.

https://github.com/vuejs/core/assets/49036220/55445451-359e-478c-8b70-ff9e23e8da84