### PR TITLE
chore(reactivity): remove unnecessary array copy

### DIFF
--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -119,9 +119,8 @@ export class EffectScope {
     if (this._active) {
       this._active = false
       let i, l
-      const effects = this.effects.slice()
-      for (i = 0, l = effects.length; i < l; i++) {
-        effects[i].stop()
+      for (i = 0, l = this.effects.length; i < l; i++) {
+        this.effects[i].stop()
       }
       this.effects.length = 0
 


### PR DESCRIPTION
this change was for #5783 in #12373. it's not necessary since #5783 was fixed via 2193284