### PR TITLE
fix(transition): respect `duration` setting even when it is `0`

### DIFF
--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -344,7 +344,7 @@ function whenTransitionEnds(
     }
   }
 
-  if (explicitTimeout) {
+  if (explicitTimeout != null) {
     return setTimeout(resolveIfNotStale, explicitTimeout)
   }
 


### PR DESCRIPTION
### Description

This PR addresses the behavior when using `<Transitions :duration="0">`. According to the expected behavior, when the `duration` is set to `0`, no animations should be executed. However, the current implementation still triggers animations internally. This fix ensures that when the `duration` is set to `0`, animations are correctly skipped.

### Minimal reproduction

https://play.vuejs.org/#eNqNU8Fu2zAM/RXWO3QDasdDt0M9t9hW9LAd2mHL0RdFphM1smRIdJIiyL+PslwnG4qiN+rxvedHmdon37ou2/SYFEnppVMdgUfqu5vKqLazjmAPDhs4QONsC+dMPa+MtMYTCElqg3AdCO8boT1+qEw5izZswAfCttOCkE8A5aInsga+Sq3k+rpKJoOzWFXJwAO4DYRBMouaqD9LUyjnThivSLGRES2yTSNqlkJR904EnKGPbAVpehM185XysLVuHaDB6U0meTA5Gtw/zP8xYZtabWCTqmaaZZpgbEotvOfuwu64Vc4Ye9ZOdTk7pmGgnJ1cGh89PelQZuwB+yDYqppWBVzmebf7EoAVquWKTpGFkOuls72pU2m1dQW8y6+uuHUInlkYNkVD6NKY++IZ1Cg2OILxazSFK8B2Qip6gjz77AGFx5ccw6L850c2eo36AvIo5GUZp0suEvK8Vo1aZo/eGt7HQVEl0rad0ugeupDBV0kRvUJPaG23PweMXB+miLhcoVy/gD96/g0FF78cenThf009Em6JFNt3f+5xx/XUbG3da2a/0vyN3uo+ZIy073z5HPuEN6T9MbwqZZZzf7cj5KsdhwpBA/Mw8KuEX9rtK6Mf415mnwYd32hy+Atu80Ir