### PR TITLE
fix(compiler-sfc): fallback to UNKNOWN when union contains uninferrable types

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -460,6 +460,29 @@ describe('resolveType', () => {
     })
   })
 
+  test('should fallback to UNKNOWN when union contains uninferrable types', () => {
+    const files = {
+      '/foo.ts': `
+        const MySymbol = Symbol();
+        export type SymbolType = typeof MySymbol
+      `,
+    }
+
+    const { props } = resolve(
+      `
+      import { SymbolType } from './foo'
+      defineProps<{
+        foo: SymbolType | boolean;
+      }>()
+      `,
+      files,
+    )
+
+    expect(props).toStrictEqual({
+      foo: [UNKNOWN_TYPE],
+    })
+  })
+
   test('keyof', () => {
     const files = {
       '/foo.ts': `export type IMP = { ${1}: 1 };`,

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1689,8 +1689,10 @@ export function inferRuntimeType(
       case 'TSParenthesizedType':
         return inferRuntimeType(ctx, node.typeAnnotation, scope)
 
-      case 'TSUnionType':
-        return flattenTypes(ctx, node.types, scope, isKeyOf)
+      case 'TSUnionType': {
+        const types = flattenTypes(ctx, node.types, scope, isKeyOf)
+        return types.some(t => t === UNKNOWN_TYPE) ? [UNKNOWN_TYPE] : types
+      }
       case 'TSIntersectionType': {
         return flattenTypes(ctx, node.types, scope, isKeyOf).filter(
           t => t !== UNKNOWN_TYPE,


### PR DESCRIPTION
close #12234