### PR TITLE
fix(compat): click modifiers

### DIFF
--- a/packages/vue-compat/__tests__/compiler.spec.ts
+++ b/packages/vue-compat/__tests__/compiler.spec.ts
@@ -113,6 +113,26 @@ test('COMPILER_V_ON_NATIVE', () => {
   expect(CompilerDeprecationTypes.COMPILER_V_ON_NATIVE).toHaveBeenWarned()
 })
 
+test('COMPILER_V_ON_NATIVE with capture modifier', () => {
+  const spy = vi.fn()
+  const vm = new Vue({
+    template: `<child @click.capture="spy" />`,
+    components: {
+      child: {
+        template: `<button />`,
+      },
+    },
+    methods: {
+      spy,
+    },
+  }).$mount()
+
+  expect(vm.$el).toBeInstanceOf(HTMLButtonElement)
+  triggerEvent(vm.$el as HTMLButtonElement, 'click')
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(CompilerDeprecationTypes.COMPILER_V_ON_NATIVE).toHaveBeenWarned()
+})
+
 test('COMPILER_V_IF_V_FOR_PRECEDENCE', () => {
   new Vue({ template: `<div v-if="true" v-for="i in 1"/>` }).$mount()
   expect(


### PR DESCRIPTION
     - when the click "native" modifier is used in conjunction
       with the click "capture" modifier, the click is not
       registered in tests
     - see https://gitlab.com/groups/gitlab-org/-/epics/14951
       for more details
       
  
![image](https://github.com/user-attachments/assets/899806ab-98cf-4574-a332-6987bc516f6d)
