### PR TITLE
perf(reactivity): avoid unnecessary recursion in removeSub

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -426,23 +426,24 @@ function removeSub(link: Link, soft = false) {
     nextSub.prevSub = prevSub
     link.nextSub = undefined
   }
-  if (dep.subs === link) {
-    // was previous tail, point new tail to prev
-    dep.subs = prevSub
-  }
   if (__DEV__ && dep.subsHead === link) {
     // was previous head, point new head to next
     dep.subsHead = nextSub
   }
 
-  if (!dep.subs && dep.computed) {
-    // if computed, unsubscribe it from all its deps so this computed and its
-    // value can be GCed
-    dep.computed.flags &= ~EffectFlags.TRACKING
-    for (let l = dep.computed.deps; l; l = l.nextDep) {
-      // here we are only "soft" unsubscribing because the computed still keeps
-      // referencing the deps and the dep should not decrease its sub count
-      removeSub(l, true)
+  if (dep.subs === link) {
+    // was previous tail, point new tail to prev
+    dep.subs = prevSub
+
+    if (!prevSub && dep.computed) {
+      // if computed, unsubscribe it from all its deps so this computed and its
+      // value can be GCed
+      dep.computed.flags &= ~EffectFlags.TRACKING
+      for (let l = dep.computed.deps; l; l = l.nextDep) {
+        // here we are only "soft" unsubscribing because the computed still keeps
+        // referencing the deps and the dep should not decrease its sub count
+        removeSub(l, true)
+      }
     }
   }
 


### PR DESCRIPTION
I stumbled across an edge case where the performance of `computed` can go awry:

- [Playground - 3.5.11](https://play.vuejs.org/#eNp9U11v2jAU/St3fiGozEC7vTDo1k1o2jRtU9uXCVdTGi4hxbEjf1AkxH/ftZMQ2KbyQJxzj88999jZs5uq4luPbMKmNjNF5cCi89W1UEVZaeNgDwZXA8h0WXmHSzjAyugSerSpJ5RQmVbWwWNqEWaBmoz7LehMkedoGtwZj8dSK2epuHjodL7d/Jrf3hF4eRnAlTaQSHRQEDR6R49pQ6H1xUUf9kIBiYWtmBpZxG4LzvmxQRQPnOadV96ukwB1YJL0YXZdi4WfoQiMikPxbSo9wkUrzw0ufYZJYn1JqcR9tCRCVlMHMKIpg8ohPunv0M3n0kKSw/PGgdZk1bR73/lddM4lqtyt4TWMHxreBEZCUQehgnANxty8ylyhFeSaOpyEZF1KZzqDCg1lW6YqQ670cxI1/nYxg1dnQGSc9alltUQudZ707osSibFBNYEeRZL804bMRwv9NpbpsL52FAK9OCwrmTqMkUwfvXM0w4dMFtlmJliuBYsVgM86MoY1hcDp8GQvGzBnydmqyPmT1Ypud8xAsBBmIdH8qEI8VrBJe+qCpVLq568RC3d10OLZGrPNf/AnuwuYYD8NWjRbFOxYoxlzdHV5fvcdd7Q+Fku99JLYLxRvkVL1wWNN++jVkmyf8KLbL/EbLVR+b+c7h8q2QwWjgXmIfMHoa/30wuid3Sv+Ju6j46EUf2/RBE0K8Iq/5eMxO/wBXUVlIA==)

The time taken grows exponentially with the value of `LAYERS`. I used `22` in the example, but you may need to tweak it depending on your hardware.

The problem is with cleaning up the subs. `removeSub()` calls itself recursively if `dep.subs` is `undefined`. But in this example, `deps.subs` is always `undefined` for all `deps`, so it ends up calling `removeSub()` a huge number of times. The same links are being removed over and over.

I've attempted to fix it by additionally checking that `deps.subs` wasn't already `undefined`.

The diff makes the change look more complicated than it actually is. I've moved the `if (dep.subs === link) {` part further down and wrapped it around the clean-up section.

- [Playground - this PR](https://deploy-preview-12135--vue-sfc-playground.netlify.app/#eNp9U11v2jAU/St3fiEIFmi3JwbduglNm6Ztavsy4T6k4RJcHDvyB0VC/PddOwmBtioPxDn3+Nxzj509u66qdOuRTdjU5kZUDiw6X11xJcpKGwd7MLgaQq7LyjtcwgFWRpfQo009rrjKtbIOHjKLMAvU5KLfgs6IokDT4M54PJZaOUvFxX2n8+v63/zmlsDLywCutIFEogNB0PgTPaYNhdaDQR/2XAGJha2YGSlit0WapscGUTxwmve08nadBKgDk6QPs6taLPwMRWBUHCrdZtIjDFr51ODS55gk1peUStxHSyLkNXUIY5oyqBzik/4O3XwuE5IcnjcOtCarpt3nzu+icy5RFW4N7+HivuFNYMwVdeAqCNdgzM2r3AmtoNDU4SQk6zI60xlUaCjbMlM5pko/JVHjuYsZvDsDIuOsTy2rJaZSF0nvTpRIjA2qCfQokuRFGzIfLfTbWKaj+tpRCPTisKxk5jBGMn3wztEMX3Ip8s2Ms0JzFisA33VkjGoKgdPRyV42ZM6Ss5Uo0kerFd3umAFnIUwh0fypQjyWs0l76pxlUuqnnxELd3XY4vka880r+KPdBYyzvwYtmi1ydqzRjAW6ujy//Y07Wh+LpV56Sew3ijdIqfrgsaZ99WpJtk940e2P+I0KVdzZ+c6hsu1QwWhgHiKfM/pav70xemf3Q/ox7qPjYYf/p0hfpw==)