### PR TITLE
feat: lazy hydration strategies for async components

### DIFF
--- a/packages/runtime-core/__tests__/hydrationStrategies.spec.ts
+++ b/packages/runtime-core/__tests__/hydrationStrategies.spec.ts
@@ -1,1 +1,0 @@
-describe('async component hydration strategies', () => {})

--- a/packages/runtime-core/__tests__/hydrationStrategies.spec.ts
+++ b/packages/runtime-core/__tests__/hydrationStrategies.spec.ts
@@ -1,0 +1,1 @@
+describe('async component hydration strategies', () => {})

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -123,7 +123,14 @@ export function defineAsyncComponent<
 
     __asyncHydrate(el, instance, hydrate) {
       const doHydrate = hydrateStrategy
-        ? () => hydrateStrategy(hydrate, cb => forEachElement(el, cb))
+        ? () => {
+            const teardown = hydrateStrategy(hydrate, cb =>
+              forEachElement(el, cb),
+            )
+            if (teardown) {
+              ;(instance.bum || (instance.bum = [])).push(teardown)
+            }
+          }
         : hydrate
       if (resolvedComp) {
         doHydrate()

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -122,7 +122,8 @@ export function defineAsyncComponent<
     __asyncLoader: load,
 
     __asyncHydrate(el, instance, hydrate) {
-      const doHydrate = hydrateStrategy ? hydrateStrategy(el, hydrate) : hydrate
+      const doHydrate = () =>
+        hydrateStrategy ? hydrateStrategy(hydrate, el) : hydrate()
       if (resolvedComp) {
         doHydrate()
       } else {

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -16,7 +16,7 @@ import { ErrorCodes, handleError } from './errorHandling'
 import { isKeepAlive } from './components/KeepAlive'
 import { queueJob } from './scheduler'
 import { markAsyncBoundary } from './helpers/useId'
-import type { HydrationStrategy } from './hydrationStrategies'
+import { type HydrationStrategy, forEachElement } from './hydrationStrategies'
 
 export type AsyncComponentResolveResult<T = Component> = T | { default: T } // es modules
 
@@ -122,8 +122,9 @@ export function defineAsyncComponent<
     __asyncLoader: load,
 
     __asyncHydrate(el, instance, hydrate) {
-      const doHydrate = () =>
-        hydrateStrategy ? hydrateStrategy(hydrate, el) : hydrate()
+      const doHydrate = hydrateStrategy
+        ? () => hydrateStrategy(hydrate, cb => forEachElement(el, cb))
+        : hydrate
       if (resolvedComp) {
         doHydrate()
       } else {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -199,6 +199,14 @@ export interface ComponentOptionsBase<
    * @internal
    */
   __asyncResolved?: ConcreteComponent
+  /**
+   * Exposed for lazy hydration
+   * @internal
+   */
+  __asyncHydrate?: (
+    instance: ComponentInternalInstance,
+    hydrate: () => void,
+  ) => void
 
   // Type differentiators ------------------------------------------------------
 

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -204,6 +204,7 @@ export interface ComponentOptionsBase<
    * @internal
    */
   __asyncHydrate?: (
+    el: Element,
     instance: ComponentInternalInstance,
     hydrate: () => void,
   ) => void

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -46,7 +46,7 @@ export type RootHydrateFunction = (
   container: (Element | ShadowRoot) & { _vnode?: VNode },
 ) => void
 
-enum DOMNodeTypes {
+export enum DOMNodeTypes {
   ELEMENT = 1,
   TEXT = 3,
   COMMENT = 8,
@@ -75,7 +75,7 @@ const getContainerType = (container: Element): 'svg' | 'mathml' | undefined => {
   return undefined
 }
 
-const isComment = (node: Node): node is Comment =>
+export const isComment = (node: Node): node is Comment =>
   node.nodeType === DOMNodeTypes.COMMENT
 
 // Note: hydration is DOM-specific

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -49,7 +49,7 @@ export const hydrateOnInteraction: HydrationStrategyFactory<
   (hydrate, node) => {
     if (isString(interactions)) interactions = [interactions]
     let hasHydrated = false
-    const doHydrate = () => {
+    const doHydrate = (e: Event) => {
       if (!hasHydrated) {
         hasHydrated = true
         forEachNode(node, el => {
@@ -58,6 +58,8 @@ export const hydrateOnInteraction: HydrationStrategyFactory<
           }
         })
         hydrate()
+        // replay event
+        e.target!.dispatchEvent(new (e.constructor as any)(e.type, e))
       }
     }
     forEachNode(node, el => {

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -1,19 +1,83 @@
-export type HydrationStrategy = (el: Element, hydrate: () => void) => () => void
+import { isString } from '@vue/shared'
+import { DOMNodeTypes, isComment } from './hydration'
+
+export type HydrationStrategy = (hydrate: () => void, el: Node) => void
 
 export type HydrationStrategyFactory<Options = any> = (
   options?: Options,
 ) => HydrationStrategy
 
-export const hydrateOnTimeout: HydrationStrategyFactory<number> =
-  (delay = 100) =>
-  (el, hydrate) =>
-  () =>
-    setTimeout(hydrate, delay)
-
-export const hydrateOnVisible: HydrationStrategyFactory<number> = margin => {
-  return hydrate => () => hydrate
+export const hydrateOnIdle: HydrationStrategyFactory = () => hydrate => {
+  requestIdleCallback(hydrate)
 }
 
-export const hydrateOnMediaQuery: HydrationStrategyFactory<string> = query => {
-  return hydrate => () => hydrate
+export const hydrateOnVisible: HydrationStrategyFactory<string | number> =
+  (margin = 0) =>
+  (hydrate, node) => {
+    const ob = new IntersectionObserver(
+      entries => {
+        for (const e of entries) {
+          if (!e.isIntersecting) continue
+          ob.disconnect()
+          hydrate()
+          break
+        }
+      },
+      {
+        rootMargin: isString(margin) ? margin : margin + 'px',
+      },
+    )
+    forEachNode(node, el => ob.observe(el))
+  }
+
+export const hydrateOnMediaQuery: HydrationStrategyFactory<string> =
+  query => hydrate => {
+    if (query) {
+      const mql = matchMedia(query)
+      if (mql.matches) {
+        hydrate()
+      } else {
+        mql.addEventListener('change', hydrate, { once: true })
+      }
+    }
+  }
+
+export const hydrateOnInteraction: HydrationStrategyFactory<
+  string | string[]
+> =
+  (interactions = []) =>
+  (hydrate, node) => {
+    if (isString(interactions)) interactions = [interactions]
+    let hasHydrated = false
+    const doHydrate = () => {
+      if (!hasHydrated) {
+        hydrate()
+        hasHydrated = true
+        for (const el of els) {
+          for (const i of interactions) {
+            el.removeEventListener(i, doHydrate)
+          }
+        }
+      }
+    }
+    const els: Element[] = []
+    forEachNode(node, el => {
+      for (const i of interactions) {
+        el.addEventListener(i, doHydrate, { once: true })
+        els.push(el)
+      }
+    })
+  }
+
+function forEachNode(node: Node, cb: (el: Element) => void) {
+  // fragment
+  if (isComment(node) && node.data === '[') {
+    let next = node.nextSibling
+    while (next && next.nodeType === DOMNodeTypes.ELEMENT) {
+      cb(next as Element)
+      next = next.nextSibling
+    }
+  } else {
+    cb(node as Element)
+  }
 }

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -1,0 +1,19 @@
+export type HydrationStrategy = (el: Element, hydrate: () => void) => () => void
+
+export type HydrationStrategyFactory<Options = any> = (
+  options?: Options,
+) => HydrationStrategy
+
+export const hydrateOnTimeout: HydrationStrategyFactory<number> =
+  (delay = 100) =>
+  (el, hydrate) =>
+  () =>
+    setTimeout(hydrate, delay)
+
+export const hydrateOnVisible: HydrationStrategyFactory<number> = margin => {
+  return hydrate => () => hydrate
+}
+
+export const hydrateOnMediaQuery: HydrationStrategyFactory<string> = query => {
+  return hydrate => () => hydrate
+}

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -75,9 +75,18 @@ export const hydrateOnInteraction: HydrationStrategyFactory<
 export function forEachElement(node: Node, cb: (el: Element) => void) {
   // fragment
   if (isComment(node) && node.data === '[') {
+    let depth = 1
     let next = node.nextSibling
-    while (next && next.nodeType === DOMNodeTypes.ELEMENT) {
-      cb(next as Element)
+    while (next) {
+      if (next.nodeType === DOMNodeTypes.ELEMENT) {
+        cb(next as Element)
+      } else if (isComment(next)) {
+        if (next.data === ']') {
+          if (--depth === 0) break
+        } else if (next.data === '[') {
+          depth++
+        }
+      }
       next = next.nextSibling
     }
   } else {

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -51,20 +51,18 @@ export const hydrateOnInteraction: HydrationStrategyFactory<
     let hasHydrated = false
     const doHydrate = () => {
       if (!hasHydrated) {
-        hydrate()
         hasHydrated = true
-        for (const el of els) {
+        forEachNode(node, el => {
           for (const i of interactions) {
             el.removeEventListener(i, doHydrate)
           }
-        }
+        })
+        hydrate()
       }
     }
-    const els: Element[] = []
     forEachNode(node, el => {
       for (const i of interactions) {
         el.addEventListener(i, doHydrate, { once: true })
-        els.push(el)
       }
     })
   }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -64,7 +64,12 @@ export { useAttrs, useSlots } from './apiSetupHelpers'
 export { useModel } from './helpers/useModel'
 export { useTemplateRef } from './helpers/useTemplateRef'
 export { useId } from './helpers/useId'
-export { hydrateOnTimeout } from './hydrationStrategies'
+export {
+  hydrateOnIdle,
+  hydrateOnVisible,
+  hydrateOnMediaQuery,
+  hydrateOnInteraction,
+} from './hydrationStrategies'
 
 // <script setup> API ----------------------------------------------------------
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -64,6 +64,7 @@ export { useAttrs, useSlots } from './apiSetupHelpers'
 export { useModel } from './helpers/useModel'
 export { useTemplateRef } from './helpers/useTemplateRef'
 export { useId } from './helpers/useId'
+export { hydrateOnTimeout } from './hydrationStrategies'
 
 // <script setup> API ----------------------------------------------------------
 
@@ -327,6 +328,10 @@ export type {
   AsyncComponentOptions,
   AsyncComponentLoader,
 } from './apiAsyncComponent'
+export type {
+  HydrationStrategy,
+  HydrationStrategyFactory,
+} from './hydrationStrategies'
 export type { HMRRuntime } from './hmr'
 
 // Internal API ----------------------------------------------------------------

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1325,16 +1325,10 @@ function baseCreateRenderer(
             }
           }
 
-          if (
-            isAsyncWrapperVNode &&
-            !(type as ComponentOptions).__asyncResolved
-          ) {
-            ;(type as ComponentOptions).__asyncLoader!().then(
-              // note: we are moving the render call into an async callback,
-              // which means it won't track dependencies - but it's ok because
-              // a server-rendered async wrapper is already in resolved state
-              // and it will never need to change.
-              () => !instance.isUnmounted && hydrateSubTree(),
+          if (isAsyncWrapperVNode) {
+            ;(type as ComponentOptions).__asyncHydrate!(
+              instance,
+              hydrateSubTree,
             )
           } else {
             hydrateSubTree()

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1327,6 +1327,7 @@ function baseCreateRenderer(
 
           if (isAsyncWrapperVNode) {
             ;(type as ComponentOptions).__asyncHydrate!(
+              el as Element,
               instance,
               hydrateSubTree,
             )

--- a/packages/vue/__tests__/e2e/e2eUtils.ts
+++ b/packages/vue/__tests__/e2e/e2eUtils.ts
@@ -30,12 +30,19 @@ export async function expectByPolling(
   }
 }
 
-export function setupPuppeteer() {
+export function setupPuppeteer(args?: string[]) {
   let browser: Browser
   let page: Page
 
+  const resolvedOptions = args
+    ? {
+        ...puppeteerOptions,
+        args: [...puppeteerOptions.args!, ...args],
+      }
+    : puppeteerOptions
+
   beforeAll(async () => {
-    browser = await puppeteer.launch(puppeteerOptions)
+    browser = await puppeteer.launch(resolvedOptions)
   }, 20000)
 
   beforeEach(async () => {

--- a/packages/vue/__tests__/e2e/hydration-strat-custom.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-custom.html
@@ -1,0 +1,40 @@
+<script src="../../dist/vue.global.js"></script>
+
+<div><span id="custom-trigger">click here to hydrate</span></div>
+<div id="app"><button>0</button></div>
+
+<script>
+  window.isHydrated = false
+  const { createSSRApp, defineAsyncComponent, h, ref, onMounted } = Vue
+
+  const Comp = {
+    setup() {
+      const count = ref(0)
+      onMounted(() => {
+        console.log('hydrated')
+        window.isHydrated = true
+      })
+      return () => {
+        return h('button', { onClick: () => count.value++ }, count.value)
+      }
+    },
+  }
+
+  const AsyncComp = defineAsyncComponent({
+    loader: () => Promise.resolve(Comp),
+    hydrate: (hydrate, el) => {
+      document.getElementById('custom-trigger').addEventListener('click', () => {
+        hydrate()
+      }, { once: true })
+    }
+  })
+
+  createSSRApp({
+    setup() {
+      onMounted(() => {
+        window.isRootMounted = true
+      })
+      return () => h(AsyncComp)
+    }
+  }).mount('#app')
+</script>

--- a/packages/vue/__tests__/e2e/hydration-strat-custom.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-custom.html
@@ -23,18 +23,22 @@
   const AsyncComp = defineAsyncComponent({
     loader: () => Promise.resolve(Comp),
     hydrate: (hydrate, el) => {
-      document.getElementById('custom-trigger').addEventListener('click', () => {
-        hydrate()
-      }, { once: true })
+      const triggerEl = document.getElementById('custom-trigger')
+      triggerEl.addEventListener('click', hydrate, { once: true })
+      return () => {
+        window.teardownCalled = true
+        triggerEl.removeEventListener('click', hydrate)
+      }
     }
   })
 
+  const show = window.show = ref(true)
   createSSRApp({
     setup() {
       onMounted(() => {
         window.isRootMounted = true
       })
-      return () => h(AsyncComp)
+      return () => show.value ? h(AsyncComp) : 'off'
     }
   }).mount('#app')
 </script>

--- a/packages/vue/__tests__/e2e/hydration-strat-idle.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-idle.html
@@ -1,0 +1,37 @@
+<script src="../../dist/vue.global.js"></script>
+
+<div id="app"><button>0</button></div>
+
+<script>
+  const { createSSRApp, defineAsyncComponent, h, ref, onMounted, hydrateOnIdle } = Vue
+
+  const Comp = {
+    setup() {
+      const count = ref(0)
+      onMounted(() => {
+        console.log('hydrated')
+        window.isHydrated = true
+      })
+      return () => h('button', { onClick: () => count.value++ }, count.value)
+    },
+  }
+
+  const AsyncComp = defineAsyncComponent({
+    loader: () => new Promise(resolve => {
+      setTimeout(() => {
+        console.log('resolve')
+        resolve(Comp)
+        requestIdleCallback(() => {
+          console.log('busy')
+        })
+      }, 10)
+    }),
+    hydrate: hydrateOnIdle()
+  })
+
+  createSSRApp({
+    render() {
+      return h(AsyncComp)
+    },
+  }).mount('#app')
+</script>

--- a/packages/vue/__tests__/e2e/hydration-strat-idle.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-idle.html
@@ -3,6 +3,7 @@
 <div id="app"><button>0</button></div>
 
 <script>
+  window.isHydrated = false
   const { createSSRApp, defineAsyncComponent, h, ref, onMounted, hydrateOnIdle } = Vue
 
   const Comp = {
@@ -30,8 +31,6 @@
   })
 
   createSSRApp({
-    render() {
-      return h(AsyncComp)
-    },
+    render: () => h(AsyncComp)
   }).mount('#app')
 </script>

--- a/packages/vue/__tests__/e2e/hydration-strat-interaction.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-interaction.html
@@ -1,0 +1,47 @@
+<script src="../../dist/vue.global.js"></script>
+
+<div>click to hydrate</div>
+<div id="app"><button>0</button></div>
+<style>body { margin: 0 }</style>
+
+<script>
+  const isFragment = location.search.includes('?fragment')
+  if (isFragment) {
+    document.getElementById('app').innerHTML = `<!--[--><span>one</span><button>0</button><span>two</span><!--]-->`
+  }
+
+  window.isHydrated = false
+  const { createSSRApp, defineAsyncComponent, h, ref, onMounted, hydrateOnInteraction } = Vue
+
+  const Comp = {
+    setup() {
+      const count = ref(0)
+      onMounted(() => {
+        console.log('hydrated')
+        window.isHydrated = true
+      })
+      return () => {
+        const button = h('button', { onClick: () => count.value++ }, count.value)
+        if (isFragment) {
+          return [h('span', 'one'), button, h('span', 'two')]
+        } else {
+          return button
+        }
+      }
+    },
+  }
+
+  const AsyncComp = defineAsyncComponent({
+    loader: () => Promise.resolve(Comp),
+    hydrate: hydrateOnInteraction(['click', 'wheel'])
+  })
+
+  createSSRApp({
+    setup() {
+      onMounted(() => {
+        window.isRootMounted = true
+      })
+      return () => h(AsyncComp)
+    }
+  }).mount('#app')
+</script>

--- a/packages/vue/__tests__/e2e/hydration-strat-interaction.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-interaction.html
@@ -7,7 +7,8 @@
 <script>
   const isFragment = location.search.includes('?fragment')
   if (isFragment) {
-    document.getElementById('app').innerHTML = `<!--[--><span>one</span><button>0</button><span>two</span><!--]-->`
+    document.getElementById('app').innerHTML =
+      `<!--[--><!--[--><span>one</span><!--]--><button>0</button><span>two</span><!--]-->`
   }
 
   window.isHydrated = false
@@ -23,7 +24,7 @@
       return () => {
         const button = h('button', { onClick: () => count.value++ }, count.value)
         if (isFragment) {
-          return [h('span', 'one'), button, h('span', 'two')]
+          return [[h('span', 'one')], button, h('span', 'two')]
         } else {
           return button
         }

--- a/packages/vue/__tests__/e2e/hydration-strat-media.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-media.html
@@ -1,0 +1,36 @@
+<script src="../../dist/vue.global.js"></script>
+
+<div>resize the window width to < 500px to hydrate</div>
+<div id="app"><button>0</button></div>
+
+<script>
+  window.isHydrated = false
+  const { createSSRApp, defineAsyncComponent, h, ref, onMounted, hydrateOnMediaQuery } = Vue
+
+  const Comp = {
+    setup() {
+      const count = ref(0)
+      onMounted(() => {
+        console.log('hydrated')
+        window.isHydrated = true
+      })
+      return () => {
+        return h('button', { onClick: () => count.value++ }, count.value)
+      }
+    },
+  }
+
+  const AsyncComp = defineAsyncComponent({
+    loader: () => Promise.resolve(Comp),
+    hydrate: hydrateOnMediaQuery('(max-width:500px)')
+  })
+
+  createSSRApp({
+    setup() {
+      onMounted(() => {
+        window.isRootMounted = true
+      })
+      return () => h(AsyncComp)
+    }
+  }).mount('#app')
+</script>

--- a/packages/vue/__tests__/e2e/hydration-strat-visible.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-visible.html
@@ -1,0 +1,46 @@
+<script src="../../dist/vue.global.js"></script>
+
+<div style="height: 1000px">scroll to the bottom to hydrate</div>
+<div id="app"><button>0</button></div>
+
+<script>
+  const isFragment = location.search.includes('?fragment')
+  if (isFragment) {
+    document.getElementById('app').innerHTML = `<!--[--><span>one</span><button>0</button><span>two</span><!--]-->`
+  }
+
+  window.isHydrated = false
+  const { createSSRApp, defineAsyncComponent, h, ref, onMounted, hydrateOnVisible } = Vue
+
+  const Comp = {
+    setup() {
+      const count = ref(0)
+      onMounted(() => {
+        console.log('hydrated')
+        window.isHydrated = true
+      })
+      return () => {
+        const button = h('button', { onClick: () => count.value++ }, count.value)
+        if (isFragment) {
+          return [h('span', 'one'), button, h('span', 'two')]
+        } else {
+          return button
+        }
+      }
+    },
+  }
+
+  const AsyncComp = defineAsyncComponent({
+    loader: () => Promise.resolve(Comp),
+    hydrate: hydrateOnVisible()
+  })
+
+  createSSRApp({
+    setup() {
+      onMounted(() => {
+        window.isRootMounted = true
+      })
+      return () => h(AsyncComp)
+    }
+  }).mount('#app')
+</script>

--- a/packages/vue/__tests__/e2e/hydration-strat-visible.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-visible.html
@@ -2,8 +2,10 @@
 
 <div style="height: 1000px">scroll to the bottom to hydrate</div>
 <div id="app"><button>0</button></div>
+<style>body { margin: 0 }</style>
 
 <script>
+  const rootMargin = location.search.match(/rootMargin=(\d+)/)?.[1] ?? 0
   const isFragment = location.search.includes('?fragment')
   if (isFragment) {
     document.getElementById('app').innerHTML = `<!--[--><span>one</span><button>0</button><span>two</span><!--]-->`
@@ -32,7 +34,7 @@
 
   const AsyncComp = defineAsyncComponent({
     loader: () => Promise.resolve(Comp),
-    hydrate: hydrateOnVisible()
+    hydrate: hydrateOnVisible(rootMargin + 'px')
   })
 
   createSSRApp({

--- a/packages/vue/__tests__/e2e/hydration-strat-visible.html
+++ b/packages/vue/__tests__/e2e/hydration-strat-visible.html
@@ -8,7 +8,8 @@
   const rootMargin = location.search.match(/rootMargin=(\d+)/)?.[1] ?? 0
   const isFragment = location.search.includes('?fragment')
   if (isFragment) {
-    document.getElementById('app').innerHTML = `<!--[--><span>one</span><button>0</button><span>two</span><!--]-->`
+    document.getElementById('app').innerHTML =
+      `<!--[--><!--[--><span>one</span><!--]--><button>0</button><span>two</span><!--]-->`
   }
 
   window.isHydrated = false
@@ -24,7 +25,7 @@
       return () => {
         const button = h('button', { onClick: () => count.value++ }, count.value)
         if (isFragment) {
-          return [h('span', 'one'), button, h('span', 'two')]
+          return [[h('span', 'one')], button, h('span', 'two')]
         } else {
           return button
         }

--- a/packages/vue/__tests__/e2e/hydrationStrategies.spec.ts
+++ b/packages/vue/__tests__/e2e/hydrationStrategies.spec.ts
@@ -1,0 +1,42 @@
+import path from 'node:path'
+import { setupPuppeteer } from './e2eUtils'
+
+declare const window: { isHydrated: boolean }
+
+describe('async component hydration strategies', () => {
+  const { page, click, text } = setupPuppeteer()
+
+  async function goToCase(name: string) {
+    const file = `file://${path.resolve(__dirname, `./hydration-strat-${name}.html`)}`
+    await page().goto(file)
+  }
+
+  async function assertHydrationSuccess() {
+    await click('button')
+    expect(await text('button')).toBe('1')
+  }
+
+  test('idle', async () => {
+    const messages: string[] = []
+    page().on('console', e => messages.push(e.text()))
+
+    await goToCase('idle')
+    // not hydrated yet
+    expect(await page().evaluate(() => window.isHydrated)).toBe(undefined)
+    // wait for hydration
+    await page().waitForFunction(() => window.isHydrated)
+    // assert message order: hyration should happen after already queued main thread work
+    expect(messages.slice(1)).toMatchObject(['resolve', 'busy', 'hydrated'])
+    await assertHydrationSuccess()
+  })
+
+  test('visible', async () => {})
+
+  test('visible (fragment)', async () => {})
+
+  test('media query', async () => {})
+
+  test('interaction', async () => {})
+
+  test('interaction (fragment)', async () => {})
+})

--- a/packages/vue/__tests__/e2e/hydrationStrategies.spec.ts
+++ b/packages/vue/__tests__/e2e/hydrationStrategies.spec.ts
@@ -90,4 +90,13 @@ describe('async component hydration strategies', () => {
     expect(await text('button')).toBe('1')
     await assertHydrationSuccess('2')
   })
+
+  test('custom', async () => {
+    await goToCase('custom')
+    await page().waitForFunction(() => window.isRootMounted)
+    expect(await page().evaluate(() => window.isHydrated)).toBe(false)
+    await click('#custom-trigger')
+    await page().waitForFunction(() => window.isHydrated)
+    await assertHydrationSuccess()
+  })
 })


### PR DESCRIPTION
Async components can now control when they are hydrated by providing a hydration strategy.

- Vue provides a number of built-in hydration strategies. These built-in strategies need to be individually imported so they can be tree-shaken if not used.

- The design is intentionally low-level for flexibility. Compiler syntax sugar can potentially be built on top of this in the future either in core or in higher level solutions (e.g. Nuxt).

- Why is it coupled to async components? Mostly because async components are already natural boundaries for async operations inside a render tree. Async sub trees require special handling in regards of reactivity tracking and suspense resolution. By coupling async hydration to async components we can support the feature without introducing extra complexities when it interacts with those other areas of concerns.

  The result of this coupling is that one can't have a component that is eagerly loaded but lazily hydrated - which seems illogical to begin with.

### Hydrate on Idle

Hydrates via `requestIdleCallback`:

```js
import { defineAsyncComponent, hydrateOnIdle } from 'vue'

const AsyncComp = defineAsyncComponent({
  loader: () => import('./Comp.vue'),
  hydrate: hydrateOnIdle()
})
```

### Hydrate on Visible

Hydrate when element(s) become visible via `IntersectionObserver`.

```js
import { defineAsyncComponent, hydrateOnVisible } from 'vue'

const AsyncComp = defineAsyncComponent({
  loader: () => import('./Comp.vue'),
  hydrate: hydrateOnVisible()
})
```

Can optionally pass in a `rootMargin` value for the observer:

```js
// if string, must be valid value for the `rootMargin` option for IntersectionObserver
hydrateOnVisible('100px')

// can also be a number - px will be auto-appended
hydrateOnVisible(100)
```

### Hydrate on Media Query

Hydrates when the specified media query matches.

```js
import { defineAsyncComponent, hydrateOnMediaQuery } from 'vue'

const AsyncComp = defineAsyncComponent({
  loader: () => import('./Comp.vue'),
  hydrate: hydrateOnMediaQuery('(max-width:500px)')
})
```

### Hydrate on Interaction

Hydrates when specified event(s) are triggered on the component element(s). The event that triggered the hydration will also be replayed once hydration is complete.

```js
import { defineAsyncComponent, hydrateOnInteraction } from 'vue'

const AsyncComp = defineAsyncComponent({
  loader: () => import('./Comp.vue'),
  hydrate: hydrateOnInteraction('click')
})
```

Can also be a list of multiple event types:

```js
hydrateOnInteraction(['wheel', 'mouseover'])
```

### Custom Strategy

```ts
import { defineAsyncComponent, type HydrationStrategy } from 'vue'

const myStrategy: HydrationStrategy = (hydrate, forEachElement) => {
  // forEachElement is a helper to iterate through all the root elememts
  // in the component's non-hydrated DOM, since the root can be a fragment
  // instead of a single element
  forEachElement(el => {
    // ...
  })
  // call `hydrate` when ready
  hydrate()
  return () => {
    // return a teardown function if needed
  }
}

const AsyncComp = defineAsyncComponent({
  loader: () => import('./Comp.vue'),
  hydrate: myStrategy
})
```