### PR TITLE
fix(runtime-core): fix inject with currentApp

### DIFF
--- a/packages/runtime-core/__tests__/apiCreateApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiCreateApp.spec.ts
@@ -126,11 +126,13 @@ describe('api: createApp', () => {
 
         childApp.provide('foo', 2)
         expect(childApp.runWithContext(() => inject('foo'))).toBe(2)
+        expect(childApp.runWithContext(() => inject('bar'))).toBe('bar')
 
         return () => h('div')
       },
     })
     app.provide('foo', 1)
+    app.provide('bar', 'bar')
 
     expect(app.runWithContext(() => inject('foo'))).toBe(1)
     const root = nodeOps.createElement('div')

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -68,10 +68,10 @@ export function inject(
     if (currentApp) {
       const currentProvides = currentApp._context.provides
       if ((key as string | symbol) in currentProvides) {
-        const target = currentProvides[key as string]
-        return target
+        return currentProvides[key as string]
       }
-    } else if (provides && (key as string | symbol) in provides) {
+    }
+    if (provides && (key as string | symbol) in provides) {
       // TS doesn't allow symbol as index type
       return provides[key as string]
     } else if (arguments.length > 1) {

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -59,11 +59,6 @@ export function inject(
     // to support `app.use` plugins,
     // fallback to appContext's `provides` if the instance is at root
     // #11488, in a nested createApp, prioritize using the provides from currentApp
-    const provides = instance
-      ? instance.parent == null
-        ? instance.vnode.appContext && instance.vnode.appContext.provides
-        : instance.parent.provides
-      : undefined
 
     if (currentApp) {
       const currentProvides = currentApp._context.provides
@@ -71,6 +66,13 @@ export function inject(
         return currentProvides[key as string]
       }
     }
+
+    const provides = instance
+      ? instance.parent == null
+        ? instance.vnode.appContext && instance.vnode.appContext.provides
+        : instance.parent.provides
+      : undefined
+
     if (provides && (key as string | symbol) in provides) {
       // TS doesn't allow symbol as index type
       return provides[key as string]

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -59,15 +59,19 @@ export function inject(
     // to support `app.use` plugins,
     // fallback to appContext's `provides` if the instance is at root
     // #11488, in a nested createApp, prioritize using the provides from currentApp
-    const provides = currentApp
-      ? currentApp._context.provides
-      : instance
-        ? instance.parent == null
-          ? instance.vnode.appContext && instance.vnode.appContext.provides
-          : instance.parent.provides
-        : undefined
+    const provides = instance
+      ? instance.parent == null
+        ? instance.vnode.appContext && instance.vnode.appContext.provides
+        : instance.parent.provides
+      : undefined
 
-    if (provides && (key as string | symbol) in provides) {
+    if (currentApp) {
+      const currentProvides = currentApp._context.provides
+      if ((key as string | symbol) in currentProvides) {
+        const target = currentProvides[key as string]
+        return target
+      }
+    } else if (provides && (key as string | symbol) in provides) {
       // TS doesn't allow symbol as index type
       return provides[key as string]
     } else if (arguments.length > 1) {


### PR DESCRIPTION
```ts
const app = createApp({
  setup() {
    const childApp = createApp({
      setup() { },
    })
    expect(childApp.runWithContext(() => inject('bar'))).toBe('bar')
    return () => h('div')
  },
})

app.provide('bar', 'bar')
```

What is expected?
` expect(childApp.runWithContext(() => inject('bar'))).toBe('bar')`
What is actually happening?
![image](https://github.com/user-attachments/assets/11984d03-1f94-4b7e-a423-7884e19ee796)
