### PR TITLE
chore(sfc-playgroud): highlight the commit and latest version when active in dropdown

### DIFF
--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -80,7 +80,7 @@ function toggleDark() {
         pkg="vue"
         label="Vue Version"
       >
-        <li>
+        <li :class="{ active: vueVersion === `@${currentCommit}` }">
           <a @click="resetVueVersion">This Commit ({{ currentCommit }})</a>
         </li>
         <li>

--- a/packages/sfc-playground/src/VersionSelect.vue
+++ b/packages/sfc-playground/src/VersionSelect.vue
@@ -74,7 +74,12 @@ onMounted(() => {
 
     <ul class="versions" :class="{ expanded }">
       <li v-if="!versions"><a>loading versions...</a></li>
-      <li v-for="(ver, index) of versions" :class="{ active: ver === version || (version === 'latest' && index === 0) }">
+      <li
+        v-for="(ver, index) of versions"
+        :class="{
+          active: ver === version || (version === 'latest' && index === 0),
+        }"
+      >
         <a @click="setVersion(ver)">v{{ ver }}</a>
       </li>
       <div @click="expanded = false">

--- a/packages/sfc-playground/src/VersionSelect.vue
+++ b/packages/sfc-playground/src/VersionSelect.vue
@@ -74,7 +74,7 @@ onMounted(() => {
 
     <ul class="versions" :class="{ expanded }">
       <li v-if="!versions"><a>loading versions...</a></li>
-      <li v-for="ver of versions" :class="{ active: ver === version }">
+      <li v-for="(ver, index) of versions" :class="{ active: ver === version || (version === 'latest' && index === 0) }">
         <a @click="setVersion(ver)">v{{ ver }}</a>
       </li>
       <div @click="expanded = false">


### PR DESCRIPTION
Before:

<img width="497" alt="sfc-version-list-highlight-before" src="https://github.com/user-attachments/assets/d95a07c8-5339-4c34-8cfd-2288400454c8">


After:

<img width="959" alt="sfc-version-list-highlight" src="https://github.com/user-attachments/assets/0d2e2620-857f-40fb-afb1-f447b22de1b6">

