### PR TITLE
test: defineOptions dts tests

### DIFF
--- a/packages/dts-test/README.md
+++ b/packages/dts-test/README.md
@@ -4,4 +4,4 @@ Tests TypeScript types to ensure the types remain as expected.
 
 - This directory is included in the root `tsconfig.json`, where package imports are aliased to `src` directories, so in IDEs and the `pnpm check` script the types are validated against source code.
 
-- When running `tsc` with `packages/dts-test/tsconfig.test.json`, packages are resolved using normal `node` resolution, so the types are validated against actual **built** types. This requires the types to be built first via `pnpm build-types`.
+- When running `tsc` with `packages/dts-test/tsconfig.test.json`, packages are resolved using normal `node` resolution, so the types are validated against actual **built** types. This requires the types to be built first via `pnpm build-dts`.

--- a/packages/dts-test/setupHelpers.test-d.ts
+++ b/packages/dts-test/setupHelpers.test-d.ts
@@ -5,6 +5,7 @@ import {
   defineComponent,
   defineEmits,
   defineModel,
+  defineOptions,
   defineProps,
   defineSlots,
   toRefs,
@@ -500,4 +501,22 @@ describe('toRefs w/ type declaration', () => {
     file?: File | File[]
   }>()
   expectType<Ref<File | File[] | undefined>>(toRefs(props).file)
+})
+
+describe('defineOptions', () => {
+  defineOptions({
+    name: 'MyComponent',
+    inheritAttrs: true,
+  })
+
+  defineOptions({
+    // @ts-expect-error props should be defined via defineProps()
+    props: ['props'],
+    // @ts-expect-error emits should be defined via defineEmits()
+    emits: ['emits'],
+    // @ts-expect-error slots should be defined via defineSlots()
+    slots: { default: 'default' },
+    // @ts-expect-error expose should be defined via defineExpose()
+    expose: ['expose'],
+  })
 })


### PR DESCRIPTION
Evan was faster than me to fix #10841 but I thought the tests I started to add in my PR could still be useful to prevent future regressions, as the `defineOptions` helper has currently no dts tests