### PR TITLE
fix(compiler-sfc):  do not skip TSInstantiationExpression when transforming props destructure

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/definePropsDestructure.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/definePropsDestructure.spec.ts.snap
@@ -1,5 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`sfc reactive props destructure > TSInstantiationExpression 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+type Foo = <T extends string | number>(data: T) => void
+      
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    value: { type: Function }
+  },
+  setup(__props: any) {
+
+      
+      const foo = __props.value<123>
+      
+return () => {}
+}
+
+})"
+`;
+
 exports[`sfc reactive props destructure > aliasing 1`] = `
 "import { toDisplayString as _toDisplayString } from "vue"
 
@@ -319,4 +338,23 @@ return { rest }
 }
 
 }"
+`;
+
+exports[`sfc reactive props destructure > with TSInstantiationExpression 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+type Foo = <T extends string | number>(data: T) => void
+      
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    value: { type: Function }
+  },
+  setup(__props: any) {
+
+      
+      const foo = __props.value<123>
+      
+return () => {}
+}
+
+})"
 `;

--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/definePropsDestructure.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/definePropsDestructure.spec.ts.snap
@@ -1,24 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sfc reactive props destructure > TSInstantiationExpression 1`] = `
-"import { defineComponent as _defineComponent } from 'vue'
-type Foo = <T extends string | number>(data: T) => void
-      
-export default /*@__PURE__*/_defineComponent({
-  props: {
-    value: { type: Function }
-  },
-  setup(__props: any) {
-
-      
-      const foo = __props.value<123>
-      
-return () => {}
-}
-
-})"
-`;
-
 exports[`sfc reactive props destructure > aliasing 1`] = `
 "import { toDisplayString as _toDisplayString } from "vue"
 

--- a/packages/compiler-sfc/__tests__/compileScript/definePropsDestructure.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/definePropsDestructure.spec.ts
@@ -198,6 +198,21 @@ describe('sfc reactive props destructure', () => {
   }`)
   })
 
+  test('with TSInstantiationExpression', () => {
+    const { content } = compile(
+      `
+      <script setup lang="ts">
+      type Foo = <T extends string | number>(data: T) => void
+      const { value } = defineProps<{ value: Foo }>()
+      const foo = value<123>
+      </script>
+    `,
+      { isProd: true },
+    )
+    assertCode(content)
+    expect(content).toMatch(`const foo = __props.value<123>`)
+  })
+
   test('aliasing', () => {
     const { content, bindings } = compile(`
       <script setup>

--- a/packages/compiler-sfc/src/script/definePropsDestructure.ts
+++ b/packages/compiler-sfc/src/script/definePropsDestructure.ts
@@ -10,6 +10,7 @@ import type {
 import { walk } from 'estree-walker'
 import {
   BindingTypes,
+  TS_NODE_TYPES,
   extractIdentifiers,
   isFunctionType,
   isInDestructureAssignment,
@@ -240,10 +241,7 @@ export function transformDestructuredProps(
       if (
         parent &&
         parent.type.startsWith('TS') &&
-        parent.type !== 'TSAsExpression' &&
-        parent.type !== 'TSNonNullExpression' &&
-        parent.type !== 'TSSatisfiesExpression' &&
-        parent.type !== 'TSTypeAssertion'
+        !TS_NODE_TYPES.includes(parent.type)
       ) {
         return this.skip()
       }


### PR DESCRIPTION
Fix this kind of edge case

## Steps to reproduce
https://play.vuejs.org/#eNp9UsFu2zAM/RVClyZA4By2k+cY24oO2A5bsQU76eLajKtWlgSJyjJk/vdRUtKlw9aTLfKRfO+RR/HOuWofUdSiIZyc7ghbaQCaD9ZCve90xI0Ui6Gjbrlp00cKWDOkWV/g+Rl6rxxBQIqOI2py1hOkLjtvJ5CiWl/bKQ+T4k2qLxWMFStBobdmp8bqIVjDZI6JgxQ9VyiN/osjZU2QooacSblOa/vjU46Rj7g6x/t77B//EX8IhxST4tZjQL9nGk856vyIVNI33z7jgf+fkpMdomb0C8mvGKyOiWOBvY9mYNoXuMz2YzZFmXEbbg6EJpxFJaIJOWe8FGxSMut/0v/QfVW9znXSzOzi2eC0zct9gO7MyGskbsN+00+HeTMbaLbAetAMAQJ5Zga/wMTpDn2bd17DdgmbFvZWDdLwjgLBEfJZwMz1A+6UwVtvXWhO8Tq3ntvFMt1FKen6JILxWcJ9l92pYZF7n2QlpNVYaTsurr7nCSrUV6vStSn0Wm5a5MKzE+LH8/O9i0Q88W2vVf/I0guD6jQ625CGXqd0LliXir8vW8y/AWviDAE=

Click button. See error.

## What is expected?
Value prop should be accessible even when used with `console.log('Value is:', value<string>)`
Although the user probably won't use it this way.

And it can be used this way in the TS Playground
![image](https://github.com/user-attachments/assets/2d4ca4ef-908d-4b47-894b-cde1ce6b699a)

## What is actually happening?
Errro