### PR TITLE
test(reactive): use vitest fn instead of counting manually

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -61,7 +61,7 @@ describe('reactivity/ref', () => {
 
     // mutating b.value should trigger the effect twice. (once for a.value change and once for b.value change)
     b.value = 5
-    expect(fn).toHaveBeenCalledTimes(3)
+    expect(fn).toHaveBeenCalledTimes(4)
     expect(dummy).toBe(5)
   })
 

--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -46,26 +46,22 @@ describe('reactivity/ref', () => {
   it('ref wrapped in reactive should not track internal _value access', () => {
     const a = ref(1)
     const b = reactive(a)
-    let calls = 0
     let dummy
-
-    effect(() => {
-      calls++
+    const fn = vi.fn(() => {
       dummy = b.value // this will observe both b.value and a.value access
     })
-    expect(calls).toBe(1)
+    effect(fn)
+    expect(fn).toHaveBeenCalledTimes(1)
     expect(dummy).toBe(1)
 
     // mutating a.value should only trigger effect once
-    calls = 0
     a.value = 3
-    expect(calls).toBe(1)
+    expect(fn).toHaveBeenCalledTimes(2)
     expect(dummy).toBe(3)
 
     // mutating b.value should trigger the effect twice. (once for a.value change and once for b.value change)
-    calls = 0
     b.value = 5
-    expect(calls).toBe(2)
+    expect(fn).toHaveBeenCalledTimes(3)
     expect(dummy).toBe(5)
   })
 


### PR DESCRIPTION
 I think it is more recommended to use Vitest's way instead
