### PR TITLE
feat(runtime-core): useId()

### DIFF
--- a/packages/runtime-core/__tests__/helpers/useId.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useId.spec.ts
@@ -61,6 +61,16 @@ describe('useId', () => {
     ).toBe('v0:0 v0:1')
   })
 
+  test('with config.idPrefix', async () => {
+    expect(
+      await getOutput(() => {
+        const app = createApp(BasicComponentWithUseId)
+        app.config.idPrefix = 'foo-'
+        return [app, []]
+      }),
+    ).toBe('foo-0:0 foo-0:1')
+  })
+
   test('async component', async () => {
     const factory = (
       delay1: number,

--- a/packages/runtime-core/__tests__/helpers/useId.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useId.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  type App,
+  Suspense,
+  createApp,
+  defineAsyncComponent,
+  defineComponent,
+  h,
+  useId,
+} from 'vue'
+import { renderToString } from '@vue/server-renderer'
+
+type TestCaseFactory = () => [App, Promise<any>[]]
+
+async function runOnClient(factory: TestCaseFactory) {
+  const [app, deps] = factory()
+  const root = document.createElement('div')
+  app.mount(root)
+  await Promise.all(deps)
+  await promiseWithDelay(null, 0)
+  return root.innerHTML
+}
+
+async function runOnServer(factory: TestCaseFactory) {
+  const [app, _] = factory()
+  return (await renderToString(app))
+    .replace(/<!--[\[\]]-->/g, '') // remove fragment wrappers
+    .trim()
+}
+
+async function getOutput(factory: TestCaseFactory) {
+  const clientResult = await runOnClient(factory)
+  const serverResult = await runOnServer(factory)
+  expect(serverResult).toBe(clientResult)
+  return clientResult
+}
+
+function promiseWithDelay(res: any, delay: number) {
+  return new Promise<any>(r => {
+    setTimeout(() => r(res), delay)
+  })
+}
+
+const BasicComponentWithUseId = defineComponent({
+  setup() {
+    const id1 = useId()
+    const id2 = useId()
+    return () => [id1, ' ', id2]
+  },
+})
+
+describe('useId', () => {
+  test('basic', async () => {
+    expect(
+      await getOutput(() => {
+        const app = createApp(BasicComponentWithUseId)
+        return [app, []]
+      }),
+    ).toBe('v0:0 v0:1')
+  })
+
+  test('async component', async () => {
+    const factory = (
+      delay1: number,
+      delay2: number,
+    ): ReturnType<TestCaseFactory> => {
+      const p1 = promiseWithDelay(BasicComponentWithUseId, delay1)
+      const p2 = promiseWithDelay(BasicComponentWithUseId, delay2)
+      const AsyncOne = defineAsyncComponent(() => p1)
+      const AsyncTwo = defineAsyncComponent(() => p2)
+      const app = createApp({
+        setup() {
+          const id1 = useId()
+          const id2 = useId()
+          return () => [id1, ' ', id2, ' ', h(AsyncOne), ' ', h(AsyncTwo)]
+        },
+      })
+      return [app, [p1, p2]]
+    }
+
+    const expected =
+      'v0:0 v0:1 ' + // root
+      'v1:0 v1:1 ' + // inside first async subtree
+      'v2:0 v2:1' // inside second async subtree
+    // assert different async resolution order does not affect id stable-ness
+    expect(await getOutput(() => factory(10, 20))).toBe(expected)
+    expect(await getOutput(() => factory(20, 10))).toBe(expected)
+  })
+
+  test('serverPrefetch', async () => {
+    const factory = (
+      delay1: number,
+      delay2: number,
+    ): ReturnType<TestCaseFactory> => {
+      const p1 = promiseWithDelay(null, delay1)
+      const p2 = promiseWithDelay(null, delay2)
+
+      const SPOne = defineComponent({
+        async serverPrefetch() {
+          await p1
+        },
+        render() {
+          return h(BasicComponentWithUseId)
+        },
+      })
+
+      const SPTwo = defineComponent({
+        async serverPrefetch() {
+          await p2
+        },
+        render() {
+          return h(BasicComponentWithUseId)
+        },
+      })
+
+      const app = createApp({
+        setup() {
+          const id1 = useId()
+          const id2 = useId()
+          return () => [id1, ' ', id2, ' ', h(SPOne), ' ', h(SPTwo)]
+        },
+      })
+      return [app, [p1, p2]]
+    }
+
+    const expected =
+      'v0:0 v0:1 ' + // root
+      'v1:0 v1:1 ' + // inside first async subtree
+      'v2:0 v2:1' // inside second async subtree
+    // assert different async resolution order does not affect id stable-ness
+    expect(await getOutput(() => factory(10, 20))).toBe(expected)
+    expect(await getOutput(() => factory(20, 10))).toBe(expected)
+  })
+
+  test('async setup()', async () => {
+    const factory = (
+      delay1: number,
+      delay2: number,
+    ): ReturnType<TestCaseFactory> => {
+      const p1 = promiseWithDelay(null, delay1)
+      const p2 = promiseWithDelay(null, delay2)
+
+      const ASOne = defineComponent({
+        async setup() {
+          await p1
+          return {}
+        },
+        render() {
+          return h(BasicComponentWithUseId)
+        },
+      })
+
+      const ASTwo = defineComponent({
+        async setup() {
+          await p2
+          return {}
+        },
+        render() {
+          return h(BasicComponentWithUseId)
+        },
+      })
+
+      const app = createApp({
+        setup() {
+          const id1 = useId()
+          const id2 = useId()
+          return () =>
+            h(Suspense, null, {
+              default: h('div', [id1, ' ', id2, ' ', h(ASOne), ' ', h(ASTwo)]),
+            })
+        },
+      })
+      return [app, [p1, p2]]
+    }
+
+    const expected =
+      '<div>' +
+      'v0:0 v0:1 ' + // root
+      'v1:0 v1:1 ' + // inside first async subtree
+      'v2:0 v2:1' + // inside second async subtree
+      '</div>'
+    // assert different async resolution order does not affect id stable-ness
+    expect(await getOutput(() => factory(10, 20))).toBe(expected)
+    expect(await getOutput(() => factory(20, 10))).toBe(expected)
+  })
+})

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -15,6 +15,7 @@ import { ref } from '@vue/reactivity'
 import { ErrorCodes, handleError } from './errorHandling'
 import { isKeepAlive } from './components/KeepAlive'
 import { queueJob } from './scheduler'
+import { markAsyncBoundary } from './helpers/useId'
 
 export type AsyncComponentResolveResult<T = Component> = T | { default: T } // es modules
 
@@ -157,6 +158,8 @@ export function defineAsyncComponent<
                   })
                 : null
           })
+      } else {
+        markAsyncBoundary(instance)
       }
 
       const loaded = ref(false)

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -131,6 +131,11 @@ export interface AppConfig {
    * But in some cases, e.g. SSR, throwing might be more desirable.
    */
   throwUnhandledErrorInProduction?: boolean
+
+  /**
+   * Prefix for all useId() calls within this app
+   */
+  idPrefix?: string
 }
 
 export interface AppContext {

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -359,12 +359,11 @@ export interface ComponentInternalInstance {
   provides: Data
   /**
    * for tracking useId()
-   * first number is the index of the current async boundrary
+   * first element is the current boundary prefix
    * second number is the index of the useId call within that boundary
-   * third number is the count of child async boundaries
    * @internal
    */
-  ids: [number, number, number]
+  ids: [string, number, number]
   /**
    * Tracking reactive effects (e.g. watchers) associated with this component
    * so that they can be automatically stopped on component unmount
@@ -628,7 +627,7 @@ export function createComponentInstance(
     withProxy: null,
 
     provides: parent ? parent.provides : Object.create(appContext.provides),
-    ids: parent ? parent.ids : [0, 0, 0],
+    ids: parent ? parent.ids : ['', 0, 0],
     accessCache: null!,
     renderCache: [],
 

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -84,6 +84,7 @@ import {
   type ComponentTypeEmits,
   normalizePropsOrEmits,
 } from './apiSetupHelpers'
+import { markAsyncBoundary } from './helpers/useId'
 
 /**
  * Interface for declaring custom options.
@@ -770,6 +771,10 @@ export function applyOptions(instance: ComponentInternalInstance) {
     isCompatEnabled(DeprecationTypes.FILTERS, instance)
   ) {
     instance.filters = filters
+  }
+
+  if (__SSR__ && serverPrefetch) {
+    markAsyncBoundary(instance)
   }
 }
 

--- a/packages/runtime-core/src/helpers/useId.ts
+++ b/packages/runtime-core/src/helpers/useId.ts
@@ -7,7 +7,7 @@ import { warn } from '../warning'
 export function useId() {
   const i = getCurrentInstance()
   if (i) {
-    return (i.appContext.config.idPrefix || 'v') + i.ids[0] + ':' + i.ids[1]++
+    return (i.appContext.config.idPrefix || 'v') + ':' + i.ids[0] + i.ids[1]++
   } else if (__DEV__) {
     warn(
       `useId() is called when there is no active component ` +
@@ -23,5 +23,5 @@ export function useId() {
  * - components with serverPrefetch
  */
 export function markAsyncBoundary(instance: ComponentInternalInstance) {
-  instance.ids = [++instance.ids[2], 0, 0]
+  instance.ids = [instance.ids[0] + instance.ids[2]++ + '-', 0, 0]
 }

--- a/packages/runtime-core/src/helpers/useId.ts
+++ b/packages/runtime-core/src/helpers/useId.ts
@@ -1,0 +1,27 @@
+import {
+  type ComponentInternalInstance,
+  getCurrentInstance,
+} from '../component'
+import { warn } from '../warning'
+
+export function useId() {
+  const i = getCurrentInstance()
+  if (i) {
+    return (i.appContext.config.idPrefix || 'v') + i.ids[0] + ':' + i.ids[1]++
+  } else if (__DEV__) {
+    warn(
+      `useId() is called when there is no active component ` +
+        `instance to be associated with.`,
+    )
+  }
+}
+
+/**
+ * There are 3 types of async boundaries:
+ * - async components
+ * - components with async setup()
+ * - components with serverPrefetch
+ */
+export function markAsyncBoundary(instance: ComponentInternalInstance) {
+  instance.ids = [++instance.ids[2], 0, 0]
+}

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -63,6 +63,7 @@ export { defineAsyncComponent } from './apiAsyncComponent'
 export { useAttrs, useSlots } from './apiSetupHelpers'
 export { useModel } from './helpers/useModel'
 export { useTemplateRef } from './helpers/useTemplateRef'
+export { useId } from './helpers/useId'
 
 // <script setup> API ----------------------------------------------------------
 


### PR DESCRIPTION
Similar to React's [useId](https://react.dev/reference/react/useId), this composable returns a unique ID that can be used for form elements and accessibility attributes.

The generated IDs look like `v:1-2-3` and are unique across each app instance and are stable across server rendering and client rendering. This is ensured by dividing an app into async boundaries (async components, async setup, serverPrefetch). The order of appearance of direct child async boundaries are always consistent assuming the same data is used between server and client, but their order of resolution may be different. Even if two async boundaries resolve in different orders between server and client, `useId()` calls inside the two boundaries should not affect each other.