### PR TITLE
chore(sfc-playground): adjust the tooltip text for toggling the theme

### DIFF
--- a/packages-private/sfc-playground/src/App.vue
+++ b/packages-private/sfc-playground/src/App.vue
@@ -123,6 +123,7 @@ onMounted(() => {
     :prod="productionMode"
     :ssr="useSSRMode"
     :autoSave="autoSave"
+    :theme="theme"
     @toggle-theme="toggleTheme"
     @toggle-prod="toggleProdMode"
     @toggle-ssr="toggleSSR"

--- a/packages-private/sfc-playground/src/Header.vue
+++ b/packages-private/sfc-playground/src/Header.vue
@@ -118,9 +118,9 @@ function toggleDark() {
       >
         <span>{{ autoSave ? 'AutoSave ON' : 'AutoSave OFF' }}</span>
       </button>
-      <button 
-        :title="`Switch to ${ theme === 'dark' ? 'light' : 'dark' } theme`"
-        class="toggle-dark" 
+      <button
+        :title="`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`"
+        class="toggle-dark"
         @click="toggleDark"
       >
         <Sun class="light" />

--- a/packages-private/sfc-playground/src/Header.vue
+++ b/packages-private/sfc-playground/src/Header.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
   prod: boolean
   ssr: boolean
   autoSave: boolean
+  theme: 'dark' | 'light'
 }>()
 const emit = defineEmits([
   'toggle-theme',
@@ -117,7 +118,11 @@ function toggleDark() {
       >
         <span>{{ autoSave ? 'AutoSave ON' : 'AutoSave OFF' }}</span>
       </button>
-      <button title="Toggle dark mode" class="toggle-dark" @click="toggleDark">
+      <button 
+        :title="`Switch to ${ theme === 'dark' ? 'light' : 'dark' } theme`"
+        class="toggle-dark" 
+        @click="toggleDark"
+      >
         <Sun class="light" />
         <Moon class="dark" />
       </button>


### PR DESCRIPTION
Before:

It always shows the text "Toggle dark mode" when hovering over the theme icon.

After:

It will show "Switch to light theme" if the theme is dark; otherwise, it shows "Switch to dark theme".