### PR TITLE
fix(compiler-sfc): fix The withDefaults function loses arguments when assigning a function default value

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -517,7 +517,9 @@ export default /*@__PURE__*/_defineComponent({
     qux: { type: Function, required: false, default() { return 1 } },
     quux: { type: Function, required: false, default() { } },
     quuxx: { type: Promise, required: false, async default() { return await Promise.resolve('hi') } },
-    fred: { type: String, required: false, get default() { return 'fred' } }
+    fred: { type: String, required: false, get default() { return 'fred' } },
+    toLowerCase: { type: Function, required: true, default: (str: string) => str.toLowerCase() },
+    toUpperCase: { type: Function, required: true, default(str: string) { return str.toUpperCase() } }
   },
   setup(__props: any, { expose: __expose }) {
   __expose();

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -388,12 +388,16 @@ const props = defineProps({ foo: String })
       quux?(): void
       quuxx?: Promise<string>;
       fred?: string
+      toLowerCase: (str: string) => string
+      toUpperCase: (str: string) => string
     }>(), {
       foo: 'hi',
       qux() { return 1 },
       ['quux']() { },
       async quuxx() { return await Promise.resolve('hi') },
-      get fred() { return 'fred' }
+      get fred() { return 'fred' },
+      toLowerCase: (str: string) => str.toLowerCase(),
+      toUpperCase(str: string){ return str.toUpperCase() } 
     })
     </script>
     `)
@@ -415,6 +419,12 @@ const props = defineProps({ foo: String })
     expect(content).toMatch(
       `fred: { type: String, required: false, get default() { return 'fred' } }`,
     )
+    expect(content).toMatch(
+      `toLowerCase: { type: Function, required: true, default: (str: string) => str.toLowerCase() }`,
+    )
+    expect(content).toMatch(
+      `toUpperCase: { type: Function, required: true, default(str: string) { return str.toUpperCase() } }`,
+    )
     expect(content).toMatch(`const props = __props`)
     expect(bindings).toStrictEqual({
       foo: BindingTypes.PROPS,
@@ -424,6 +434,8 @@ const props = defineProps({ foo: String })
       quux: BindingTypes.PROPS,
       quuxx: BindingTypes.PROPS,
       fred: BindingTypes.PROPS,
+      toLowerCase: BindingTypes.PROPS,
+      toUpperCase: BindingTypes.PROPS,
       props: BindingTypes.SETUP_CONST,
     })
   })

--- a/packages/compiler-sfc/src/script/defineProps.ts
+++ b/packages/compiler-sfc/src/script/defineProps.ts
@@ -262,7 +262,7 @@ function genRuntimePropFromType(
       } else {
         defaultString = `${prop.async ? 'async ' : ''}${
           prop.kind !== 'method' ? `${prop.kind} ` : ''
-        }default() ${ctx.getString(prop.body)}`
+        }default(${prop.params.map(node => ctx.getString(node)).join(',')}) ${ctx.getString(prop.body)}`
       }
     }
   }


### PR DESCRIPTION
close #5253