### PR TITLE
refactor: simplify traverse() for deep watchers

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -466,19 +466,11 @@ export function createPathGetter(ctx: any, path: string) {
 
 export function traverse(
   value: unknown,
-  depth?: number,
-  currentDepth = 0,
+  depth = Infinity,
   seen?: Set<unknown>,
 ) {
-  if (!isObject(value) || (value as any)[ReactiveFlags.SKIP]) {
+  if (depth <= 0 || !isObject(value) || (value as any)[ReactiveFlags.SKIP]) {
     return value
-  }
-
-  if (depth && depth > 0) {
-    if (currentDepth >= depth) {
-      return value
-    }
-    currentDepth++
   }
 
   seen = seen || new Set()
@@ -486,19 +478,20 @@ export function traverse(
     return value
   }
   seen.add(value)
+  depth--
   if (isRef(value)) {
-    traverse(value.value, depth, currentDepth, seen)
+    traverse(value.value, depth, seen)
   } else if (isArray(value)) {
     for (let i = 0; i < value.length; i++) {
-      traverse(value[i], depth, currentDepth, seen)
+      traverse(value[i], depth, seen)
     }
   } else if (isSet(value) || isMap(value)) {
     value.forEach((v: any) => {
-      traverse(v, depth, currentDepth, seen)
+      traverse(v, depth, seen)
     })
   } else if (isPlainObject(value)) {
     for (const key in value) {
-      traverse(value[key], depth, currentDepth, seen)
+      traverse(value[key], depth, seen)
     }
   }
   return value


### PR DESCRIPTION
This PR simplifies the logic in `traverse()`. It should also shave a few bytes off the bundle.

The current implementation of `traverse()` takes two numbers, the `depth` and the `currentDepth`. The function calls itself recursively, incrementing `currentDepth` at each stage and then comparing that to `depth`.

But there's no need to use two numbers. Just one is enough. Each recursion can just decrement `depth` and then check whether it is still greater than 0.

For `deep: true`, a `depth` value of `Infinity` can be used, rather than trying to handle it specially.

The current depth logic was originally introduced in #9928, partly in preparation for adding #9572. While my proposed changes will introduce small conflicts with that second PR, I believe they are easily fixable, just by treating `deep: true` as `deep: Infinity`.