### PR TITLE
perf(runtime-core): improve efficiency of normalizePropsOptions

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -563,26 +563,30 @@ export function normalizePropsOptions(
         const prop: NormalizedProp = (normalized[normalizedKey] =
           isArray(opt) || isFunction(opt) ? { type: opt } : extend({}, opt))
         const propType = prop.type
+        let shouldCast = false
         let shouldCastTrue = true
 
-        const checkForBoolean = (
-          type: PropConstructor | true | null | undefined,
-        ) => {
-          const typeName = isFunction(type) && type.name
+        if (isArray(propType)) {
+          for (let index = 0; index < propType.length; ++index) {
+            const type = propType[index]
+            const typeName = isFunction(type) && type.name
 
-          // If we find `String` before `Boolean`, e.g. `[String, Boolean]`, we need to handle the casting slightly
-          // differently. Props passed as `<Comp checked="">` or `<Comp checked="checked">` will either be treated as
-          // strings or converted to a boolean `true`, depending on the order of the types.
-          if (typeName === 'String') {
-            shouldCastTrue = false
+            if (typeName === 'Boolean') {
+              shouldCast = true
+              break
+            } else if (typeName === 'String') {
+              // If we find `String` before `Boolean`, e.g. `[String, Boolean]`,
+              // we need to handle the casting slightly differently. Props
+              // passed as `<Comp checked="">` or `<Comp checked="checked">`
+              // will either be treated as strings or converted to a boolean
+              // `true`, depending on the order of the types.
+              shouldCastTrue = false
+            }
           }
-
-          return typeName === 'Boolean'
+        } else {
+          shouldCast = isFunction(propType) && propType.name === 'Boolean'
         }
 
-        const shouldCast = isArray(propType)
-          ? propType.some(checkForBoolean)
-          : checkForBoolean(propType)
         prop[BooleanFlags.shouldCast] = shouldCast
         prop[BooleanFlags.shouldCastTrue] = shouldCastTrue
         // if the prop needs boolean casting or default value


### PR DESCRIPTION
Closes #9739.

The result of `normalizePropsOptions` is cached, so the performance usually doesn't matter too much. But there are two cases where the cache may not help:

- SSR. The cache is per application instance, so a new cache is used for each request.
- Components created on-the-fly, e.g. by defining them inside the `<script setup>` block of another component.

A lot of time in `normalizePropsOptions` is spent in `getType`, trying to figure out the values of the `shouldCast` and `shouldCastTrue` flags. I go into a bit more detail about that at https://github.com/vuejs/core/pull/9739#issuecomment-2144177971.

The Playground isn't necessarily the best tool for benchmarking, but here's an example to try to illustrate that my changes have improved the performance:

- [Playground - 3.4.33](https://play.vuejs.org/#__PROD__eNqtVl1v2jAU/SuWX0ZVCATafSCo1nad1En9UNtpD8s0peFCUxI7chxKhfLfd69NSCgdPJBKRfH18fG5517HWfDTJHFmGfA+H6SBChPNUtBZcuKJME6k0mzBFIybTIozGEsFP5ORr4HG9mnEcjZWMmYfkOXDatXV6/lTGI2WU057OaatEOSJQIpUsym8siHxNzoHFB1nItChFBRSkD41DtjCE4yl2kfOIevQINSgfEKlGDk2IeRxZn6UweGhJ3JiigATKVfRcG0dxjyxnlMDdxueVDdsDVkCChGxLwJwhHxpoMzcSF3lv7ns8N1ljNF/q1XKIBpMZ8waZWyZMFKBfghjkJmubkB/a8lSIG+iDWaHnEGUQgElj2UETiQnDaPMYmwGg7YtNxYaBxriJMJscMTY4DHTGovwNYjCYDr0+LIaHj9ZLEzN8nzQtiC7YBTOWB8nEIu/iLMCBkUXzFroBk4KFgrmdjodj7O2XdrGtfg0aFck8CbXKaofhxPnOZUCm9Ok5PFAxkkYgbpJrIO8XyTrcT+K5MsPE9Mqg2YRD54gmL4Tf07nFPP4LSYHagYeX82hWxPQdvri/hrm+LyajOUoixC9ZfIO0PmMNFrYWSZGKLuCM2ovzWEJxeQhvZhrEGmRFAk1xTJ4j+OxOd+Seim35xwVRUYXK6funQNuz+ClEKCIHE+F7TSRRRF1xWrGSZRM6NSYDWng9tnvb+Y9cJ3Fj6Ca7FQp//WPkUuALgLuYHIxT0rImcRu9EUJ6iGomPy+PPpNdq8VOlKijhBl2Eumm8dnCHQJOd4l52Nlp6WMzY0+IegW31dhWiEqdJWwzwi78it5vVXzBQH3oP8rxu0g4Bf40zWWDXfcTZM3xbhk9A533KrPS+zb3F1yeadDLhm9u2Iu2W2DW1SR3euTK3WrKpR7WCOMY+hthYbKUQMNFW1/mi6VtgYaKn0NNNQcNdBU+2cPmmqL7UFT7cE9aKqvhD1o6unibj1d3K2ni3t7dbH5Atv2eVHeOPQN8Pbm/zsDRfcgXlh4mTm9Hs//AZiQhIQ=)
- [Playground - this PR](https://deploy-preview-11409--vue-sfc-playground.netlify.app/#__PROD__eNqtVttu2kAQ/ZWVX0IUMJgkvSCImqSplEq5KEnVh7oPjhmIg71rrdeECPnfO7PrG4HCA44UxM6cPXvmzKzx0jqPY3uegjWwhokvg1ixBFQan7k8iGIhFVsyCZM2E/wCJkLCr3jsKaC1+TZmGZtIEbEDZDkod928X74E4ThP2d18TUchyOW+4IliM3hnI+Jv9Q4pOkm5rwLBKSQheWkdsqXLGUuUh5wj1qNFoEB6hEowcqpDyGPPvTCFoyOXZ8QUAhZS7aLlyj6MuXy1phaeNjqrH9gZsRgkIiKP+2Bz8dZCmZmWWta/vu1o4zbG6L/TqWQQDZYzYa0qlheMVKCegghEquoH0N9KsRTI2miDPiFjECZQQMljEYIdimlLKzMYU8Gwa9qNjcaFgigOsRpcMTZ8TpXCJnzzw8CfjVwr74ZrnS2XumdZNuwakNkwDuZsgAnE4ifijIBhMQXzDrqBSc4Czpxer+darGu2dnEvfht2axKstqUSVD8JpvZrIjgOpy7JtXwRxUEI8i42DlqDoljX8sJQvP3UMSVTaBdx/wX82Yb4a7KgmGvdY3Eg5+BaZQ7dmoIy6avHW1jg9zIZiXEaInpL8gHQ+ZQ0GthFyscou4bTaq/1ZQn49Cm5WijgSVEUCdXN0njXwmtzuaX0Su6xfVI0GV2s3boNF9zcwWvOQRI53gozaTwNQ5qKMmPHUsR0a/SBtHAG7M93/Ry4TaNnkG12LqX3/lfLJUAfAQ8wvVrEFeRC4DR6vAIdI6hI/sivfps9KomOVKgTRGn2iunu+RV8VUFOd8n5VDspl7F+0GcE3ePzKkhqRIWuCvYFYTdera6Par4i4BHUf8U4PQT8Bm+2wrLmjrNu8roYh4ze4Y5T9znHfqzdIZd3OuSQ0bs75pDdJrhFFdm9mizVlV2ozjBGaMfQ2xoNtaMBGmra/jR9am0DNNT6BmhoOBqgqc/PHjT1EduDpj6De9DUHwl70DQzxf1mprjfzBQf7zXF+g1s2+tF9YtD7wCrv/zZP27Zfwg=)

I based my branch on 3.4.33, so it should be a fair comparison. It seems to be faster in both Chrome and Firefox (I didn't try other browsers).

The Playground example isn't very 'real'. It's designed to focus on the performance of `normalizePropsOptions` as much as possible, so the performance benefit would be much less in real applications. But if performance can be improved without hurting bundle size or maintainability, it seems worth it to me.

The Playground uses small arrays for the `type`. I think that's representative of real code. I didn't think it would be realistic to test with arrays of hundreds or thousands of items, so my conclusions are all based on the assumption that the arrays will be relatively short.

Most of my benchmarking I did using Node instead, calling `normalizePropsOptions` directly. Using a similar `props` definition to the one in the Playground above I saw an improvement of about 35%. There's a version of the code I used at:

 - https://gist.github.com/skirtles-code/99f3a65e38ea68c65560558bcc7919a3

That's using arrays for the prop types. I also tested using other values, such as `type: String`. The performance still seemed slightly better, maybe about 10% better, but it was less clear relative to the background noise in the measurements.

I also tried to reduce the size of the build. There was a lot of code involved in performing the `shouldCast`/`shouldCastTrue` checks, much of which is no longer needed. I experimented with various implementations, testing both the performance and build size. The first commit on this PR, https://github.com/vuejs/core/pull/11409/commits/3f37cf79616208cf03cff69c1fd898f1e53a5034, gave a slightly smaller build size (saving 176 bytes rather than 116), but it wasn't quite as fast as the second version (about 30% faster than 3.4.33, rather than 35%).

---

The original motivation for these changes came from #9739, which proposed adding a cache to `getType`. Since that PR was opened there have been other changes to `getType` via #10327. I think those other changes make adding a cache less effective. The remaining problem is just that `getType` gets called so much, which is essentially the problem I'm attempting to address here.

---

One of the changes introduced by #10327 was this code:

https://github.com/vuejs/core/blob/422ef34e487f801e1162bed80c0e88e868576e1d/packages/runtime-core/src/componentProps.ts#L610-L614

I'm not entirely sure why this code was added. It isn't explained in the PR description and there aren't any tests for it. I suspect it may have been introduced by mistake. It leads to strange handling of some edge cases. For example, consider a prop with `type: [new Boolean(true)]`. Obviously that's nonsense, but as of 3.4.19 (which is the first release to include that change) it behaves the same as `type: Boolean`. [Playground example](https://play.vuejs.org/#eNp9Uc1OwzAMfpUoFzZpag/jNFVIDO0AEjABN4JQ1bojI42jJO02VX13nJT9CI3d4u/H+Wx3/NaYpG2Az3jmCiuNZw58Y26ElrVB69nj7g5rwyqLNbtK0qEMliuhs3TwkJoKD7VRuQeqGMt+fSlVWXpC8Qn3rkBdyVWydqjp5y4YBC9ILxXYZ+Mlaif4jEUmcLlSuHmImLcNTPZ48QXF9xl87bYBE3xpwYFtQfAD53O7Aj/Qi9cn2NL7QNZYNorUF8gXcKiakHGQzRtdUuwTXUx7H/cn9erNLbYetNsPFYIGZR/1gtMuw6r+G/0Yd5pcR5/QPW3xeIkzxyuhkhqWFo0bxU4V4qGn3xmYsXcNGzZHVJDrUcg0/th3H18+bSnb+GCs60Jj1pOJ8HQg/p77swUbhqeYNEEynfL+B4tY0bo=).

In the changes I've made in this PR I have not attempted to retain this behaviour. I'm now just checking for `isFunction(type) && type.name`, which seems to be all we need in practice.

My code does duplicate this check, once for array types and then again for non-arrays. I did try to remove the duplication, but it just ended up adding extra bytes to the build, or making it slower, or both. To see an example of one of my attempts, take a look at the first commit on this PR, https://github.com/vuejs/core/pull/11409/commits/3f37cf79616208cf03cff69c1fd898f1e53a5034. That does remove the duplication, but at the expense of being slower. I also felt that version was slightly more difficult to understand for future contributors.

---

I've made a change to `NormalizedProp` to remove `null` from the type. From what I can tell, the `null` was needed when that type was first introduced, but other code has changed since, so it can now be removed. Removing the `null` allowed me to remove the `if (prop)` check in `normalizePropsOptions`. While this doesn't really impact the performance, it did seem to be redundant and shaves a few bytes off the bundle.

---

The main change is to introduce a single `for` loop over the `type` array. The type is then checked directly against the strings `'Boolean'` and `'String'`, rather than using multiple calls to `getType` to get those strings. The `getType` function is no longer used here, and is now only used in dev code, allowing it be to treeshaken.

I experimented with using other types of loop, such as `some` and `for`/`of`, but ultimately a basic `for` seemed to give the best performance. In particular, using `for`/`of` seemed slightly slower in Firefox. The superior performance of a basic `for` is maybe no great surprise, but nevertheless I did try to confirm that it really was best when working with short arrays in current browsers.

---

Slight tangent...

I find the Brotli sizes to be a bit erratic. They seem to jump around almost randomly. For example, at the time of writing, the **Brotli**/**overall** value given in the size report is **+2**. But if I swap round these two lines to be in the opposite order, it jumps to **-41**:

```js
let shouldCast = false
let shouldCastTrue = true
```

I gave up chasing the Brotli size and chose to focus on **Size** and **Gzip** instead, as they seemed like a more reliable way to judge progress.