### PR TITLE
fix(ssr): handle manually using the h function (return a HTMLElement)

### DIFF
--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -1229,5 +1229,16 @@ function testRender(type: string, render: typeof renderToString) {
       // during the render phase
       expect(getterSpy).toHaveBeenCalledTimes(2)
     })
+
+    test('manually using the h function (return a HTMLElement)', async () => {
+      const MyNode = h('div', { id: 'aaaa' })
+      const app = createSSRApp({
+        ssrRender(_ctx, push, parent) {
+          push(ssrRenderComponent(MyNode, null, null, parent))
+        },
+      })
+      const html = await render(app)
+      expect(html).toBe(`<div id="aaaa"></div>`)
+    })
   })
 }

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -93,6 +93,11 @@ export function renderComponentVNode(
   parentComponent: ComponentInternalInstance | null = null,
   slotScopeId?: string,
 ): SSRBuffer | Promise<SSRBuffer> {
+  if (isString(vnode.type)) {
+    const { getBuffer, push } = createBuffer()
+    renderVNode(push, vnode, parentComponent!, slotScopeId)
+    return getBuffer()
+  }
   const instance = (vnode.component = createComponentInstance(
     vnode,
     parentComponent,


### PR DESCRIPTION
only fix this https://github.com/vuejs/core/issues/12520#issuecomment-2535533419

If use the h function manually (return a HTMLElement), Vue will compile this into a component in sfc

![image](https://github.com/user-attachments/assets/0adb421b-fb21-447d-bce4-5bf50c90b990)

 but this is not a component, so it causes Hydration mismatches
