### PR TITLE
types(runtime-core): export some types

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -270,7 +270,13 @@ export type {
   RuntimeCompilerOptions,
   ComponentInjectOptions,
 } from './componentOptions'
-export type { EmitsOptions, ObjectEmitsOptions } from './componentEmits'
+export type {
+  EmitsOptions,
+  ObjectEmitsOptions,
+  EmitsToProps,
+  ShortEmitsToObject,
+  EmitFn,
+} from './componentEmits'
 export type {
   ComponentPublicInstance,
   ComponentCustomProperties,


### PR DESCRIPTION
## example:
`props.ts`:
```ts
export const formEmits: ObjectEmitsOptions = {
    submit: (values) => isObject(values)
}

export type FormEmits = typeof formEmits;
```
`Form.vue`:
```vue
<script setup lang="ts">
import { formEmits } from './props' 

const emit = defineEmits(formEmits)

const { handleSubmit } = useFormEvents({ emit })
</script>
```

`useFormEvents.ts`
```ts
import type { EmitFn } from 'vue'
import type { FormEmits } from './props'

type UseFormEventParams = {
   emit: EmitFn<FormEmits>
}

export const useFormEvents({ emit }: UseFormEventParams) {
  const handleSubmit = (values) => {
      // type check / auto-completion
      emit('submit', values) 
  }
  
  return {
      handleSubmit
  }
}
```

