### PR TITLE
fix(rollup-plugin-dts.js): update warning message when `temp/packages` directory is missing

### DIFF
--- a/rollup.dts.config.js
+++ b/rollup.dts.config.js
@@ -7,7 +7,7 @@ import dts from 'rollup-plugin-dts'
 
 if (!existsSync('temp/packages')) {
   console.warn(
-    'no temp dts files found. run `tsc -p tsconfig.build.json` first.',
+    'no temp dts files found. run `tsc -p tsconfig.build-browser.json && tsc -p tsconfig.build-node.json` first.',
   )
   process.exit(1)
 }


### PR DESCRIPTION
In Vue versions 3.4.22 and later, the command for building declaration files (.dts) in the `scripts` field of `package.json` has been updated from `"build-dts": "tsc -p tsconfig.build.json && rollup -c rollup.dts.config.js"` to `"build-dts": "tsc -p tsconfig.build-browser.json && tsc -p tsconfig.build-node.json && rollup -c rollup.dts.config.js"`. 

However, the warning message `'no temp dts files found. run tsc -p tsconfig.build.json first.'` in the `rollup.dts.config.js` file, which checks for the existence of `temp/packages` files, has not been updated synchronously. This may lead to confusion or unnecessary troubles for developers.

Should modify the warning message `'no temp dts files found. run tsc -p tsconfig.build.json first.'` in the `rollup.dts.config.js` file to `'no temp dts files found. run tsc -p tsconfig.build-browser.json && tsc -p tsconfig.build-node.json first.'` to reflect the latest build command.