### PR TITLE
fix(hydration): add null check to toStyleMap function to prevent TypeError

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -838,6 +838,7 @@ function isSetEqual(a: Set<string>, b: Set<string>): boolean {
 
 function toStyleMap(str: string): Map<string, string> {
   const styleMap: Map<string, string> = new Map()
+  if (!str) return styleMap
   for (const item of str.split(';')) {
     let [key, value] = item.split(':')
     key = key?.trim()


### PR DESCRIPTION
This pull request addresses a TypeError that occurs when switching to different routes. The issue arises due to potential null values in the `str` parameter of the `toStyleMap` function. To resolve this, I have added a null check at the beginning of the function to handle cases where `str` is null or undefined, preventing the TypeError from occurring.

![error](https://github.com/vuejs/core/assets/64184826/eadf1aa4-13aa-4a30-95ac-daf56e0db9ee)
