### PR TITLE
refactor(reactivity): simplify type declaration of isRef

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -94,7 +94,6 @@ export function triggerRefValue(
  * @param r - The value to inspect.
  * @see {@link https://vuejs.org/api/reactivity-utilities.html#isref}
  */
-export function isRef<T>(r: Ref<T> | unknown): r is Ref<T>
 export function isRef(r: any): r is Ref {
   return !!(r && r.__v_isRef === true)
 }


### PR DESCRIPTION
This Pull Request edited the unneeded type declaration of `isRef`, removed the overload that includes a generic.

**Please note that this Pull Request may introduce a minor breaking change.**