### PR TITLE
Fix waiting for server prefetch in server renderer plus async refactor

### DIFF
--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -873,6 +873,26 @@ function testRender(type: string, render: typeof renderToString) {
       expect(html).toBe(`<div>hello</div>`)
     })
 
+    test('serverPrefetch w/ async setup', async () => {
+      const msg = Promise.resolve('hello')
+      const app = createApp({
+        data() {
+          return {
+            msg: '',
+          }
+        },
+        async serverPrefetch() {
+          this.msg = await msg
+        },
+        render() {
+          return h('div', this.msg)
+        },
+        async setup() {},
+      })
+      const html = await render(app)
+      expect(html).toBe(`<div>hello</div>`)
+    })
+
     // #2763
     test('error handling w/ async setup', async () => {
       const fn = vi.fn()


### PR DESCRIPTION
Refactors `renderComponentVNode` to be async, which allows the implementation to be a little more simple and less repetitive.

* This removes some internal logic, and it now always returns a promise.
* The motivation for this is here https://github.com/vuejs/core/pull/10893#discussion_r1719474822

❗ This PR is intended to be merged into https://github.com/vuejs/core/pull/10893, not the `main` brach, [in order to amend it to satisfy feedback](https://github.com/vuejs/core/pull/10893#discussion_r1719474822).