### PR TITLE
chore(sfc-playground): add item key of versions list

### DIFF
--- a/packages/sfc-playground/src/VersionSelect.vue
+++ b/packages/sfc-playground/src/VersionSelect.vue
@@ -74,7 +74,7 @@ onMounted(() => {
 
     <ul class="versions" :class="{ expanded }">
       <li v-if="!versions"><a>loading versions...</a></li>
-      <li v-for="ver of versions" :class="{ active: ver === version }">
+      <li v-for="ver of versions" :key="ver" :class="{ active: ver === version }">
         <a @click="setVersion(ver)">v{{ ver }}</a>
       </li>
       <div @click="expanded = false">


### PR DESCRIPTION
I see https://vuejs.org/style-guide/rules-essential.html#use-keyed-v-for ,
So, maybe can add a key to the version list item?