### PR TITLE
fix(compiler-core): recognize empty string as non-identifier

### DIFF
--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -63,7 +63,7 @@ export function isCoreComponent(tag: string): symbol | void {
   }
 }
 
-const nonIdentifierRE = /^\d|[^\$\w\xA0-\uFFFF]/
+const nonIdentifierRE = /^$|^\d|[^\$\w\xA0-\uFFFF]/
 export const isSimpleIdentifier = (name: string): boolean =>
   !nonIdentifierRE.test(name)
 


### PR DESCRIPTION
https://play.vuejs.org/#eNp9kLuOwjAQRX8lmpoNxW6FIqTdFQUUgIDSTZQMweB4LHscIqH8O7YRjwLR2fecse74Ar/G5J1HmEDB2BpVMk6FzrKill3Wfe2J8mkxDpeQFuMXBUbAriK9l01+dKTDC5c4KKCi1kiFdmVYknYCJlkikZVK0XmRMrYeR/e8OmB1epMfXR8zAWuLDm2HAh6MS9sg3/Bsu8Q+nB+wpdqrYH+AG3SkfOx40/68rkPtFy+1nbeGLEvd7NysZ9TuvlQsGs0h+QLCN/5/WP1Z9zv/SXNCDzBcAU2TfbA=

![image](https://github.com/user-attachments/assets/3597e2ce-e515-48fa-84a6-9da27082d6f9)