### PR TITLE
fix(reactivity): add warning for array operations on null/undefined v…

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -144,7 +144,24 @@ class MutableReactiveHandler extends BaseReactiveHandler {
     value: unknown,
     receiver: object,
   ): boolean {
-    let oldValue = target[key]
+    if (__DEV__) {
+      if (isArray(target)) {
+        if (
+          key === 'length' || 
+          !Number.isNaN(Number(key))
+        ) {
+          const targetValue = target[key as keyof typeof target]
+          if (targetValue === null || targetValue === undefined) {
+            console.warn(
+              `Attempting to perform array operation on null/undefined value at index ${key}. ` +
+              `This may cause unexpected behavior.`,
+            )
+          }
+        }
+      }
+    }
+
+    let oldValue = (target as any)[key]
     if (!this._isShallow) {
       const isOldValueReadonly = isReadonly(oldValue)
       if (!isShallow(value) && !isReadonly(value)) {


### PR DESCRIPTION
…alues

Enhance the MutableReactiveHandler to include a development-only warning when attempting to perform operations on null or undefined values in arrays. This change aims to prevent unexpected behavior during reactive state management.