### PR TITLE
feat(custom-element): inject child components styles to custom element shadow root

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -417,7 +417,7 @@ export interface ComponentInternalInstance {
    * is custom element?
    * @internal
    */
-  ce?: Element
+  ce?: ComponentCustomElementInterface
   /**
    * custom element specific HMR method
    * @internal
@@ -1236,4 +1236,9 @@ export function formatComponentName(
 
 export function isClassComponent(value: unknown): value is ClassComponent {
   return isFunction(value) && '__vccOpts' in value
+}
+
+export interface ComponentCustomElementInterface {
+  injectChildStyle(type: ConcreteComponent): void
+  removeChildStlye(type: ConcreteComponent): void
 }

--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -159,6 +159,11 @@ function reload(id: string, newComp: HMRComponent) {
         '[HMR] Root or manually mounted instance modified. Full reload required.',
       )
     }
+
+    // update custom element child style
+    if (instance.root.ce && instance !== instance.root) {
+      instance.root.ce.removeChildStlye(oldComp)
+    }
   }
 
   // 5. make sure to cleanup dirty hmr components after update

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -263,6 +263,7 @@ export type {
   GlobalComponents,
   GlobalDirectives,
   ComponentInstance,
+  ComponentCustomElementInterface,
 } from './component'
 export type {
   DefineComponent,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1276,8 +1276,8 @@ function baseCreateRenderer(
     const componentUpdateFn = () => {
       if (!instance.isMounted) {
         let vnodeHook: VNodeHook | null | undefined
-        const { el, props, type } = initialVNode
-        const { bm, m, parent } = instance
+        const { el, props } = initialVNode
+        const { bm, m, parent, root, type } = instance
         const isAsyncWrapperVNode = isAsyncWrapper(initialVNode)
 
         toggleRecurse(instance, false)
@@ -1335,6 +1335,11 @@ function baseCreateRenderer(
             hydrateSubTree()
           }
         } else {
+          // custom element style injection
+          if (root.ce) {
+            root.ce.injectChildStyle(type)
+          }
+
           if (__DEV__) {
             startMeasure(instance, `render`)
           }


### PR DESCRIPTION
close #4662
close #6610
close #7941

This references both #6610 and #7942 but implements it in a way that minimizes changes to `runtime-core` and also handles HMR for child-injected styles, without relying on changes to `@vitejs/plugin-vue`.

With this change, a `*.ce.vue` component can import other `*.ce.vue` components and use them directly as Vue child components instead of custom elements. Child component's styles will be injected as native `<style>` tags into the root custom element's shadow root:

```js
import { defineCustomElement } from 'vue'
import Root from './Root.ce.vue'

customElements.define('my-el', defineCustomElement(Root))
```

```vue
<!-- Root.ce.vue -->
<script setup>
import Child from './Child.ce.vue'
</script>
```

```vue
<!-- Child.ce.vue -->
<style>
div { color: red }; /* will be injected to Root.ce.vue's shadow root */
</style>
```