### PR TITLE
fix(compiler-core): initialize `isProp.exp` with `arg.loc` instead of `isProp.loc`

### DIFF
--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -250,7 +250,7 @@ export function resolveComponentType(
         exp = isProp.exp
         if (!exp) {
           // #10469 handle :is shorthand
-          exp = createSimpleExpression(`is`, false, isProp.loc)
+          exp = createSimpleExpression(`is`, false, isProp.arg!.loc)
           if (!__BROWSER__) {
             exp = isProp.exp = processExpression(exp, context)
           }


### PR DESCRIPTION
![122fde0b1e904c2efb3bb26ab7a9832d](https://github.com/user-attachments/assets/c70d2f11-f240-48d4-853d-b7a8f9d1eb94)

align with https://github.com/vuejs/core/blob/29425df1acb9e520c6ae894d06bcff73fde90edd/packages/compiler-core/src/transforms/vBind.ts#L106