### PR TITLE
workflow: only verify commit message on main&minor branch

### DIFF
--- a/scripts/verify-commit.js
+++ b/scripts/verify-commit.js
@@ -2,27 +2,38 @@
 import pico from 'picocolors'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
+import { exec } from './utils.js'
 
-const msgPath = path.resolve('.git/COMMIT_EDITMSG')
-const msg = readFileSync(msgPath, 'utf-8').trim()
+main()
 
-const commitRE =
-  /^(revert: )?(feat|fix|docs|dx|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release)(\(.+\))?: .{1,50}/
+async function main() {
+  const { stdout: branch } = await exec('git', ['branch', '--show-current'])
+  // only verify commit message on main and minor branches
+  if (branch !== 'main' && branch !== 'minor') {
+    return
+  }
 
-if (!commitRE.test(msg)) {
-  console.log()
-  console.error(
-    `  ${pico.white(pico.bgRed(' ERROR '))} ${pico.red(
-      `invalid commit message format.`,
-    )}\n\n` +
-      pico.red(
-        `  Proper commit message format is required for automated changelog generation. Examples:\n\n`,
-      ) +
-      `    ${pico.green(`feat(compiler): add 'comments' option`)}\n` +
-      `    ${pico.green(
-        `fix(v-model): handle events on blur (close #28)`,
+  const msgPath = path.resolve('.git/COMMIT_EDITMSG')
+  const msg = readFileSync(msgPath, 'utf-8').trim()
+
+  const commitRE =
+    /^(revert: )?(feat|fix|docs|dx|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release)(\(.+\))?: .{1,50}/
+
+  if (!commitRE.test(msg)) {
+    console.log()
+    console.error(
+      `  ${pico.white(pico.bgRed(' ERROR '))} ${pico.red(
+        `invalid commit message format.`,
       )}\n\n` +
-      pico.red(`  See .github/commit-convention.md for more details.\n`),
-  )
-  process.exit(1)
+        pico.red(
+          `  Proper commit message format is required for automated changelog generation. Examples:\n\n`,
+        ) +
+        `    ${pico.green(`feat(compiler): add 'comments' option`)}\n` +
+        `    ${pico.green(
+          `fix(v-model): handle events on blur (close #28)`,
+        )}\n\n` +
+        pico.red(`  See .github/commit-convention.md for more details.\n`),
+    )
+    process.exit(1)
+  }
 }


### PR DESCRIPTION
For other branches, the commit message is set by the PR title before merging.