### PR TITLE
workflow: fix the vitest bench ran twice

### DIFF
--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -10,5 +10,8 @@ export default mergeConfig(config, {
       },
     },
     include: ['packages/vue/__tests__/e2e/*.spec.ts'],
+    benchmark: {
+      exclude: ['**'],
+    },
   },
 })


### PR DESCRIPTION
Our repo has two vitest config files, `vitest.e2e.config.ts` and `vitest.unit.config.ts`. these two config are responsible for different parts.

However. the same Benchmark was mistakenly run twice because the `exclude` and `include` for the benchmark needs to be configured separately.

![image](https://github.com/user-attachments/assets/0063dd28-c0cb-4c96-9fa9-6d70b3c0b196)
