### PR TITLE
chore(runtime-vapor): remove redundant DEV check

### DIFF
--- a/packages/runtime-vapor/src/apiCreateIf.ts
+++ b/packages/runtime-vapor/src/apiCreateIf.ts
@@ -8,7 +8,7 @@ export function createIf(
   once?: boolean,
   // hydrationNode?: Node,
 ): DynamicFragment {
-  const frag = __DEV__ ? new DynamicFragment('if') : new DynamicFragment()
+  const frag = new DynamicFragment('if')
   if (once) {
     frag.update(condition() ? b1 : b2)
   } else {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -114,7 +114,7 @@ export function createSlot(
   const instance = currentInstance as VaporComponentInstance
   const rawSlots = instance.rawSlots
   const isDynamicName = isFunction(name)
-  const fragment = __DEV__ ? new DynamicFragment('slot') : new DynamicFragment()
+  const fragment = new DynamicFragment('slot')
   const slotProps = rawProps
     ? new Proxy(rawProps, dynamicSlotsPropsProxyHandlers)
     : EMPTY_OBJ


### PR DESCRIPTION
There is already a DEV check when initializing `this.anchor`
https://github.com/vuejs/core/blob/6c0e8a8f242e46055f645e76892fa42e88aa9903/packages/runtime-vapor/src/block.ts#L37-L41