### PR TITLE
ci: fix RCE vulnerability in file overwrite

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -40,12 +40,13 @@ jobs:
         with:
           name: pr-number
           run_id: ${{ github.event.workflow_run.id }}
+          path: /tmp/pr-number
 
       - name: Read PR Number
         id: pr-number
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./pr.txt
+          path: /tmp/pr-number/pr.txt
 
       - name: Download Size Data
         uses: dawidd6/action-download-artifact@v3


### PR DESCRIPTION
Critical RCE Vulnerability:

An attacker can exploit this vulnerability by uploading files named `scripts/size-report.ts`, which will overwrite the existing file and subsequently execute the injected code.

This flaw grants the attacker the ability to execute arbitrary code in a secure environment that has write permissions to both `pull-requests` and `issues`.

Special thanks to @RedYetiDev