### PR TITLE
fix(reactivity): prevent overwriting `next` property during batch processing

### DIFF
--- a/packages/reactivity/__tests__/watch.spec.ts
+++ b/packages/reactivity/__tests__/watch.spec.ts
@@ -260,4 +260,21 @@ describe('watch', () => {
     src.value = 10
     expect(spy).toHaveBeenCalledTimes(2)
   })
+
+  test('should ensure correct execution order in batch processing', () => {
+    const dummy: number[] = []
+    const n1 = ref(0)
+    const n2 = ref(0)
+    const sum = computed(() => n1.value + n2.value)
+    watch(n1, () => {
+      dummy.push(1)
+      n2.value++
+    })
+    watch(sum, () => dummy.push(2))
+    watch(n1, () => dummy.push(3))
+
+    n1.value++
+
+    expect(dummy).toEqual([1, 2, 3])
+  })
 })

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -121,7 +121,7 @@ export class ComputedRefImpl<T = any> implements Subscriber {
       // avoid infinite self recursion
       activeSub !== this
     ) {
-      batch(this)
+      batch(this, true)
       return true
     } else if (__DEV__) {
       // TODO warn

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -237,6 +237,9 @@ let batchedSub: Subscriber | undefined
 
 export function batch(sub: Subscriber): void {
   sub.flags |= EffectFlags.NOTIFIED
+  // If sub.next is set, the subscriber is already in a batch,
+  // return to avoid overwriting it and losing previous subscriptions.
+  if (sub.next) return
   sub.next = batchedSub
   batchedSub = sub
 }

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -240,12 +240,8 @@ export function batch(sub: Subscriber, isComputed = false): void {
   sub.flags |= EffectFlags.NOTIFIED
   if (isComputed) {
     batchedCleanup.push(() => {
-      // clear notified flags for computed upfront
-      // we use the ACTIVE flag as a discriminator between computed and effect,
-      // since NOTIFIED is useless for an inactive effect anyway.
-      if (!(sub.flags & EffectFlags.ACTIVE)) {
-        sub.flags &= ~EffectFlags.NOTIFIED
-      }
+      // clear notified flags for computed
+      sub.flags &= ~EffectFlags.NOTIFIED
     })
     return
   }

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -236,12 +236,13 @@ let batchDepth = 0
 let batchedSub: Subscriber | undefined
 const batchedCleanup: (() => void)[] = []
 
-export function batch(sub: Subscriber): void {
+export function batch(sub: Subscriber, isComputed = false): void {
   sub.flags |= EffectFlags.NOTIFIED
-  // If sub.next is set, the subscriber is already in a batch,
-  // return to avoid overwriting it and losing previous subscriptions.
-  if (sub.next) {
+  if (isComputed) {
     batchedCleanup.push(() => {
+      // clear notified flags for computed upfront
+      // we use the ACTIVE flag as a discriminator between computed and effect,
+      // since NOTIFIED is useless for an inactive effect anyway.
       if (!(sub.flags & EffectFlags.ACTIVE)) {
         sub.flags &= ~EffectFlags.NOTIFIED
       }
@@ -268,30 +269,19 @@ export function endBatch(): void {
     return
   }
 
+  if (batchedCleanup.length) {
+    for (let i = 0; i < batchedCleanup.length; i++) {
+      batchedCleanup[i]()
+    }
+    batchedCleanup.length = 0
+  }
+
   let error: unknown
   while (batchedSub) {
     let e: Subscriber | undefined = batchedSub
-    let next: Subscriber | undefined
-    // 1st pass: clear notified flags for computed upfront
-    // we use the ACTIVE flag as a discriminator between computed and effect,
-    // since NOTIFIED is useless for an inactive effect anyway.
-    while (e) {
-      if (!(e.flags & EffectFlags.ACTIVE)) {
-        e.flags &= ~EffectFlags.NOTIFIED
-      }
-      e = e.next
-    }
-    if (batchedCleanup.length) {
-      for (let i = 0; i < batchedCleanup.length; i++) {
-        batchedCleanup[i]()
-      }
-      batchedCleanup.length = 0
-    }
-    e = batchedSub
     batchedSub = undefined
-    // 2nd pass: run effects
     while (e) {
-      next = e.next
+      const next: Subscriber | undefined = e.next
       e.next = undefined
       e.flags &= ~EffectFlags.NOTIFIED
       if (e.flags & EffectFlags.ACTIVE) {


### PR DESCRIPTION
close #12072