### PR TITLE
fix(types/ref): correct type inference for generics w/ `Ref` when omitting initial value

### DIFF
--- a/packages/dts-test/ref.test-d.ts
+++ b/packages/dts-test/ref.test-d.ts
@@ -209,6 +209,37 @@ describe('allow computed getter and setter types to be unrelated', () => {
   expectType<string>(c.value)
 })
 
+declare class Foo {
+  private _: number
+}
+
+describe('omit the initial value and specify a generic type w/ `Ref` type', <T>() => {
+  const a = ref<{ foo: Ref<number> }>()
+  expectType<{ foo: number } | undefined>(a.value)
+  expectType<number>(a.value!.foo)
+  a.value = undefined
+  a.value = { foo: ref(1) }
+  a.value!.foo = 2
+  // @ts-expect-error
+  a.value.foo.value = 2
+
+  const b = ref<Ref<number>>()
+  expectType<Ref<number> | undefined>(b.value)
+  expectType<number>(b.value!.value)
+  b.value = undefined
+  b.value = ref(1)
+  b.value!.value = 1
+
+  const c = ref<T>()
+  c.value = undefined
+  c.value = {} as T
+
+  const d = ref<Foo>()
+  expectType<Ref<Foo | undefined>>(d)
+  d.value = new Foo()
+  expectType<Foo | undefined>(d.value)
+})
+
 // shallowRef
 type Status = 'initial' | 'ready' | 'invalidating'
 const shallowStatus = shallowRef<Status>('initial')

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -1,5 +1,6 @@
 import {
   type IfAny,
+  type PublicOf,
   hasChanged,
   isArray,
   isFunction,
@@ -55,7 +56,13 @@ export function isRef(r: any): r is Ref {
 export function ref<T>(
   value: T,
 ): [T] extends [Ref] ? IfAny<T, Ref<T>, T> : Ref<UnwrapRef<T>, UnwrapRef<T> | T>
-export function ref<T = any>(): Ref<T | undefined>
+
+export function ref<T = any>(): [T] extends [Ref]
+  ? Ref<T | undefined>
+  : PublicOf<T> extends T
+    ? Ref<UnwrapRef<T> | undefined, UnwrapRef<T> | T | undefined>
+    : Ref<T | undefined>
+
 export function ref(value?: unknown) {
   return createRef(value, false)
 }

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -30,6 +30,13 @@ export type OverloadParameters<T extends (...args: any[]) => any> = Parameters<
   OverloadUnion<T>
 >
 
+/**
+ * Utility for strip out `private` / `protected` fields
+ */
+export type PublicOf<T> = {
+  [P in keyof T]: T[P]
+}
+
 type OverloadProps<TOverload> = Pick<TOverload, keyof TOverload>
 
 type OverloadUnionRecursive<


### PR DESCRIPTION
close #10799