### PR TITLE
docs: modify email link error

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,6 @@ Please note that we do not consider XSS via template expressions a valid attack 
 
 We would like to thank the following security researchers for responsibly disclosing security issues to us.
 
-- Jeet Pal - [@jeetpal2007](https://github.com/jeetpal2007) | [Email](jeetpal2007@gmail.com) | [LinkedIn](https://in.linkedin.com/in/jeet-pal-22601a290)
+- Jeet Pal - [@jeetpal2007](https://github.com/jeetpal2007) | [Email](mailto:jeetpal2007@gmail.com) | [LinkedIn](https://in.linkedin.com/in/jeet-pal-22601a290)
 - Mix - [@mnixry](https://github.com/mnixry)
 - Aviv Keller - [@RedYetiDev](https://github.com/redyetidev) | [LinkedIn](https://www.linkedin.com/in/redyetidev) <redyetidev@gmail.com>


### PR DESCRIPTION
Update SECURITY.md

Incorrect linking causes the email to jump to an error, which I think needs attention, although it does not affect the overall usability.