### PR TITLE
chore: input[type=date], the modifier number could converted to a timestamp

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1377,6 +1377,61 @@ describe('vModel', () => {
     expect(data.value).toEqual('使用拼音输入')
   })
 
+  it('should trasform date to timestamp with numebr modifier', async () => {
+    const component = defineComponent({
+      data() {
+        return { date: null, datetime: null }
+      },
+      render() {
+        return [
+          withVModel(
+            h('input', {
+              class: 'date',
+              type: 'date',
+              'onUpdate:modelValue': (val: any) => {
+                this.date = val
+              },
+            }),
+            this.date,
+            {
+              number: true,
+            },
+          ),
+          withVModel(
+            h('input', {
+              class: 'datetime',
+              type: 'datetime-local',
+              'onUpdate:modelValue': (val: any) => {
+                console.log('zxxx', val)
+                this.datetime = val
+              },
+            }),
+            this.datetime,
+            {
+              number: true,
+            },
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const date = root.querySelector('.date')
+    const datetime = root.querySelector('.datetime')
+    const data = root._vnode.component.data
+
+    date.value = '2024-11-11'
+    triggerEvent('input', date)
+    await nextTick()
+    expect(data.date).toEqual(new Date('2024-11-11').getTime())
+
+    datetime.value = '2024-11-11T20:00'
+    triggerEvent('input', datetime)
+    await nextTick()
+    expect(data.datetime).toEqual(new Date('2024-11-11T20:00').getTime())
+  })
+
+  // #10503
   it('multiple select (model is number, option value is string)', async () => {
     const component = defineComponent({
       data() {

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -53,15 +53,19 @@ export const vModelText: ModelDirective<
 > = {
   created(el, { modifiers: { lazy, trim, number } }, vnode) {
     el[assignKey] = getModelAssigner(vnode)
-    const castToNumber =
-      number || (vnode.props && vnode.props.type === 'number')
+    const vnodeType = vnode.props && vnode.props.type
+    const castToNumber = number || vnodeType === 'number'
+    const castToTimeStamp =
+      number && (vnodeType === 'date' || vnodeType === 'datetime-local')
     addEventListener(el, lazy ? 'change' : 'input', e => {
       if ((e.target as any).composing) return
       let domValue: string | number = el.value
       if (trim) {
         domValue = domValue.trim()
       }
-      if (castToNumber) {
+      if (castToTimeStamp) {
+        domValue = new Date(domValue).getTime()
+      } else if (castToNumber) {
         domValue = looseToNumber(domValue)
       }
       el[assignKey](domValue)
@@ -110,6 +114,11 @@ export const vModelText: ModelDirective<
       }
       if (trim && el.value.trim() === newValue) {
         return
+      }
+      if (number && (el.type === 'date' || el.type === 'datetime-local')) {
+        if (new Date(el.value).getTime() === value) {
+          return
+        }
       }
     }
 


### PR DESCRIPTION
when an input element with type="date" or "datetime-local", the modifier number converts `2023-07-01T20:00` and `2023-07-01` to 2023, which is a bit odd and would make sense if it could be converted to a timestamp

```
String(new Date())
> 'Sat Jul 01 2023 22:19:11 GMT+0800 (China Standard Time)'
Number(new Date())
> 1688221156086
```

[Preview](https://deploy-preview-8687--vue-sfc-playground.netlify.app/#eNp9ksFOwzAQRH/F8iUgtYlEb1VaCVAPcAAE3DCHkGxbF8e27HUoivLvrBMaigQ9xZl5nsw6bvmltWkTgM957ksnLTIPGOxSaFlb45C1zMGadWztTM0SQhOhhS6N9siqAoEtInCWJOfHKsoaFqOeZ0M2peYItVVExHUlm/jYXizb9iVue+26PKNXEqW2ARl+WlgIHj3BWTOtTQUq1aF+AzfqvzPip0/lRH+qTFmo/xIjMaRm3w2zsTWfcPQ051pu0p03mg6uFZoxwUtTW6nA3VuUdA6Cz1nvRK9Qynzc9hq6AJODXm6hfP9D3/l91AR/cODBNVRn9LBwG8DBXj3dwZ7Wo0nTBEX0CfMRvFEhdhywq6Arqn3E9W1v+t8v9ebZr/YI2h+GikUj2fW84HQlrk+M/lN3ls76fUJ3vPsCqyXWcg==)