### PR TITLE
feat: runtime-support for type unions in props

### DIFF
--- a/packages-private/dts-test/setupHelpers.test-d.ts
+++ b/packages-private/dts-test/setupHelpers.test-d.ts
@@ -207,6 +207,99 @@ describe('defineProps w/ generic type declaration + withDefaults', <T extends
   expectType<boolean>(res.bool)
 })
 
+describe('defineProps w/union type', () => {
+  type PP =
+    | {
+        type: 'text'
+        mm: string
+      }
+    | {
+        type: 'number'
+        mm: number | null
+      }
+
+  const res = defineProps<PP>()
+  expectType<string | number | null>(res.mm)
+
+  if (res.type === 'text') {
+    expectType<string>(res.mm)
+  }
+
+  if (res.type === 'number') {
+    expectType<number | null>(res.mm)
+  }
+})
+
+describe('defineProps w/distributive union type', () => {
+  type PP =
+    | {
+        type1: 'text'
+        mm1: string
+      }
+    | {
+        type2: 'number'
+        mm2: number | null
+      }
+
+  const res = defineProps<PP>()
+
+  if ('type1' in res) {
+    expectType<string>(res.mm1)
+  }
+
+  if ('type2' in res) {
+    expectType<number | null>(res.mm2)
+  }
+})
+
+describe('withDefaults w/ union type', () => {
+  type PP =
+    | {
+        type?: 'text'
+        mm: string
+      }
+    | {
+        type?: 'number'
+        mm: number | null
+      }
+
+  const res = withDefaults(defineProps<PP>(), {
+    type: 'text',
+  })
+
+  if (res.type && res.type === 'text') {
+    expectType<string>(res.mm)
+  }
+
+  if (res.type === 'number') {
+    expectType<number | null>(res.mm)
+  }
+})
+
+describe('withDefaults w/ generic union type', <T extends
+  | string
+  | number>() => {
+  type PP =
+    | {
+        tt?: 'a'
+        mm: T
+      }
+    | {
+        tt?: 'b'
+        mm: T[]
+      }
+
+  const res = withDefaults(defineProps<PP>(), {
+    tt: 'a',
+  })
+
+  if (res.tt === 'a') {
+    expectType<T>(res.mm)
+  } else {
+    expectType<T[]>(res.mm)
+  }
+})
+
 describe('withDefaults w/ boolean type', () => {
   const res1 = withDefaults(
     defineProps<{

--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -93,6 +93,68 @@ return { foo }
 })"
 `;
 
+exports[`defineProps > discriminated union 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    tag: { type: [String, Number], required: true, union: [['d1'], ['d2']] },
+    d1: { type: Number, required: true, union: ['tag'] },
+    d2: { type: String, required: true, union: ['tag'] }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+      const props = __props;
+    
+return { props }
+}
+
+})"
+`;
+
+exports[`defineProps > distributive union w/ conditional keys 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    a: { type: String, required: false, union: ['b'] },
+    b: { type: Number, required: true, union: ['a'] },
+    c: { type: Number, required: true, union: ['d'] },
+    d: { type: String, required: false, union: ['c'] }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+      const props = __props;
+    
+return { props }
+}
+
+})"
+`;
+
+exports[`defineProps > distributive union with boolean keys 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    a: { type: String, required: true, union: ['b'] },
+    b: { type: Number, required: true, union: ['a'] },
+    c: { type: Boolean, required: true, union: ['d'] },
+    d: { type: String, required: true, union: ['c'] }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+      const props = __props;
+    
+return { props }
+}
+
+})"
+`;
+
 exports[`defineProps > should escape names w/ special symbols 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -399,6 +399,54 @@ const props = defineProps({ foo: String })
     assertCode(content)
   })
 
+  test('distributive union w/ conditional keys', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+      const props = withDefaults(defineProps<{
+        a?: string;
+        b: number;
+      } | {
+       c: number;
+       d?: string;
+       }>(), {
+      });
+    </script>
+    `)
+    assertCode(content)
+  })
+
+  test('discriminated union', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+      const props = withDefaults(defineProps<{
+        tag: string;
+        d1: number;
+      } | {
+        tag: number;
+        d2: string;
+       }>(), {
+      });
+    </script>
+    `)
+    assertCode(content)
+  })
+
+  test('distributive union with boolean keys', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+      const props = withDefaults(defineProps<{
+        a: string;
+        b: number;
+      } | {
+        c: boolean;
+        d: string;
+      }>(), {
+      });
+    </script>
+    `)
+    assertCode(content)
+  })
+
   // #7111
   test('withDefaults (static) w/ production mode', () => {
     const { content } = compile(

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -313,9 +313,6 @@ export function defineModel(): any {
 }
 
 type NotUndefined<T> = T extends undefined ? never : T
-type MappedOmit<T, K extends keyof any> = {
-  [P in keyof T as P extends K ? never : P]: T[P]
-}
 
 type InferDefaults<T> = {
   [K in keyof T]?: InferDefault<T, T[K]>
@@ -331,7 +328,7 @@ type PropsWithDefaults<
   T,
   Defaults extends InferDefaults<T>,
   BKeys extends keyof T,
-> = Readonly<MappedOmit<T, keyof Defaults>> & {
+> = Readonly<T> & {
   readonly [K in keyof Defaults as K extends keyof T
     ? K
     : never]-?: K extends keyof T


### PR DESCRIPTION
One of the last missing features regarding TypeScript support in Vue is the ability to use discriminated- and distributive union types in props with runtime validation. This PR aims to address these limitations and provides a more flexible way to define props.

#### Fixes
* https://github.com/vuejs/core/issues/11758
* https://github.com/vuejs/core/issues/8952
* https://github.com/vuejs/core/issues/9125

#### Implementation
Through compiling and validating the new **internal** prop option `union`, we can skip validation for props that are not part of an active sub-union.

In the following example, `a` and `b` are in an active sub-union, `c` and `d` are not. Defining either `a` or `b` should trigger warnings for missing props for the other prop in the same sub-union.

```typescript
defineProps<
  | {
      a: string
      b: number
    }
  | {
      c: string
      d: number
    }
>()

// Usage
defineProps({a: 'foo'}) // Should trigger missing required prop warning only for `b`
```