### PR TITLE
refactor(scheduler): remove invalidateJob

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -3,7 +3,6 @@ import {
   SchedulerJobFlags,
   flushPostFlushCbs,
   flushPreFlushCbs,
-  invalidateJob,
   nextTick,
   queueJob,
   queuePostFlushCb,
@@ -411,33 +410,6 @@ describe('scheduler', () => {
       await nextTick()
       expect(calls).toEqual(['job1', 'job2', 'cb1', 'cb2'])
     })
-  })
-
-  test('invalidateJob', async () => {
-    const calls: string[] = []
-    const job1 = () => {
-      calls.push('job1')
-      invalidateJob(job2)
-      job2()
-    }
-    const job2 = () => {
-      calls.push('job2')
-    }
-    const job3 = () => {
-      calls.push('job3')
-    }
-    const job4 = () => {
-      calls.push('job4')
-    }
-    // queue all jobs
-    queueJob(job1)
-    queueJob(job2)
-    queueJob(job3)
-    queuePostFlushCb(job4)
-    expect(calls).toEqual([])
-    await nextTick()
-    // job2 should be called only once
-    expect(calls).toEqual(['job1', 'job2', 'job3', 'job4'])
   })
 
   test('sort job based on id', async () => {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -45,7 +45,6 @@ import {
   type SchedulerJobs,
   flushPostFlushCbs,
   flushPreFlushCbs,
-  invalidateJob,
   queueJob,
   queuePostFlushCb,
 } from './scheduler'
@@ -1255,9 +1254,6 @@ function baseCreateRenderer(
       } else {
         // normal update
         instance.next = n2
-        // in case the child component is also queued, remove it to avoid
-        // double updating the same child component in the same flush.
-        invalidateJob(instance.update)
         // instance.update is the reactive effect.
         instance.update()
       }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -118,13 +118,6 @@ function queueFlush() {
   }
 }
 
-export function invalidateJob(job: SchedulerJob): void {
-  const i = queue.indexOf(job)
-  if (i > flushIndex) {
-    queue.splice(i, 1)
-  }
-}
-
 export function queuePostFlushCb(cb: SchedulerJobs): void {
   if (!isArray(cb)) {
     if (activePostFlushCbs && cb.id === -1) {


### PR DESCRIPTION
Closes #7745.

I have an old PR, #7745, that fixes a minor bug in `invalidateJob`. However, since Vue 3.4, the external symptoms of the bug disappeared. The problem in the code is still present, but it can no longer be reproduced via the public API.

Longer explanation at https://github.com/vuejs/core/pull/7745#issuecomment-2143943660.

In short, I believe we no longer need to use `invalidateJob` to remove child jobs from the queue. We can just leave the job in the queue. Since 3.4, update jobs check their `dirty` flag before doing anything else, so running an unnecessary job is very cheap.

Removing the job involves calls to `indexOf` and `splice`, neither of which are cheap operations. Using a flag instead is similar to the approach used by `invalidateMount` (see https://github.com/vuejs/core/pull/9370#issuecomment-2154128432).

The test for `invalidateJob` had to be removed too. I've added a couple of new tests to try to cover some of the relevant edge cases, but testing via the public API.