### PR TITLE
fix(sfc-playground): remove comments in PROD mode to align with default behavior

### DIFF
--- a/packages-private/sfc-playground/src/App.vue
+++ b/packages-private/sfc-playground/src/App.vue
@@ -62,6 +62,7 @@ const sfcOptions = computed(
       compilerOptions: {
         isCustomElement: (tag: string) =>
           tag === 'mjx-container' || tag.startsWith('custom-'),
+        comments: !productionMode.value,
       },
     },
   }),


### PR DESCRIPTION
Align with the default behavior: https://vuejs.org/api/application.html#app-config-compileroptions-comments