### PR TITLE
fix(compiler-core): change v-for key type to match Object.keys

### DIFF
--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -42,7 +42,7 @@ export function renderList<T>(
   source: T,
   renderItem: <K extends keyof T>(
     value: T[K],
-    key: K,
+    key: string,
     index: number,
   ) => VNodeChild,
 ): VNodeChild[]


### PR DESCRIPTION
close #8819 

When using `v-for` with an object of type `T`, the type assigned to the item keys is `keyof T`.
Since TS 2.9, calling `keyof {[key: string]: any}` produces a type `string | number`.

Behind the scenes, vue calls the `Object.keys` method to produce the keys when using `v-for`. (see L.81 of renderList.ts)
`Object.keys`'s return type being `string[]`, it sometimes creates a difference between the actual type of the key and the type assigned by vue.

One could argue that `keyof` is able to provide stricter typing of the keys in some other cases but microsoft deliberately took the decision of typing `Object.keys` that way and doing differently would only induce more confusion. 
