### PR TITLE
feat(compiler): support `v-generic`

### DIFF
--- a/packages/compiler-dom/src/index.ts
+++ b/packages/compiler-dom/src/index.ts
@@ -31,6 +31,7 @@ export const DOMNodeTransforms: NodeTransform[] = [
 
 export const DOMDirectiveTransforms: Record<string, DirectiveTransform> = {
   cloak: noopDirectiveTransform,
+  generic: noopDirectiveTransform,
   html: transformVHtml,
   text: transformVText,
   model: transformModel, // override compiler-core


### PR DESCRIPTION
~~Related to #8015. Type support has been implemented by vuejs/language-tools#4971.~~

We can support both `v-generic` and `@vue-generic`.