### PR TITLE
fix: When patching the elements that use innerHTML or textContent should first `unmountChildren`

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -465,15 +465,7 @@ export function createHydrationFunctions(
               // force hydrate v-bind with .prop modifiers
               key[0] === '.'
             ) {
-              patchProp(
-                el,
-                key,
-                null,
-                props[key],
-                undefined,
-                undefined,
-                parentComponent,
-              )
+              patchProp(el, key, null, props[key], undefined, parentComponent)
             }
           }
         } else if (props.onClick) {
@@ -484,7 +476,6 @@ export function createHydrationFunctions(
             'onClick',
             null,
             props.onClick,
-            undefined,
             undefined,
             parentComponent,
           )

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -832,9 +832,8 @@ function baseCreateRenderer(
       optimized = false
       dynamicChildren = null
     }
-    // the following args are passed only due to potential innerHTML/textContent
-    // overriding existing VNodes, in which case the old tree must be properly
-    // unmounted.
+    // due to potential innerHTML/textContent overriding existing VNodes,
+    // in which case the old tree must be properly unmounted.
     if (
       oldProps.innerHTML !== undefined ||
       oldProps.textContent !== undefined

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -820,6 +820,8 @@ function baseCreateRenderer(
       dynamicChildren = null
     }
 
+    // #9135 innerHTML / textContent unset needs to happen before possible
+    // new children mount
     if (
       (oldProps.innerHTML && newProps.innerHTML == null) ||
       (oldProps.textContent && newProps.textContent == null)

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -107,10 +107,7 @@ export interface RendererOptions<
     prevValue: any,
     nextValue: any,
     namespace?: ElementNamespace,
-    prevChildren?: VNode<HostNode, HostElement>[],
     parentComponent?: ComponentInternalInstance | null,
-    parentSuspense?: SuspenseBoundary | null,
-    unmountChildren?: UnmountChildrenFn,
   ): void
   insert(el: HostNode, parent: HostElement, anchor?: HostNode | null): void
   remove(el: HostNode): void
@@ -670,17 +667,7 @@ function baseCreateRenderer(
     if (props) {
       for (const key in props) {
         if (key !== 'value' && !isReservedProp(key)) {
-          hostPatchProp(
-            el,
-            key,
-            null,
-            props[key],
-            namespace,
-            vnode.children as VNode[],
-            parentComponent,
-            parentSuspense,
-            unmountChildren,
-          )
+          hostPatchProp(el, key, null, props[key], namespace, parentComponent)
         }
       }
       /**
@@ -919,17 +906,7 @@ function baseCreateRenderer(
             const next = newProps[key]
             // #1471 force patch value
             if (next !== prev || key === 'value') {
-              hostPatchProp(
-                el,
-                key,
-                prev,
-                next,
-                namespace,
-                n1.children as VNode[],
-                parentComponent,
-                parentSuspense,
-                unmountChildren,
-              )
+              hostPatchProp(el, key, prev, next, namespace, parentComponent)
             }
           }
         }
@@ -1026,10 +1003,7 @@ function baseCreateRenderer(
               oldProps[key],
               null,
               namespace,
-              vnode.children as VNode[],
               parentComponent,
-              parentSuspense,
-              unmountChildren,
             )
           }
         }
@@ -1041,17 +1015,7 @@ function baseCreateRenderer(
         const prev = oldProps[key]
         // defer patching value
         if (next !== prev && key !== 'value') {
-          hostPatchProp(
-            el,
-            key,
-            prev,
-            next,
-            namespace,
-            vnode.children as VNode[],
-            parentComponent,
-            parentSuspense,
-            unmountChildren,
-          )
+          hostPatchProp(el, key, prev, next, namespace, parentComponent)
         }
       }
       if ('value' in newProps) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -819,16 +819,12 @@ function baseCreateRenderer(
       optimized = false
       dynamicChildren = null
     }
-    // due to potential innerHTML/textContent overriding existing VNodes,
-    // in which case the old tree must be properly unmounted.
+
     if (
-      oldProps.innerHTML !== undefined ||
-      oldProps.textContent !== undefined
+      (oldProps.innerHTML && newProps.innerHTML == null) ||
+      (oldProps.textContent && newProps.textContent == null)
     ) {
-      hostSetElementText(n1.el!, '')
-      if (n1.children) {
-        unmountChildren(n1.children as VNode[], parentComponent, parentSuspense)
-      }
+      hostSetElementText(el, '')
     }
 
     if (dynamicChildren) {
@@ -867,15 +863,7 @@ function baseCreateRenderer(
       // (i.e. at the exact same position in the source template)
       if (patchFlag & PatchFlags.FULL_PROPS) {
         // element props contain dynamic keys, full diff needed
-        patchProps(
-          el,
-          n2,
-          oldProps,
-          newProps,
-          parentComponent,
-          parentSuspense,
-          namespace,
-        )
+        patchProps(el, oldProps, newProps, parentComponent, namespace)
       } else {
         // class
         // this flag is matched when the element has dynamic class bindings.
@@ -921,15 +909,7 @@ function baseCreateRenderer(
       }
     } else if (!optimized && dynamicChildren == null) {
       // unoptimized, full diff
-      patchProps(
-        el,
-        n2,
-        oldProps,
-        newProps,
-        parentComponent,
-        parentSuspense,
-        namespace,
-      )
+      patchProps(el, oldProps, newProps, parentComponent, namespace)
     }
 
     if ((vnodeHook = newProps.onVnodeUpdated) || dirs) {
@@ -986,11 +966,9 @@ function baseCreateRenderer(
 
   const patchProps = (
     el: RendererElement,
-    vnode: VNode,
     oldProps: Data,
     newProps: Data,
     parentComponent: ComponentInternalInstance | null,
-    parentSuspense: SuspenseBoundary | null,
     namespace: ElementNamespace,
   ) => {
     if (oldProps !== newProps) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -832,6 +832,18 @@ function baseCreateRenderer(
       optimized = false
       dynamicChildren = null
     }
+    // the following args are passed only due to potential innerHTML/textContent
+    // overriding existing VNodes, in which case the old tree must be properly
+    // unmounted.
+    if (
+      oldProps.innerHTML !== undefined ||
+      oldProps.textContent !== undefined
+    ) {
+      hostSetElementText(n1.el!, '')
+      if (n1.children) {
+        unmountChildren(n1.children as VNode[], parentComponent, parentSuspense)
+      }
+    }
 
     if (dynamicChildren) {
       patchBlockChildren(

--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -1,5 +1,5 @@
 import { patchProp } from '../src/patchProp'
-import { h, render } from '../src'
+import { h, nextTick, ref, render } from '../src'
 
 describe('runtime-dom: props patching', () => {
   test('basic', () => {
@@ -131,6 +131,25 @@ describe('runtime-dom: props patching', () => {
     render(h('svg', { innerHTML: '<g></g>' }), root)
     expect(root.innerHTML).toBe(`<svg><g></g></svg>`)
     expect(fn).toHaveBeenCalled()
+  })
+
+  test('patch innerHTML porp', async () => {
+    const root = document.createElement('div')
+    const state = ref(false)
+    const Comp = {
+      render: () => {
+        if (state.value) {
+          return h('div', { key: 1 }, [h('del', null, 'baz')])
+        } else {
+          return h('div', { key: 1, innerHTML: 'baz' })
+        }
+      },
+    }
+    render(h(Comp), root)
+    expect(root.innerHTML).toBe(`<div>baz</div>`)
+    state.value = true
+    await nextTick()
+    expect(root.innerHTML).toBe(`<div><del>baz</del></div>`)
   })
 
   test('textContent unmount prev children', () => {

--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -139,9 +139,9 @@ describe('runtime-dom: props patching', () => {
     const Comp = {
       render: () => {
         if (state.value) {
-          return h('div', { key: 1 }, [h('del', null, 'baz')])
+          return h('div', [h('del', null, 'baz')])
         } else {
-          return h('div', { key: 1, innerHTML: 'baz' })
+          return h('div', { innerHTML: 'baz' })
         }
       },
     }

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -13,6 +13,8 @@ export function patchDOMProp(
   parentComponent: any,
 ) {
   if (key === 'innerHTML' || key === 'textContent') {
+    // null value case is handled in renderer patchElement before patching
+    // children
     if (value === null) return
     el[key] = value
     return

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -9,14 +9,15 @@ import { includeBooleanAttr } from '@vue/shared'
 export function patchDOMProp(
   el: any,
   key: string,
-  prevValue: any,
-  nextValue: any,
+  value: any,
   parentComponent: any,
 ) {
   if (key === 'innerHTML' || key === 'textContent') {
-    if (prevValue && nextValue == null) return
-    el[key] = nextValue == null ? '' : nextValue
-    return
+    if (value === null) return
+    else {
+      el[key] = value
+      return
+    }
   }
 
   const tag = el.tagName
@@ -31,38 +32,38 @@ export function patchDOMProp(
     // compare against its attribute value instead.
     const oldValue =
       tag === 'OPTION' ? el.getAttribute('value') || '' : el.value
-    const newValue = nextValue == null ? '' : String(nextValue)
+    const newValue = value == null ? '' : String(value)
     if (oldValue !== newValue || !('_value' in el)) {
       el.value = newValue
     }
-    if (nextValue == null) {
+    if (value == null) {
       el.removeAttribute(key)
     }
     // store value as _value as well since
     // non-string values will be stringified.
-    el._value = nextValue
+    el._value = value
     return
   }
 
   let needRemove = false
-  if (nextValue === '' || nextValue == null) {
+  if (value === '' || value == null) {
     const type = typeof el[key]
     if (type === 'boolean') {
       // e.g. <select multiple> compiles to { multiple: '' }
-      nextValue = includeBooleanAttr(nextValue)
-    } else if (nextValue == null && type === 'string') {
+      value = includeBooleanAttr(value)
+    } else if (value == null && type === 'string') {
       // e.g. <div :id="null">
-      nextValue = ''
+      value = ''
       needRemove = true
     } else if (type === 'number') {
       // e.g. <img :width="null">
-      nextValue = 0
+      value = 0
       needRemove = true
     }
   } else {
     if (
       __COMPAT__ &&
-      nextValue === false &&
+      value === false &&
       compatUtils.isCompatEnabled(
         DeprecationTypes.ATTR_FALSE_VALUE,
         parentComponent,
@@ -76,7 +77,7 @@ export function patchDOMProp(
             parentComponent,
             key,
           )
-        nextValue = type === 'number' ? 0 : ''
+        value = type === 'number' ? 0 : ''
         needRemove = true
       }
     }
@@ -86,13 +87,13 @@ export function patchDOMProp(
   // some properties has getter, no setter, will error in 'use strict'
   // eg. <select :type="null"></select> <select :willValidate="null"></select>
   try {
-    el[key] = nextValue
+    el[key] = value
   } catch (e: any) {
     // do not warn if value is auto-coerced from nullish values
     if (__DEV__ && !needRemove) {
       warn(
         `Failed setting prop "${key}" on <${tag.toLowerCase()}>: ` +
-          `value ${nextValue} is invalid.`,
+          `value ${value} is invalid.`,
         e,
       )
     }

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -14,10 +14,8 @@ export function patchDOMProp(
 ) {
   if (key === 'innerHTML' || key === 'textContent') {
     if (value === null) return
-    else {
-      el[key] = value
-      return
-    }
+    el[key] = value
+    return
   }
 
   const tag = el.tagName

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -43,7 +43,7 @@ export const patchProp: DOMRendererOptions['patchProp'] = (
         ? ((key = key.slice(1)), false)
         : shouldSetAsProp(el, key, nextValue, isSVG)
   ) {
-    patchDOMProp(el, key, prevValue, nextValue, parentComponent)
+    patchDOMProp(el, key, nextValue, parentComponent)
     // #6007 also set form state as attributes so they work with
     // <input type="reset"> or libs / extensions that expect attributes
     // #11163 custom elements may use value as an prop and set it as object

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -21,10 +21,7 @@ export const patchProp: DOMRendererOptions['patchProp'] = (
   prevValue,
   nextValue,
   namespace,
-  prevChildren,
   parentComponent,
-  parentSuspense,
-  unmountChildren,
 ) => {
   const isSVG = namespace === 'svg'
   if (key === 'class') {

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -43,15 +43,7 @@ export const patchProp: DOMRendererOptions['patchProp'] = (
         ? ((key = key.slice(1)), false)
         : shouldSetAsProp(el, key, nextValue, isSVG)
   ) {
-    patchDOMProp(
-      el,
-      key,
-      nextValue,
-      prevChildren,
-      parentComponent,
-      parentSuspense,
-      unmountChildren,
-    )
+    patchDOMProp(el, key, prevValue, nextValue, parentComponent)
     // #6007 also set form state as attributes so they work with
     // <input type="reset"> or libs / extensions that expect attributes
     // #11163 custom elements may use value as an prop and set it as object


### PR DESCRIPTION
close #9135 