### PR TITLE
feat(types): provide internal options for using `$el` type in language tools

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1810,6 +1810,15 @@ describe('__typeRefs backdoor, object syntax', () => {
   expectType<number>(refs.child.$refs.foo)
 })
 
+describe('__typeEl backdoor', () => {
+  const Comp = defineComponent({
+    __typeEl: {} as HTMLAnchorElement,
+  })
+  const c = new Comp()
+
+  expectType<HTMLAnchorElement>(c.$el)
+})
+
 defineComponent({
   props: {
     foo: [String, null],

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -68,6 +68,7 @@ export type DefineComponent<
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
   MakeDefaultsOptional extends boolean = true,
   TypeRefs extends Record<string, unknown> = {},
+  TypeEl extends Element = any,
 > = ComponentPublicInstanceConstructor<
   CreateComponentPublicInstanceWithMixins<
     Props,
@@ -86,7 +87,8 @@ export type DefineComponent<
     LC & GlobalComponents,
     Directives & GlobalDirectives,
     Exposed,
-    TypeRefs
+    TypeRefs,
+    TypeEl
   >
 > &
   ComponentOptionsBase<
@@ -213,6 +215,7 @@ export function defineComponent<
   ResolvedProps = Readonly<InferredProps> &
     Readonly<EmitsToProps<ResolvedEmits>>,
   TypeRefs extends Record<string, unknown> = {},
+  TypeEl extends Element = any,
 >(
   options: {
     props?: (RuntimePropsOptions & ThisType<void>) | RuntimePropsKeys[]
@@ -228,6 +231,10 @@ export function defineComponent<
      * @private for language-tools use only
      */
     __typeRefs?: TypeRefs
+    /**
+     * @private for language-tools use only
+     */
+    __typeEl?: TypeEl
   } & ComponentOptionsBase<
     ResolvedProps,
     SetupBindings,
@@ -288,7 +295,8 @@ export function defineComponent<
   // MakeDefaultsOptional - if TypeProps is provided, set to false to use
   // user props types verbatim
   unknown extends TypeProps ? true : false,
-  TypeRefs
+  TypeRefs,
+  TypeEl
 >
 
 // implementation, close to no-op

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -233,6 +233,7 @@ export type CreateComponentPublicInstanceWithMixins<
   Directives extends Record<string, Directive> = {},
   Exposed extends string = string,
   TypeRefs extends Data = {},
+  TypeEl extends Element = any,
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
   // mixin inference
   PublicMixin = IntersectionMixin<Mixin> & IntersectionMixin<Extends>,
@@ -277,7 +278,8 @@ export type CreateComponentPublicInstanceWithMixins<
   I,
   S,
   Exposed,
-  TypeRefs
+  TypeRefs,
+  TypeEl
 >
 
 export type ExposedKeys<
@@ -302,6 +304,7 @@ export type ComponentPublicInstance<
   S extends SlotsType = {},
   Exposed extends string = '',
   TypeRefs extends Data = {},
+  TypeEl extends Element = any,
 > = {
   $: ComponentInternalInstance
   $data: D
@@ -315,7 +318,7 @@ export type ComponentPublicInstance<
   $parent: ComponentPublicInstance | null
   $host: Element | null
   $emit: EmitFn<E>
-  $el: any
+  $el: TypeEl
   $options: Options & MergedComponentOptionsOverride
   $forceUpdate: () => void
   $nextTick: typeof nextTick


### PR DESCRIPTION
related to https://github.com/vue/language-tools#4805 