### PR TITLE
perf: remove unnecessary check as filter is always non-null

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -195,10 +195,10 @@ const KeepAliveImpl: ComponentOptions = {
       _unmount(vnode, instance, parentSuspense, true)
     }
 
-    function pruneCache(filter?: (name: string) => boolean) {
+    function pruneCache(filter: (name: string) => boolean) {
       cache.forEach((vnode, key) => {
         const name = getComponentName(vnode.type as ConcreteComponent)
-        if (name && (!filter || !filter(name))) {
+        if (name && !filter(name)) {
           pruneCacheEntry(key)
         }
       })


### PR DESCRIPTION
the filter is always not null
https://github.com/vuejs/core/blob/ad603c663dbde31e520afe9d6cd6d81e3e293dcd/packages/runtime-core/src/components/KeepAlive.ts#L224-L225