### PR TITLE
ci: re-fix size report

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -13,7 +13,6 @@ permissions:
 
 env:
   PUPPETEER_SKIP_DOWNLOAD: 'true'
-  COMMENT_MARKER: <!-- VUE_CORE_SIZE -->
 
 jobs:
   size-report:
@@ -54,14 +53,12 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Prepare report
-        run: |
-          pnpm tsx scripts/size-report.ts > size-report.md
-          echo '${{ env.COMMENT_MARKER }}' >> size-report.md
+        run: pnpm tsx scripts/size-report.ts > size-report.md
 
       - name: Create Comment
         uses: thollander/actions-comment-pull-request@v2.5.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           filePath: size-report.md
-          comment_tag: ${{ env.COMMENT_MARKER }}
           pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          comment_tag: VUE_CORE_SIZE


### PR DESCRIPTION
Follow-up of #11203 (see [this comment](https://github.com/vuejs/core/pull/11203#issuecomment-2185010423))

* comment_tag comes last so GH Actions interpreter doesn't trip with special characters from the previous' input
* The action already encloses the tag with the appropiate hidden markers