### PR TITLE
chore: use pnpm catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": "^9.6.0",
     "eslint-plugin-import-x": "^0.5.3",
     "eslint-plugin-vitest": "^0.5.4",
-    "estree-walker": "^2.0.2",
+    "estree-walker": "catalog:",
     "jsdom": "^24.1.0",
     "lint-staged": "^15.2.7",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ catalogs:
       specifier: ^7.24.7
       version: 7.24.7
     '@babel/types':
-      specifier: ^7.2.47
+      specifier: ^7.24.7
       version: 7.24.7
     estree-walker:
       specifier: ^2.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         specifier: ^0.5.4
         version: 0.5.4(eslint@9.6.0)(typescript@5.4.5)(vitest@1.6.0(@types/node@20.14.10)(jsdom@24.1.0)(sass@1.77.6)(terser@5.31.1))
       estree-walker:
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.0.2
       jsdom:
         specifier: ^24.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
 
 catalog:
   '@babel/parser': ^7.24.7
-  '@babel/types': ^7.2.47
+  '@babel/types': ^7.24.7
   'estree-walker': ^2.0.2
   'magic-string': ^0.30.10
   'source-map-js': ^1.2.0


### PR DESCRIPTION
Replenish #11317
@yyx990803 When using the pnpm catalog, the `@babel/types` version was incorrectly written.