### PR TITLE
fix(Hydration): implement proper check for __asyncHydrate

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -15,7 +15,6 @@ import {
 } from './vnode'
 import {
   type ComponentInternalInstance,
-  type ComponentOptions,
   type Data,
   type LifecycleHook,
   createComponentInstance,
@@ -1330,12 +1329,12 @@ function baseCreateRenderer(
             }
           }
 
-          if (isAsyncWrapperVNode) {
-            ;(type as ComponentOptions).__asyncHydrate!(
-              el as Element,
-              instance,
-              hydrateSubTree,
-            )
+          if (
+            isAsyncWrapperVNode &&
+            '__asyncHydrate' in type &&
+            type.__asyncHydrate
+          ) {
+            type.__asyncHydrate(el as Element, instance, hydrateSubTree)
           } else {
             hydrateSubTree()
           }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1331,10 +1331,13 @@ function baseCreateRenderer(
 
           if (
             isAsyncWrapperVNode &&
-            '__asyncHydrate' in type &&
-            type.__asyncHydrate
+            (type as ComponentOptions).__asyncHydrate
           ) {
-            type.__asyncHydrate(el as Element, instance, hydrateSubTree)
+            ;(type as ComponentOptions).__asyncHydrate!(
+              el as Element,
+              instance,
+              hydrateSubTree,
+            )
           } else {
             hydrateSubTree()
           }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -15,6 +15,7 @@ import {
 } from './vnode'
 import {
   type ComponentInternalInstance,
+  type ComponentOptions,
   type Data,
   type LifecycleHook,
   createComponentInstance,


### PR DESCRIPTION
Fixes #11793

Simply add a proper check on the existance of `__asyncHydrate` so that vue 3.5 and `vue3-lazy-hydration` can coexist until we get vue3-lazy-hydration up to date with the new hydration api