### PR TITLE
fix(runtime-core): withDefaults & union types

### DIFF
--- a/packages-private/dts-test/setupHelpers.test-d.ts
+++ b/packages-private/dts-test/setupHelpers.test-d.ts
@@ -207,6 +207,77 @@ describe('defineProps w/ generic type declaration + withDefaults', <T extends
   expectType<boolean>(res.bool)
 })
 
+describe('defineProps w/union type', () => {
+  type PP =
+    | {
+        type: 'text'
+        mm: string
+      }
+    | {
+        type: 'number'
+        mm: number | null
+      }
+
+  const res = defineProps<PP>()
+  expectType<string | number | null>(res.mm)
+
+  if (res.type === 'text') {
+    expectType<string>(res.mm)
+  }
+
+  if (res.type === 'number') {
+    expectType<number | null>(res.mm)
+  }
+})
+
+describe('withDefaults w/ union type', () => {
+  type PP =
+    | {
+        type?: 'text'
+        mm: string
+      }
+    | {
+        type?: 'number'
+        mm: number | null
+      }
+
+  const res = withDefaults(defineProps<PP>(), {
+    type: 'text',
+  })
+
+  if (res.type && res.type === 'text') {
+    expectType<string>(res.mm)
+  }
+
+  if (res.type === 'number') {
+    expectType<number | null>(res.mm)
+  }
+})
+
+describe('withDefaults w/ generic union type', <T extends
+  | string
+  | number>() => {
+  type PP =
+    | {
+        tt?: 'a'
+        mm: T
+      }
+    | {
+        tt?: 'b'
+        mm: T[]
+      }
+
+  const res = withDefaults(defineProps<PP>(), {
+    tt: 'a',
+  })
+
+  if (res.tt === 'a') {
+    expectType<T>(res.mm)
+  } else {
+    expectType<T[]>(res.mm)
+  }
+})
+
 describe('withDefaults w/ boolean type', () => {
   const res1 = withDefaults(
     defineProps<{

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -313,9 +313,6 @@ export function defineModel(): any {
 }
 
 type NotUndefined<T> = T extends undefined ? never : T
-type MappedOmit<T, K extends keyof any> = {
-  [P in keyof T as P extends K ? never : P]: T[P]
-}
 
 type InferDefaults<T> = {
   [K in keyof T]?: InferDefault<T, T[K]>
@@ -331,7 +328,7 @@ type PropsWithDefaults<
   T,
   Defaults extends InferDefaults<T>,
   BKeys extends keyof T,
-> = Readonly<MappedOmit<T, keyof Defaults>> & {
+> = Readonly<T> & {
   readonly [K in keyof Defaults as K extends keyof T
     ? K
     : never]-?: K extends keyof T


### PR DESCRIPTION
Improves typing of props when using union types in combination with `withDefaults`. 

#### Fixes
* https://github.com/vuejs/core/issues/11758
* https://github.com/vuejs/core/issues/8952

#### Affects
https://github.com/vuejs/core/issues/9125

#### Explanation
We can skip the Omit<T, Defaults> in
```typescript
Readonly<Omit<T, keyof Defaults>>
```

because we're overloading the omitted keys with key/value of Defaults and the mapped type modifier anyways:

```typescript
  & {
    readonly [K in keyof Defaults as K extends keyof T ? K : never]-?: ...
``` 

