### PR TITLE
fix(reactivity): prevent endless recursion in computed getters

### DIFF
--- a/packages/reactivity/src/dep.ts
+++ b/packages/reactivity/src/dep.ts
@@ -46,7 +46,7 @@ export class Dep {
   }
 
   track(debugInfo?: DebuggerEventExtraInfo): Link | undefined {
-    if (!activeSub || !shouldTrack) {
+    if (!activeSub || !shouldTrack || activeSub === this.computed) {
       return
     }
 


### PR DESCRIPTION
As shared on Twitter with @yyx990803, here the fix for the endless recursion that is sadly very difficult to isolate form our code-base. I will keep trying to create a simple test-case.