### PR TITLE
chore: add explicit type annotation to `initDirectivesForSSR`

### DIFF
--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -283,7 +283,7 @@ let ssrDirectiveInitialized = false
 /**
  * @internal
  */
-export const initDirectivesForSSR = __SSR__
+export const initDirectivesForSSR: () => void = __SSR__
   ? () => {
       if (!ssrDirectiveInitialized) {
         ssrDirectiveInitialized = true


### PR DESCRIPTION
Resolves TS error `Variable must have an explicit type annotation with –isolatedDeclarations.ts(9010)`