### PR TITLE
fix(runtime-core): correctly infer `TypeEmits` with both tuple and function syntax

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -57,16 +57,13 @@ export type EmitsToProps<T extends EmitsOptions | ComponentTypeEmits> =
         }
       : {}
 
-export type TypeEmitsToOptions<T extends ComponentTypeEmits> =
-  T extends Record<string, any[]>
-    ? {
-        [K in keyof T]: T[K] extends [...args: infer Args]
-          ? (...args: Args) => any
-          : () => any
-      }
-    : T extends (...args: any[]) => any
-      ? ParametersToFns<OverloadParameters<T>>
-      : {}
+export type TypeEmitsToOptions<T extends ComponentTypeEmits> = {
+  [K in keyof T & string]: T[K] extends [...args: infer Args]
+    ? (...args: Args) => any
+    : () => any
+} & (T extends (...args: any[]) => any
+  ? ParametersToFns<OverloadParameters<T>>
+  : {})
 
 type ParametersToFns<T extends any[]> = {
   [K in T[0]]: K extends `${infer C}`


### PR DESCRIPTION
fix #11836