### PR TITLE
fix(runtime-core): do not warn `Symbol.unscopables` access

### DIFF
--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -443,7 +443,7 @@ describe('component: proxy', () => {
     ).not.toHaveBeenWarned()
   })
 
-  test('should allow symbol to access on render', () => {
+  test('should not warn Symbol.unscopables access on render', () => {
     const Comp = {
       render() {
         if ((this as any)[Symbol.unscopables]) {
@@ -460,7 +460,7 @@ describe('component: proxy', () => {
       `Property ${JSON.stringify(
         Symbol.unscopables,
       )} was accessed during render ` + `but is not defined on instance.`,
-    ).toHaveBeenWarned()
+    ).not.toHaveBeenWarned()
   })
 
   test('should prevent mutating script setup bindings', () => {

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -308,7 +308,14 @@ const hasSetupBinding = (state: Data, key: string) =>
   state !== EMPTY_OBJ && !state.__isScriptSetup && hasOwn(state, key)
 
 export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
-  get({ _: instance }: ComponentRenderContext, key: string) {
+  get(
+    { _: instance }: ComponentRenderContext,
+    key: string | typeof Symbol.unscopables,
+  ) {
+    if (key === Symbol.unscopables) {
+      return
+    }
+
     if (key === ReactiveFlags.SKIP) {
       return true
     }


### PR DESCRIPTION
Fixes #7910 
Related #1731, #2910 [comment](https://github.com/vuejs/core/pull/1731#issuecomment-752263923)

#### Explanation:
[Generated render function](https://github.com/vuejs/core/blob/main/packages/compiler-core/src/codegen.ts#L330) uses `with` statement to wrap its contents in some conditions. Example:

![image](https://github.com/vuejs/core/assets/74474615/38db941e-9922-4517-b38f-30f78787026e)

As `_ctx` is a `Proxy` inside `with` statement it, on the first time, traps access to `Symbol.unscopables` and only then the actual property. You can see that `ProxyHandlers` get `Symbol.unscopables` as the key on the screenshot below:

![image](https://github.com/vuejs/core/assets/74474615/98632daf-80e4-48e5-93d2-cad505d58748)

To reproduce these steps you can place a debugger in the warning message in the Stackblitz reproduction.


#### Why this should be fixed

This warning is unrelated to user code and makes lots of noise when a compiled template has a lot of proxy property access

[StackBlitz Reproduction](https://stackblitz.com/edit/vitejs-vite-3p98r7?file=src%2FApp.vue,src%2Fmain.js&terminal=dev)

Simple HTML page reproduction:
<details>
<summary>Test.html</summary>

```html
<script src="../../dist/vue.global.js"></script>
<script src="../../../compiler-dom/dist/compiler-dom.global.js"></script>

<div id="demo">
</div>

<script>
  Vue.createApp({
    setup() {
      const inlineTemplateString = `<div> {{ state.text }} </div>`;
      const { code } = VueCompilerDOM.compile(inlineTemplateString);

      return new Function('Vue', code)(Vue);
    },
    computed: {
      state() {
        return {
          text: 123,
        };
      },
    },
  }).mount('#demo');
</script>  
```
</details>