### PR TITLE
fix(computed): When no dependencies are passed in, computed does not use the cache #12857

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -386,8 +386,7 @@ export function refreshComputed(computed: ComputedRefImpl): undefined {
   if (
     dep.version > 0 &&
     !computed.isSSR &&
-    computed.deps &&
-    !isDirty(computed)
+    (computed.deps ? !isDirty(computed) : !(computed.flags & EffectFlags.DIRTY))
   ) {
     computed.flags &= ~EffectFlags.RUNNING
     return


### PR DESCRIPTION
```vue
<script setup>
import { reactive,computed } from 'vue'
const state = reactive({
  a: 1
})
const stateComputed = computed(() => {
  console.log('a')
  return 1
})
console.log(stateComputed.value)
state.a++
console.log(stateComputed.value)
</script>
```
expected output a 1 1