### PR TITLE
feat(runtime-vapor): expose VaporFragment

### DIFF
--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -5,7 +5,7 @@ export { vaporInteropPlugin } from './vdomInterop'
 export type { VaporDirective } from './directives/custom'
 
 // compiler-use only
-export { insert, prepend, remove } from './block'
+export { insert, prepend, remove, isFragment, VaporFragment } from './block'
 export { createComponent, createComponentWithFallback } from './component'
 export { renderEffect } from './renderEffect'
 export { createSlot } from './componentSlots'


### PR DESCRIPTION
jsx-vapor's helper code need VaporFragment.

https://github.com/unplugin/unplugin-vue-jsx-vapor/blob/main/packages/unplugin/src/core/helper/code.js#L9