### PR TITLE
fix(renderer): support modifying `el` in `beforeMount`

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1284,7 +1284,7 @@ function baseCreateRenderer(
     const componentUpdateFn = () => {
       if (!instance.isMounted) {
         let vnodeHook: VNodeHook | null | undefined
-        const { el, props } = initialVNode
+        const { props } = initialVNode
         const { bm, m, parent, root, type } = instance
         const isAsyncWrapperVNode = isAsyncWrapper(initialVNode)
 
@@ -1308,7 +1308,7 @@ function baseCreateRenderer(
         }
         toggleRecurse(instance, true)
 
-        if (el && hydrateNode) {
+        if (initialVNode.el && hydrateNode) {
           // vnode has adopted host node - perform hydration instead of mount.
           const hydrateSubTree = () => {
             if (__DEV__) {
@@ -1322,7 +1322,7 @@ function baseCreateRenderer(
               startMeasure(instance, `hydrate`)
             }
             hydrateNode!(
-              el as Node,
+              initialVNode.el as Node,
               instance.subTree,
               instance,
               parentSuspense,


### PR DESCRIPTION
### Summary
This merge request updates the condition in the renderer to support modifying the `el` property during the `beforeMount` lifecycle hook.

### Changes
- Changed the condition from `if (el && hydrateNode)` to `if (initialVNode.el && hydrateNode)` in `renderer.ts`.

### Reason
The modification allows developers to change the `el` property in the `beforeMount` lifecycle hook, providing more flexibility in the rendering process.

### Testing
- Verified that the `el` property can be modified in the `beforeMount` hook without causing issues during hydration.