### PR TITLE
chore: fix wrong test name for useShadowRoot

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -975,7 +975,7 @@ describe('defineCustomElement', () => {
     })
   })
 
-  describe('useCustomElementRoot', () => {
+  describe('useShadowRoot', () => {
     test('should work for style injection', () => {
       const Foo = defineCustomElement({
         setup() {


### PR DESCRIPTION
My PR was originally fixing the warning as well, but Evan already fixed it in https://github.com/vuejs/core/commit/197afc2c: the test is still with the previous name though.