### PR TITLE
types(runtime-core): fix type restriction for `default` in `PropOptions`

### DIFF
--- a/packages-private/dts-test/setupHelpers.test-d.ts
+++ b/packages-private/dts-test/setupHelpers.test-d.ts
@@ -440,8 +440,24 @@ describe('defineModel', () => {
     },
   })
 
-  // @ts-expect-error type / default mismatch
-  defineModel<string>({ default: 123 })
+  // default mismatch
+  {
+    // @ts-expect-error
+    defineModel<string>({ default: 123 })
+    // @ts-expect-error
+    defineModel<string>({ default: () => 123 })
+    // @ts-expect-error
+    defineModel<{ foo: number }>({ default: { foo: '' } })
+    // @ts-expect-error
+    defineModel<{ foo: number }>({
+      default: () => ({ foo: '' }),
+    })
+    // @ts-expect-error
+    defineModel<() => number>({
+      default: () => '',
+    })
+  }
+
   // @ts-expect-error unknown props option
   defineModel({ foo: 123 })
 

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -55,7 +55,14 @@ type DefaultFactory<T> = (props: Data) => T | null | undefined
 export interface PropOptions<T = any, D = T> {
   type?: PropType<T> | true | null
   required?: boolean
-  default?: D | DefaultFactory<D> | null | undefined | object
+  default?:
+    | null
+    | undefined
+    | (T extends Function
+        ? T extends infer F
+          ? F
+          : never
+        : DefaultFactory<D> | D)
   validator?(value: unknown, props: Data): boolean
   /**
    * @internal


### PR DESCRIPTION
close #12145

Correct the `default` field type to prevent assigning arbitrary objects.

refix #1891. If `type` specifies a `Function`, the `default` field type should match the specified function type.

---

**NOTE:** Due to TypeScript's [literal-inference](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference), when `type` is a literal type, the `default` cannot be strictly enforced.

Consider the following example:

```ts
// `foo.default` is inferred as `string` instead of the literal type `'foo'`
const foo = {
  type: String as PropType<'foo' | 'bar'>,
  default: 'foo',
}

// Strictly enforcing `default` to be `'foo' | 'bar'` would break existing cases:
defineComponent({
  props: { foo }, // should allow
})