### PR TITLE
fix(types): should not intersect `PublicProps` with `Props`

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -79,7 +79,7 @@ export type DefineComponent<
     Mixin,
     Extends,
     E,
-    PP & Props,
+    PP,
     Defaults,
     MakeDefaultsOptional,
     {},


### PR DESCRIPTION
relate to #12059 

https://github.com/vuejs/core/blob/29de6f8b0bb1a604f247b0712daac29e93aa6f3e/packages/runtime-core/src/componentPublicInstance.ts#L311-L313

![image](https://github.com/user-attachments/assets/79af77d2-e6c8-4d97-aa65-02f1ed81ad5d)
