### PR TITLE
types(jsx): HTMLDialogElement add close event

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -416,6 +416,7 @@ export interface DelHTMLAttributes extends HTMLAttributes {
 
 export interface DialogHTMLAttributes extends HTMLAttributes {
   open?: Booleanish
+  onClose?: (payload: Event) => void
 }
 
 export interface EmbedHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
Add missing "close" event on the `HTMLDialogElement`.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/close_event