### PR TITLE
fix(reactivity): chained computeds lost reactivity

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -93,8 +93,10 @@ export class ReactiveEffect<T = any> {
           if (
             dep.computed.effect._dirtyLevel ===
             DirtyLevels.MaybeDirty_ComputedSideEffect_Origin
-          )
+          ) {
+            resetTracking()
             return true
+          }
           triggerComputed(dep.computed)
           if (this._dirtyLevel >= DirtyLevels.Dirty) {
             break


### PR DESCRIPTION
When getting `dirty` and `_dirtyLevel === DirtyLevels.MaybeDirty_ComputedSideEffect_Origin`, it's supposed to execute `resetTracking` before `return true`. Otherwise, `computed` after that cannot be tracked and ends up losing reactivity.

Fix #11169 