### PR TITLE
fix: make `ForIteratorExpression`'s `returns` property optional

### DIFF
--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -571,7 +571,7 @@ export interface ForRenderListExpression extends CallExpression {
 }
 
 export interface ForIteratorExpression extends FunctionExpression {
-  returns: BlockCodegenNode
+  returns?: BlockCodegenNode
 }
 
 // AST Utilities ---------------------------------------------------------------


### PR DESCRIPTION
Upstream: https://github.com/vuejs/language-tools/issues/4409

Usage here: https://github.com/vuejs/core/blob/530d9ec5f69a39246314183d942d37986c01dc46/packages/compiler-core/src/transforms/vFor.ts#L206-L223 shows that a `ForIteratorExpression`'s `returns` property can be `undefined`, so changed the type definition to match the runtime result.