### PR TITLE
refactor(reactivity): simplify the wrapping logic for returned values

### DIFF
--- a/packages/reactivity/src/arrayInstrumentations.ts
+++ b/packages/reactivity/src/arrayInstrumentations.ts
@@ -237,7 +237,7 @@ function apply(
   wrappedRetFn?: (result: any) => unknown,
 ) {
   const arr = shallowReadArray(self)
-  let needsWrap
+  let needsWrap = false
   let wrappedFn = fn
   if (arr !== self) {
     needsWrap = !isShallow(self)

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -60,9 +60,9 @@ export function renderList(
   let ret: VNodeChild[]
   const cached = (cache && cache[index!]) as VNode[] | undefined
   const sourceIsArray = isArray(source)
-  const sourceIsReactiveArray = sourceIsArray && isReactive(source)
 
   if (sourceIsArray || isString(source)) {
+    const sourceIsReactiveArray = sourceIsArray && isReactive(source)
     if (sourceIsReactiveArray) {
       source = shallowReadArray(source)
     }


### PR DESCRIPTION
- reuse the `isProxy` and `isShallow` checks within the `apply` method