### PR TITLE
chore: move custom matcher types to setup-vitest.ts

### DIFF
--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -19,15 +19,6 @@ declare var __FEATURE_PROD_DEVTOOLS__: boolean
 declare var __FEATURE_SUSPENSE__: boolean
 declare var __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
 
-// for tests
-declare namespace jest {
-  interface Matchers<R, T> {
-    toHaveBeenWarned(): R
-    toHaveBeenWarnedLast(): R
-    toHaveBeenWarnedTimes(n: number): R
-  }
-}
-
 declare module '*.vue' {}
 
 declare module 'file-saver' {

--- a/scripts/setup-vitest.ts
+++ b/scripts/setup-vitest.ts
@@ -1,5 +1,16 @@
 import type { MockInstance } from 'vitest'
 
+declare module 'vitest' {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers {}
+}
+
+interface CustomMatchers<R = unknown> {
+  toHaveBeenWarned(): R
+  toHaveBeenWarnedLast(): R
+  toHaveBeenWarnedTimes(n: number): R
+}
+
 vi.stubGlobal('MathMLElement', class MathMLElement {})
 
 expect.extend({


### PR DESCRIPTION
- Removed Jest custom matcher types from `global.d.ts`.
- Align with Vitest and keep related type declarations and implementations together.