### PR TITLE
fix(runtime-core): force patch radio input checked prop (#10929)

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -903,7 +903,7 @@ function baseCreateRenderer(
             const prev = oldProps[key]
             const next = newProps[key]
             // #1471 force patch value
-            if (next !== prev || key === 'value') {
+            if (next !== prev || key === 'value' || key === 'checked') {
               hostPatchProp(
                 el,
                 key,


### PR DESCRIPTION
In same case, input radio's checked value is not synced with prop checked, which cause some problems.
This problem like input value not synced issue, so I force patch update when prop key is checked.

Fixes https://github.com/vuejs/core/issues/10929.