### PR TITLE
fix(runtime-core): avoid traversing static children for vnodes w/ PatchFlags.BAIL

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2473,7 +2473,8 @@ export function traverseStaticChildren(n1: VNode, n2: VNode, shallow = false) {
           c2 = ch2[i] = cloneIfMounted(ch2[i] as VNode)
           c2.el = c1.el
         }
-        if (!shallow) traverseStaticChildren(c1, c2)
+        if (!shallow && c2.patchFlag !== PatchFlags.BAIL)
+          traverseStaticChildren(c1, c2)
       }
       // #6852 also inherit for text nodes
       if (c2.type === Text) {


### PR DESCRIPTION
close #10547

Calling `traverseStaticChildren` on vnodes with `PatchFlags.BAIL` appears to cause unexpected behavior. In development mode, HMR requires `traverseStaticChildren` to ensure static vnode elements (`el`) are correctly updated. However, it seems that for vnodes that are fully diffed (`PatchFlags.BAIL`), this traversal may not be necessary and could lead to issues.

Change:
- Added a check to skip `traverseStaticChildren` for vnodes with `PatchFlags.BAIL`.
