### PR TITLE
fix(hydration): normalize text content to prevent false mismatch warnings

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1858,6 +1858,13 @@ describe('SSR hydration', () => {
       expect(`Hydration text content mismatch`).toHaveBeenWarned()
     })
 
+    test('element text content w/ escape characters', () => {
+      mountWithHydration(`<div>bar\r\nfoo\r</div>`, () =>
+        h('div', 'bar\r\nfoo\r'),
+      )
+      expect(`Hydration text content mismatch`).not.toHaveBeenWarned()
+    })
+
     test('not enough children', () => {
       const { container } = mountWithHydration(`<div></div>`, () =>
         h('div', [h('span', 'foo'), h('span', 'bar')]),


### PR DESCRIPTION
close #12535

Normalize text content during hydration to align with browser parsing behavior and prevent unnecessary mismatch warnings, inspired by [React's approach](https://github.com/facebook/react/blob/ca587425fe21b644bebb336f058f1a0d9763631b/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L307).