### PR TITLE
dx(useTemplateRef): warn when declaring with the same key

### DIFF
--- a/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
@@ -68,4 +68,18 @@ describe('useTemplateRef', () => {
     expect(t2!.value).toBe(root.children[0])
     expect(t1!.value).toBe(null)
   })
+
+  test('should warn on duplicate useTemplateRef', () => {
+    const root = nodeOps.createElement('div')
+    render(
+      h(() => {
+        useTemplateRef('foo')
+        useTemplateRef('foo')
+        return ''
+      }),
+      root,
+    )
+
+    expect(`useTemplateRef('foo') already exists.`).toHaveBeenWarned()
+  })
 })

--- a/packages/runtime-core/src/helpers/useTemplateRef.ts
+++ b/packages/runtime-core/src/helpers/useTemplateRef.ts
@@ -10,11 +10,21 @@ export function useTemplateRef<T = unknown>(
   const r = shallowRef(null)
   if (i) {
     const refs = i.refs === EMPTY_OBJ ? (i.refs = {}) : i.refs
-    Object.defineProperty(refs, key, {
-      enumerable: true,
-      get: () => r.value,
-      set: val => (r.value = val),
-    })
+
+    let desc: PropertyDescriptor | undefined
+    if (
+      __DEV__ &&
+      (desc = Object.getOwnPropertyDescriptor(refs, key)) &&
+      !desc.configurable
+    ) {
+      warn(`useTemplateRef('${key}') already exists.`)
+    } else {
+      Object.defineProperty(refs, key, {
+        enumerable: true,
+        get: () => r.value,
+        set: val => (r.value = val),
+      })
+    }
   } else if (__DEV__) {
     warn(
       `useTemplateRef() is called when there is no active component ` +


### PR DESCRIPTION
Declaring `useTemplateRef` with the same key multiple times results in a `TypeError: Cannot redefine property: xxx` at runtime, see [playground](https://play.vuejs.org/#eNp9kE9Lw0AQxb/Kspco1EQIvdQYUOlBDyq1xwUJySTdutld9k8MhHx3ZxNbK2hvu+/3ZubNDPRO67jzQFc0c9BqUTjImSQkq3hHDNS3jNZKMZpnCSqIsuTEh19bGq4dseC8JqKQDVY4iwVM8lYr48hAvIXtd9EGajKS2qiWRDg3uglNfvOLCCdGl0j+07NknprTBc4qlax5E++tkrjGENIzWqpWcwHmRTuuJOZZkYkEVgihPp8mzRkPi4Ne7qD8+EPf2z5ojL4asGA6YPTIXGEacDNevz1Dj+8jbFXlBbrPwA1YJXzIONvuvaww9olvSvs4nZLLZmvXvQNpD0uFoME5Tn5G8aYPZ1b/iZvG6VTH5IhXfO/AhJ54wDRextdXhdC7Il7S8QtbtLVb)

---

There's another issue: in dev mode, the `useTemplateRef` returned value is `readonly`:

```ts
return (__DEV__ ? readonly(r) : r) as any
```

When a variable declared with `useTemplateRef` has the same name as a template ref, a readonly warning appears, see [playground](https://play.vuejs.org/#eNp9UE1Lw0AQ/SvDXqJQU6H0UtOCSg96UKk9LkhIJ+nWze6yHzEQ8t+dTWwtIr3tvo+ZN69j98akTUC2YJnH2sjc44orgGwnGrBYLjkrteZslU0JISqbnuno6worjAeHPhiQuarI4R0ZuBK10dZDB8Hh9se0wRJ6KK2uIaG9yV0cUmjlPNAeWP7RXiWEJtekyqbjphWb0HxylKJKD04rit7FxJwVujZCon01XtBEzhYwMJHLpdRfzwPmbcDJES/2WHz+gx9cGzHO3iw6tA1yduJ8biv0I71+f8GW3iey1rsgSX2B3KDTMsSMo+whqB3FPtMNaZ+G+oSqtm7delTueFQMGpX9oOeMeny8cPpv3Fk6G3xc9dTiR4M2zqQCZ+k8vb3Jpdnn6Zz13/CnsNU=).

To avoid this issue, it seems that we need to check if `setupState[ref]` is `readonly` before setting its value every time in `rendererTemplateRef.ts`.

I'm not sure if this is worth it. Maybe we should only limit the `readonly` return type at the type level?