### PR TITLE
feat(effectScope): allow multiple  `on()` calls by tracking call count

### DIFF
--- a/packages/reactivity/__tests__/effectScope.spec.ts
+++ b/packages/reactivity/__tests__/effectScope.spec.ts
@@ -296,6 +296,19 @@ describe('reactivity/effect/scope', () => {
     })
   })
 
+  it('calling on() and off() multiple times inside an active scope should not break currentScope', () => {
+    const parentScope = effectScope()
+    parentScope.run(() => {
+      const childScope = effectScope(true)
+      childScope.on()
+      childScope.on()
+      childScope.off()
+      childScope.off()
+      childScope.off()
+      expect(getCurrentScope()).toBe(parentScope)
+    })
+  })
+
   it('should pause/resume EffectScope', async () => {
     const counter = reactive({ num: 0 })
     const fnSpy = vi.fn(() => counter.num)

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -122,6 +122,7 @@ export class EffectScope {
   off(): void {
     if (this._on > 0 && --this._on === 0) {
       activeEffectScope = this.prevScope
+      this.prevScope = undefined
     }
   }
 

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -11,7 +11,7 @@ export class EffectScope {
   /**
    * @internal track `on` calls, allow `on` call multiple times
    */
-  private _onCallCount = 0
+  private _on = 0
   /**
    * @internal
    */
@@ -109,8 +109,7 @@ export class EffectScope {
    * @internal
    */
   on(): void {
-    this._onCallCount++
-    if (this._onCallCount === 1) {
+    if (++this._on === 1) {
       this.prevScope = activeEffectScope
       activeEffectScope = this
     }
@@ -121,8 +120,7 @@ export class EffectScope {
    * @internal
    */
   off(): void {
-    this._onCallCount = Math.max(0, this._onCallCount - 1)
-    if (this._onCallCount === 0) {
+    if (this._on > 0 && --this._on === 0) {
       activeEffectScope = this.prevScope
     }
   }

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -9,6 +9,10 @@ export class EffectScope {
    */
   private _active = true
   /**
+   * @internal track `on` calls, allow `on` call multiple times
+   */
+  private _onCallCount = 0
+  /**
    * @internal
    */
   effects: ReactiveEffect[] = []
@@ -105,8 +109,11 @@ export class EffectScope {
    * @internal
    */
   on(): void {
-    this.prevScope = activeEffectScope
-    activeEffectScope = this
+    this._onCallCount++
+    if (this._onCallCount === 1) {
+      this.prevScope = activeEffectScope
+      activeEffectScope = this
+    }
   }
 
   /**
@@ -114,7 +121,10 @@ export class EffectScope {
    * @internal
    */
   off(): void {
-    activeEffectScope = this.prevScope
+    this._onCallCount = Math.max(0, this._onCallCount - 1)
+    if (this._onCallCount === 0) {
+      activeEffectScope = this.prevScope
+    }
   }
 
   stop(fromParent?: boolean): void {


### PR DESCRIPTION
The following code does not work correctly in the current `vapor` branch. When the `button` is clicked, the button text does not update.
```vue
<script setup>
import { ref } from 'vue'
const count = ref(0)
</script>

<template>
  <button id="btn" @click="count++">{{ count }}</button>
  <div v-if="count < 1">{{ count }}</div>
  <div v-else>{{ count * 2 }}</div>
</template>
```
The issue is because `scope.on` is called twice:
- inside `simpleSetCurrentInstance` > `i.scope.on()`
- `if (scope) scope.on()`
https://github.com/vuejs/core/blob/c2e7312da44cd79f8a66750085dd8a2ca0115a58/packages/runtime-vapor/src/renderEffect.ts#L30-L31

if `scope` equals `i.scope` the following happens
```js
scope1.on()  // activeEffectScope = scope1, prevScope = undefined
scope1.on()  // activeEffectScope = scope1, prevScope = scope1 (❌)
scope1.off() // activeEffectScope = scope1 (❌)
scope1.off() // activeEffectScope = undefined
```

The core also has a similar issue, see #12631. It is also caused by `scope.on()` being called multiple times. I have already created a PR #12632 to fix it. The changes in #12632 aim to avoid redundant updates to currentInstance, while this PR supports multiple calls to `on`. If this PR is merged, #12632 will no longer be needed.