### PR TITLE
fix(runtime-core): disambiguate the `Comment` type in hydration.ts

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -1,8 +1,8 @@
 import {
-  Comment,
   Fragment,
   Static,
   Text,
+  Comment as VComment,
   type VNode,
   type VNodeHook,
   createTextVNode,
@@ -195,7 +195,7 @@ export function createHydrationFunctions(
           nextNode = nextSibling(node)
         }
         break
-      case Comment:
+      case VComment:
         if (isTemplateNode(node)) {
           nextNode = nextSibling(node)
           // wrapped <transition appear>


### PR DESCRIPTION
Related: https://github.com/microsoft/TypeScript/issues/60031

oxc cannot replicate tsc's ID behavior because tsc accidently type referenced the `Comment` to the global in
[dom.d.ts](https://github.com/microsoft/TypeScript/blob/88809467e8761e71483e2f4948ef411d8e447188/src/lib/dom.generated.d.ts#L5811-L5822)

This PR renames the imported `Comment` type to `VComment` for ID to behave correctly in a non-type-reference context, oxc will keep the imported `Comment` type otherwise.