### PR TITLE
fix(shared): convert reactive string correctly in interpolation

### DIFF
--- a/packages/shared/__tests__/toDisplayString.spec.ts
+++ b/packages/shared/__tests__/toDisplayString.spec.ts
@@ -64,6 +64,11 @@ describe('toDisplayString', () => {
     )
   })
 
+  test('ref with String', () => {
+    const n = ref('foo')
+    expect(toDisplayString(n)).toBe(n.value)
+  })
+
   test('refs', () => {
     const n = ref(1)
     const np = computed(() => n.value + 1)

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -17,18 +17,20 @@ import {
 export const toDisplayString = (val: unknown): string => {
   return isString(val)
     ? val
-    : val == null
-      ? ''
-      : isArray(val) ||
-          (isObject(val) &&
-            (val.toString === objectToString || !isFunction(val.toString)))
-        ? JSON.stringify(val, replacer, 2)
-        : String(val)
+    : isRef(val) && isString(val.value)
+      ? val.value
+      : val == null
+        ? ''
+        : isArray(val) ||
+            (isObject(val) &&
+              (val.toString === objectToString || !isFunction(val.toString)))
+          ? JSON.stringify(val, replacer, 2)
+          : String(val)
 }
 
 const replacer = (_key: string, val: any): any => {
   // can't use isRef here since @vue/shared has no deps
-  if (val && val.__v_isRef) {
+  if (isRef(val)) {
     return replacer(_key, val.value)
   } else if (isMap(val)) {
     return {
@@ -57,3 +59,5 @@ const stringifySymbol = (v: unknown, i: number | string = ''): any =>
   // Symbol.description in es2019+ so we need to cast here to pass
   // the lib: es2016 check
   isSymbol(v) ? `Symbol(${(v as any).description ?? i})` : v
+
+const isRef = (val: any): val is { value: any } => val && val.__v_isRef

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -17,8 +17,8 @@ import {
 export const toDisplayString = (val: unknown): string => {
   return isString(val)
     ? val
-    : isRef(val) && isString(val.value)
-      ? val.value
+    : isRef(val)
+      ? toDisplayString(val.value)
       : val == null
         ? ''
         : isArray(val) ||
@@ -29,7 +29,6 @@ export const toDisplayString = (val: unknown): string => {
 }
 
 const replacer = (_key: string, val: any): any => {
-  // can't use isRef here since @vue/shared has no deps
   if (isRef(val)) {
     return replacer(_key, val.value)
   } else if (isMap(val)) {
@@ -55,9 +54,10 @@ const replacer = (_key: string, val: any): any => {
   return val
 }
 
+// can't use isRef from @vue/reactivity here since @vue/shared has no deps
+const isRef = (val: any): val is { value: any } => val && val.__v_isRef
+
 const stringifySymbol = (v: unknown, i: number | string = ''): any =>
   // Symbol.description in es2019+ so we need to cast here to pass
   // the lib: es2016 check
   isSymbol(v) ? `Symbol(${(v as any).description ?? i})` : v
-
-const isRef = (val: any): val is { value: any } => val && val.__v_isRef


### PR DESCRIPTION
fix #11199 