### PR TITLE
fix(runtime-dom): ensure only symbols are explicitly stringified during attribute patching

### DIFF
--- a/packages/runtime-dom/__tests__/patchAttrs.spec.ts
+++ b/packages/runtime-dom/__tests__/patchAttrs.spec.ts
@@ -69,4 +69,23 @@ describe('runtime-dom: attrs patching', () => {
     patchProp(el, 'value', null, symbol)
     expect(el.value).toBe(symbol.toString())
   })
+
+  // #11177
+  test('should allow setting value to object, leaving stringification to the element/browser', () => {
+    // normal behavior
+    const el = document.createElement('div')
+    const obj = { toString: () => 'foo' }
+    patchProp(el, 'data-test', null, obj)
+    expect(el.dataset.test).toBe('foo')
+
+    const el2 = document.createElement('div')
+    let testvalue: null | typeof obj = null
+    // simulating a web component that implements its own setAttribute handler
+    el2.setAttribute = (name, value) => {
+      testvalue = value
+    }
+    patchProp(el2, 'data-test', null, obj)
+    expect(el2.dataset.test).toBe(undefined)
+    expect(testvalue).toBe(obj)
+  })
 })

--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -37,7 +37,10 @@ export function patchAttr(
       el.removeAttribute(key)
     } else {
       // attribute value is a string https://html.spec.whatwg.org/multipage/dom.html#attributes
-      el.setAttribute(key, isBoolean ? '' : String(value))
+      el.setAttribute(
+        key,
+        isBoolean ? '' : typeof value === 'symbol' ? String(value) : value,
+      )
     }
   }
 }

--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -2,6 +2,7 @@ import {
   NOOP,
   includeBooleanAttr,
   isSpecialBooleanAttr,
+  isSymbol,
   makeMap,
 } from '@vue/shared'
 import {
@@ -39,7 +40,7 @@ export function patchAttr(
       // attribute value is a string https://html.spec.whatwg.org/multipage/dom.html#attributes
       el.setAttribute(
         key,
-        isBoolean ? '' : typeof value === 'symbol' ? String(value) : value,
+        isBoolean ? '' : isSymbol(value) ? String(value) : value,
       )
     }
   }


### PR DESCRIPTION
This covers an edge case where a web component actually overrides `el.setAttribute` and thus is able to receive non-string values as attribute values (appareantly, extJS web components do this).

This patch ensures that we leave stringification to the browser when patching an element attribute except for the case of symbols, where we need to explicitly stringify it ourselves as the browser would throw an error.

fix: #11177