### PR TITLE
fix(runtime-core): use feature flag for call to `resolveMergedOptions`

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -1006,7 +1006,7 @@ export function finishComponentSetup(
           instance.vnode.props &&
           instance.vnode.props['inline-template']) ||
         Component.template ||
-        resolveMergedOptions(instance).template
+        (__FEATURE_OPTIONS_API__ && resolveMergedOptions(instance).template)
       if (template) {
         if (__DEV__) {
           startMeasure(instance, `compile`)


### PR DESCRIPTION
Not sure whether this counts as `fix`, `perf` or `refactor`. Feel free to adjust accordingly.

I was doing some analysis of bundle size across Vue versions and noticed a jump in 3.2.39. This seems to have been caused by #6250. We didn't have size checks on PRs back then, and I don't see it discussed on the PR, so I assume this just slipped through.

It only impacts projects using `__VUE_OPTIONS_API__: false`.

The call to `resolveMergedOptions` prevents a big chunk of the Options API from being treeshaken. It's used to resolve `template` from `extends` and `mixins`, but I believe that is only relevant when `__FEATURE_OPTIONS_API__` is `true`.