### PR TITLE
fix(types/custom-element): `defineCustomElement` with required props

### DIFF
--- a/packages/dts-test/defineCustomElement.test-d.ts
+++ b/packages/dts-test/defineCustomElement.test-d.ts
@@ -99,4 +99,37 @@ describe('defineCustomElement using defineComponent return type', () => {
     expectType<number | undefined>(instance.a)
     instance.a = 42
   })
+
+  test('with required props', () => {
+    const Comp1Vue = defineComponent({
+      props: {
+        a: { type: Number, required: true },
+      },
+    })
+    const Comp = defineCustomElement(Comp1Vue)
+    expectType<VueElementConstructor>(Comp)
+
+    const instance = new Comp()
+    expectType<number>(instance.a)
+    instance.a = 42
+  })
+
+  test('with default props', () => {
+    const Comp1Vue = defineComponent({
+      props: {
+        a: {
+          type: Number,
+          default: 1,
+          validator: () => true,
+        },
+      },
+      emits: ['click'],
+    })
+    const Comp = defineCustomElement(Comp1Vue)
+    expectType<VueElementConstructor>(Comp)
+
+    const instance = new Comp()
+    expectType<number>(instance.a)
+    instance.a = 42
+  })
 })

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -9,6 +9,7 @@ import {
   type ComponentOptionsBase,
   type ComponentOptionsMixin,
   type ComponentProvideOptions,
+  type ComponentPublicInstance,
   type ComputedOptions,
   type ConcreteComponent,
   type CreateAppFunction,
@@ -153,14 +154,13 @@ export function defineCustomElement<
 // overload 3: defining a custom element from the returned value of
 // `defineComponent`
 export function defineCustomElement<
-  T extends DefineComponent<any, any, any, any>,
+  // this should be `ComponentPublicInstanceConstructor` but that type is not exported
+  T extends { new (...args: any[]): ComponentPublicInstance<any> },
 >(
   options: T,
   extraOptions?: CustomElementOptions,
 ): VueElementConstructor<
-  T extends DefineComponent<infer P, any, any, any>
-    ? ExtractPropTypes<P>
-    : unknown
+  T extends DefineComponent<infer P, any, any, any> ? P : unknown
 >
 
 /*! #__NO_SIDE_EFFECTS__ */


### PR DESCRIPTION
Fixes type error when using `defineCustomElement` with `required: true` props.

```ts
const Comp1Vue = defineComponent({
  props: {
    a: { type: Number, required: true },
  },
})
const Comp = defineCustomElement(Comp1Vue)
//                               ^^^^^^^^ No overload matches this call. ts(2769)
```
```
No overload matches this call.
  The last overload gave the following error.
    Argument of type 'DefineComponent<ExtractPropTypes<{ a: { type: NumberConstructor; required: true; }; }>, ...>' is not assignable to parameter of type 'DefineComponent<any, any, any, any>'.
      Type 'DefineComponent<ExtractPropTypes<{ a: { type: NumberConstructor; required: true; }; }>, ...>' is not assignable to type 'ComponentOptionsBase<Readonly<any>, ...>'.
        Types of property 'setup' are incompatible.
          Type '(this: void, props: LooseRequired<Readonly<{ a: number; } & {} & {}> & {}>, ...) => void | ...' is not assignable to type '(this: void, props: LooseRequired<Readonly<any> & {}>, ...) => any'.
            Types of parameters 'props' and 'props' are incompatible.
              Property 'a' is missing in type 'LooseRequired<Readonly<any> & {}>' but required in type 'LooseRequired<Readonly<{ a: number; } & {} & {}> & {}>'.
```

---

In addition, this PR also removes an unnecessary `ExtractPropTypes`. Before this change:
```ts
const Comp: VueElementConstructor<ExtractPropTypes<ExtractPropTypes<{
    a: {
        type: NumberConstructor;
        required: true;
    };
}>>>
// `Comp` is `VueElementConstructor<{ a?: number | undefined }>`
```
After this change:
```ts
const Comp: VueElementConstructor<ExtractPropTypes<{
    a: {
        type: NumberConstructor;
        required: true;
    };
}>>
// `Comp` is `VueElementConstructor<{ a: number }>`
```