### PR TITLE
perf(server-renderer): optimize `unrollBuffer` by avoiding promises

### DIFF
--- a/packages/server-renderer/__tests__/unrollBuffer.bench.ts
+++ b/packages/server-renderer/__tests__/unrollBuffer.bench.ts
@@ -1,0 +1,74 @@
+import { bench, describe } from 'vitest'
+
+import { type SSRBuffer, createBuffer } from '../src/render'
+import { unrollBuffer } from '../src/renderToString'
+
+function createSyncBuffer(levels: number, itemsPerLevel: number): SSRBuffer {
+  const buffer = createBuffer()
+
+  function addItems(buf: ReturnType<typeof createBuffer>, level: number) {
+    for (let i = 1; i <= levels * itemsPerLevel; i++) {
+      buf.push(`sync${level}.${i}`)
+    }
+    if (level < levels) {
+      const subBuffer = createBuffer()
+      addItems(subBuffer, level + 1)
+      buf.push(subBuffer.getBuffer())
+    }
+  }
+
+  addItems(buffer, 1)
+  return buffer.getBuffer()
+}
+
+function createMixedBuffer(levels: number, itemsPerLevel: number): SSRBuffer {
+  const buffer = createBuffer()
+
+  function addItems(buf: ReturnType<typeof createBuffer>, level: number) {
+    for (let i = 1; i <= levels * itemsPerLevel; i++) {
+      if (i % 3 === 0) {
+        // @ts-expect-error testing...
+        buf.push(Promise.resolve(`async${level}.${i}`))
+      } else {
+        buf.push(`sync${level}.${i}`)
+      }
+    }
+    if (level < levels) {
+      const subBuffer = createBuffer()
+      addItems(subBuffer, level + 1)
+      buf.push(subBuffer.getBuffer())
+    }
+  }
+
+  addItems(buffer, 1)
+  return buffer.getBuffer()
+}
+
+describe('unrollBuffer', () => {
+  let syncBuffer = createBuffer().getBuffer()
+  let mixedBuffer = createBuffer().getBuffer()
+
+  bench(
+    'sync',
+    () => {
+      return unrollBuffer(syncBuffer) as any
+    },
+    {
+      setup() {
+        syncBuffer = createSyncBuffer(5, 3)
+      },
+    },
+  )
+
+  bench(
+    'mixed',
+    () => {
+      return unrollBuffer(mixedBuffer) as any
+    },
+    {
+      setup() {
+        mixedBuffer = createMixedBuffer(5, 3)
+      },
+    },
+  )
+})

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -21,30 +21,24 @@ function nestedUnrollBuffer(
   }
 
   let ret = parentRet
-
   for (let i = startIndex; i < buffer.length; i += 1) {
     const item = buffer[i]
-
     if (isString(item)) {
       ret += item
-
       continue
     }
 
     if (isPromise(item)) {
       return item.then(nestedItem => {
         buffer[i] = nestedItem
-
         return nestedUnrollBuffer(buffer, ret, i)
       })
     }
 
     const result = nestedUnrollBuffer(item, ret, 0)
-
     if (isPromise(result)) {
       return result.then(nestedItem => {
         buffer[i] = nestedItem
-
         return nestedUnrollBuffer(buffer, '', i)
       })
     }

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -11,7 +11,7 @@ import { type SSRBuffer, type SSRContext, renderComponentVNode } from './render'
 
 const { isVNode } = ssrUtils
 
-async function unrollBuffer(buffer: SSRBuffer): Promise<string> {
+export async function unrollBuffer(buffer: SSRBuffer): Promise<string> {
   if (buffer.hasAsync) {
     let ret = ''
     for (let i = 0; i < buffer.length; i++) {

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -11,26 +11,52 @@ import { type SSRBuffer, type SSRContext, renderComponentVNode } from './render'
 
 const { isVNode } = ssrUtils
 
-export async function unrollBuffer(buffer: SSRBuffer): Promise<string> {
-  if (buffer.hasAsync) {
-    let ret = ''
-    for (let i = 0; i < buffer.length; i++) {
-      let item = buffer[i]
-      if (isPromise(item)) {
-        item = await item
-      }
-      if (isString(item)) {
-        ret += item
-      } else {
-        ret += await unrollBuffer(item)
-      }
-    }
-    return ret
-  } else {
-    // sync buffer can be more efficiently unrolled without unnecessary await
-    // ticks
-    return unrollBufferSync(buffer)
+function nestedUnrollBuffer(
+  buffer: SSRBuffer,
+  parentRet: string,
+  startIndex: number,
+): Promise<string> | string {
+  if (!buffer.hasAsync) {
+    return parentRet + unrollBufferSync(buffer)
   }
+
+  let ret = parentRet
+
+  for (let i = startIndex; i < buffer.length; i += 1) {
+    const item = buffer[i]
+
+    if (isString(item)) {
+      ret += item
+
+      continue
+    }
+
+    if (isPromise(item)) {
+      return item.then(nestedItem => {
+        buffer[i] = nestedItem
+
+        return nestedUnrollBuffer(buffer, ret, i)
+      })
+    }
+
+    const result = nestedUnrollBuffer(item, ret, 0)
+
+    if (isPromise(result)) {
+      return result.then(nestedItem => {
+        buffer[i] = nestedItem
+
+        return nestedUnrollBuffer(buffer, '', i)
+      })
+    }
+
+    ret = result
+  }
+
+  return ret
+}
+
+export function unrollBuffer(buffer: SSRBuffer): Promise<string> | string {
+  return nestedUnrollBuffer(buffer, '', 0)
 }
 
 function unrollBufferSync(buffer: SSRBuffer): string {


### PR DESCRIPTION
Currently, `unrollBuffer` is an `async` function, which results in approximately a 10x slowdown in a mixed buffer and around a 1.5x slowdown in a synchronous buffer. Any `Promise` on the hot path is a performance killer.

In this PR, `unrollBuffer` will return a `Promise` only if a child buffer does; otherwise, it will always operate synchronously. However, even if a child buffer returns a `Promise`, we can continue to operate synchronously if further nesting is not required for another child buffer.

Of course, there are other functions where something similar happens, such as `renderComponentVNode`, but this requires separate consideration.

Performance was tested on the following hardware:
CPU: `AMD Ryzen 7950x3D`
System: `WSL 2 Arch Linux on Windows 11`
Node.js: `v22.4.0`

Before

```
 ✓ packages/server-renderer/__tests__/unrollBuffer.bench.ts (2) 1820ms
   ✓ unrollBuffer (2) 1819ms
     name             hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · sync   3,526,611.07  0.0002  0.3646  0.0003  0.0003  0.0005  0.0006  0.0009  ±0.59%  1763307   fastest
   · mixed    303,890.63  0.0028  0.4434  0.0033  0.0032  0.0049  0.0055  0.0233  ±0.77%   151946
```

After

```
 ✓ packages/server-renderer/__tests__/unrollBuffer.bench.ts (2) 2321ms
   ✓ unrollBuffer (2) 2320ms
     name             hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · sync   5,118,319.85  0.0002  0.0730  0.0002  0.0002  0.0002  0.0003  0.0005  ±0.11%  2559160   fastest
   · mixed  3,301,545.89  0.0003  0.2527  0.0003  0.0003  0.0005  0.0006  0.0009  ±0.48%  1650773
```