### PR TITLE
fix(compiler): resolve inner content for incomplete SFC root tag

### DIFF
--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -419,6 +419,13 @@ const tokenizer = new Tokenizer(stack, {
 
   onend() {
     const end = currentInput.length
+    // resolve inner content for incomplete SFC root tag
+    if (currentRoot && currentRoot.children.length) {
+      const el = currentRoot.children[currentRoot.children.length - 1];
+      if (el.type === 1 && !new RegExp(`<\/${el.tag}\s*>$`).test(el.loc.source)) {
+        el.innerLoc = getLoc(el.innerLoc!.start.offset, end);
+      }
+    }
     // EOF ERRORS
     if ((__DEV__ || !__BROWSER__) && tokenizer.state !== State.Text) {
       switch (tokenizer.state) {


### PR DESCRIPTION
When `<template>` is the last SFC block, if the file ends with an incorrect or incomplete closing tag, the parser will completely ignore that tag. This means that we cannot obtain the complete inner content of the `<template>` based on the locs of the child nodes.

This PR attempts to fix the issue by setting the end position of `innerLoc` to the end of the document when the last SFC block is not properly closed.