### PR TITLE
chore(scheduler): increase recursion limit number

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -53,7 +53,7 @@ let postFlushIndex = 0
 const resolvedPromise = /*@__PURE__*/ Promise.resolve() as Promise<any>
 let currentFlushPromise: Promise<void> | null = null
 
-const RECURSION_LIMIT = 100
+const RECURSION_LIMIT = 1000
 type CountMap = Map<SchedulerJob, number>
 
 export function nextTick<T = void, R = void>(


### PR DESCRIPTION
close #11807
close #11712
[feedback from discussion](https://github.com/orgs/vuejs/discussions/11800)

After the reactivity system is refactored, it can easily reach the 100 maximum limit per batch.