### PR TITLE
fix(runtime-core): ensure unmount dynamic components in optimized mode

### DIFF
--- a/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
+++ b/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
@@ -487,6 +487,32 @@ describe('renderer: optimized mode', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
+  test('should call onUnmounted hook for dynamic components w/ component children', async () => {
+    const spy = vi.fn()
+    const show = ref(1)
+    const Child = {
+      setup() {
+        onUnmounted(spy)
+        return () => 'child'
+      },
+    }
+    const foo = h('div', null, h(Child))
+    const app = createApp({
+      render() {
+        return show.value
+          ? (openBlock(),
+            createBlock('div', null, [(openBlock(), createBlock(foo))]))
+          : createCommentVNode('v-if', true)
+      },
+    })
+
+    app.mount(root)
+    show.value = 0
+    await nextTick()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
   // #2444
   // `KEYED_FRAGMENT` and `UNKEYED_FRAGMENT` always need to diff its children
   test('non-stable Fragment always need to diff its children', () => {

--- a/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
+++ b/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
@@ -487,7 +487,7 @@ describe('renderer: optimized mode', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  test('should call onUnmounted hook for dynamic components w/ component children', async () => {
+  test('should call onUnmounted hook for dynamic components receiving an existing vnode w/ component children', async () => {
     const spy = vi.fn()
     const show = ref(1)
     const Child = {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2112,6 +2112,11 @@ function baseCreateRenderer(
       dirs,
       memoIndex,
     } = vnode
+
+    if (patchFlag === PatchFlags.BAIL) {
+      optimized = false
+    }
+
     // unset ref
     if (ref != null) {
       setRef(ref, null, parentSuspense, vnode, true)
@@ -2177,8 +2182,7 @@ function baseCreateRenderer(
         (type === Fragment &&
           patchFlag &
             (PatchFlags.KEYED_FRAGMENT | PatchFlags.UNKEYED_FRAGMENT)) ||
-        ((!optimized || patchFlag === PatchFlags.BAIL) &&
-          shapeFlag & ShapeFlags.ARRAY_CHILDREN)
+        (!optimized && shapeFlag & ShapeFlags.ARRAY_CHILDREN)
       ) {
         unmountChildren(children as VNode[], parentComponent, parentSuspense)
       }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2177,7 +2177,8 @@ function baseCreateRenderer(
         (type === Fragment &&
           patchFlag &
             (PatchFlags.KEYED_FRAGMENT | PatchFlags.UNKEYED_FRAGMENT)) ||
-        (!optimized && shapeFlag & ShapeFlags.ARRAY_CHILDREN)
+        ((!optimized || patchFlag === PatchFlags.BAIL) &&
+          shapeFlag & ShapeFlags.ARRAY_CHILDREN)
       ) {
         unmountChildren(children as VNode[], parentComponent, parentSuspense)
       }


### PR DESCRIPTION
close #11168

The optimized mode's fast path skips the unmount process for dynamic component receiving an exting vnode with component children (component not in `dynamicChildren`), causing the `onUnmounted` hook to be missed, a simplified reproduction in [playground](https://play.vuejs.org/#eNqNVE2Pm0AM/SsWFxIpC0lQLylEald72B7aVT9uo1YIzMcuzKCZgY0U8d/rmWkIjdJ0L1FsP9vPnmeO3oeuC4YevZ0Xq0zWnQaFuu/2jNdtJ6SGI0gsVlDBCIUULfiE9t9P4XvRdn8CQWgMU81nnPFMcKUh66WExNRYrJeUxngYwn2F2QvoCsGARIPWm1H2BsTLlGrtBKqFqbsiJjxtcQe+MTc+jMspbXuRtqW0xRKSPSX7eT34K+B909AY12ptTa2JnMmPdoAHXfMSBi5yhFfnFhw5NajqJpfo0LlAxX0NWtZliRIE/8Fb0XON+ZxQZOf4P5XoTIXe4ZHKyCFtFm6WI+NgFxqQr0f4mcCG8XEFm/V6TcuIQ/eE9HhkaGy7JtVIFkBMnWG4q4uEeaYC86ybAue5drUyUbNcCsfhFLkF3b4dGl2BxiERo39xONH1Vp5WtLmiLoNnJThJ0w7uitQNyi+drmmzzNu5lZhY2jTi9ZP1adnj6uTPjNSu+J/VwfiY9yRR0ZKReVNMp7JE7cIP3z6TEmbBVuQ9CfZW8CuSpnvD0cE+9jwn2jOcZftoL4hE9l09HDRydRrKEDXI0eKZRxdltPGv0c90oyCyeSQK2uLpGi9vG5qUl/QmmsrM73wm3ctjJ5SRYpFmCE9SdMp1d8JVpH1eEor6njTfWVACORY1R5sS29/9wql71uwvdbvvQdCIcuH3DkEXY8sFph3J3Nz9Dakf3UHBSHRmsmKcVvJrQGnWTCuJgnfB+i5tuioNtt74G3wzrqA=).

Change:
- Updated `unmount` logic to include a check for `PatchFlags.BAIL` to ensure components are unmounted correctly.