### PR TITLE
feat(compiler-sfc): transform use href add no-inline query

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
@@ -34,7 +34,7 @@ export function render(_ctx, _cache) {
 
 exports[`compiler sfc: transform asset url > support uri fragment 1`] = `
 "import { createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-import _imports_0 from '@svg/file.svg'
+import _imports_0 from '@svg/file.svg?no-inline'
 
 
 const _hoisted_1 = _imports_0 + '#fragment'

--- a/packages/compiler-sfc/src/template/transformAssetUrl.ts
+++ b/packages/compiler-sfc/src/template/transformAssetUrl.ts
@@ -114,6 +114,13 @@ export const transformAssetUrl: NodeTransform = (
       }
 
       const url = parseUrl(attr.value.content)
+      if (
+        node.tag === 'use' &&
+        attr.name === 'href' &&
+        url.path?.endsWith('.svg')
+      ) {
+        url.path = url.path + '?no-inline'
+      }
       if (options.base && attr.value.content[0] === '.') {
         // explicit base - directly rewrite relative urls into absolute url
         // to avoid generating extra imports


### PR DESCRIPTION
In https://github.com/vitejs/vite/pull/18581, vite will automatically convert SVGs smaller than `assetsInlineLimit` into base64, Since loading `data:` in the use tag in SVG will result in an error, it is more reasonable to add `no-inline` query when vue converts the href value of the use tag. WDYT? @bluwy

about https://github.com/vitejs/vite-plugin-vue/issues/490
refer https://developer.chrome.com/blog/migrate-way-from-data-urls-in-svg-use

