### PR TITLE
refactor: init newIndexToOldIndexMap

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1905,8 +1905,7 @@ function baseCreateRenderer(
       // and oldIndex = 0 is a special value indicating the new node has
       // no corresponding old node.
       // used for determining longest stable subsequence
-      const newIndexToOldIndexMap = new Array(toBePatched)
-      for (i = 0; i < toBePatched; i++) newIndexToOldIndexMap[i] = 0
+      const newIndexToOldIndexMap = new Array(toBePatched).fill(0)
 
       for (i = s1; i <= e1; i++) {
         const prevChild = c1[i]


### PR DESCRIPTION
I think this change enhances code readability and improves performance.

If it's unnecessary, just close it~

<img width="1686" alt="image" src="https://github.com/user-attachments/assets/d8bb5c3f-28b9-4b5e-9252-7ed9c9c9c491">
