### PR TITLE
fix(ci): use `with` instead of `assert` syntax

### DIFF
--- a/scripts/size-report.js
+++ b/scripts/size-report.js
@@ -111,7 +111,7 @@ async function renderUsages() {
  */
 async function importJSON(filePath) {
   if (!existsSync(filePath)) return undefined
-  return (await import(filePath, { assert: { type: 'json' } })).default
+  return (await import(filePath, { with: { type: 'json' } })).default
 }
 
 /**


### PR DESCRIPTION
The size-report script failed to run because node22 no longer supports assert syntax.
Ref: https://github.com/nodejs/node/pull/52104