### PR TITLE
chore(reactivity): effectScope.ts variable declarations optimized and remove useless code in effect.ts

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -258,8 +258,7 @@ export function startBatch(): void {
  * @internal
  */
 export function endBatch(): void {
-  batchDepth--
-  if (batchDepth > 1) {
+  if (batchDepth-- > 0) {
     return
   }
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -258,12 +258,11 @@ export function startBatch(): void {
  * @internal
  */
 export function endBatch(): void {
+  batchDepth--
   if (batchDepth > 1) {
-    batchDepth--
     return
   }
 
-  batchDepth--
   let error: unknown
   while (batchedEffect) {
     let e: ReactiveEffect | undefined = batchedEffect

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -258,8 +258,7 @@ export function startBatch(): void {
  * @internal
  */
 export function endBatch(): void {
-  batchDepth--
-  if (batchDepth > 0) {
+  if (--batchDepth > 0) {
     return
   }
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -258,7 +258,8 @@ export function startBatch(): void {
  * @internal
  */
 export function endBatch(): void {
-  if (batchDepth-- > 0) {
+  batchDepth--
+  if (batchDepth > 0) {
     return
   }
 

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -53,12 +53,13 @@ export class EffectScope {
   pause(): void {
     if (this._active) {
       this._isPaused = true
+      let i, l
       if (this.scopes) {
-        for (let i = 0, l = this.scopes.length; i < l; i++) {
+        for (i = 0, l = this.scopes.length; i < l; i++) {
           this.scopes[i].pause()
         }
       }
-      for (let i = 0, l = this.effects.length; i < l; i++) {
+      for (i = 0, l = this.effects.length; i < l; i++) {
         this.effects[i].pause()
       }
     }
@@ -71,12 +72,13 @@ export class EffectScope {
     if (this._active) {
       if (this._isPaused) {
         this._isPaused = false
+        let i, l
         if (this.scopes) {
-          for (let i = 0, l = this.scopes.length; i < l; i++) {
+          for (i = 0, l = this.scopes.length; i < l; i++) {
             this.scopes[i].resume()
           }
         }
-        for (let i = 0, l = this.effects.length; i < l; i++) {
+        for (i = 0, l = this.effects.length; i < l; i++) {
           this.effects[i].resume()
         }
       }


### PR DESCRIPTION
This PR primarily modifies effectScope.ts, attempting to replace multiple let declarations within for loops with a single let declaration to enhance performance and maintain consistency with the stop function's style. Additionally, it removes redundant code from effect.ts.