### PR TITLE
fix(sfc-playground): resolve autosave conflict issue

### DIFF
--- a/packages-private/sfc-playground/src/App.vue
+++ b/packages-private/sfc-playground/src/App.vue
@@ -136,7 +136,8 @@ onMounted(() => {
     @keydown.ctrl.s.prevent
     @keydown.meta.s.prevent
     :ssr="useSSRMode"
-    :autoSave="autoSave"
+    :model-value="autoSave"
+    :editorOptions="{ autoSaveText: false }"
     :store="store"
     :showCompileOutput="true"
     :autoResize="true"


### PR DESCRIPTION
I discovered that after upgrading from @vue/repl@4.4.0 to v4.4.2 #11939, there were issues with autosave conflicts and failure. The cause is that some default operations for [autoSave](https://github.com/vuejs/repl/pull/283/files) were added in [@vue/repl@4.4.1](https://github.com/vuejs/repl/releases/tag/v4.4.1), which led to changes in the property. This PR aims to resolve the conflict.