### PR TITLE
fix: img src supports setting `null`

### DIFF
--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -59,13 +59,12 @@ export function patchDOMProp(
       value = includeBooleanAttr(value)
     } else if (value == null && type === 'string') {
       // e.g. <div :id="null">
-      if (tag === 'IMG' && key === 'src' && value === null) {
+      if (tag !== 'IMG' || key !== 'src' || value !== null) {
         // e.g. <img :src="null">
         // should allow set img src to null, that will trigger <img> error
-        return
+        value = ''
+        needRemove = true
       }
-      value = ''
-      needRemove = true
     } else if (type === 'number') {
       // e.g. <img :width="null">
       value = 0

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -59,6 +59,11 @@ export function patchDOMProp(
       value = includeBooleanAttr(value)
     } else if (value == null && type === 'string') {
       // e.g. <div :id="null">
+      if (tag === 'IMG' && key === 'src' && value === null) {
+        // e.g. <img :src="null">
+        // should allow set img src to null, that will trigger <img> error
+        return
+      }
       value = ''
       needRemove = true
     } else if (type === 'number') {


### PR DESCRIPTION
When the src value of the img tag is set to `null`, it is hoped that the error event can be triggered. [example](https://play.vuejs.org/#eNp9kU1Lw0AQhv/KuJe0UNKDnkpa/KCgHlRU8LKXkEzj1v1iP2qh5L87u7GxB+klZN73ncwzmQO7sbbcRWQLVvnGCRvAY4h2xbVQ1rgAB3C4gR42zigoKFpwzXVjtA+gfAfL5E+Ke5TSwIdxsr0opseAd81vQEcpR1maul07ZxyZkyksV3DgGiCZRmIpTTcpMPnpSz3X1XxgIyoqAior64BUAVRCdbCgOUvO6MkZXOdOKscpnM0pW81PGtmMBU/zNqIrt95o2j8jcNYYZYVE92yDIB7OFgNc8mra8fsxa8FFnB315hObr3/0rd8njbMXhx7dDjkbvVC7DsNgr9+ecE/vo6lMGyWlz5ivSP8qJsYhdht1S9gnuUz7kK8odPfu1/uA2h+XSqAp2ec8Z3TZuzOr/+Felle5jy7D+h/8Fr/j)

The scenarios in which the error event is triggered when the image loading fails provided by [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#:~:text=The%20src%20attribute%20is%20empty%20(%22%22)%20or%20null.) include the case where the src value is null.