### PR TITLE
fix(runtime-core): When computed is executed early, the update method of instance in setupRenderEffect should be called using callWithErrorHandling

### DIFF
--- a/packages/runtime-core/__tests__/errorHandling.spec.ts
+++ b/packages/runtime-core/__tests__/errorHandling.spec.ts
@@ -1,4 +1,5 @@
 import {
+  computed,
   createApp,
   defineComponent,
   h,
@@ -608,6 +609,28 @@ describe('error handling', () => {
     expect(handler).toHaveBeenCalledWith(error, {}, 'render function')
     expect(handler).toHaveBeenCalledTimes(1)
   })
+  test('handle error in componentUpdateFn', async () => {
+    const error1 = new Error('error1')
+    const handler = vi.fn()
+    const count = ref(1)
+    const app = createApp({
+      setup() {
+        const x = computed(() => {
+          if (count.value === 1) return count.value + 3
+          if (count.value !== 2) throw error1
+        })
+        return () => {
+          return [h('div', x.value)]
+        }
+      },
+    })
 
+    app.config.errorHandler = handler
+    app.mount(nodeOps.createElement('div'))
+    count.value = 100
+    await nextTick()
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(error1, {}, 'component update fn')
+  })
   // native event handler handling should be tested in respective renderers
 })

--- a/packages/runtime-core/__tests__/errorHandling.spec.ts
+++ b/packages/runtime-core/__tests__/errorHandling.spec.ts
@@ -533,7 +533,9 @@ describe('error handling', () => {
       `Unhandled error during execution of setup function`,
     ).toHaveBeenWarned()
     expect(caughtError).toBe(err)
-
+    expect(
+      `Unhandled error during execution of component update fn`,
+    ).toHaveBeenWarned()
     groupCollapsed.mockRestore()
     log.mockRestore()
   })

--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -22,6 +22,7 @@ export enum ErrorCodes {
   APP_WARN_HANDLER,
   FUNCTION_REF,
   ASYNC_COMPONENT_LOADER,
+  COMPONENT_UPDATE_FN,
   SCHEDULER,
 }
 
@@ -54,6 +55,7 @@ export const ErrorTypeStrings: Record<LifecycleHooks | ErrorCodes, string> = {
   [ErrorCodes.APP_WARN_HANDLER]: 'app warnHandler',
   [ErrorCodes.FUNCTION_REF]: 'ref function',
   [ErrorCodes.ASYNC_COMPONENT_LOADER]: 'async component loader',
+  [ErrorCodes.COMPONENT_UPDATE_FN]: 'component update fn',
   [ErrorCodes.SCHEDULER]:
     'scheduler flush. This is likely a Vue internals bug. ' +
     'Please open an issue at https://github.com/vuejs/core .',

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -75,6 +75,7 @@ import { isAsyncWrapper } from './apiAsyncComponent'
 import { isCompatEnabled } from './compat/compatConfig'
 import { DeprecationTypes } from './compat/compatConfig'
 import type { TransitionHooks } from './components/BaseTransition'
+import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 
 export interface Renderer<HostElement = RendererElement> {
   render: RootRenderFunction<HostElement>
@@ -1583,9 +1584,15 @@ function baseCreateRenderer(
     ))
 
     const update: SchedulerJob = (instance.update = () => {
-      if (effect.dirty) {
-        effect.run()
-      }
+      callWithErrorHandling(
+        () => {
+          if (effect.dirty) {
+            effect.run()
+          }
+        },
+        instance,
+        ErrorCodes.COMPONENT_UPDATE_FN,
+      )
     })
     update.id = instance.uid
     // allowRecurse


### PR DESCRIPTION
close #11286