### PR TITLE
docs(github): update the minimum requeird version of pnpm

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -82,7 +82,7 @@ Hi! I'm really excited that you are interested in contributing to Vue.js. Before
 
 ## Development Setup
 
-You will need [Node.js](https://nodejs.org) **version 18.12+**, and [PNPM](https://pnpm.io) **version 8+**.
+You will need [Node.js](https://nodejs.org) **version 18.12+**, and [PNPM](https://pnpm.io) **version 9.5+**.
 
 We also recommend installing [@antfu/ni](https://github.com/antfu/ni) to help switching between repos using different package managers. `ni` also provides the handy `nr` command which running npm scripts easier.
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -82,7 +82,7 @@ Hi! I'm really excited that you are interested in contributing to Vue.js. Before
 
 ## Development Setup
 
-You will need [Node.js](https://nodejs.org) **version 18.12+**, and [PNPM](https://pnpm.io) **version 9.5+**.
+You will need [Node.js](https://nodejs.org) with minimum version as specified in the [`.node-version`](https://github.com/vuejs/core/blob/main/.node-version) file, and [PNPM](https://pnpm.io) with minimum version as specified in the [`"packageManager"` field in `package.json`](https://github.com/vuejs/core/blob/main/package.json#L4).
 
 We also recommend installing [@antfu/ni](https://github.com/antfu/ni) to help switching between repos using different package managers. `ni` also provides the handy `nr` command which running npm scripts easier.
 


### PR DESCRIPTION
The project uses the catalogs added in `pnpm`v9.5.0, and the contribution guide should be updated synchronously.

ref https://pnpm.io/catalogs

If the pnpm version used is lower than 9.5, the following error will occur when installing dependencies:

<img width="823" alt="low-version-pnpm-error" src="https://github.com/user-attachments/assets/71ced484-ad7a-46dd-8d9e-c544467107fe">
