### PR TITLE
chore(types): migrate global types to packages-private

### DIFF
--- a/packages-private/global.d.ts
+++ b/packages-private/global.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+// Global compile-time constants
+declare var __COMMIT__: string
+
+declare module 'file-saver' {
+  export function saveAs(blob: any, name: any): void
+}

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="vite/client" />
-
 // Global compile-time constants
 declare var __DEV__: boolean
 declare var __TEST__: boolean
@@ -9,7 +7,6 @@ declare var __ESM_BUNDLER__: boolean
 declare var __ESM_BROWSER__: boolean
 declare var __CJS__: boolean
 declare var __SSR__: boolean
-declare var __COMMIT__: string
 declare var __VERSION__: string
 declare var __COMPAT__: boolean
 
@@ -20,10 +17,6 @@ declare var __FEATURE_SUSPENSE__: boolean
 declare var __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
 
 declare module '*.vue' {}
-
-declare module 'file-saver' {
-  export function saveAs(blob: any, name: any): void
-}
 
 declare module 'estree-walker' {
   export function walk<T>(


### PR DESCRIPTION
- Fix type errors in `packages-private` due to missing global types
- Clean up unused global types from the main package