### PR TITLE
feat(watch): accept watch callback return cleanup function

### DIFF
--- a/packages/reactivity/__tests__/watch.spec.ts
+++ b/packages/reactivity/__tests__/watch.spec.ts
@@ -193,4 +193,21 @@ describe('watch', () => {
     scope.stop()
     expect(calls).toEqual(['sync 2', 'post 2'])
   })
+
+  test('watch callback return cleanup function', async () => {
+    const fn = vi.fn()
+
+    const scope = new EffectScope()
+
+    scope.run(() => {
+      const ource = ref(0)
+      watch(ource, () => fn)
+      ource.value++
+    })
+
+    scope.stop()
+    await nextTick()
+
+    expect(fn).toBeCalledTimes(1)
+  })
 })

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -60,7 +60,7 @@ export interface WatchOptions<Immediate = boolean> extends DebuggerOptions {
     fn: Function | Function[],
     type: WatchErrorCodes,
     args?: unknown[],
-  ) => void
+  ) => any
 }
 
 export type WatchStopHandle = () => void
@@ -257,10 +257,13 @@ export function watch(
                 : oldValue,
             boundCleanup,
           ]
-          call
+          const cleanup = call
             ? call(cb!, WatchErrorCodes.WATCH_CALLBACK, args)
             : // @ts-expect-error
               cb!(...args)
+          if (isFunction(cleanup)) {
+            boundCleanup(cleanup)
+          }
           oldValue = newValue
         } finally {
           activeWatcher = currentWatcher


### PR DESCRIPTION
In the current version, we can clear the callback side effects using `watch` as follows:

```ts
watch(id, async (newId, oldId, onCleanup) => {
  const { response, cancel } = doAsyncWork(newId)
  // `cancel` will be called if `id` changes, cancelling
  // the previous request if it hasn't completed yet
  onCleanup(cancel)
  data.value = await response
})
```

After version 3.5.0-beta.3, we can use `onWatcherCleanup` to clear side effects:

```ts
watch(id, async (newId, oldId) => {
  const { response, cancel } = doAsyncWork(newId)
  // `cancel` will be called if `id` changes, cancelling
  // the previous request if it hasn't completed yet
  onWatcherCleanup(cancel)
  data.value = await response
})
```

This pull request proposes discussing the possibility of introducing a method to support returning a function as one way of cleanup.

```ts
watch(id, (newId, oldId) => {
  const { response, cancel } = doAsyncWork(newId)
  response.then(result => data.value = result)
  return cancel
})
```

The inspiration for this approach comes from React’s `useEffect`:

```ts
  useEffect(() => {
    const connection = createConnection(serverUrl, roomId);
    connection.connect();
    return () => {
      connection.disconnect();
    };
  }, [serverUrl, roomId]);
```

I believe this could be particularly friendly for developers transitioning from React to Vue, hence my initiative to introduce it here.

However, this might introduce some migration costs, such as when using arrow functions:

```ts
watch(value, (newValue) => array.push(newValue))
```

Here, the callback returns a number, which clearly isn't a cleanup function. Therefore, in implementation, it would only collect as a cleanup function if the return is a function. From my personal experience, it is uncommon to return a function in this context, so the impact should be minimal.

I would be most grateful for any feedback on this approach. If there are any concerns or alternative suggestions, please do not hesitate to share them. I am eager to make any necessary adjustments to accommodate community insights.