### PR TITLE
fix(build): update paths for private packages in `dev` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dev-sfc-serve": "vite packages-private/sfc-playground --host",
     "dev-sfc-run": "run-p \"dev compiler-sfc -f esm-browser\" \"dev vue -if esm-bundler-runtime\" \"dev vue -ipf esm-browser-runtime\" \"dev server-renderer -if esm-bundler\" dev-sfc-serve",
     "serve": "serve",
-    "open": "open http://localhost:3000/packages/template-explorer/local.html",
+    "open": "open http://localhost:3000/packages-private/template-explorer/local.html",
     "build-sfc-playground": "run-s build-all-cjs build-runtime-esm build-browser-esm build-ssr-esm build-sfc-playground-self",
     "build-all-cjs": "node scripts/build.js vue runtime compiler reactivity shared -af cjs",
     "build-runtime-esm": "node scripts/build.js runtime reactivity shared -af esm-bundler && node scripts/build.js vue -f esm-bundler-runtime && node scripts/build.js vue -f esm-browser-runtime",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -5,6 +5,7 @@
 // smaller files and provides better tree-shaking.
 
 import esbuild from 'esbuild'
+import fs from 'node:fs'
 import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
@@ -52,11 +53,17 @@ const postfix = format.endsWith('-runtime')
   ? `runtime.${format.replace(/-runtime$/, '')}`
   : format
 
+const privatePackages = fs.readdirSync('packages-private')
+
 for (const target of targets) {
-  const pkg = require(`../packages/${target}/package.json`)
+  const pkgBase = privatePackages.includes(target)
+    ? `packages-private`
+    : `packages`
+  const pkgBasePath = `../${pkgBase}/${target}`
+  const pkg = require(`${pkgBasePath}/package.json`)
   const outfile = resolve(
     __dirname,
-    `../packages/${target}/dist/${
+    `${pkgBasePath}/dist/${
       target === 'vue-compat' ? `vue` : target
     }.${postfix}.${prod ? `prod.` : ``}js`,
   )
@@ -122,7 +129,7 @@ for (const target of targets) {
 
   esbuild
     .context({
-      entryPoints: [resolve(__dirname, `../packages/${target}/src/index.ts`)],
+      entryPoints: [resolve(__dirname, `${pkgBasePath}/src/index.ts`)],
       outfile,
       bundle: true,
       external,


### PR DESCRIPTION
Corrected the paths in the `dev` scripts for `template-explorer` after its migration to the `packages-private` directory