### PR TITLE
fix(reactivity): ensure array extension methods execute correctly

### DIFF
--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -725,5 +725,26 @@ describe('reactivity/reactive/Array', () => {
       expect(state.things.map('foo', 'bar', 'baz')).toEqual(['1', '2', '3'])
       expect(state.things.some('foo', 'bar', 'baz')).toBe(true)
     })
+
+    test('computed + extend methods', () => {
+      class Collection extends Array {
+        find(matcher: any) {
+          return super.find(matcher)
+        }
+      }
+
+      const state = reactive({
+        // @ts-expect-error
+        things: new Collection({ foo: '' }),
+      })
+
+      const bar = computed(() => {
+        return state.things.find((obj: any) => obj.foo === 'bar')
+      })
+      bar.value
+      state.things[0].foo = 'bar'
+
+      expect(bar.value).toEqual({ foo: 'bar' })
+    })
   })
 })

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -86,7 +86,12 @@ class BaseReactiveHandler implements ProxyHandler<Target> {
 
     if (!isReadonly) {
       let fn: Function | undefined
-      if (targetIsArray && (fn = arrayInstrumentations[key])) {
+      if (
+        targetIsArray &&
+        // @ts-expect-error our code is limited to es2016 but user code is not
+        (target as any[])[key] === Array.prototype[key] &&
+        (fn = arrayInstrumentations[key])
+      ) {
         return fn
       }
       if (key === 'hasOwnProperty') {


### PR DESCRIPTION
close #11759

[this pr -- playground](https://deploy-preview-11761--vue-sfc-playground.netlify.app/#eNp9U8Fu2zAM/RVCFztA4By2UxCn64oetsM2bDvq4ti061SWBIlKOxj+91HS3GXAEMCGYfLp8T2SmsW9tdUloNiLg2/daAk8UrBHqcfJGkcwQ2smGwi7LThsWhovCAv0zkxQ8MlCaqlb1XgPD0YpZIDRgK+EuvNw71zzC2apAfpRd+XUUPuEbpNDwIwUnAYfLLrqH0TML1Lzw/RGexZGDSHUbyrKxEFPox78HjS+XAkoZ+iN2UNRwMJU8V1pTo1jktVUWW6gPmY5q5hYp8q8WZM5nSOIPxWzQl3XUDBN8Ye5Dzq75mS5SVS5FDVuQOJqtyiT0w5PYRjQJUfpVK6U66Q2HHZ5QDwa/iGcrGJS/gM4WIfHeU7W7u6g0IZYS9BdsSyHXUzGM4w7BSLW+aFVY/tcS1Fu6mMSLUUiYuExAxMm+C7jOXXYXRUUW0GeHfbjUJ290bw8ybQUsaujQvfVxn54KfbroKVolDIvn1OMXMDtGudpt8//iZ/9a4xJ8c2hR3dBKd5yuUU5/fjjC2/bVXIyXVCMvpH8jt6oEDVm2EfuFcu+wiW1n9IV4KH99I9xof1qKgpNC5rwUvA9eLhh/a/cd9X7dbHF8hvH5y2N)

I reverted these two PRs. I think it's more reasonable to judge whether a method is an extended array method when accessing array methods

[#11574] [#11629 ]