### PR TITLE
fix(runtime-core): prevent readonly warning when using `useTemplateRef` with same variable name as template ref

### DIFF
--- a/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
@@ -27,12 +27,16 @@ describe('useTemplateRef', () => {
   test('should be readonly', () => {
     let tRef
     const key = 'refKey'
+    const key2 = 'foo'
     const Comp = {
       setup() {
         tRef = useTemplateRef(key)
+        // naming a variable declared with the same as a template ref
+        const foo = useTemplateRef(key2)
+        return { [key2]: foo }
       },
       render() {
-        return h('div', { ref: key })
+        return h('div', { ref: key }, [h('div', { ref: key2 })])
       },
     }
     const root = nodeOps.createElement('div')
@@ -42,7 +46,7 @@ describe('useTemplateRef', () => {
     tRef.value = 123
 
     expect(tRef!.value).toBe(root.children[0])
-    expect('target is readonly').toHaveBeenWarned()
+    expect('target is readonly').toHaveBeenWarnedTimes(1)
   })
 
   test('should be updated for ref of dynamic strings', async () => {

--- a/packages/runtime-core/src/helpers/useTemplateRef.ts
+++ b/packages/runtime-core/src/helpers/useTemplateRef.ts
@@ -3,6 +3,8 @@ import { getCurrentInstance } from '../component'
 import { warn } from '../warning'
 import { EMPTY_OBJ } from '@vue/shared'
 
+export const TEMPLATE_REF_KEYS = '__v_ref_keys'
+
 export function useTemplateRef<T = unknown, Keys extends string = string>(
   key: Keys,
 ): Readonly<ShallowRef<T | null>> {
@@ -19,6 +21,15 @@ export function useTemplateRef<T = unknown, Keys extends string = string>(
     ) {
       warn(`useTemplateRef('${key}') already exists.`)
     } else {
+      if (refs[TEMPLATE_REF_KEYS]) {
+        ;(refs[TEMPLATE_REF_KEYS] as any).add(key)
+      } else {
+        const set = new Set([key])
+        Object.defineProperty(refs, TEMPLATE_REF_KEYS, {
+          get: () => set,
+        })
+      }
+
       Object.defineProperty(refs, key, {
         enumerable: true,
         get: () => r.value,


### PR DESCRIPTION
close #11795