### PR TITLE
fix(runtime-core): avoid rendering plain object as VNode

### DIFF
--- a/packages/runtime-core/__tests__/rendererChildren.spec.ts
+++ b/packages/runtime-core/__tests__/rendererChildren.spec.ts
@@ -65,6 +65,15 @@ test('array children -> text children', () => {
   expect(inner(root)).toBe('<div>hello</div>')
 })
 
+test('plain object child', () => {
+  const root = nodeOps.createElement('div')
+  const foo = { foo: '1' }
+  // @ts-expect-error
+  render(h('div', null, [foo]), root)
+  expect('Invalid VNode type').not.toHaveBeenWarned()
+  expect(inner(root)).toBe('<div>[object Object]</div>')
+})
+
 describe('renderer: keyed children', () => {
   let root: TestElement
   let elm: TestElement

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -793,7 +793,7 @@ export function normalizeVNode(child: VNodeChild): VNode {
       // #3666, avoid reference pollution when reusing vnode
       child.slice(),
     )
-  } else if (typeof child === 'object') {
+  } else if (isVNode(child)) {
     // already vnode, this should be the most common since compiled templates
     // always produce all-vnode children arrays
     return cloneIfMounted(child)


### PR DESCRIPTION
close #12035 
close https://github.com/vitejs/vite-plugin-vue/issues/353

I initially planned to fix this in [@vue/babel-plugin-jsx](https://github.com/vuejs/babel-plugin-jsx) [like this](https://github.com/vitejs/vite-plugin-vue/issues/353#issuecomment-2370012473). However, I encountered [this scenario](https://vue-jsx-explorer.netlify.app/#import%20%7B%20ref%2C%20defineComponent%20%7D%20from%20'vue'%0A%0Aexport%20const%20A%20%3D%20defineComponent(%7B%0A%20%20render()%20%7B%0A%20%20%20%20const%20textarea%20%3D%20%3Ctextarea%20id%3D%22textarea%22%2F%3E%3B%0A%20%20%20%20return%20(%0A%20%20%20%20%20%20%3Cdiv%3E%7Btextarea%7D%3C%2Fdiv%3E%0A%20%20%20%20)%3B%0A%20%20%7D%2C%0A%7D)%0A) during the process. It might require introducing additional runtime checks to determine whether the child is a VNode or an Object. Doing so could lead to some performance loss, so I abandoned this approach.