### PR TITLE
test(watch): watching a reactive array

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -96,6 +96,30 @@ describe('api: watch', () => {
     expect(spy).toBeCalledWith([1], [1], expect.anything())
   })
 
+  it('should not call functions inside a reactive source array', () => {
+    const spy1 = vi.fn()
+    const array = reactive([spy1])
+    const spy2 = vi.fn()
+    watch(array, spy2, { immediate: true })
+    expect(spy1).toBeCalledTimes(0)
+    expect(spy2).toBeCalledWith([spy1], undefined, expect.anything())
+  })
+
+  it('should not unwrap refs in a reactive source array', async () => {
+    const val = ref({ foo: 1 })
+    const array = reactive([val])
+    const spy = vi.fn()
+    watch(array, spy, { immediate: true })
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith([val], undefined, expect.anything())
+
+    // deep by default
+    val.value.foo++
+    await nextTick()
+    expect(spy).toBeCalledTimes(2)
+    expect(spy).toBeCalledWith([val], [val], expect.anything())
+  })
+
   it('should not fire if watched getter result did not change', async () => {
     const spy = vi.fn()
     const n = ref(0)
@@ -184,6 +208,24 @@ describe('api: watch', () => {
     src.state = { count: 1 }
     await nextTick()
     expect(dummy).toBe(1)
+  })
+
+  it('directly watching reactive array with explicit deep: false', async () => {
+    const val = ref(1)
+    const array: any[] = reactive([val])
+    const spy = vi.fn()
+    watch(array, spy, { immediate: true, deep: false })
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith([val], undefined, expect.anything())
+
+    val.value++
+    await nextTick()
+    expect(spy).toBeCalledTimes(1)
+
+    array[1] = 2
+    await nextTick()
+    expect(spy).toBeCalledTimes(2)
+    expect(spy).toBeCalledWith([val, 2], [val, 2], expect.anything())
   })
 
   // #9916


### PR DESCRIPTION
These tests were inspired by the changes in #9417. I don't think the changes proposed there can be merged as they would break backwards compatibility, but I found it interesting that they didn't cause the existing tests to fail.

It seems we have relatively few tests for `watch(reactiveArray, ...)`, and in particular how it differs from `watch(plainArray, ...)`. I experimented locally and found I was able to introduce various bugs without triggering any test failures.

Here I've aimed to test 3 ways that reactive arrays behave differently from plain arrays when passed as a source to `watch`:

1. If the reactive array contains a function, it should not be invoked.
2. If the reactive array contains a ref, it should not be unwrapped in the `newValue` or `oldValue` passed to the callback.
3. A reactive array should be `deep: true` by default.
4. A reactive array with an explicit `deep: false` should be watched one level deep, starting from the array itself.