### PR TITLE
WatchCallback returns `void`, not `any`

### DIFF
--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -42,7 +42,7 @@ export type WatchCallback<V = any, OV = any> = (
   value: V,
   oldValue: OV,
   onCleanup: OnCleanup,
-) => any
+) => void
 
 export type OnCleanup = (cleanupFn: () => void) => void
 


### PR DESCRIPTION
This matches the [documentation](https://github.com/vuejs/docs/blob/fe96839c9fe1ce82150e5a4396235cb3d1fb76e2/src/api/reactivity-core.md?plain=1#L378-L382) and better expresses that the return value is (mostly) ignored.