### PR TITLE
perf: avoid array iterators over objects

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -693,8 +693,8 @@ export function compileScript(
   checkInvalidScopeReference(ctx.propsDestructureDecl, DEFINE_PROPS)
   checkInvalidScopeReference(ctx.emitsRuntimeDecl, DEFINE_EMITS)
   checkInvalidScopeReference(ctx.optionsRuntimeDecl, DEFINE_OPTIONS)
-  for (const { runtimeOptionNodes } of Object.values(ctx.modelDecls)) {
-    for (const node of runtimeOptionNodes) {
+  for (const decl in ctx.modelDecls) {
+    for (const node of ctx.modelDecls[decl].runtimeOptionNodes) {
       checkInvalidScopeReference(node, DEFINE_MODEL)
     }
   }


### PR DESCRIPTION
Object iterators like Object.keys, Object.values, and Object.entries, when used for iteration, create a temporary intermediate array by internally making another iteration, essentially doubling the memory usage and execution time. Using object iterators will avoid that intermediate array and the extra internal iteration.

Benchmark:
```ts
const largeObject = {}
for (let i=0; i<100000;i++) {
    largeObject[i] = i
}

console.time("array method")
for (const num of Object.keys(largeObject)) {
    // It doesn't matter what happens within the loop as the main slowdown is the keys iterator
}
console.timeEnd("array method")

console.time("obj method")
for (const num in largeObject) {
    // It doesn't matter what happens within the loop as the main slowdown is the keys iterator
}
console.timeEnd("obj method")
```

Performance results:
![image](https://github.com/user-attachments/assets/0464740e-000b-4dbc-9fbe-1ce55db855ac)
![image](https://github.com/user-attachments/assets/666854ba-96c1-485b-8a49-35c7453a3c72)

Memory results:
![image](https://github.com/user-attachments/assets/5d0b698b-ddc7-49ef-9cc2-34338d00ef95)
![image](https://github.com/user-attachments/assets/b2b61d46-0d6a-412b-9ff2-8cfb5a37e686)


In places where prototype pollution may be a concern, a review would be appreciated so I could add own property checks