### PR TITLE
fix(compiler-dom): restrict createStaticVNode usage with option elements

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/stringifyStatic.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/stringifyStatic.spec.ts.snap
@@ -1,5 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`stringify static html > should bail for <option> elements with number values 1`] = `
+"const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+const _hoisted_1 = /*#__PURE__*/_createElementVNode("select", null, [
+  /*#__PURE__*/_createElementVNode("option", { value: 1 }),
+  /*#__PURE__*/_createElementVNode("option", { value: 1 }),
+  /*#__PURE__*/_createElementVNode("option", { value: 1 }),
+  /*#__PURE__*/_createElementVNode("option", { value: 1 }),
+  /*#__PURE__*/_createElementVNode("option", { value: 1 })
+], -1 /* HOISTED */)
+const _hoisted_2 = [
+  _hoisted_1
+]
+
+return function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _hoisted_2))
+}"
+`;
+
 exports[`stringify static html > should bail on bindings that are hoisted but not stringifiable 1`] = `
 "const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 
@@ -11,6 +30,19 @@ const _hoisted_1 = /*#__PURE__*/_createElementVNode("div", null, [
   /*#__PURE__*/_createElementVNode("span", { class: "foo" }, "foo"),
   /*#__PURE__*/_createElementVNode("img", { src: _imports_0_ })
 ], -1 /* HOISTED */)
+const _hoisted_2 = [
+  _hoisted_1
+]
+
+return function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _hoisted_2))
+}"
+`;
+
+exports[`stringify static html > should work for <option> elements with string values 1`] = `
+"const { createElementVNode: _createElementVNode, createStaticVNode: _createStaticVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+const _hoisted_1 = /*#__PURE__*/_createStaticVNode("<select><option value=\\"1\\"></option><option value=\\"1\\"></option><option value=\\"1\\"></option><option value=\\"1\\"></option><option value=\\"1\\"></option></select>", 1)
 const _hoisted_2 = [
   _hoisted_1
 ]

--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -225,6 +225,19 @@ function analyzeNode(node: StringifiableNode): [number, number] | false {
         ) {
           return bail()
         }
+        if (
+          p.arg &&
+          p.arg.isStatic &&
+          p.exp &&
+          p.exp.ast &&
+          p.exp.ast.type !== 'StringLiteral' &&
+          node.ns === Namespaces.HTML
+        ) {
+          // <option :value="1"> cannot be safely stringified
+          if (node.tag === 'option' && p.arg.content === 'value') {
+            return bail()
+          }
+        }
       }
     }
     for (let i = 0; i < node.children.length; i++) {


### PR DESCRIPTION
Close #6568.

This fixes an edge case for code like this:

```html
<select v-model="foo">
  <option :value="1">...</option>
  <option :value="2">...</option>
  <option :value="3">...</option>
  <option :value="4">...</option>
  <option :value="5">...</option>
</select>
```

For 5 or more `<option>` elements, a static VNode is created. But this loses the type information on the `value`, so `v-model` treats it as a string.

- [Playground](https://play.vuejs.org/#eNqFkstOwzAQRX9l5E1B6kN9baoUCVAXsAAELL2J0klJcWzLnoSiKP/O2KEFJNruPPeeSWau3Yhra4d1hWIhEp+5whJ4pMpeSV2U1jiCBhzm0ELuTAk9RntSZ0Z7gtwYWAb34lLqZNS1cyMXhKVVKSFXAIlHhRlBPSjNGtVSCu6UInrsGkuF0bCoU1Uhm2O2xsmok49BE4Ym56ApQ9Nz0Iyh2TloztD8D8T7xq1i0TQxjLaFQTjTp0WTf0shmkMcoi/Ic3p5sRluvdEcexM+IEVmSlsodI/xF16KBUQneKlS5uM+auQq7O/17A2z93/0rd8FTYonhx5djVIcPErdBqmzVy8PuOPzweT7qRTTJ8xn9EZVYcYOu6n0msf+xcVp7+LjKfTm1a92hNrvlwqDBrKNvBT8oG5PrP4z7nQ4i31St6L9Ajx55A0=)

There is already an existing PR that attempts to fix this problem, #7434. That PR attempts to add support for passing type information using `v-stringify-type='number'`. In my opinion, this edge case is not important enough to justify that extra complexity.

The fix I've attempted here will just bail out from using `createStaticVNode` if a non-string `value` is used with an `<option>`.

I'm not aware of any other elements that have this same problem. A checkbox or radio `<input>` can have a number for `value`, but the `v-model` will already avoid `createStaticVNode`. The problem with `<option>` occurs because the `v-model` is on the parent `<select>` instead.