### PR TITLE
fix(runtime-core): fixed the teleport in the production environment cannot set el

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2471,7 +2471,7 @@ export function traverseStaticChildren(n1: VNode, n2: VNode, shallow = false) {
       }
       // also inherit for comment nodes, but not placeholders (e.g. v-if which
       // would have received .el during block patch)
-      if (__DEV__ && c2.type === Comment && !c2.el) {
+      if (c2.type === Comment && !c2.el) {
         c2.el = c1.el
       }
     }


### PR DESCRIPTION
close #10870

![image](https://github.com/vuejs/core/assets/40790268/f715e4de-68b4-4ded-8136-665c03f78f33)
---
fixed the teleport use commentVnode in the production environment cannot set el

