### PR TITLE
fix(server-renderer): Fix call to serverPrefetch in server renderer with an async setup

### DIFF
--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -873,6 +873,26 @@ function testRender(type: string, render: typeof renderToString) {
       expect(html).toBe(`<div>hello</div>`)
     })
 
+    test('serverPrefetch w/ async setup', async () => {
+      const msg = Promise.resolve('hello')
+      const app = createApp({
+        data() {
+          return {
+            msg: '',
+          }
+        },
+        async serverPrefetch() {
+          this.msg = await msg
+        },
+        render() {
+          return h('div', this.msg)
+        },
+        async setup() {},
+      })
+      const html = await render(app)
+      expect(html).toBe(`<div>hello</div>`)
+    })
+
     // #2763
     test('error handling w/ async setup', async () => {
       const fn = vi.fn()

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -99,7 +99,7 @@ export function renderComponentVNode(
     const p: Promise<unknown> = Promise.resolve(res as Promise<void>)
       .then(() => {
         // instance.sp may be null until an async setup resolves, so evaluate it here
-        prefetches = instance.sp
+        if (hasAsyncSetup) prefetches = instance.sp
         if (prefetches) {
           return Promise.all(
             prefetches.map(prefetch => prefetch.call(instance.proxy)),

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -96,13 +96,10 @@ export function renderComponentVNode(
   const hasAsyncSetup = isPromise(res)
   let prefetches = instance.sp /* LifecycleHooks.SERVER_PREFETCH */
   if (hasAsyncSetup || prefetches) {
-    let p: Promise<unknown> = (
-      hasAsyncSetup
-        ? // instance.sp may be null until an async setup resolves, so evaluate it here
-          (res as Promise<void>).then(() => (prefetches = instance.sp))
-        : Promise.resolve()
-    )
+    const p: Promise<unknown> = Promise.resolve(res as Promise<void>)
       .then(() => {
+        // instance.sp may be null until an async setup resolves, so evaluate it here
+        prefetches = instance.sp
         if (prefetches) {
           return Promise.all(
             prefetches.map(prefetch => prefetch.call(instance.proxy)),


### PR DESCRIPTION
This fixes a bug where the serverPrefetch option _would not be called_ with an async setup method.

### About the fix

A `prefetches` reference was created while `instance.sp` was `null`. However, with an async setup, `instance.sp` has the serverPrefetch methods only after setup resolves.

The fix is achieved by waiting to for setup to resolve before trying to access the the serverPrefetch options from `instance.sp`.

I added a unit test that reproduces the problem, by adding an async setup to the component definition. FWIW, I considered and experimented with adding more async setup variations of the existing tests, but backed out after they did not reproduce the problem and decided they weren't critical.

### Impact of the bug

The bug can break SSR because the server renderer will not wait long enough to produce serializable state.

Specifically, this bug exists when using:

1. `defineNuxtComponent` from Nuxt 3 (because [it creates an async setup method](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/composables/component.ts#L63-L68))
2. with the vue-apollo package options API ([because it defines a `serverPrefetch` method that resolves when all apollo promises resolve](https://github.com/vuejs/apollo/blob/v4/packages/vue-apollo-option/src/mixin.js#L126-L144))

The server will make a request, but the renderer doesn't wait for it to finish. Nuxt dispatches `app:rendered`, serializes whatever state it has (which excludes the in-flight apollo graphql requests). Then the page loads in a blank state, then the client in the browser will issue the now redundant graphql requests, and finally render the complete page.

This problem affects Nuxt 2 apollo apps that are migrating to Nuxt 3 and is a regression in the ecosystem.