### PR TITLE
fix(compiler-core): emit error on empty directive modifier

### DIFF
--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -68,6 +68,7 @@ export enum ErrorCodes {
   X_MISSING_END_TAG,
   X_MISSING_INTERPOLATION_END,
   X_MISSING_DIRECTIVE_NAME,
+  X_MISSING_DIRECTIVE_MODIFIER,
   X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END,
 
   // transform errors
@@ -151,6 +152,8 @@ export const errorMessages: Record<ErrorCodes, string> = {
     'End bracket for dynamic directive argument was not found. ' +
     'Note that dynamic directive argument cannot contain spaces.',
   [ErrorCodes.X_MISSING_DIRECTIVE_NAME]: 'Legal directive name was expected.',
+  [ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER]:
+    'Legal directive modifier was expected.',
 
   // transform errors
   [ErrorCodes.X_V_IF_NO_EXPRESSION]: `v-if/v-else-if is missing expression.`,

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -275,6 +275,9 @@ const tokenizer = new Tokenizer(stack, {
       }
     } else {
       const exp = createSimpleExpression(mod, true, getLoc(start, end))
+      if (exp.content === '') {
+        emitError(ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER, start)
+      }
       ;(currentProp as DirectiveNode).modifiers.push(exp)
     }
   },

--- a/packages/compiler-dom/src/errors.ts
+++ b/packages/compiler-dom/src/errors.ts
@@ -21,7 +21,7 @@ export function createDOMCompilerError(
 }
 
 export enum DOMErrorCodes {
-  X_V_HTML_NO_EXPRESSION = 53 /* ErrorCodes.__EXTEND_POINT__ */,
+  X_V_HTML_NO_EXPRESSION = 54 /* ErrorCodes.__EXTEND_POINT__ */,
   X_V_HTML_WITH_CHILDREN,
   X_V_TEXT_NO_EXPRESSION,
   X_V_TEXT_WITH_CHILDREN,


### PR DESCRIPTION
Or treat it as an empty string modifier and solve it in codegen?

https://play.vuejs.org/#eNp9kLuOwjAQRX8lmpoNxW6FIqTdFQUUgIDSTZQMweB4LHscIqH8O7YRjwLR2fecse74Ar/G5J1HmEDB2BpVMk6FzrKill3Wfe2J8mkxDpeQFuMXBUbAriK9l01+dKTDC5c4KKCi1kiFdmVYknYCJlkikZVK0XmRMrYeR/e8OmB1epMfXR8zAWuLDm2HAh6MS9sg3/Bsu8Q+nB+wpdqrYH+AG3SkfOx40/68rkPtFy+1nbeGLEvd7NysZ9TuvlQsGs0h+QLCN/5/WP1Z9zv/SXNCDzBcAU2TfbA=

![image](https://github.com/user-attachments/assets/3597e2ce-e515-48fa-84a6-9da27082d6f9)
