### PR TITLE
fix(runtime-core): fix unwanted warning with disabled compat flag

### DIFF
--- a/packages/runtime-core/src/compat/compatConfig.ts
+++ b/packages/runtime-core/src/compat/compatConfig.ts
@@ -611,10 +611,13 @@ export function softAssertCompatEnabled(
   instance: ComponentInternalInstance | null,
   ...args: any[]
 ) {
-  if (__DEV__) {
+  const isEnabled = isCompatEnabled(key, instance)
+
+  if (isEnabled && __DEV__) {
     warnDeprecation(key, instance, ...args)
   }
-  return isCompatEnabled(key, instance)
+
+  return isEnabled
 }
 
 /**

--- a/packages/vue-compat/__tests__/misc.spec.ts
+++ b/packages/vue-compat/__tests__/misc.spec.ts
@@ -208,6 +208,31 @@ test('ATTR_FALSE_VALUE', () => {
   ).toHaveBeenWarned()
 })
 
+test("ATTR_FALSE_VALUE with false value shouldn't throw warning", () => {
+  const vm = new Vue({
+    template: `<div :id="false" :foo="false"/>`,
+    compatConfig: {
+      ATTR_FALSE_VALUE: false,
+    },
+  }).$mount()
+
+  expect(vm.$el).toBeInstanceOf(HTMLDivElement)
+  expect(vm.$el.hasAttribute('id')).toBe(true)
+  expect(vm.$el.getAttribute('id')).toBe('false')
+  expect(vm.$el.hasAttribute('foo')).toBe(true)
+  expect(vm.$el.getAttribute('foo')).toBe('false')
+  expect(
+    (deprecationData[DeprecationTypes.ATTR_FALSE_VALUE].message as Function)(
+      'id',
+    ),
+  ).not.toHaveBeenWarned()
+  expect(
+    (deprecationData[DeprecationTypes.ATTR_FALSE_VALUE].message as Function)(
+      'foo',
+    ),
+  ).not.toHaveBeenWarned()
+})
+
 test('ATTR_ENUMERATED_COERCION', () => {
   const vm = new Vue({
     template: `<div :draggable="null" :spellcheck="0" contenteditable="foo" />`,


### PR DESCRIPTION
If you disable the "ATTR_FALSE_VALUE" in your compat config you expect that no warning will be thrown afterwards. But this still seems to be the case.

The warning also contains a instruction how to suppress the warning: `...suppress this warning with: configureCompat({ ATTR_FALSE_VALUE: false })`. So it will be expected that using this instruction the warning should be suppressed which is not the case.

The issue reproduction can be found in the test. I hope it is the correct place 🙂 

My fix switches the order and first checks, if the feature is enabled. If this is the case then it shows the warning. But with a disabled feature the warning for this feature won't be triggered anymore.