### PR TITLE
chore: improve error message for missing template and script tag in vue file

### DIFF
--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -235,7 +235,7 @@ export function parse(
   if (!descriptor.template && !descriptor.script && !descriptor.scriptSetup) {
     errors.push(
       new SyntaxError(
-        `At least one <template> or <script> is required in a single file component.`,
+        `At least one <template> or <script> is required in a single file component. ${descriptor.filename}`,
       ),
     )
   }


### PR DESCRIPTION
Some error messages are missing this information, which results in search, which file is the reason for this:

![image](https://github.com/user-attachments/assets/3b936953-49c2-40b9-a8b9-a374572edd7a)
