### PR TITLE
fix(types): update examples in JSDoc for augmenting global properties and custom options

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -91,7 +91,7 @@ import { markAsyncBoundary } from './helpers/useId'
  *
  * @example
  * ```ts
- * declare module '@vue/runtime-core' {
+ * declare module 'vue' {
  *   interface ComponentCustomOptions {
  *     beforeRouteUpdate?(
  *       to: Route,

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -65,7 +65,7 @@ import type { Directive } from './directives'
  * import { createApp } from 'vue'
  * import { Router, createRouter } from 'vue-router'
  *
- * declare module '@vue/runtime-core' {
+ * declare module 'vue' {
  *   interface ComponentCustomProperties {
  *     $router: Router
  *   }


### PR DESCRIPTION
Update JSDoc examples for augmentation to be consistent with the examples in the docs https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties.

Fixes #11605.