### PR TITLE
fix(compiler-sfc): support keyof for intersection types

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -517,24 +517,24 @@ describe('resolveType', () => {
   test('keyof: intersection type', () => {
     const { props } = resolve(`
     type A = { name: string }
-    type B = A & { color: string }
+    type B = A & { [key: number]: string }
     defineProps<{
       foo: keyof B
     }>()`)
     expect(props).toStrictEqual({
-      foo: ['String'],
+      foo: ['String', 'Number'],
     })
   })
 
   test('keyof: union type', () => {
     const { props } = resolve(`
     type A = { name: string }
-    type B = A | { color: string }
+    type B = A | { [key: number]: string }
     defineProps<{
       foo: keyof B
     }>()`)
     expect(props).toStrictEqual({
-      foo: ['String'],
+      foo: ['String', 'Number'],
     })
   })
 

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -513,6 +513,19 @@ describe('resolveType', () => {
     })
   })
 
+  // #11129
+  test('keyof: intersection type', () => {
+    const { props } = resolve(`
+    type A = { name: string }
+    type B = A & { color: string }
+    defineProps<{
+      foo: keyof B
+    }>()`)
+    expect(props).toStrictEqual({
+      foo: ['String'],
+    })
+  })
+
   test('keyof: utility type', () => {
     const { props } = resolve(
       `

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -526,6 +526,18 @@ describe('resolveType', () => {
     })
   })
 
+  test('keyof: union type', () => {
+    const { props } = resolve(`
+    type A = { name: string }
+    type B = A | { color: string }
+    defineProps<{
+      foo: keyof B
+    }>()`)
+    expect(props).toStrictEqual({
+      foo: ['String'],
+    })
+  })
+
   test('keyof: utility type', () => {
     const { props } = resolve(
       `

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1688,7 +1688,7 @@ export function inferRuntimeType(
       case 'TSUnionType':
         return flattenTypes(ctx, node.types, scope)
       case 'TSIntersectionType': {
-        return flattenTypes(ctx, node.types, scope).filter(
+        return flattenTypes(ctx, node.types, scope, isKeyOf).filter(
           t => t !== UNKNOWN_TYPE,
         )
       }
@@ -1760,14 +1760,15 @@ function flattenTypes(
   ctx: TypeResolveContext,
   types: TSType[],
   scope: TypeScope,
+  isKeyOf: boolean = false,
 ): string[] {
   if (types.length === 1) {
-    return inferRuntimeType(ctx, types[0], scope)
+    return inferRuntimeType(ctx, types[0], scope, isKeyOf)
   }
   return [
     ...new Set(
       ([] as string[]).concat(
-        ...types.map(t => inferRuntimeType(ctx, t, scope)),
+        ...types.map(t => inferRuntimeType(ctx, t, scope, isKeyOf)),
       ),
     ),
   ]

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1686,7 +1686,7 @@ export function inferRuntimeType(
         return inferRuntimeType(ctx, node.typeAnnotation, scope)
 
       case 'TSUnionType':
-        return flattenTypes(ctx, node.types, scope)
+        return flattenTypes(ctx, node.types, scope, isKeyOf)
       case 'TSIntersectionType': {
         return flattenTypes(ctx, node.types, scope, isKeyOf).filter(
           t => t !== UNKNOWN_TYPE,


### PR DESCRIPTION
fixes #11129 