### PR TITLE
refactor(runtime-core): add undefined check of directive handling

### DIFF
--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -129,7 +129,7 @@ export function invokeDirectiveHook(
   const oldBindings = prevVNode && prevVNode.dirs!
   for (let i = 0; i < bindings.length; i++) {
     const binding = bindings[i]
-    if (oldBindings) {
+    if (oldBindings && oldBindings[i]) {
       binding.oldValue = oldBindings[i].value
     }
     let hook = binding.dir[name] as DirectiveHook | DirectiveHook[] | undefined


### PR DESCRIPTION
relate to #11555

In some cases, the directive array length may change dynamically (when using dynamic vnode with `withDirectives`). 

Adds an `undefined` check in the directive handling logic to prevent potential runtime errors.