### PR TITLE
fix: ref getter value error

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -470,9 +470,20 @@ describe('reactivity/ref', () => {
 
   // #11532
   test('ref should be unwrapped when getting the value', () => {
-    const b = ref(ref(1))
+    const a = ref(0)
+    const b = ref()
+    b.value = a
+    expect(b.value).toBe(0)
+
+    b.value++
     expect(b.value).toBe(1)
+    expect(a.value).toBe(1)
+
     b.value = ref(2)
     expect(b.value).toBe(2)
+
+    b.value++
+    expect(b.value).toBe(3)
+    expect(a.value).toBe(1)
   })
 })

--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -467,4 +467,12 @@ describe('reactivity/ref', () => {
     expect(toValue(c)).toBe(3)
     expect(toValue(d)).toBe(4)
   })
+
+  // #11532
+  test('ref should be unwrapped when getting the value', () => {
+    const b = ref(ref(1))
+    expect(b.value).toBe(1)
+    b.value = ref(2)
+    expect(b.value).toBe(2)
+  })
 })

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -158,7 +158,6 @@ function createRef(rawValue: unknown, shallow: boolean) {
 class RefImpl<T> {
   private _value: T
   private _rawValue: T
-
   public dep?: Dep = undefined
   public readonly __v_isRef = true
 
@@ -176,14 +175,18 @@ class RefImpl<T> {
   }
 
   set value(newVal) {
-    const useDirectValue =
-      this.__v_isShallow || isShallow(newVal) || isReadonly(newVal)
-    newVal = useDirectValue ? newVal : toRaw(newVal)
-    if (hasChanged(newVal, this._rawValue)) {
-      const oldVal = this._rawValue
-      this._rawValue = newVal
-      this._value = useDirectValue ? newVal : toReactive(newVal)
-      triggerRefValue(this, DirtyLevels.Dirty, newVal, oldVal)
+    if (!isRef(newVal) && isRef(this._rawValue)) {
+      this._rawValue.value = newVal
+    } else {
+      const useDirectValue =
+        this.__v_isShallow || isShallow(newVal) || isReadonly(newVal)
+      newVal = useDirectValue ? newVal : toRaw(newVal)
+      if (hasChanged(newVal, this._rawValue)) {
+        const oldVal = this._rawValue
+        this._rawValue = newVal
+        this._value = useDirectValue ? newVal : toReactive(newVal)
+        triggerRefValue(this, DirtyLevels.Dirty, newVal, oldVal)
+      }
     }
   }
 }

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -172,7 +172,7 @@ class RefImpl<T> {
 
   get value() {
     trackRefValue(this)
-    return this._value
+    return unref(this._value)
   }
 
   set value(newVal) {


### PR DESCRIPTION
fix #11532

Ref should be unwrapped when getting the value; otherwise, it can cause the following issues:

```ts
const b = ref(ref(1))
console.log(b.value) // 1

b.value = ref(2)
console.log(b.value) // ref(2)
```

When we set a new ref to the ref setter, subsequent getter and setter operations will be handled by the new ref instead of the original ref. This is to maintain consistency with `ref(ref(1))` returning `ref(1)`. However, while the reference returned by `ref(ref(1))` is the same, the setter ref involves two different refs: 

```ts
const a = ref(0)
const b = ref(a)
console.log(a === b) // true
b.value++ // a.value === b.value === 1

const c = ref(0)
const d = ref()
d.value = c
console.log(c === d) // false
d.value++ // d.value === c.value === 1
```