### PR TITLE
fix(reactivity): pass oldValue to computed getter

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -33,6 +33,20 @@ describe('reactivity/computed', () => {
     expect(cValue.value).toBe(1)
   })
 
+  it('support get previous value', () => {
+    const count = ref(0)
+    const preValue = ref()
+    const cValue = computed(pre => {
+      preValue.value = pre
+      return count.value
+    })
+    expect(cValue.value).toBe(0)
+    expect(preValue.value).toBe(undefined)
+    count.value++
+    expect(cValue.value).toBe(1)
+    expect(preValue.value).toBe(0)
+  })
+
   it('should compute lazily', () => {
     const value = reactive<{ foo?: number }>({})
     const getter = vi.fn(() => value.foo)

--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -33,18 +33,18 @@ describe('reactivity/computed', () => {
     expect(cValue.value).toBe(1)
   })
 
-  it('support get previous value', () => {
+  it('pass oldValue to computed getter', () => {
     const count = ref(0)
-    const preValue = ref()
-    const cValue = computed(pre => {
-      preValue.value = pre
+    const oldValue = ref()
+    const curValue = computed(pre => {
+      oldValue.value = pre
       return count.value
     })
-    expect(cValue.value).toBe(0)
-    expect(preValue.value).toBe(undefined)
+    expect(curValue.value).toBe(0)
+    expect(oldValue.value).toBe(undefined)
     count.value++
-    expect(cValue.value).toBe(1)
-    expect(preValue.value).toBe(0)
+    expect(curValue.value).toBe(1)
+    expect(oldValue.value).toBe(0)
   })
 
   it('should compute lazily', () => {

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -381,7 +381,7 @@ export function refreshComputed(computed: ComputedRefImpl): false | undefined {
 
   try {
     prepareDeps(computed)
-    const value = computed.fn()
+    const value = computed.fn(computed._value)
     if (dep.version === 0 || hasChanged(value, computed._value)) {
       computed._value = value
       dep.version++


### PR DESCRIPTION
fix #11812 