### PR TITLE
ci: correct PR number retrieval to fix size-report action

### DIFF
--- a/.github/workflows/size-data.yml
+++ b/.github/workflows/size-data.yml
@@ -41,3 +41,13 @@ jobs:
         with:
           name: size-data
           path: temp/size
+
+      - name: Save PR number
+        if: ${{github.event_name == 'pull_request'}}
+        run: echo ${{ github.event.number }} > ./pr.txt
+
+      - uses: actions/upload-artifact@v4
+        if: ${{github.event_name == 'pull_request'}}
+        with:
+          name: pr-number
+          path: pr.txt

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -68,10 +68,18 @@ jobs:
       - name: Prepare report
         run: pnpm tsx scripts/size-report.ts > size-report.md
 
-      - name: Create Comment
-        uses: thollander/actions-comment-pull-request@v2.5.0
+      - name: Read Size Report
+        id: size-report
+        uses: juliangruber/read-file-action@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          filePath: size-report.md
-          pr_number: ${{ steps.pr-number.outputs.content }}
-          comment_tag: VUE_CORE_SIZE
+          path: ./size-report.md
+
+      - name: Create Comment
+        uses: actions-cool/maintain-one-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.pr-number.outputs.content }}
+          body: |
+            ${{ steps.size-report.outputs.content }}
+            <!-- VUE_CORE_SIZE -->
+          body-include: '<!-- VUE_CORE_SIZE -->'

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -73,5 +73,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           filePath: size-report.md
-          pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          pr_number: ${{ steps.pr-number.outputs.content }}
           comment_tag: VUE_CORE_SIZE

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -35,6 +35,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Download PR number
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          name: pr-number
+          run_id: ${{ github.event.workflow_run.id }}
+          path: /tmp/pr-number
+
+      - name: Read PR Number
+        id: pr-number
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: /tmp/pr-number/pr.txt
+
       - name: Download Size Data
         uses: dawidd6/action-download-artifact@v6
         with:


### PR DESCRIPTION
I noticed that the [size report action](https://github.com/vuejs/core/actions/workflows/size-report.yml) has not been working recently. 

The failure is due to the action using `github.event.workflow_run.pull_requests[0].number` to read the PR number. However, according to GitHub's security policy (ref: https://github.com/orgs/community/discussions/25220), this approach does not work for PRs from forked repositories as `pull_requests` can be empty.

To resolve this, I have reverted the method of retrieving the PR number to the previous implementation using artifact.