### PR TITLE
fix: optimize the order of keys in mergeProps

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -874,4 +874,21 @@ describe('component props', () => {
     await nextTick()
     expect(props).not.toHaveProperty('onEvent')
   })
+
+  // #11880
+  test('merged props order', async () => {
+    const Child = defineComponent({
+      props: ['fooBar'],
+      template: `<div>{{ fooBar }}</div>`,
+    })
+
+    const Comp = defineComponent({
+      components: { Child },
+      template: `<Child :foo-bar="1" v-bind="{ fooBar: 2, 'foo-bar': 3 }"/>`,
+    })
+
+    const root = document.createElement('div')
+    domRender(h(Comp), root)
+    expect(root.innerHTML).toBe('<div>3</div>')
+  })
 })

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -890,6 +890,8 @@ export function mergeProps(...args: (Data & VNodeProps)[]): Data {
             : incoming
         }
       } else if (key !== '') {
+        // #11880: order of the later updated keys should also be moved to the end.
+        delete ret[key]
         ret[key] = toMerge[key]
       }
     }


### PR DESCRIPTION
fix #11880 

The cause of this bug is that during the execution of `mergeProps`, `my-info="default 1"` first adds `my-info` to `props`, then `v-bind="{ myInfo: 'default 2', 'my-info': 'Some value' }"` adds `myInfo` to `props` and updates the value of `my-info` (but does not change the order of the keys). During rendering, the keys in `props` are rendered in the order they were added. Since `myInfo` was added after `my-info`, the final rendered value is that of `myInfo`. 
Therefore, during the execution of `mergeProps`, the order of keys corresponding to later updates should always remain at the end.