### PR TITLE
fix(runtime-dom): fix getContainerType

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -71,8 +71,9 @@ const isMathMLContainer = (container: Element) =>
   container.namespaceURI!.includes('MathML')
 
 const getContainerType = (
-  container: Element | ShadowRoot,
+  container: Element | ShadowRoot | null,
 ): 'svg' | 'mathml' | undefined => {
+  if (null === container) return undefined
   if (container.nodeType !== DOMNodeTypes.ELEMENT) return undefined
   if (isSVGContainer(container as Element)) return 'svg'
   if (isMathMLContainer(container as Element)) return 'mathml'
@@ -342,7 +343,7 @@ export function createHydrationFunctions(
             vnode,
             parentComponent,
             parentSuspense,
-            getContainerType(parentNode(node)!),
+            getContainerType(parentNode(node)),
             slotScopeIds,
             optimized,
             rendererInternals,


### PR DESCRIPTION
TL;DR async components with lazy hydration break when interacted with very quickly after hydration

The `getContainerType` function does not accept null, however in `packages/runtime-core/src/hydration.ts:281` the following code `const container = parentNode(node)!` assumes `container` will not be null, but in fact, it is, and reading a field from it in `getContainerType` fails. I do not understand the need to use the non-null assertion operator throughout the code base of Vue, but I guess sometimes it can be OK for performance reasons.

Something else I do not understand is, after fixing `getContainerType` locally, we did not experience any further crashes (for now), and looking at the code, `mountComponent` expects to always get a container, but whenever that happens (container = null), and it does happen now and then since `getContainerType` used to crash in 1 of 5 test runs, no observable malfunctions happen. How can `mountComponent` still function properly when it requires a container, but gets passed a null?!

```
TypeError: Cannot read properties of null (reading 'nodeType')
    at getContainerType (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:3781:17)
    at hydrateNode (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:3943:13)
    at hydrateSubTree (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:7440:13) unknown {"name":"TypeError","message":"Cannot read properties of null (reading 'nodeType')","trace":"TypeError: Cannot read properties of null (reading 'nodeType')\n    at getContainerType (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:3781:17)\n    at hydrateNode (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:3943:13)\n    at hydrateSubTree (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:7440:13)"} Error: Uncaught TypeError: Cannot read properties of null (reading 'nodeType') @ File https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:3781:17 https://acme.local:3000/wedding-rings/mens/platinum
Cannot read properties of null (reading 'nodeType')
TypeError: Cannot read properties of null (reading 'nodeType')
    at getContainerType (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:3781:17)
    at hydrateNode (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:3943:13)
    at hydrateSubTree (https://acme.local:3000/node_modules/.vite/deps/chunk-TBLKTZOQ.js?v=11ed4a1a:7440:13)
```

```js
# 3780 through 3785
var getContainerType = (container) => {
  if (container.nodeType !== 1) return void 0;
  if (isSVGContainer(container)) return "svg";
  if (isMathMLContainer(container)) return "mathml";
  return void 0;
};
```

```js
# 3927 through 3956
        } else if (shapeFlag & 6) {
          vnode.slotScopeIds = slotScopeIds;
          const container = parentNode(node);
          if (isFragmentStart) {
            nextNode = locateClosingAnchor(node);
          } else if (isComment(node) && node.data === "teleport start") {
            nextNode = locateClosingAnchor(node, node.data, "teleport end");
          } else {
            nextNode = nextSibling(node);
          }
          mountComponent(
            vnode,
            container,
            null,
            parentComponent,
            parentSuspense,
            getContainerType(container),
            optimized
          );
          if (isAsyncWrapper(vnode)) {
            let subTree;
            if (isFragmentStart) {
              subTree = createVNode(Fragment);
              subTree.anchor = nextNode ? nextNode.previousSibling : container.lastChild;
            } else {
              subTree = node.nodeType === 3 ? createTextVNode("") : createVNode("div");
            }
            subTree.el = node;
            vnode.component.subTree = subTree;
          }
```

```js
# 7413 through 7450
  const setupRenderEffect = (instance, initialVNode, container, anchor, parentSuspense, namespace, optimized) => {
    const componentUpdateFn = () => {
      if (!instance.isMounted) {
        let vnodeHook;
        const { el, props } = initialVNode;
        const { bm, m, parent, root, type } = instance;
        const isAsyncWrapperVNode = isAsyncWrapper(initialVNode);
        toggleRecurse(instance, false);
        if (bm) {
          invokeArrayFns(bm);
        }
        if (!isAsyncWrapperVNode && (vnodeHook = props && props.onVnodeBeforeMount)) {
          invokeVNodeHook(vnodeHook, parent, initialVNode);
        }
        toggleRecurse(instance, true);
        if (el && hydrateNode) {
          const hydrateSubTree = () => {
            if (true) {
              startMeasure(instance, `render`);
            }
            instance.subTree = renderComponentRoot(instance);
            if (true) {
              endMeasure(instance, `render`);
            }
            if (true) {
              startMeasure(instance, `hydrate`);
            }
            hydrateNode(
              el,
              instance.subTree,
              instance,
              parentSuspense,
              null
            );
            if (true) {
              endMeasure(instance, `hydrate`);
            }
          };
```
