### PR TITLE
fix(reativity): support for trigger responsive getters in onTrack

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -750,6 +750,7 @@ describe('reactivity/effect', () => {
     let events: DebuggerEvent[] = []
     let dummy
     const onTrack = vi.fn((e: DebuggerEvent) => {
+      obj.foo // #12259
       events.push(e)
     })
     const obj = reactive({ foo: 1, bar: 2 })

--- a/packages/reactivity/src/dep.ts
+++ b/packages/reactivity/src/dep.ts
@@ -7,6 +7,8 @@ import {
   type Subscriber,
   activeSub,
   endBatch,
+  pauseTracking,
+  resetTracking,
   shouldTrack,
   startBatch,
 } from './effect'
@@ -143,6 +145,7 @@ export class Dep {
     }
 
     if (__DEV__ && activeSub.onTrack) {
+      pauseTracking()
       activeSub.onTrack(
         extend(
           {
@@ -151,6 +154,7 @@ export class Dep {
           debugInfo,
         ),
       )
+      resetTracking()
     }
 
     return link


### PR DESCRIPTION
fix #12259 
Simply try it.