### PR TITLE
ci: omit pr number

### DIFF
--- a/.github/workflows/size-data.yml
+++ b/.github/workflows/size-data.yml
@@ -41,13 +41,3 @@ jobs:
         with:
           name: size-data
           path: temp/size
-
-      - name: Save PR number
-        if: ${{github.event_name == 'pull_request'}}
-        run: echo ${{ github.event.number }} > ./pr.txt
-
-      - uses: actions/upload-artifact@v4
-        if: ${{github.event_name == 'pull_request'}}
-        with:
-          name: pr-number
-          path: pr.txt

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -35,19 +35,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Download PR number
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          name: pr-number
-          run_id: ${{ github.event.workflow_run.id }}
-          path: /tmp/pr-number
-
-      - name: Read PR Number
-        id: pr-number
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: /tmp/pr-number/pr.txt
-
       - name: Download Size Data
         uses: dawidd6/action-download-artifact@v3
         with:
@@ -78,7 +65,6 @@ jobs:
         uses: actions-cool/maintain-one-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ steps.pr-number.outputs.content }}
           body: |
             ${{ steps.size-report.outputs.content }}
             <!-- VUE_CORE_SIZE -->


### PR DESCRIPTION
In the latest version of `maintain-one-comment`, pr number can be set automatically https://github.com/actions-cool/maintain-one-comment/pull/9

See also https://github.com/vuejs/core/pull/10985#issuecomment-2122885655