### PR TITLE
fix(defineModel): detect changes respect custom getter and setter

### DIFF
--- a/packages/runtime-core/__tests__/helpers/useModel.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useModel.spec.ts
@@ -657,4 +657,50 @@ describe('useModel', () => {
     expect(setValue).toBeCalledTimes(2)
     expect(msg.value).toBe(defaultVal)
   })
+
+    test('custom setter',() => {
+    let changeChildMsg!: (val: boolean) => void
+
+    const Comp = defineComponent({
+      props: ['msg'],
+      emits: ['update:msg'],
+      setup(props) {
+        const childMsg = useModel(props, 'msg',{
+          set: (value) => {
+            if (value === msg.value) {
+              return null;
+            } else {
+              return value;
+            }
+          }
+        })
+        changeChildMsg = (val: boolean) => (childMsg.value = val)
+        return () => {
+          return childMsg.value
+        }
+      },
+    })
+
+    const defaultVal = false
+    const msg = ref(defaultVal)
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          h(Comp, {
+            msg: msg.value,
+            'onUpdate:msg': val => {
+              msg.value = val
+            },
+          })
+      },
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Parent), root)
+
+    changeChildMsg(true)
+    expect(msg.value).toBe(true)
+
+    changeChildMsg(true)
+    expect(msg.value).toBe(null)
 })

--- a/packages/runtime-core/__tests__/helpers/useModel.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useModel.spec.ts
@@ -658,21 +658,21 @@ describe('useModel', () => {
     expect(msg.value).toBe(defaultVal)
   })
 
-   test('custom setter',() => {
+  test('custom setter', () => {
     let changeChildMsg!: (val: boolean) => void
 
     const Comp = defineComponent({
       props: ['msg'],
       emits: ['update:msg'],
       setup(props) {
-        const childMsg = useModel(props, 'msg',{
-          set: (value) => {
+        const childMsg = useModel(props, 'msg', {
+          set: value => {
             if (value === msg.value) {
-              return null;
+              return null
             } else {
-              return value;
+              return value
             }
-          }
+          },
         })
         changeChildMsg = (val: boolean) => (childMsg.value = val)
         return () => {

--- a/packages/runtime-core/__tests__/helpers/useModel.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useModel.spec.ts
@@ -701,6 +701,7 @@ describe('useModel', () => {
     changeChildMsg(!getter(msg.value))
     expect(msg.value).toBe(false)
   })
+
   // #11541
   test('custom setter', () => {
     let changeChildMsg!: (val: boolean) => void

--- a/packages/runtime-core/__tests__/helpers/useModel.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useModel.spec.ts
@@ -658,6 +658,49 @@ describe('useModel', () => {
     expect(msg.value).toBe(defaultVal)
   })
 
+  test('custom getter', () => {
+    let changeChildMsg!: (val: boolean) => void
+    const getter = (value: boolean) => !value
+
+    const Comp = defineComponent({
+      props: ['msg'],
+      emits: ['update:msg'],
+      setup(props) {
+        const childMsg = useModel(props, 'msg', {
+          get: getter,
+          set: value => !value,
+        })
+        changeChildMsg = (val: boolean) => (childMsg.value = val)
+        return () => {
+          return childMsg.value
+        }
+      },
+    })
+
+    const defaultVal = false
+    const msg = ref(defaultVal)
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          h(Comp, {
+            msg: msg.value,
+            'onUpdate:msg': val => {
+              msg.value = val
+            },
+          })
+      },
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Parent), root)
+
+    changeChildMsg(!getter(msg.value))
+    expect(msg.value).toBe(true)
+
+    changeChildMsg(!getter(msg.value))
+    expect(msg.value).toBe(false)
+  })
+
   test('custom setter', () => {
     let changeChildMsg!: (val: boolean) => void
 

--- a/packages/runtime-core/__tests__/helpers/useModel.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useModel.spec.ts
@@ -658,6 +658,7 @@ describe('useModel', () => {
     expect(msg.value).toBe(defaultVal)
   })
 
+  // #11526
   test('custom getter', () => {
     let changeChildMsg!: (val: boolean) => void
     const getter = (value: boolean) => !value
@@ -700,7 +701,7 @@ describe('useModel', () => {
     changeChildMsg(!getter(msg.value))
     expect(msg.value).toBe(false)
   })
-
+  // #11541
   test('custom setter', () => {
     let changeChildMsg!: (val: boolean) => void
 

--- a/packages/runtime-core/__tests__/helpers/useModel.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useModel.spec.ts
@@ -658,7 +658,7 @@ describe('useModel', () => {
     expect(msg.value).toBe(defaultVal)
   })
 
-    test('custom setter',() => {
+   test('custom setter',() => {
     let changeChildMsg!: (val: boolean) => void
 
     const Comp = defineComponent({
@@ -703,4 +703,5 @@ describe('useModel', () => {
 
     changeChildMsg(true)
     expect(msg.value).toBe(null)
+  })
 })

--- a/packages/runtime-core/src/helpers/useModel.ts
+++ b/packages/runtime-core/src/helpers/useModel.ts
@@ -51,8 +51,9 @@ export function useModel(
       },
 
       set(value) {
+        const emittedValue = options.set ? options.set(value) : value
         if (
-          !hasChanged(value, localValue) &&
+          !hasChanged(emittedValue, localValue) &&
           !(prevSetValue !== EMPTY_OBJ && hasChanged(value, prevSetValue))
         ) {
           return
@@ -74,7 +75,7 @@ export function useModel(
           localValue = value
           trigger()
         }
-        const emittedValue = options.set ? options.set(value) : value
+        
         i.emit(`update:${name}`, emittedValue)
         // #10279: if the local value is converted via a setter but the value
         // emitted to parent was the same, the parent will not trigger any

--- a/packages/runtime-core/src/helpers/useModel.ts
+++ b/packages/runtime-core/src/helpers/useModel.ts
@@ -75,7 +75,7 @@ export function useModel(
           localValue = value
           trigger()
         }
-        
+
         i.emit(`update:${name}`, emittedValue)
         // #10279: if the local value is converted via a setter but the value
         // emitted to parent was the same, the parent will not trigger any


### PR DESCRIPTION
resolve: https://github.com/vuejs/core/issues/11541
resolve: https://github.com/vuejs/core/issues/11526
related: https://github.com/vuejs/core/pull/11527

This change can solve both problems https://github.com/vuejs/core/issues/11541 and https://github.com/vuejs/core/issues/11526 at the same time, but it is only for the sake of solving the problem. I think it needs to be fundamentally solved from the design point of view. The logic of `haschange` should judge the custom setter and getter together. 

```ts
 set(value) {
  if (
    !hasChanged(options.set ? options.set(value) : value, options.get ? options.get(localValue) : localValue) &&
    !(prevSetValue !== EMPTY_OBJ && hasChanged(value, prevSetValue))
  ) {
    return
    }
     ....
}
```

If it is changed like this, then the phenomenon of https://github.com/vuejs/core/issues/11526 It's not a problem, it's in line with expectations