### PR TITLE
fix(ci): canary release workflow

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -95,7 +95,6 @@ export async function exec(command, args, options) {
       const ok = code === 0
       const stderr = Buffer.concat(stderrChunks).toString().trim()
       const stdout = Buffer.concat(stdoutChunks).toString().trim()
-      const result = { ok, code, stderr, stdout }
 
       if (ok) {
         const result = { ok, code, stderr, stdout }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -99,12 +99,13 @@ export async function exec(command, args, options) {
       if (ok) {
         const result = { ok, code, stderr, stdout }
         resolve(result)
+      } else {
+        reject(
+          new Error(
+            `Failed to execute command: ${command} ${args.join(' ')}: ${stderr}`,
+          )
+        )
       }
-      reject(
-        new Error(
-          `Failed to execute command: ${command} ${args.join(' ')}: ${stderr}`,
-        ),
-      )
     })
   })
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -96,7 +96,16 @@ export async function exec(command, args, options) {
       const stderr = Buffer.concat(stderrChunks).toString().trim()
       const stdout = Buffer.concat(stdoutChunks).toString().trim()
       const result = { ok, code, stderr, stdout }
-      resolve(result)
+
+      if (ok) {
+        const result = { ok, code, stderr, stdout }
+        resolve(result)
+      }
+      reject(
+        new Error(
+          `Failed to execute command: ${command} ${args.join(' ')}: ${stderr}`,
+        ),
+      )
     })
   })
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -103,7 +103,7 @@ export async function exec(command, args, options) {
         reject(
           new Error(
             `Failed to execute command: ${command} ${args.join(' ')}: ${stderr}`,
-          )
+          ),
         )
       }
     })


### PR DESCRIPTION
This fixes the canary release workflow which has not run successfully in weeks due to the new exec util introduced in https://github.com/vuejs/core/commit/93324b2ec06b26662b77abc2a75d21ecbe8913db#diff-0b21831cd9ed897d64279bd0b4bb242a206cbf2f949101967ca14dba17bb7dd4 that doesn't reject bad exit codes compared to execa.

