### PR TITLE
fix(runtime-core): When hydrateTeleport, the targetNode of disabled Teleport should use the node of nextSibling

### DIFF
--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -406,6 +406,21 @@ function hydrateTeleport(
     }
     updateCssVars(vnode)
   }
+  if (!target && isTeleportDisabled(vnode.props)) {
+    const targetNode = nextSibling(node)
+    if (vnode.shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
+      vnode.anchor = hydrateChildren(
+        nextSibling(node),
+        vnode,
+        parentNode(node)!,
+        parentComponent,
+        parentSuspense,
+        slotScopeIds,
+        optimized,
+      )
+      vnode.targetAnchor = targetNode
+    }
+  }
   return vnode.anchor && nextSibling(vnode.anchor as Node)
 }
 


### PR DESCRIPTION
close #11230