### PR TITLE
fix(escapeHtmlComment): Avoid throwing errors due to `src` not being a …

### DIFF
--- a/packages/shared/src/escapeHtml.ts
+++ b/packages/shared/src/escapeHtml.ts
@@ -48,7 +48,7 @@ export function escapeHtml(string: unknown): string {
 const commentStripRE = /^-?>|<!--|-->|--!>|<!-$/g
 
 export function escapeHtmlComment(src: string): string {
-  return src.replace(commentStripRE, '')
+  return src.toString().replace(commentStripRE, '')
 }
 
 export const cssVarNameEscapeSymbolsRE: RegExp =


### PR DESCRIPTION
When building my project, Vue threw the error `src. replace is not a function`. After adding `toString()` to the function `escapeHtmlComment`, this error did not occur again