### PR TITLE
fix(runtime-dom): set `text` as an attribute for `a` tags

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -394,4 +394,12 @@ describe('runtime-dom: props patching', () => {
 
     expect(fn).toBeCalledTimes(0)
   })
+
+  // #12211
+  test('should not override content when `text` attribute is set', () => {
+    const root = document.createElement('div')
+    render(h('a', { text: '' }, ['foo']), root)
+    const a = root.children[0]
+    expect(a.textContent).toBe('foo')
+  })
 })

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -122,6 +122,11 @@ function shouldSetAsProp(
     return false
   }
 
+  // #12211 <a text> must be set as attribute
+  if (key === 'text' && el.tagName === 'A') {
+    return false
+  }
+
   // #8780 the width or height of embedded tags must be set as attribute
   if (key === 'width' || key === 'height') {
     const tag = el.tagName


### PR DESCRIPTION
close #12211