### PR TITLE
refactor(effect): cache tracking value

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -306,14 +306,19 @@ export function triggerEffects(
 ) {
   pauseScheduling()
   for (const effect of dep.keys()) {
+    // dep.get(effect) is very expensive, we need to calculate it lazily and reuse the result
+    let tracking: boolean | undefined
+
     if (!dep.computed && effect.computed) {
-      if (dep.get(effect) === effect._trackId && effect._runnings > 0) {
+      if (
+        (tracking ??= dep.get(effect) === effect._trackId) &&
+        effect._runnings > 0
+      ) {
         effect._dirtyLevel = DirtyLevels.MaybeDirty_ComputedSideEffect_Origin
         continue
       }
     }
-    // dep.get(effect) is very expensive, we need to calculate it lazily and reuse the result
-    let tracking: boolean | undefined
+
     if (
       effect._dirtyLevel < dirtyLevel &&
       (tracking ??= dep.get(effect) === effect._trackId)

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -311,8 +311,8 @@ export function triggerEffects(
 
     if (!dep.computed && effect.computed) {
       if (
-        (tracking ??= dep.get(effect) === effect._trackId) &&
-        effect._runnings > 0
+        effect._runnings > 0 &&
+        (tracking ??= dep.get(effect) === effect._trackId)
       ) {
         effect._dirtyLevel = DirtyLevels.MaybeDirty_ComputedSideEffect_Origin
         continue


### PR DESCRIPTION
Cached the result of `dep.get(effect)` to reuse it within the same scope