### PR TITLE
fix(computed): remove legacy computed warn related configurations

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -96,12 +96,6 @@ export class ComputedRefImpl<T = any> implements Subscriber {
   // dev only
   onTrigger?: (event: DebuggerEvent) => void
 
-  /**
-   * Dev only
-   * @internal
-   */
-  _warnRecursive?: boolean
-
   constructor(
     public fn: ComputedGetter<T>,
     private readonly setter: ComputedSetter<T> | undefined,

--- a/packages/runtime-core/src/apiComputed.ts
+++ b/packages/runtime-core/src/apiComputed.ts
@@ -1,17 +1,10 @@
-import { type ComputedRefImpl, computed as _computed } from '@vue/reactivity'
-import { getCurrentInstance, isInSSRComponentSetup } from './component'
+import { computed as _computed } from '@vue/reactivity'
+import { isInSSRComponentSetup } from './component'
 
 export const computed: typeof _computed = (
   getterOrOptions: any,
   debugOptions?: any,
 ) => {
   // @ts-expect-error
-  const c = _computed(getterOrOptions, debugOptions, isInSSRComponentSetup)
-  if (__DEV__) {
-    const i = getCurrentInstance()
-    if (i && i.appContext.config.warnRecursiveComputed) {
-      ;(c as unknown as ComputedRefImpl<any>)._warnRecursive = true
-    }
-  }
-  return c as any
+  return _computed(getterOrOptions, debugOptions, isInSSRComponentSetup) as any
 }

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -150,12 +150,6 @@ export interface AppConfig {
   isCustomElement?: (tag: string) => boolean
 
   /**
-   * TODO document for 3.5
-   * Enable warnings for computed getters that recursively trigger itself.
-   */
-  warnRecursiveComputed?: boolean
-
-  /**
    * Whether to throw unhandled errors in production.
    * Default is `false` to avoid crashing on any error (and only logs it)
    * But in some cases, e.g. SSR, throwing might be more desirable.


### PR DESCRIPTION
It looks like the recursive computed warning no longer exists in 3.5.