### PR TITLE
types(runtime-core): using intersection type in `Readonly<...>` breaks JSDoc emit

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -210,7 +210,8 @@ export function defineComponent<
         : ExtractPropTypes<RuntimePropsOptions>
       : { [key in RuntimePropsKeys]?: any }
     : TypeProps,
-  ResolvedProps = Readonly<InferredProps & EmitsToProps<ResolvedEmits>>,
+  ResolvedProps = Readonly<InferredProps> &
+    Readonly<EmitsToProps<ResolvedEmits>>,
   TypeRefs extends Record<string, unknown> = {},
 >(
   options: {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -1279,7 +1279,9 @@ export type ComponentOptionsWithObjectProps<
   Directives extends Record<string, Directive> = {},
   Exposed extends string = string,
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
-  Props = Prettify<Readonly<ExtractPropTypes<PropsOptions> & EmitsToProps<E>>>,
+  Props = Prettify<
+    Readonly<ExtractPropTypes<PropsOptions>> & Readonly<EmitsToProps<E>>
+  >,
   Defaults = ExtractDefaultPropTypes<PropsOptions>,
 > = ComponentOptionsBase<
   Props,


### PR DESCRIPTION
Fix a dts emit regression for v3.5.

### Input Component

```ts
import { defineComponent } from "vue";

export default defineComponent({
	props: {
		/**
		 * The hello property.
		 */
		hello: {
			type: String,
			default: 'Hello'
		},
	},
});
```

### v3.5.0 emit dts result

```ts
declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<{
    /**
     * The hello property.
     */
    hello: {
        type: StringConstructor;
        default: string;
    };
}>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{
    hello: string;
} & {} & {}>, {
    hello: string;
}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}>;
export default _default;
```

### PR emit dts result

```ts
declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<{
    /**
     * The hello property.
     */
    hello: {
        type: StringConstructor;
        default: string;
    };
}>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<{
    /**
     * The hello property.
     */
    hello: {
        type: StringConstructor;
        default: string;
    };
}>> & Readonly<{}>, {
    hello: string;
}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}>;
export default _default;
```