### PR TITLE
chore: document parameters of onWatcherCleanup

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -507,7 +507,7 @@ export function resetTracking(): void {
  * The cleanup function is called right before the next effect run, or when the
  * effect is stopped.
  *
- * Throws a warning iff there is no currenct active effect. The warning can be
+ * Throws a warning if there is no current active effect. The warning can be
  * suppressed by passing `true` to the second argument.
  *
  * @param fn - the cleanup function to be registered

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -95,6 +95,10 @@ export function getCurrentWatcher(): ReactiveEffect<any> | undefined {
  * associated effect re-runs.
  *
  * @param cleanupFn - The callback function to attach to the effect's cleanup.
+ * @param failSilently - if `true`, will not throw warning when called without
+ * an active effect.
+ * @param owner - The effect that this cleanup function should be attached to.
+ * By default, the current active effect.
  */
 export function onWatcherCleanup(
   cleanupFn: () => void,


### PR DESCRIPTION
The new API introduced in 205e5b5e277243c3af2c937d9bd46cf671296b72 has a few parameters not documented.
Also fixes some typos in `onEffectCleanup` documentation.