### PR TITLE
refactor(general): use notPrimitive to simplify both isObject and  isFunction

### DIFF
--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -6,7 +6,7 @@ import {
   currentInstance,
   isInSSRComponentSetup,
 } from './component'
-import { isFunction, isObject } from '@vue/shared'
+import { isFunction, notPrimitive } from '@vue/shared'
 import type { ComponentPublicInstance } from './componentPublicInstance'
 import { type VNode, createVNode } from './vnode'
 import { defineComponent } from './apiDefineComponent'
@@ -106,7 +106,7 @@ export function defineAsyncComponent<
             ) {
               comp = comp.default
             }
-            if (__DEV__ && comp && !isObject(comp) && !isFunction(comp)) {
+            if (__DEV__ && comp && !notPrimitive(comp)) {
               throw new Error(`Invalid async component load result: ${comp}`)
             }
             resolvedComp = comp

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -52,12 +52,15 @@ export const isString = (val: unknown): val is string => typeof val === 'string'
 export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
 export const isObject = (val: unknown): val is Record<any, any> =>
   val !== null && typeof val === 'object'
+export const notPrimitive = (
+  val: unknown,
+): val is Record<any, any> | Function => Object(val) === val
 
 export const isPromise = <T = any>(val: unknown): val is Promise<T> => {
   return (
-    (isObject(val) || isFunction(val)) &&
-    isFunction((val as any).then) &&
-    isFunction((val as any).catch)
+    notPrimitive(val) &&
+    isFunction((val as PromiseLike<T>).then) &&
+    isFunction((val as Promise<T>).catch)
   )
 }
 


### PR DESCRIPTION
- add `notPrimitive()`
- refactor `isPromise()`