### PR TITLE
refactor(reactivity): extract isRef to shared

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -8,10 +8,12 @@ import {
 import { DirtyLevels, TrackOpTypes, TriggerOpTypes } from './constants'
 import {
   type IfAny,
+  type Ref,
   hasChanged,
   isArray,
   isFunction,
   isObject,
+  isRef,
 } from '@vue/shared'
 import {
   isProxy,
@@ -27,18 +29,8 @@ import { ComputedRefImpl } from './computed'
 import { getDepFromReactive } from './reactiveEffect'
 import { warn } from './warning'
 
-declare const RefSymbol: unique symbol
+export type { Ref } from '@vue/shared'
 export declare const RawSymbol: unique symbol
-
-export interface Ref<T = any> {
-  value: T
-  /**
-   * Type differentiator only.
-   * We need this to be in public d.ts but don't want it to show up in IDE
-   * autocomplete, so we use a private Symbol instead.
-   */
-  [RefSymbol]: true
-}
 
 type RefBase<T> = {
   dep?: Dep
@@ -90,16 +82,7 @@ export function triggerRefValue(
   }
 }
 
-/**
- * Checks if a value is a ref object.
- *
- * @param r - The value to inspect.
- * @see {@link https://vuejs.org/api/reactivity-utilities.html#isref}
- */
-export function isRef<T>(r: Ref<T> | unknown): r is Ref<T>
-export function isRef(r: any): r is Ref {
-  return !!(r && r.__v_isRef === true)
-}
+export { isRef } from '@vue/shared'
 
 /**
  * Takes an inner value and returns a reactive and mutable ref object, which

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -1,4 +1,5 @@
 import { makeMap } from './makeMap'
+import type { Ref } from './typeUtils'
 
 export const EMPTY_OBJ: { readonly [key: string]: any } = __DEV__
   ? Object.freeze({})
@@ -51,6 +52,20 @@ export const isString = (val: unknown): val is string => typeof val === 'string'
 export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
 export const isObject = (val: unknown): val is Record<any, any> =>
   val !== null && typeof val === 'object'
+
+// @vue/shared can't have dependencies,
+// but this is needed here for #7306
+
+/**
+ * Checks if a value is a ref object.
+ *
+ * @param r - The value to inspect.
+ * @see {@link https://vuejs.org/api/reactivity-utilities.html#isref}
+ */
+export function isRef<T>(r: Ref<T> | unknown): r is Ref<T>
+export function isRef(r: any): r is Ref {
+  return !!(r && r.__v_isRef === true)
+}
 
 export const isPromise = <T = any>(val: unknown): val is Promise<T> => {
   return (

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -4,16 +4,12 @@ import {
   isMap,
   isObject,
   isPlainObject,
+  isRef,
   isSet,
   isString,
   isSymbol,
   objectToString,
 } from './general'
-
-// can't use isRef here since @vue/shared has no deps
-const isRef = (val: any): val is { value: unknown } => {
-  return !!(val && val.__v_isRef === true)
-}
 
 /**
  * For converting {{ interpolation }} values to displayed strings.

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -21,3 +21,15 @@ export type Awaited<T> = T extends null | undefined
       ? Awaited<V> // recursively unwrap the value
       : never // the argument to `then` was not callable
     : T // non-object or non-thenable
+
+declare const RefSymbol: unique symbol
+
+export interface Ref<T = any> {
+  value: T
+  /**
+   * Type differentiator only.
+   * We need this to be in public d.ts but don't want it to show up in IDE
+   * autocomplete, so we use a private Symbol instead.
+   */
+  [RefSymbol]: true
+}


### PR DESCRIPTION
After the merge of #7306, I noticed that isRef is redeclared in shared because shared can't have dependencies (didn't thought about that during the reviewing, sorry!). However, reactivity has shared as a dependency.

I think it makes more sense to have a single implementation in shared (and re-export from reactivity) for better tree-shaking and maintainability