### PR TITLE
fix(runtime-core): warn about negative number in v-for

### DIFF
--- a/packages/runtime-core/__tests__/helpers/renderList.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/renderList.spec.ts
@@ -27,7 +27,16 @@ describe('renderList', () => {
       renderList(3.1, () => {})
     } catch (e) {}
     expect(
-      `The v-for range expect an integer value but got 3.1.`,
+      `The v-for range expects a positive integer value but got 3.1.`,
+    ).toHaveBeenWarned()
+  })
+
+  it('should warn when given a negative N', () => {
+    try {
+      renderList(-1, () => {})
+    } catch (e) {}
+    expect(
+      `The v-for range expects a positive integer value but got -1.`,
     ).toHaveBeenWarned()
   })
 

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -83,8 +83,10 @@ export function renderList(
       )
     }
   } else if (typeof source === 'number') {
-    if (__DEV__ && !Number.isInteger(source)) {
-      warn(`The v-for range expect an integer value but got ${source}.`)
+    if (__DEV__ && (!Number.isInteger(source) || source < 0)) {
+      warn(
+        `The v-for range expects a positive integer value but got ${source}.`,
+      )
     }
     ret = new Array(source)
     for (let i = 0; i < source; i++) {

--- a/packages/server-renderer/__tests__/ssrRenderList.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderList.spec.ts
@@ -27,7 +27,14 @@ describe('ssr: renderList', () => {
   it('should warn when given a non-integer N', () => {
     ssrRenderList(3.1, () => {})
     expect(
-      `The v-for range expect an integer value but got 3.1.`,
+      `The v-for range expects a positive integer value but got 3.1.`,
+    ).toHaveBeenWarned()
+  })
+
+  it('should warn when given a negative N', () => {
+    ssrRenderList(-1, () => {})
+    expect(
+      `The v-for range expects a positive integer value but got -1.`,
     ).toHaveBeenWarned()
   })
 

--- a/packages/server-renderer/src/helpers/ssrRenderList.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderList.ts
@@ -10,8 +10,10 @@ export function ssrRenderList(
       renderItem(source[i], i)
     }
   } else if (typeof source === 'number') {
-    if (__DEV__ && !Number.isInteger(source)) {
-      warn(`The v-for range expect an integer value but got ${source}.`)
+    if (__DEV__ && (!Number.isInteger(source) || source < 0)) {
+      warn(
+        `The v-for range expects a positive integer value but got ${source}.`,
+      )
       return
     }
     for (let i = 0; i < source; i++) {


### PR DESCRIPTION
### Context

When using `v-for` with a negative value, let's say `-1`, an error occurs in the console:

`RangeError: Invalid array length`
![image](https://github.com/user-attachments/assets/71b94f4c-927f-432a-93a3-5ca9c9e5722c)

You can see a [reproduction here](https://play.vuejs.org/#eNqNU81u2zAMfhVClySAY6PITlkSYCsCtDtsQ7fbNCCqzThqZMnQT5og8DvtGfZko5Tay6ErdqPIj/w+fqDO7EPb5oeAbM4WrrSy9eDQh3bFtWxaYz2coTRNGzxW0MHWmgZGhB9xzXVptPMgPTYOlvBjdIdKmVEGnN3hibOf77kuCrgVqgxKeAS/Q9CheUQLZgtSV7IU3liXgULiFSfKgYBSWBMcKmhFLbXw0ugMnqXfwQxQYYPaO2hpCNUxTxz3moZLR60OM1JEcKXAoguKBGqY3mTwaFHspa6TjM1hujV2k5rHypg9CJ8KcSejMEdrjYXNg9A1rmM8J5KDULICYS1JVahrv9vAZPBh2IfM6D0bjyewXME4mZRfeqCA2QSmcDMhgxbFxXYynB6EaqNV9AJYVPKQAgqDeokoVhKS+iVncWzcL43nDOZ7PL2kORs6qMe1Qq/O51joOuKMz2FgoWTPUwxE/6Ts10y8w85X5H3uFQW/f/0H96K4LL4oruxgGfOOjN7KOn9yRtPBniOYs2i1VGi/tPFSSMgcUiXWBB3k86eU8zZg1ufLHZb7V/JP7hhznH2l20F7QM6Gmhe2Rn8pr799xiPFQ7ExVVCEfqP4gHRYIWq8wD4GXZHsK1xSe5++Hd3pd7c+etSuXyoKjcgu4TmjX3j7xup/5c7yd6mP6451fwCB5kqL).

----

### Proposed solution

If the number wasn't an integer, we would get a nice warning:

![image](https://github.com/user-attachments/assets/e0aac868-91be-498f-97a2-791b9772295f)

I'm just extending this warning to also includes negative integers.
This way, it's way easier to understand that the issue arises in the `v-for` and goes into debugging the issue faster.

----

### Side note

- I did a commit for the `server-renderer`, to stay aligned with the `runtime-core` change.
This one was failing silently as it's using a `for loop` compared to the `runtime-core` using a `new Array(source)` where `source` was `-1`, hence resulting in the `RangeError: Invalid array length` error message.

- I did a second commit for the `runtime-core` package, the one I want to fix.

_(actually this issue arised from using the carousel from NuxtUI, but I see that [the page / indicators calculation has now been fixed](https://github.com/nuxt/ui/commit/5cf24fa6e7ba1508458dd5bc1319ac431d908cb0) but I still think that this fix is nice to have)_