### PR TITLE
fix(compat): ensure functional component is not null in `$children`

### DIFF
--- a/packages/runtime-core/src/compat/instanceChildren.ts
+++ b/packages/runtime-core/src/compat/instanceChildren.ts
@@ -18,7 +18,11 @@ export function getCompatChildren(
 
 function walk(vnode: VNode, children: ComponentPublicInstance[]) {
   if (vnode.component) {
-    children.push(vnode.component.proxy!)
+    // `proxy` is not available for functional components
+    children.push(
+      vnode.component.proxy ||
+        (vnode.component.ctx as unknown as ComponentPublicInstance),
+    )
   } else if (vnode.shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
     const vnodes = vnode.children as VNode[]
     for (let i = 0; i < vnodes.length; i++) {

--- a/packages/vue-compat/__tests__/instance.spec.ts
+++ b/packages/vue-compat/__tests__/instance.spec.ts
@@ -209,25 +209,50 @@ describe('INSTANCE_EVENT_HOOKS', () => {
   })
 })
 
-test('INSTANCE_EVENT_CHILDREN', () => {
-  const vm = new Vue({
-    template: `<child/><div><child v-for="i in 3"/></div>`,
-    components: {
-      child: {
-        template: 'foo',
-        data() {
-          return { n: 1 }
+describe('INSTANCE_CHILDREN', () => {
+  test('$children', () => {
+    const vm = new Vue({
+      template: `<child/><div><child v-for="i in 3"/></div>`,
+      components: {
+        child: {
+          template: 'foo',
+          data() {
+            return { n: 1 }
+          },
         },
       },
-    },
-  }).$mount()
-  expect(vm.$children.length).toBe(4)
-  vm.$children.forEach((c: any) => {
-    expect(c.n).toBe(1)
+    }).$mount()
+    expect(vm.$children.length).toBe(4)
+    vm.$children.forEach((c: any) => {
+      expect(c.n).toBe(1)
+    })
+    expect(
+      deprecationData[DeprecationTypes.INSTANCE_CHILDREN].message,
+    ).toHaveBeenWarned()
   })
-  expect(
-    deprecationData[DeprecationTypes.INSTANCE_CHILDREN].message,
-  ).toHaveBeenWarned()
+
+  test('$children inside functional component', () => {
+    const vm = new Vue({
+      template: `<child-func/><child-normal/><div><child-func v-for="i in 3"/></div>`,
+      compatConfig: { COMPONENT_FUNCTIONAL: 'suppress-warning' },
+      components: {
+        childFunc: {
+          functional: true,
+          render: (h: any) => h('div'),
+        },
+        childNormal: {
+          template: 'foo',
+        },
+      },
+    }).$mount()
+    expect(vm.$children.length).toBe(5)
+    vm.$children.forEach((c: any) => {
+      expect(c).toBeTruthy()
+    })
+    expect(
+      deprecationData[DeprecationTypes.INSTANCE_CHILDREN].message,
+    ).toHaveBeenWarned()
+  })
 })
 
 test('INSTANCE_LISTENERS', () => {


### PR DESCRIPTION
In compat mode, if a component is functional, it will be `null` in `$children` array. This happens because `$children` are formed from `proxy` property which is not set for functional components:

https://github.com/vuejs/core/blob/6a8d54850610b65091b52c825b66e3510f4b9fe8/packages/runtime-core/src/component.ts#L740-L746

Inside `setupStatefulComponent`:

https://github.com/vuejs/core/blob/6a8d54850610b65091b52c825b66e3510f4b9fe8/packages/runtime-core/src/component.ts#L785

The fix is to use `component.ctx` (which is the `proxy`'s original object) as a fallback when populating `$children`. I do realize this is not the same object as the wrapped one but this *might* be sufficient for migration purposes.