### PR TITLE
fix(runtime-vapor): properly handle dynamic slot work with v-if

### DIFF
--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -70,12 +70,14 @@ export function getSlot(
       source = dynamicSources[i]
       if (isFunction(source)) {
         const slot = source()
-        if (isArray(slot)) {
-          for (const s of slot) {
-            if (s.name === key) return s.fn
+        if (slot) {
+          if (isArray(slot)) {
+            for (const s of slot) {
+              if (s.name === key) return s.fn
+            }
+          } else if (slot.name === key) {
+            return slot.fn
           }
-        } else if (slot.name === key) {
-          return slot.fn
         }
       } else if (hasOwn(source, key)) {
         return source[key]


### PR DESCRIPTION
- template code
```vue
  <Comp>
    <template v-slot:[slotName] v-if="count <10">
      <h1>{{ count * 2 }}</h1>
    </template>
  </Comp>
```
- compiled code
```js
  const n3 = _createComponent(_ctx.Comp, null, {
    $: [
      () => (_ctx.count < 10
        ? {
          name: _ctx.slotName, 
          fn: () => {
            const n1 = t1()
            _renderEffect(() => _setText(n1, _ctx.count * 2))
            return n1
          }
        }
        : void 0)
    ]
  })
```
the dynamic slot source result will be `undefined` if `_ctx.count > 10`, so we should ensure it is valid, otherwise `slot.name` will throw an error.