### PR TITLE
fix(runtime-core): multiple ref elements with the same name

### DIFF
--- a/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
@@ -125,4 +125,28 @@ describe('useTemplateRef', () => {
       __DEV__ = true
     }
   })
+
+  // 12246
+  test('should set last element if multiple with same key are defined', () => {
+    let tRef: ShallowRef
+    let key = 'refKey'
+
+    const Comp = {
+      setup() {
+        tRef = useTemplateRef(key)
+      },
+      render() {
+        return h('div', [
+          h('div', { ref: key }),
+          h('div', { ref: key }),
+          h('span', { ref: key }),
+        ])
+      },
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+
+    expect(tRef!.value.tag).toBe('span')
+  })
 })

--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -1,4 +1,5 @@
 import {
+  type ShallowRef,
   defineComponent,
   h,
   nextTick,
@@ -537,5 +538,28 @@ describe('api: template refs', () => {
     expect(serializeInner(root)).toBe(
       '<div><div>[object Object],[object Object]</div><ul><li>2</li><li>3</li></ul></div>',
     )
+  })
+
+  // 12246
+  test('should set last element if multiple with same key are defined', () => {
+    let refKey: ShallowRef
+
+    const Comp = {
+      setup() {
+        refKey = ref()
+      },
+      render() {
+        return h('div', [
+          h('div', { ref: refKey }),
+          h('div', { ref: refKey }),
+          h('span', { ref: refKey }),
+        ])
+      },
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+
+    expect(refKey!.value.tag).toBe('span')
   })
 })

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -115,9 +115,11 @@ export function setRef(
           } else {
             if (!isArray(existing)) {
               if (_isString) {
-                refs[ref] = [refValue]
-                if (canSetSetupRef(ref)) {
-                  setupState[ref] = refs[ref]
+                if (oldRef !== ref) {
+                  refs[ref] = [refValue]
+                  if (canSetSetupRef(ref)) {
+                    setupState[ref] = refs[ref]
+                  }
                 }
               } else {
                 ref.value = [refValue]
@@ -128,9 +130,11 @@ export function setRef(
             }
           }
         } else if (_isString) {
-          refs[ref] = value
-          if (canSetSetupRef(ref)) {
-            setupState[ref] = value
+          if (oldRef !== ref) {
+            refs[ref] = value
+            if (canSetSetupRef(ref)) {
+              setupState[ref] = value
+            }
           }
         } else if (_isRef) {
           ref.value = value


### PR DESCRIPTION
Solves: https://github.com/vuejs/core/issues/12246 

The solution is more like a stub. 
Idea is to keep setting the last element as a ref if name is same without breaking the code.
https://github.com/vuejs/core/compare/main...tsiotska:vue-core:fix-12246_multiple_template_refs#diff-753361986948a3a8e997f4375421f1c9d73c10aae9ece1b791a978876944dfeaR118

Added appropriate tests.
The best idea would be to set and operate via unique keys and throw a warning in dev mode.

