### PR TITLE
fix(types): avoid nullable as keys to affect the inference of `IsKeyValues`

### DIFF
--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -13,7 +13,7 @@ export type LooseRequired<T> = { [P in keyof (T & Required<T>)]: T[P] }
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
 
-export type IsKeyValues<T, K = string> = IfAny<
+export type IsKeyValues<T, K = PropertyKey> = IfAny<
   T,
   false,
   T extends object ? (NonNullable<keyof T> extends K ? true : false) : false

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -16,7 +16,7 @@ export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
 export type IsKeyValues<T, K = string> = IfAny<
   T,
   false,
-  T extends object ? (keyof T extends K ? true : false) : false
+  T extends object ? (NonNullable<keyof T> extends K ? true : false) : false
 >
 
 /**


### PR DESCRIPTION
vuejs/language-tools#4819 