### PR TITLE
fix(server-renderer): avoid using `s` regex flag

### DIFF
--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -108,7 +108,7 @@ export function ssrRenderSlotInner(
   }
 }
 
-const commentTestRE = /^<!--.*-->$/s
+const commentTestRE = /^<!--[\s\S]*-->$/
 const commentRE = /<!--[^]*?-->/gm
 function isComment(item: SSRBufferItem) {
   if (typeof item !== 'string' || !commentTestRE.test(item)) return false


### PR DESCRIPTION
The `s` (dotAll) regexp flag is not supported in ES2015.

See also https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll

The code is converted by [Babel](https://babeljs.io/repl#?browsers=chrome%2010&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBATgUwOYIB4wLwwPQD0A8AhALTEB0AVKQHwAk2EQA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=true&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=true&targets=&version=7.24.6&externalPlugins=%40babel%2Fplugin-proposal-decorators%407.24.1&assumptions=%7B%7D)