### PR TITLE
fix(compile-sfc): handle setup and data return variables with the same name

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1066,6 +1066,28 @@ describe('SFC analyze <script> bindings', () => {
     expect(bindings!.__isScriptSetup).toBe(false)
   })
 
+  it('recognizes setup return + data return', () => {
+    const { bindings } = compile(`
+      <script>
+        export default {
+          setup() {
+            return {
+              foo: 1,
+            }
+          },
+          data(){
+            return {
+              foo: 1
+            }
+          }
+        }
+      </script>
+    `)
+    expect(bindings).toStrictEqual({
+      foo: BindingTypes.SETUP_MAYBE_REF,
+    })
+  })
+
   it('recognizes exported vars', () => {
     const { bindings } = compile(`
       <script>

--- a/packages/compiler-sfc/src/script/analyzeScriptBindings.ts
+++ b/packages/compiler-sfc/src/script/analyzeScriptBindings.ts
@@ -87,6 +87,8 @@ function analyzeBindingsFromOptions(node: ObjectExpression): BindingMetadata {
           bodyItem.argument.type === 'ObjectExpression'
         ) {
           for (const key of getObjectExpressionKeys(bodyItem.argument)) {
+            // use variables in setup first, consistent with runtime
+            if (bindings[key] === BindingTypes.SETUP_MAYBE_REF) continue
             bindings[key] =
               property.key.name === 'setup'
                 ? BindingTypes.SETUP_MAYBE_REF


### PR DESCRIPTION
close #11674