### PR TITLE
perf(hydration): avoid observer if element is in viewport

### DIFF
--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -109,7 +109,10 @@ export function forEachElement(node: Node, cb: (el: Element) => void): void {
     let next = node.nextSibling
     while (next) {
       if (next.nodeType === DOMNodeTypes.ELEMENT) {
-        cb(next as Element)
+        const result = cb(next as Element)
+        if (result === false) {
+          break
+        }
       } else if (isComment(next)) {
         if (next.data === ']') {
           if (--depth === 0) break

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -102,7 +102,7 @@ export const hydrateOnInteraction: HydrationStrategyFactory<
     return teardown
   }
 
-export function forEachElement(node: Node, cb: (el: Element) => void): void {
+export function forEachElement(node: Node, cb: (el: Element) => void | false): void {
   // fragment
   if (isComment(node) && node.data === '[') {
     let depth = 1

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -102,7 +102,10 @@ export const hydrateOnInteraction: HydrationStrategyFactory<
     return teardown
   }
 
-export function forEachElement(node: Node, cb: (el: Element) => void | false): void {
+export function forEachElement(
+  node: Node,
+  cb: (el: Element) => void | false,
+): void {
   // fragment
   if (isComment(node) && node.data === '[') {
     let depth = 1

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -51,7 +51,7 @@ export const hydrateOnVisible: HydrationStrategyFactory<
     if (elementIsVisibleInViewport(el)) {
       hydrate()
       ob.disconnect()
-      return () => {}
+      return false
     }
     ob.observe(el)
   })

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -50,7 +50,8 @@ export const hydrateOnVisible: HydrationStrategyFactory<
   forEach(el => {
     if (elementIsVisibleInViewport(el)) {
       hydrate()
-      return () => ob.disconnect()
+      ob.disconnect()
+      return () => {}
     }
     ob.observe(el)
   })

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -28,6 +28,7 @@ export const hydrateOnIdle: HydrationStrategyFactory<number> =
 
 function elementIsVisibleInViewport (el: Element) {
   const { top, left, bottom, right } = el.getBoundingClientRect()
+  // eslint-disable-next-line no-restricted-globals
   const { innerHeight, innerWidth } = window
   return ((top > 0 && top < innerHeight) ||
     (bottom > 0 && bottom < innerHeight)) &&

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -12,7 +12,7 @@ import { DOMNodeTypes, isComment } from './hydration'
  */
 export type HydrationStrategy = (
   hydrate: () => void,
-  forEachElement: (cb: (el: Element) => any) => void | false,
+  forEachElement: (cb: (el: Element) => any) => void,
 ) => (() => void) | void
 
 export type HydrationStrategyFactory<Options> = (

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -12,7 +12,7 @@ import { DOMNodeTypes, isComment } from './hydration'
  */
 export type HydrationStrategy = (
   hydrate: () => void,
-  forEachElement: (cb: (el: Element) => any) => void,
+  forEachElement: (cb: (el: Element) => any) => void | false,
 ) => (() => void) | void
 
 export type HydrationStrategyFactory<Options> = (

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -26,13 +26,14 @@ export const hydrateOnIdle: HydrationStrategyFactory<number> =
     return () => cancelIdleCallback(id)
   }
 
-function elementIsVisibleInViewport (el: Element) {
+function elementIsVisibleInViewport(el: Element) {
   const { top, left, bottom, right } = el.getBoundingClientRect()
   // eslint-disable-next-line no-restricted-globals
   const { innerHeight, innerWidth } = window
-  return ((top > 0 && top < innerHeight) ||
-    (bottom > 0 && bottom < innerHeight)) &&
+  return (
+    ((top > 0 && top < innerHeight) || (bottom > 0 && bottom < innerHeight)) &&
     ((left > 0 && left < innerWidth) || (right > 0 && right < innerWidth))
+  )
 }
 
 export const hydrateOnVisible: HydrationStrategyFactory<
@@ -47,7 +48,7 @@ export const hydrateOnVisible: HydrationStrategyFactory<
     }
   }, opts)
   forEach(el => {
-    if (elementIsVisibleInViewport(el)){
+    if (elementIsVisibleInViewport(el)) {
       hydrate()
       return () => ob.disconnect()
     }

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -26,6 +26,14 @@ export const hydrateOnIdle: HydrationStrategyFactory<number> =
     return () => cancelIdleCallback(id)
   }
 
+function elementIsVisibleInViewport (el: Element) {
+  const { top, left, bottom, right } = el.getBoundingClientRect()
+  const { innerHeight, innerWidth } = window
+  return ((top > 0 && top < innerHeight) ||
+    (bottom > 0 && bottom < innerHeight)) &&
+    ((left > 0 && left < innerWidth) || (right > 0 && right < innerWidth))
+}
+
 export const hydrateOnVisible: HydrationStrategyFactory<
   IntersectionObserverInit
 > = opts => (hydrate, forEach) => {
@@ -37,7 +45,13 @@ export const hydrateOnVisible: HydrationStrategyFactory<
       break
     }
   }, opts)
-  forEach(el => ob.observe(el))
+  forEach(el => {
+    if (elementIsVisibleInViewport(el)){
+      hydrate()
+      return () => ob.disconnect()
+    }
+    ob.observe(el)
+  })
   return () => ob.disconnect()
 }
 


### PR DESCRIPTION
This PR optimizes the intersection based hydration by avoiding the observer overhead if the element is visible initially, ensuring it is immediately hydrated, as opposed to waiting for the observer to run its callback

The approach is originally taken from https://github.com/nuxt/nuxt/pull/26468/files#diff-8e89e3233ee017161774c7e5df6b9a18cc926d5a1b4081e7fcbf9651109ce45d by @huang-julien 