### PR TITLE
refactor(reactivity): reduce size of collectionHandlers

### DIFF
--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -60,12 +60,6 @@ function get(
   }
 }
 
-function size(target: IterableCollections, isReadonly = false) {
-  target = target[ReactiveFlags.RAW]
-  !isReadonly && track(toRaw(target), TrackOpTypes.ITERATE, ITERATE_KEY)
-  return Reflect.get(target, 'size', target)
-}
-
 function deleteEntry(this: CollectionTypes, key: unknown) {
   const target = toRaw(this)
   const { has, get } = getProto(target)
@@ -174,7 +168,9 @@ function createInstrumentations(
       return get(this, key, readonly, shallow)
     },
     get size() {
-      return size(this as unknown as IterableCollections, readonly)
+      const target = (this as unknown as IterableCollections)[ReactiveFlags.RAW]
+      !readonly && track(toRaw(target), TrackOpTypes.ITERATE, ITERATE_KEY)
+      return Reflect.get(target, 'size', target)
     },
     has(this: CollectionTypes, key: unknown): boolean {
       const target = this[ReactiveFlags.RAW]

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -30,22 +30,6 @@ const toShallow = <T extends unknown>(value: T): T => value
 const getProto = <T extends CollectionTypes>(v: T): any =>
   Reflect.getPrototypeOf(v)
 
-function clear(this: IterableCollections) {
-  const target = toRaw(this)
-  const hadItems = target.size !== 0
-  const oldTarget = __DEV__
-    ? isMap(target)
-      ? new Map(target)
-      : new Set(target)
-    : undefined
-  // forward the operation before queueing reactions
-  const result = target.clear()
-  if (hadItems) {
-    trigger(target, TriggerOpTypes.CLEAR, undefined, undefined, oldTarget)
-  }
-  return result
-}
-
 function createIterableMethod(
   method: string | symbol,
   isReadonly: boolean,
@@ -238,7 +222,27 @@ function createInstrumentations(
             }
             return result
           },
-          clear,
+          clear(this: IterableCollections) {
+            const target = toRaw(this)
+            const hadItems = target.size !== 0
+            const oldTarget = __DEV__
+              ? isMap(target)
+                ? new Map(target)
+                : new Set(target)
+              : undefined
+            // forward the operation before queueing reactions
+            const result = target.clear()
+            if (hadItems) {
+              trigger(
+                target,
+                TriggerOpTypes.CLEAR,
+                undefined,
+                undefined,
+                oldTarget,
+              )
+            }
+            return result
+          },
         },
   )
 


### PR DESCRIPTION
The diff looks horrendous... the change really isn't that complicated.

## Bundle size

My primary goal was to reduce the bundle size. I've removed a lot of redundancy from `collectionHandlers.ts`. That involved moving around a lot of code, but it essentially all still works the same way.

To make this a bit easier to review I've split it up into individual commits. The first commit is the key change to understand what I've done. `createInstrumentations` was previously creating 4 lots of instrumentations and then returning them. The new version just creates the instrumentations for a single case, based on the arguments `readonly` and `shallow`. Just that one change reduces the bundle size by about 566 bytes, or roughly 135 bytes after gzipping.

The other commits gradually inline each of the functions. I checked after each commit to ensure that they really did reduce the bundle size further.

The final result is about 220 bytes saved after gzipping. In the **Usages** size checks that's a saving of about 1%.

## Fixes minor bugs

A key part of the new approach is that `readonly` and `shallow` are arguments passed to `createInstrumentations`, which are then caught in the closure of the specific handlers. Previously these argument were passed directly to the handlers.

The old approach could lead to minor bugs in edge cases, due to the ghost parameters:

- [Playground example - 3.5.11](https://play.vuejs.org/#eNp9kkFPAjEQhf/KpBchWZcY9YJgooaDHtSAN2tM6Q5Q3G03bXch2ex/d1rCAtFwa+d9M31v0oY9lGVaV8iGbOSkVaUHh74q77lWRWmshwYsCulVjQkoN+3O3kzFBlpYWFPABY244JprabSLI2Dc9fU0bmCGvtfv7wFxLDcghuBthdB2wPwUmP8B5CkgjwCu7z5FAvME5Fe6MHYi5KpHllKRZUnwRsxosEtLOenisShz4ZFuAKNM1VBfUuOYMzNfg9K7sGFGn7MIATQNBLFtYXwfLofd9KjeJyEOG9A06hgNujdYwryjEAu1TNfOaFp9E1DOpClKlaN9K72ikJwNISpBE3luNi+xFoIm+7pcofz5p75221Dj7N2iQ1sjZ53mhV2i38mT2Stu6dyJhcmqnOgz4hSdyavgcYc9Vjoj20dcdPscP5DSyw832XrUbh8qGA1kG3nO6PM8nYl+sHud3sQ+rlva4neNNsykBV6nt+nVFWt/AYWW7r4=)

The reason for the inconsistency in this example is that the `add` method takes `_isShallow` as its second argument. This is only supposed to be passed internally, but it also gets passed automatically by `forEach` in the example above.

With the refactoring in this PR, those ghost parameters are removed, so these kinds of inconsistencies should no longer occur:

- [Playground example - this PR](https://deploy-preview-12152--vue-sfc-playground.netlify.app/#eNp9kjFvwjAQhf/KyUtBSsPQThSQ2oqhHdoKutUdjHOAaWJHthOQovz3nh0RQK3YfPe+O79nuWGPZZnWFbIxmzhpVenBoa/KGdeqKI310IBFIb2qMQHlFv3Zm4XYQwtrawq4oRU3XHMtjXZxBUz7uYHGPSzRD4bDIyDO5QbEGLytENoeWF0Cqz+AvATkGcD1w5dIYJWA/E7Xxs6F3A7IUiqyLAneiJmMurSUkwqPRZkLj1QBTDJVQ31Lg1POzGoHSndhw44hZxECaBoIYtvCdBaK09sMqD8kIS4b0TaamIz6O1jCvKMQa7VJd85oevomoJxJU5QqR/teekUhORtDVIIm8tzsX2MvBE2OfblF+fNPf+cOocfZh0WHtkbOes0Lu0HfyfPlGx7o3IuFyaqc6CviAp3Jq+Cxw54qnZHtMy66fYkfSOnNp5sfPGp3DBWMBrKNPGf0eZ6vRD/ZvUvv4xzXLWt/AQ6r6UU=)

## Performance

I don't think this PR should have a significant impact on performance. Inlining the handlers may have slightly improved performance in some cases, as it removes an extra function call.

For example, this Playground gives slightly quicker times for me when testing in Chrome:

- [Playground - 3.5.11](https://play.vuejs.org/#__PROD__eNp9UttuGjEQ/ZWRX3YRdAmhfSFL1YuiqpV6UZpHS9XGDHSDd2z5AkiIf+/YCwRVSfZp58zx8Zkz3ouP1labiGImaq9cawN4DNG+l9R21rgAe3DYqNBuEA6wdKaDgvmFJEnKkA/QNRbmZ1JJuIXvjS0Hg0ThZsWC5WQERVMwdAKuGXi4BKYMqARIWkZiLUNJ+gu3BrCXBNBf50PDruZg0S2N6xpSWJHZlvkkAGNQagzQ0gJ3zLu6Of7WMLlK3w0Mhxk5ykK6plolk6xxWV//V09zfegv6t0gLV72kihGY6XNqizu2w4hNGukGRQwhDIdfdOPk7Ji2Xrcr4DD5yJgZ3UTkCuA+iGGwIl8ULpV67kUfTRS5C7AXaSnPR395nPj/iDT6vFZUYxE8Oxu2a6qR2+It5+jkEKZzrYa3U+bFuClmJ1CkqLR2my/ZSy4iKMTrv6iWj+DP/pdwqT45dCj26AU5x5PnRzm9u3vH7jj/3OzM4uomf1K8w452Zg89rRPkRZs+4KX3X7Nb7il1b2/3QUkfxoqGc3LzHwp+El/fmX0J7vT6u3xERw4xT8bdEmTA5xW76rJRBz+AdlAFQo=)
- [Playground - this PR](https://deploy-preview-12152--vue-sfc-playground.netlify.app/#__PROD__eNp9UttuIjEM/RUrLzMIdmjLPtFhtRdVq11pL2r7mJdpMHRKxolyASTEv9fJAEVV2zzFx8fO8XF24pu11TqimIraK9faAB5DtF8ktZ01LsAOHDYqtGuEPSyc6aBgfiFJkjLkA3SNhdmJVBJu4E9jy8EgUThZccPycgRFUzB0BK4YeDgHJgyoBEhaROJehlLrn5wawE4SQP+cDw2rmoFFtzCua0hhRWZT5koAxqDUGKClOW6Zd3F9uNZweZHONQyHGTm0hfRMtUwiucd5fPUqnuR43z/Uq0Gav68lUYzGSptlWdy3HUJoVkhTKGAIZSr91I+TvOK29bhfAZvPQcDO6iYgRwD1QwyBHfmqdKtWMyl6a6TIWYDbSC97OujNdeO+kGn1+NRRjETwrG7RLqsnb4i3n62QQpnOthrdP5sW4KWYHk2SotHabH5nLLiIoyOuHlGt3sCf/DZhUvx36NGtUYpTjqdOCnP65u4vbvl+SnZmHjWzP0jeIjsbk8ae9j3SnGWf8bLaX/kPt7S89zfbgOSPQyWheZmZLwV/6R8fjP4id1J9PnyCvdg/A2VkD5E=)

## Impact on other PRs

Such a large amount of churn, albeit within a single file, is a cause for concern. I've checked how this would impact existing PRs.

These PRs would conflict with this PR:
- #7328 - This change looks good to me and can probably be merged. The conflict should be trivial to resolve, whichever PR gets merged first.
- #9141 - I think only the imports would conflict, so trivially resolved.
- #11399 - The conflicts should be easily fixable. If anything, the changes here will simplify that PR, as it currently repeats much of the code.

These PRs make changes to `collectionHandler.ts`, but I don't think this PR would cause any conflicts:
- #6350
- #6355