### PR TITLE
dx(reactivity): warn on nested readonly ref update during unwrapping

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -496,9 +496,10 @@ describe('reactivity/readonly', () => {
     const r = ref(false)
     const ror = readonly(r)
     const obj = reactive({ ror })
-    expect(() => {
-      obj.ror = true
-    }).toThrow()
+    obj.ror = true
+    expect(
+      `Set operation on key "ror" failed: target is readonly.`,
+    ).toHaveBeenWarned()
     expect(obj.ror).toBe(false)
   })
 

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -151,7 +151,13 @@ class MutableReactiveHandler extends BaseReactiveHandler {
       }
       if (!isArray(target) && isRef(oldValue) && !isRef(value)) {
         if (isOldValueReadonly) {
-          return false
+          if (__DEV__) {
+            warn(
+              `Set operation on key "${String(key)}" failed: target is readonly.`,
+              oldValue,
+            )
+          }
+          return true
         } else {
           oldValue.value = value
           return true


### PR DESCRIPTION
1. Warn instead of throwing an error when updating a nested readonly ref, keeping consistency with the `readonly` API.
2. Improved error message for better clarity.

**Before:** `TypeError: 'set' on proxy: trap returned falsish for property 'foo'`
**After:** `[Vue warn] Set operation on key "foo" failed: target is readonly.`