### PR TITLE
test: update coverage exclude

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,8 @@ export default defineConfig({
         'packages/runtime-dom/src/components/Transition*',
         // mostly entries
         'packages/vue-compat/**',
+        'packages/sfc-playground/**',
+        'scripts/**',
       ],
     },
   },


### PR DESCRIPTION
If the newly added folder is not excluded, an error will be reported when running `pnpm test-coverage`.

<img width="997" alt="image" src="https://github.com/vuejs/core/assets/24516654/65c72f94-15bf-4aff-befb-060c09ad7929">
