### PR TITLE
fix(types): correct type inference of union event names

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -66,10 +66,16 @@ export type TypeEmitsToOptions<T extends ComponentTypeEmits> = {
   : {})
 
 type ParametersToFns<T extends any[]> = {
-  [K in T[0]]: K extends `${infer C}`
-    ? (...args: T extends [C, ...infer Args] ? Args : never) => any
+  [K in T[0]]: isStringLiteral<K> extends true
+    ? (...args: T extends [string, ...infer Args] ? Args : never) => any
     : never
 }
+
+type isStringLiteral<T> = T extends string
+  ? string extends T
+    ? false
+    : true
+  : false
 
 export type ShortEmitsToObject<E> =
   E extends Record<string, any[]>

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -66,12 +66,12 @@ export type TypeEmitsToOptions<T extends ComponentTypeEmits> = {
   : {})
 
 type ParametersToFns<T extends any[]> = {
-  [K in T[0]]: isStringLiteral<K> extends true
+  [K in T[0]]: IsStringLiteral<K> extends true
     ? (...args: T extends [string, ...infer Args] ? Args : never) => any
     : never
 }
 
-type isStringLiteral<T> = T extends string
+type IsStringLiteral<T> = T extends string
   ? string extends T
     ? false
     : true

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -67,7 +67,13 @@ export type TypeEmitsToOptions<T extends ComponentTypeEmits> = {
 
 type ParametersToFns<T extends any[]> = {
   [K in T[0]]: IsStringLiteral<K> extends true
-    ? (...args: T extends [string, ...infer Args] ? Args : never) => any
+    ? (
+        ...args: T extends [e: infer E, ...args: infer P]
+          ? K extends E
+            ? P
+            : never
+          : never
+      ) => any
     : never
 }
 


### PR DESCRIPTION
fix vuejs/language-tools#4875 