### PR TITLE
types(runtime-core): add components option for DefineSetupFnComponent

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -156,7 +156,7 @@ export function defineComponent<
     props: Props,
     ctx: SetupContext<E, S>,
   ) => RenderFunction | Promise<RenderFunction>,
-  options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
+  options?: Pick<ComponentOptions, 'name' | 'inheritAttrs' | 'components'> & {
     props?: (keyof Props)[]
     emits?: E | EE[]
     slots?: S
@@ -172,7 +172,7 @@ export function defineComponent<
     props: Props,
     ctx: SetupContext<E, S>,
   ) => RenderFunction | Promise<RenderFunction>,
-  options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
+  options?: Pick<ComponentOptions, 'name' | 'inheritAttrs' | 'components'> & {
     props?: ComponentObjectPropsOptions<Props>
     emits?: E | EE[]
     slots?: S


### PR DESCRIPTION
I what use resolveComponent to generate dynamic component, For that It must manual add those components to  the components option. 
But the `DefineSetupFnComponent` type don't have the components option. So I create this PR.
```tsx
export default defineComponent((props:{ type: 'input' | 'time-picker'})=>{
 return () => (
   <ElFormItem>
     { 
       h(resolveComponent(`el-${props.type || 'input'}`))
     }
   </ElFormItem>
 )
}, { components: { ElInput, ElTimePicker } } )
```