### PR TITLE
perf(SSR): remove slow regular expression for escapeHtml

### DIFF
--- a/packages/shared/src/escapeHtml.ts
+++ b/packages/shared/src/escapeHtml.ts
@@ -1,18 +1,11 @@
-const escapeRE = /["'&<>]/
-
 export function escapeHtml(string: unknown): string {
   const str = '' + string
-  const match = escapeRE.exec(str)
-
-  if (!match) {
-    return str
-  }
 
   let html = ''
   let escaped: string
   let index: number
   let lastIndex = 0
-  for (index = match.index; index < str.length; index++) {
+  for (index = 0; index < str.length; index++) {
     switch (str.charCodeAt(index)) {
       case 34: // "
         escaped = '&quot;'


### PR DESCRIPTION
Regular expression is slow, removing them in escapeHtml should makes things faster

The perf result shows it's 2x~3x faster: https://jsbench.me/rqm4ehfndc/1

Ping @edison1105 @Justineo @bgoscinski, for you commented on another perf PR, so I guess you might also have interest in this one :)