### PR TITLE
fix(compiler-ssr): handle newlines at the beginning of textarea content

### DIFF
--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -130,7 +130,9 @@ export const ssrTransformElement: NodeTransform = (node, context) => {
                   createSimpleExpression(`"value" in ${tempId}`, false),
                   createSimpleExpression(`${tempId}.value`, false),
                   createSimpleExpression(
-                    existingText ? existingText.content : ``,
+                    existingText
+                      ? `${existingText.content[0] === '\n' ? '\n' : ''}${existingText.content}`
+                      : ``,
                     true,
                   ),
                   false,

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1913,7 +1913,7 @@ describe('SSR hydration', () => {
         createSSRApp({ template: '<textarea>\n</textarea>' }),
       )
       mountWithHydration(html, () => h('textarea', null, '\n'))
-      expect(`Hydration attribute mismatch`).not.toHaveBeenWarned()
+      expect(`Hydration text content mismatch`).not.toHaveBeenWarned()
     })
 
     test('boolean attr handling', () => {

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1908,6 +1908,14 @@ describe('SSR hydration', () => {
       expect(`Hydration attribute mismatch`).toHaveBeenWarned()
     })
 
+    test('<textarea> with newlines at the beginning', async () => {
+      const html = await renderToString(
+        createSSRApp({ template: '<textarea>\n</textarea>' }),
+      )
+      mountWithHydration(html, () => h('textarea', null, '\n'))
+      expect(`Hydration attribute mismatch`).not.toHaveBeenWarned()
+    })
+
     test('boolean attr handling', () => {
       mountWithHydration(`<input />`, () => h('input', { readonly: false }))
       expect(`Hydration attribute mismatch`).not.toHaveBeenWarned()


### PR DESCRIPTION
close #11873

I've learned from React's implementation and applied it here.

![image](https://github.com/user-attachments/assets/581aa68c-484c-477a-a9c2-82688ffa7699)
