### PR TITLE
fix(runtime core) : improve slot type definitions

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -2027,3 +2027,35 @@ expectString(instance.actionText)
 // public prop on $props should be optional
 // @ts-expect-error
 expectString(instance.$props.actionText)
+
+describe('with Slot', () => {
+  defineComponent({
+    slots: Object as SlotsType<{
+      default: { foo: string; bar: number }
+      optional?: { data: string }
+    }>,
+    setup(props, { slots }) {
+      expectType<
+        (scope: {
+          foo: string
+          bar: number
+        }) => VNode[] | VNode | null | undefined
+      >(slots.default)
+      expectType<
+        | ((scope: { data: string }) => VNode[] | VNode | null | undefined)
+        | undefined
+      >(slots.optional)
+
+      // Test slot invocation
+      const defaultResult = slots.default({ foo: 'foo', bar: 1 })
+      expectType<VNode[] | VNode | null | undefined>(defaultResult)
+
+      const optionalResult = slots.optional?.({ data: 'foo' })
+      expectType<VNode[] | VNode | null | undefined | undefined>(optionalResult)
+
+      // Test that single VNode, null, and undefined are allowed
+      slots.default({ foo: 'foo', bar: 1 })
+      slots.optional?.({ data: 'foo' })
+    },
+  })
+})


### PR DESCRIPTION
closes #11671 
## Description
This PR enhances the Slot type definition to allow for more flexible return types.

### Modified Slot type definition

Before: `(...args: any[]) => VNode[]`
After: `(...args: any[]) => VNode[] | VNode | null | undefined`


This change allows slot functions to return a single VNode, null, or undefined, better reflecting common patterns in actual Vue components.

Updated the normalizeSlot function to be compatible with the new Slot type.
Added type tests to ensure the new Slot type works as intended.