### PR TITLE
fix(ref): fix ref prop normalization

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -443,10 +443,8 @@ const normalizeRef = ({
     ref = '' + ref
   }
   return (
-    ref != null
-      ? isString(ref) || isRef(ref) || isFunction(ref)
-        ? { i: currentRenderingInstance, r: ref, k: ref_key, f: !!ref_for }
-        : ref
+    ref != null && (isString(ref) || isRef(ref) || isFunction(ref))
+      ? { i: currentRenderingInstance, r: ref, k: ref_key, f: !!ref_for }
       : null
   ) as any
 }

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -443,7 +443,7 @@ const normalizeRef = ({
     ref = '' + ref
   }
   return (
-    (isString(ref) || isRef(ref) || isFunction(ref))
+    isString(ref) || isRef(ref) || isFunction(ref)
       ? { i: currentRenderingInstance, r: ref, k: ref_key, f: !!ref_for }
       : null
   ) as any

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -443,7 +443,7 @@ const normalizeRef = ({
     ref = '' + ref
   }
   return (
-    ref != null && (isString(ref) || isRef(ref) || isFunction(ref))
+    (isString(ref) || isRef(ref) || isFunction(ref))
       ? { i: currentRenderingInstance, r: ref, k: ref_key, f: !!ref_for }
       : null
   ) as any


### PR DESCRIPTION
Close #12029

Hey everyone!

I ran into inconsistencies with how template refs are treated between dev and prod here: https://github.com/vuejs/core/issues/12029

I have an element whose `ref` prop points to a non-ref object. Like this:
```vue
<script setup>
class A {}
const p = new A()
</script>

<template>
  <p ref="p">Hello</p>
</template>
```

While this is obviously useless code, it has happened to me and several of our colleagues during development, by accident. In dev, this fails silently and everything keeps working, making it hard to spot that you did something wrong. During production, the code fails and often nukes the entire component or page. This inconsistency is quite dangerous as it causes unintended production bugs on code that worked in development.

This is NOT the same issue as in https://github.com/vuejs/core/issues/11373 and https://github.com/vuejs/core/issues/4866 - these issues are concerned about dev/prod differences when it comes to dynamically-bound refs (`:ref="x"`).

The issue starts at the fact that prod compiles the templates differently than dev. The `props` object passed to the `p` element in the dev version is `{ ref: "p" }`. However, in the prod version it becomes `{ ref_key: "p", ref: p }`. This is where the problem gets injected into the framework since we're passing `p` as the ref. This works just fine if `p` is actually a Ref, but it breaks down when it isn't. Since the compiler can't differenciate these cases statically, the fix must lie in the runtime logic.

The earliest spot I was able to catch this issue in was in `normalizeRef`. The ref that is passed in is typed as:
```ts
type _ =
  | null
  | string
  | Ref
  | ((
      ref: Element | ComponentPublicInstance | null,
      refs: Record<string, any>,
    ) => void)
```

Which led me to conclude that the current code was erroneous; if `ref` is non-null, but is also not a string, Ref, or function, then it is simply an invalid ref and should be changed to `null`. Correct me if this fix is incorrect; i.e. there is some configuration in which the "fallthrough case" (where ref is used as-is, despite being no string, Ref, or function) is intended.