### PR TITLE
fix(compiler-core): When using v-for and v-bind in a template, if v-bind has no expression, an error should be thrown

### DIFF
--- a/packages/compiler-core/src/transforms/vFor.ts
+++ b/packages/compiler-core/src/transforms/vFor.ts
@@ -93,6 +93,14 @@ export const transformFor = createStructuralDirectiveTransform(
             context,
           )
         }
+        if (
+          keyExp &&
+          keyExp.type === NodeTypes.SIMPLE_EXPRESSION &&
+          !keyExp.content.trim()
+        )
+          context.onError(
+            createCompilerError(ErrorCodes.X_V_BIND_NO_EXPRESSION, keyProp.loc),
+          )
       }
 
       const isStableFragment =


### PR DESCRIPTION
close #11322