### PR TITLE
docs: fix typo

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -116,7 +116,7 @@ type BooleanKey<T, K extends keyof T = keyof T> = K extends any
  * const emit = defineEmits<{
  *   // <eventName>: <expected arguments>
  *   change: []
- *   update: [value: string] // named tuple syntax
+ *   update: [value: number] // named tuple syntax
  * }>()
  *
  * emit('change')


### PR DESCRIPTION
Change the type from `string` to `number`, because the following code example emits a **number** instead of a **string**.

```ts
const emit = defineEmits<{
  // <eventName>: <expected arguments>
  change: []
  update: [value: number] // named tuple syntax
}>()

emit('change')
emit('update', 1)
```