### PR TITLE
fix(reactivity): handle objects with custom Symbol.toStringTag

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -112,6 +112,24 @@ describe('reactivity/reactive', () => {
     expect(dummy).toBe(false)
   })
 
+  test('reactive object with custom Symbol.toStringTag triggers reactivity', () => {
+    const original = { [Symbol.toStringTag]: 'Goat', foo: 1 }
+    const observed = reactive(original)
+
+    expect(isReactive(observed)).toBe(true)
+    expect(isProxy(observed)).toBe(true)
+
+    let dummy: number | undefined
+    effect(() => {
+      dummy = observed.foo
+    })
+
+    expect(dummy).toBe(1)
+
+    observed.foo = 2
+    expect(dummy).toBe(2)
+  })
+
   test('observed value should proxy mutations to original (Object)', () => {
     const original: any = { foo: 1 }
     const observed = reactive(original)


### PR DESCRIPTION
close #10483

# Problem

When an object from a third-party library defines a custom `Symbol.toStringTag`, the result of calling `Object.prototype.toString.call()` on that object becomes something like `"[object Goat]"` instead of the default `"[object Object]"`. Vue’s reactivity system relies on the result of this call (via its internal `toRawType()` helper) to determine whether an object is plain and should be wrapped in a reactive proxy. As a consequence, objects with a custom tag are mistakenly treated as non-reactive, and mutations to them do not trigger reactive updates.

## Solution

This PR addresses the issue by modifying the internal `getTargetType` function to include an additional check based on the object's prototype. Specifically:

- A helper function `isPlainObject` is introduced (or enhanced) to verify whether an object is plain by checking that its prototype is either `Object.prototype` or `null`.
- In the `getTargetType` function, if the initial type mapping returns `TargetType.INVALID` (due to a non-standard tag), the function then checks if the object is plain. If it is, the target type is forced to `TargetType.COMMON`, ensuring the object is wrapped in a reactive proxy.

This change ensures that objects with a custom `Symbol.toStringTag` are still recognized as plain objects and become reactive as expected.
