### PR TITLE
feat(compiler-core): allow directive modifiers to be dynamic (fix #8281)

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -1504,6 +1504,26 @@ describe('compiler: parse', () => {
       })
     })
 
+    test('directive with literal-like static modifier names', () => {
+      ;['true', 'false', 'null', 'undefined'].forEach(modifier => {
+        const onError = vi.fn()
+        const ast = baseParse(`<div v-foo.${modifier} />`, { onError })
+        const directive = (ast.children[0] as ElementNode).props[0]
+
+        expect(onError).not.toHaveBeenCalled()
+        expect(directive).toMatchObject({
+          type: NodeTypes.DIRECTIVE,
+          name: 'foo',
+          modifiers: [
+            {
+              content: modifier,
+              isStatic: true,
+            },
+          ],
+        })
+      })
+    })
+
     test('directive with empty modifier name', () => {
       let errorCode = -1
       const ast = baseParse('<div v-on./>', {
@@ -1605,39 +1625,48 @@ describe('compiler: parse', () => {
     test('directive with invalid dynamic modifier value', () => {
       const possibleWrongValues = [
         '[]',
+        'true',
+        'false',
         'null',
+        'undefined',
         '123',
         '"foo"',
         '`foo`',
         '!false',
       ]
 
-      possibleWrongValues.forEach(val => {
-        let errorCode = -1
-        const ast = baseParse(`<div v-on.[${val}] />`, {
-          onError: err => {
-            errorCode = err.code as number
-          },
-          prefixIdentifiers: true,
-        })
-        const directive = (ast.children[0] as ElementNode).props[0]
+      ;[false, true].forEach(prefixIdentifiers => {
+        possibleWrongValues.forEach(val => {
+          let errorCode = -1
+          const ast = baseParse(`<div v-on.[${val}] />`, {
+            onError: err => {
+              errorCode = err.code as number
+            },
+            prefixIdentifiers,
+          })
+          const directive = (ast.children[0] as ElementNode).props[0]
 
-        expect(errorCode).toBe(
-          ErrorCodes.X_INVALID_VALUE_IN_DYNAMIC_DIRECTIVE_MODIFIER,
-        )
+          expect(errorCode).toBe(
+            ErrorCodes.X_INVALID_VALUE_IN_DYNAMIC_DIRECTIVE_MODIFIER,
+          )
 
-        expect(directive).toStrictEqual({
-          type: NodeTypes.DIRECTIVE,
-          name: 'on',
-          rawName: `v-on.[${val}]`,
-          arg: undefined,
-          modifiers: [],
-          exp: undefined,
-          loc: {
-            end: { column: 13 + val.length, line: 1, offset: 12 + val.length },
-            source: `v-on.[${val}]`,
-            start: { column: 6, line: 1, offset: 5 },
-          },
+          expect(directive).toStrictEqual({
+            type: NodeTypes.DIRECTIVE,
+            name: 'on',
+            rawName: `v-on.[${val}]`,
+            arg: undefined,
+            modifiers: [],
+            exp: undefined,
+            loc: {
+              end: {
+                column: 13 + val.length,
+                line: 1,
+                offset: 12 + val.length,
+              },
+              source: `v-on.[${val}]`,
+              start: { column: 6, line: 1, offset: 5 },
+            },
+          })
         })
       })
     })
@@ -1846,9 +1875,9 @@ describe('compiler: parse', () => {
         },
         modifiers: [
           {
-            constType: 0,
+            constType: ConstantTypes.CAN_STRINGIFY,
             content: 'prop',
-            isStatic: false,
+            isStatic: true,
             loc: {
               end: {
                 column: 1,

--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -709,35 +709,8 @@ describe('compiler: element transform', () => {
               },
               // modifiers
               {
-                type: NodeTypes.JS_OBJECT_EXPRESSION,
-                properties: [
-                  {
-                    type: NodeTypes.JS_PROPERTY,
-                    key: {
-                      type: NodeTypes.SIMPLE_EXPRESSION,
-                      content: `mod`,
-                      isStatic: true,
-                    },
-                    value: {
-                      type: NodeTypes.SIMPLE_EXPRESSION,
-                      content: `true`,
-                      isStatic: false,
-                    },
-                  },
-                  {
-                    type: NodeTypes.JS_PROPERTY,
-                    key: {
-                      type: NodeTypes.SIMPLE_EXPRESSION,
-                      content: `mad`,
-                      isStatic: true,
-                    },
-                    value: {
-                      type: NodeTypes.SIMPLE_EXPRESSION,
-                      content: `true`,
-                      isStatic: false,
-                    },
-                  },
-                ],
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: '{ mod: true, mad: true }',
               },
             ],
           },

--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -664,12 +664,13 @@ describe('compiler: element transform', () => {
 
   test('runtime directives', () => {
     const { root, node } = parseWithElementTransform(
-      `<div v-foo v-bar="x" v-baz:[arg].mod.mad="y" />`,
+      `<div v-foo v-bar="x" v-baz:[arg].mod.mad="y" v-baa.[{dyn:true}].[mid].boo="z" />`,
     )
     expect(root.helpers).toContain(RESOLVE_DIRECTIVE)
     expect(root.directives).toContain(`foo`)
     expect(root.directives).toContain(`bar`)
     expect(root.directives).toContain(`baz`)
+    expect(root.directives).toContain(`baa`)
 
     expect(node).toMatchObject({
       directives: {
@@ -735,6 +736,54 @@ describe('compiler: element transform', () => {
                       content: `true`,
                       isStatic: false,
                     },
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: NodeTypes.JS_ARRAY_EXPRESSION,
+            elements: [
+              `_directive_baa`,
+              // exp
+              {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: `z`,
+                isStatic: false,
+              },
+              //arg
+              'void 0',
+              // modifiers
+              {
+                type: NodeTypes.JS_CALL_EXPRESSION,
+                callee: 'Object.assign',
+                arguments: [
+                  createObjectMatcher({}),
+                  {
+                    type: NodeTypes.SIMPLE_EXPRESSION,
+                    content: `{dyn:true}`,
+                  },
+                  {
+                    type: NodeTypes.SIMPLE_EXPRESSION,
+                    content: `mid`,
+                  },
+                  {
+                    type: NodeTypes.JS_OBJECT_EXPRESSION,
+                    properties: [
+                      {
+                        type: NodeTypes.JS_PROPERTY,
+                        key: {
+                          type: NodeTypes.SIMPLE_EXPRESSION,
+                          content: `boo`,
+                          isStatic: true,
+                        },
+                        value: {
+                          type: NodeTypes.SIMPLE_EXPRESSION,
+                          content: `true`,
+                          isStatic: false,
+                        },
+                      },
+                    ],
                   },
                 ],
               },

--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -265,6 +265,17 @@ describe('compiler: element transform', () => {
     })
   })
 
+  test('v-bind dynamic modifier should error', () => {
+    const onError = vi.fn()
+    parseWithElementTransform(`<div v-bind.[mods]="obj" />`, { onError })
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+      }),
+    )
+  })
+
   test('v-bind="obj" after static prop', () => {
     const { root, node } = parseWithElementTransform(
       `<div id="foo" v-bind="obj" />`,

--- a/packages/compiler-core/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vBind.spec.ts
@@ -203,6 +203,17 @@ describe('compiler: transform v-bind', () => {
     })
   })
 
+  test('dynamic modifier should error', () => {
+    const onError = vi.fn()
+    parseWithVBind(`<div v-bind:foo.[mods]="id"/>`, { onError })
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+      }),
+    )
+  })
+
   test('.camel modifier w/ no expression', () => {
     const node = parseWithVBind(`<div v-bind:foo-bar.camel />`)
     const props = (node.codegenNode as VNodeCall).props as ObjectExpression

--- a/packages/compiler-core/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vModel.spec.ts
@@ -525,6 +525,42 @@ describe('compiler: transform v-model', () => {
     })
   })
 
+  test('should generate modelModifiers for component v-model with dynamic modifiers', () => {
+    const root = parseWithVModel('<Comp v-model.trim.[bar]="foo" />', {
+      prefixIdentifiers: true,
+    })
+    const vnodeCall = (root.children[0] as ComponentNode)
+      .codegenNode as VNodeCall
+    // props
+    expect(vnodeCall.props).toMatchObject({
+      properties: [
+        { key: { content: `modelValue` } },
+        { key: { content: `onUpdate:modelValue` } },
+        {
+          key: { content: 'modelModifiers' },
+          value: {
+            arguments: [
+              {
+                properties: [
+                  {
+                    key: { content: 'trim' },
+                    value: { content: 'true', isStatic: false },
+                  },
+                ],
+              },
+              { content: '_ctx.bar', isStatic: false },
+            ],
+          },
+        },
+      ],
+    })
+    // should NOT include modelModifiers in dynamicPropNames because it's never
+    // gonna change
+    expect(vnodeCall.dynamicProps).toBe(
+      `["modelValue", "onUpdate:modelValue", "modelModifiers"]`,
+    )
+  })
+
   describe('errors', () => {
     test('missing expression', () => {
       const onError = vi.fn()

--- a/packages/compiler-core/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vModel.spec.ts
@@ -561,6 +561,56 @@ describe('compiler: transform v-model', () => {
     )
   })
 
+  test('should preserve dynamic model modifier order', () => {
+    const root = parseWithVModel('<Comp v-model.[mods].trim="foo" />', {
+      prefixIdentifiers: true,
+    })
+    const vnodeCall = (root.children[0] as ComponentNode)
+      .codegenNode as VNodeCall
+
+    expect(vnodeCall.props).toMatchObject({
+      properties: [
+        { key: { content: `modelValue` } },
+        { key: { content: `onUpdate:modelValue` } },
+        {
+          key: { content: 'modelModifiers' },
+          value: {
+            callee: 'Object.assign',
+            arguments: [
+              { properties: [] },
+              { content: '_ctx.mods', isStatic: false },
+              {
+                properties: [
+                  {
+                    key: { content: 'trim' },
+                    value: { content: 'true', isStatic: false },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    })
+  })
+
+  test('should generate quoted static model modifier names', () => {
+    const root = parseWithVModel('<Comp v-model.foo-bar="foo" />')
+    const vnodeCall = (root.children[0] as ComponentNode)
+      .codegenNode as VNodeCall
+
+    expect(vnodeCall.props).toMatchObject({
+      properties: [
+        { key: { content: `modelValue` } },
+        { key: { content: `onUpdate:modelValue` } },
+        {
+          key: { content: 'modelModifiers' },
+          value: { content: `{ "foo-bar": true }`, isStatic: false },
+        },
+      ],
+    })
+  })
+
   describe('errors', () => {
     test('missing expression', () => {
       const onError = vi.fn()

--- a/packages/compiler-core/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vModel.spec.ts
@@ -554,7 +554,7 @@ describe('compiler: transform v-model', () => {
         },
       ],
     })
-    // should NOT include modelModifiers in dynamicPropNames because it's never
+    // should now include modelModifiers in dynamicPropNames because it's
     // gonna change
     expect(vnodeCall.dynamicProps).toBe(
       `["modelValue", "onUpdate:modelValue", "modelModifiers"]`,

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -200,7 +200,7 @@ export interface DirectiveNode extends Node {
   rawName?: string
   exp: ExpressionNode | undefined
   arg: ExpressionNode | undefined
-  modifiers: SimpleExpressionNode[]
+  modifiers: ExpressionNode[]
   /**
    * optional property to cache the expression parse result for v-for
    */

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -106,6 +106,7 @@ export enum ErrorCodes {
   // placed here to preserve order for the current minor
   // TODO adjust order in 3.5
   X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
+  X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
 
   // Special value for higher-order compilers to pick up the last code
   // to avoid collision of error codes. This should always be kept as the last
@@ -164,7 +165,7 @@ export const errorMessages: Record<ErrorCodes, string> = {
     'Dynamic directive modifier value cannot be empty. ',
   [ErrorCodes.X_INVALID_VALUE_IN_DYNAMIC_DIRECTIVE_MODIFIER]:
     'Invalid value in dynamic directive modifier. ' +
-    'Note that dynamic directive modifier can only be objects or arrays.',
+    'Dynamic directive modifiers can only evaluate to modifier objects.',
   [ErrorCodes.X_MISSING_DIRECTIVE_NAME]: 'Legal directive name was expected.',
 
   // transform errors
@@ -194,6 +195,7 @@ export const errorMessages: Record<ErrorCodes, string> = {
   [ErrorCodes.X_V_MODEL_ON_CONST]: `v-model cannot be used on a const binding because it is not writable.`,
   [ErrorCodes.X_INVALID_EXPRESSION]: `Error parsing JavaScript expression: `,
   [ErrorCodes.X_KEEP_ALIVE_INVALID_CHILDREN]: `<KeepAlive> expects exactly one child component.`,
+  [ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED]: `Dynamic directive modifiers are not supported on this directive.`,
   [ErrorCodes.X_VNODE_HOOKS]: `@vnode-* hooks in templates are no longer supported. Use the vue: prefix instead. For example, @vnode-mounted should be changed to @vue:mounted. @vnode-* hooks support has been removed in 3.4.`,
 
   // generic errors

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -69,6 +69,10 @@ export enum ErrorCodes {
   X_MISSING_INTERPOLATION_END,
   X_MISSING_DIRECTIVE_NAME,
   X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END,
+  X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_END,
+  X_MISSING_DIRECTIVE_MODIFIER_NAME,
+  X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_VALUE,
+  X_INVALID_VALUE_IN_DYNAMIC_DIRECTIVE_MODIFIER,
 
   // transform errors
   X_V_IF_NO_EXPRESSION,
@@ -151,6 +155,16 @@ export const errorMessages: Record<ErrorCodes, string> = {
   [ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END]:
     'End bracket for dynamic directive argument was not found. ' +
     'Note that dynamic directive argument cannot contain spaces.',
+  [ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_END]:
+    'End bracket for dynamic directive modifier was not found. ' +
+    'Note that dynamic directive modifier cannot contain spaces.',
+  [ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER_NAME]:
+    'Directive modifier name cannot be empty. ',
+  [ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_VALUE]:
+    'Dynamic directive modifier value cannot be empty. ',
+  [ErrorCodes.X_INVALID_VALUE_IN_DYNAMIC_DIRECTIVE_MODIFIER]:
+    'Invalid value in dynamic directive modifier. ' +
+    'Note that dynamic directive modifier can only be objects or arrays.',
   [ErrorCodes.X_MISSING_DIRECTIVE_NAME]: 'Legal directive name was expected.',
 
   // transform errors

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -285,17 +285,11 @@ const tokenizer = new Tokenizer(stack, {
       )
 
       if (!exp.ast && !exp.content.trim()) {
-        if (isStatic) {
-          emitError(
-            ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER_NAME,
-            exp.loc.start.offset,
-          )
-        } else {
-          emitError(
+        emitError(
+          isStatic ? ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER_NAME : 
             ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_VALUE,
-            exp.loc.start.offset,
-          )
-        }
+          exp.loc.start.offset,
+        )
         return
       }
 

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -228,7 +228,7 @@ const tokenizer = new Tokenizer(stack, {
         rawName: raw,
         exp: undefined,
         arg: undefined,
-        modifiers: raw === '.' ? [createSimpleExpression('prop')] : [],
+        modifiers: raw === '.' ? [createSimpleExpression('prop', true)] : [],
         loc: getLoc(start),
       }
       if (name === 'pre') {
@@ -286,27 +286,15 @@ const tokenizer = new Tokenizer(stack, {
 
       if (!exp.ast && !exp.content.trim()) {
         emitError(
-          isStatic ? ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER_NAME : 
-            ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_VALUE,
+          isStatic
+            ? ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER_NAME
+            : ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_VALUE,
           exp.loc.start.offset,
         )
         return
       }
 
-      const invalidBabelNodeTypes = [
-        'ArrayExpression',
-        'UnaryExpression',
-        'StringLiteral',
-        'NumericLiteral',
-        'TemplateLiteral',
-      ]
-
-      const invalidSimpleValues = ['true', 'false', 'null', 'undefined']
-
-      if (
-        (exp.ast && invalidBabelNodeTypes.includes(exp.ast.type)) ||
-        (!exp.ast && invalidSimpleValues.includes(exp.content))
-      ) {
+      if (!isStatic && isInvalidDynamicDirectiveModifierValue(exp)) {
         emitError(
           ErrorCodes.X_INVALID_VALUE_IN_DYNAMIC_DIRECTIVE_MODIFIER,
           exp.loc.start.offset + 1,
@@ -1025,10 +1013,7 @@ function createExp(
       return exp
     }
     try {
-      const plugins = currentOptions.expressionPlugins
-      const options: BabelOptions = {
-        plugins: plugins ? [...plugins, 'typescript'] : ['typescript'],
-      }
+      const options = getBabelParserOptions()
       if (parseMode === ExpParseMode.Statements) {
         // v-on with multi-inline-statements, pad 1 char
         exp.ast = parse(` ${content} `, options).program
@@ -1044,6 +1029,53 @@ function createExp(
     }
   }
   return exp
+}
+
+const invalidDynamicDirectiveModifierBabelNodeTypes = [
+  'ArrayExpression',
+  'BigIntLiteral',
+  'BooleanLiteral',
+  'DecimalLiteral',
+  'NullLiteral',
+  'NumericLiteral',
+  'StringLiteral',
+  'TemplateLiteral',
+  'UnaryExpression',
+]
+
+const invalidDynamicDirectiveModifierSimpleValues = [
+  'true',
+  'false',
+  'null',
+  'undefined',
+]
+
+function getBabelParserOptions(): BabelOptions {
+  const plugins = currentOptions.expressionPlugins
+  return {
+    plugins: plugins ? [...plugins, 'typescript'] : ['typescript'],
+  }
+}
+
+function isInvalidDynamicDirectiveModifierValue(
+  exp: SimpleExpressionNode,
+): boolean {
+  if (invalidDynamicDirectiveModifierSimpleValues.includes(exp.content)) {
+    return true
+  }
+
+  let ast = exp.ast
+  if (!__BROWSER__ && ast === undefined && exp.content.trim()) {
+    try {
+      ast = parseExpression(`(${exp.content})`, getBabelParserOptions())
+    } catch {
+      return false
+    }
+  }
+
+  return !!(
+    ast && invalidDynamicDirectiveModifierBabelNodeTypes.includes(ast.type)
+  )
 }
 
 function emitError(code: ErrorCodes, index: number, message?: string) {

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -276,7 +276,50 @@ const tokenizer = new Tokenizer(stack, {
         setLocEnd(arg.loc, end)
       }
     } else {
-      const exp = createSimpleExpression(mod, true, getLoc(start, end))
+      const isStatic = mod[0] !== `[`
+      const exp = createExp(
+        isStatic ? mod : mod.slice(1, -1),
+        isStatic,
+        getLoc(start, end),
+        isStatic ? ConstantTypes.CAN_STRINGIFY : ConstantTypes.NOT_CONSTANT,
+      )
+
+      if (!exp.ast && !exp.content.trim()) {
+        if (isStatic) {
+          emitError(
+            ErrorCodes.X_MISSING_DIRECTIVE_MODIFIER_NAME,
+            exp.loc.start.offset,
+          )
+        } else {
+          emitError(
+            ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_VALUE,
+            exp.loc.start.offset,
+          )
+        }
+        return
+      }
+
+      const invalidBabelNodeTypes = [
+        'ArrayExpression',
+        'UnaryExpression',
+        'StringLiteral',
+        'NumericLiteral',
+        'TemplateLiteral',
+      ]
+
+      const invalidSimpleValues = ['true', 'false', 'null', 'undefined']
+
+      if (
+        (exp.ast && invalidBabelNodeTypes.includes(exp.ast.type)) ||
+        (!exp.ast && invalidSimpleValues.includes(exp.content))
+      ) {
+        emitError(
+          ErrorCodes.X_INVALID_VALUE_IN_DYNAMIC_DIRECTIVE_MODIFIER,
+          exp.loc.start.offset + 1,
+        )
+        return
+      }
+
       ;(currentProp as DirectiveNode).modifiers.push(exp)
     }
   },
@@ -384,7 +427,7 @@ const tokenizer = new Tokenizer(stack, {
             __COMPAT__ &&
             currentProp.name === 'bind' &&
             (syncIndex = currentProp.modifiers.findIndex(
-              mod => mod.content === 'sync',
+              mod => (mod as SimpleExpressionNode).content === 'sync',
             )) > -1 &&
             checkCompatEnabled(
               CompilerDeprecationTypes.COMPILER_V_BIND_SYNC,

--- a/packages/compiler-core/src/tokenizer.ts
+++ b/packages/compiler-core/src/tokenizer.ts
@@ -107,6 +107,7 @@ export enum State {
   InDirArg,
   InDirDynamicArg,
   InDirModifier,
+  InDirDynamicModifier,
   AfterAttrName,
   BeforeAttrValue,
   InAttrValueDq, // "
@@ -765,9 +766,25 @@ export default class Tokenizer {
     if (c === CharCodes.Eq || isEndOfTagSection(c)) {
       this.cbs.ondirmodifier(this.sectionStart, this.index)
       this.handleAttrNameEnd(c)
+    } else if (c === CharCodes.LeftSquare) {
+      this.state = State.InDirDynamicModifier
     } else if (c === CharCodes.Dot) {
       this.cbs.ondirmodifier(this.sectionStart, this.index)
       this.sectionStart = this.index + 1
+    }
+  }
+  private stateInDirDynamicModifier(c: number): void {
+    if (c === CharCodes.RightSquare) {
+      this.state = State.InDirModifier
+    } else if (c === CharCodes.Eq || isEndOfTagSection(c)) {
+      this.cbs.ondirmodifier(this.sectionStart, this.index + 1)
+      this.handleAttrNameEnd(c)
+      if (__DEV__ || !__BROWSER__) {
+        this.cbs.onerr(
+          ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_END,
+          this.index,
+        )
+      }
     }
   }
   private handleAttrNameEnd(c: number): void {
@@ -999,6 +1016,10 @@ export default class Tokenizer {
         }
         case State.InDirModifier: {
           this.stateInDirModifier(c)
+          break
+        }
+        case State.InDirDynamicModifier: {
+          this.stateInDirDynamicModifier(c)
           break
         }
         case State.InCommentLike: {

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -343,7 +343,7 @@ export function transform(root: RootNode, options: TransformOptions): void {
     createRootCodegen(root, context)
   }
   // finalize meta information
-  root.helpers = new Set([...context.helpers.keys()])
+  root.helpers = new Set(context.helpers.keys())
   root.components = [...context.components]
   root.directives = [...context.directives]
   root.imports = context.imports

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -52,6 +52,7 @@ import {
 import {
   findProp,
   isCoreComponent,
+  isSimpleIdentifier,
   isStaticArgOf,
   isStaticExp,
   toValidAssetId,
@@ -899,7 +900,6 @@ export function buildDirectiveArgs(
       dirArgs.push(toValidAssetId(dir.name, `directive`))
     }
   }
-  const { loc } = dir
   if (dir.exp) dirArgs.push(dir.exp)
   if (dir.arg) {
     if (!dir.exp) {
@@ -914,53 +914,73 @@ export function buildDirectiveArgs(
       }
       dirArgs.push(`void 0`)
     }
+    dirArgs.push(transformModifiers(dir))
+  }
+  return createArrayExpression(dirArgs, dir.loc)
+}
 
-    const trueExpression = createSimpleExpression(`true`, false, loc)
+export function transformModifiers(dir: DirectiveNode): Property['value'] {
+  const trueExpression = createSimpleExpression(
+    `true`,
+    false,
+    dir.loc,
+    ConstantTypes.CAN_CACHE,
+  )
 
-    const staticMods: ExpressionNode[] = []
-    const callArgs: (ObjectExpression | ExpressionNode)[] = []
+  const staticMods: ExpressionNode[] = []
+  const callArgs: (ObjectExpression | ExpressionNode)[] = []
 
-    for (let i = 0; i < dir.modifiers.length; i++) {
-      const modifier = dir.modifiers[i]
+  for (let i = 0; i < dir.modifiers.length; i++) {
+    const modifier = dir.modifiers[i] as SimpleExpressionNode
+    const isStatic = modifier.isStatic
 
-      if ((modifier as SimpleExpressionNode).isStatic) {
-        staticMods.push(modifier)
-      } else {
-        // Object expression must be first to avoid null or undefined
-        if (staticMods.length || i === 0) {
-          callArgs.push(
-            createObjectExpression(
-              staticMods.map(modifier =>
-                createObjectProperty(modifier, trueExpression),
-              ),
-              loc,
-            ),
-          )
-          staticMods.length = 0
-        }
-
-        callArgs.push(modifier)
-      }
+    if (isStatic) {
+      staticMods.push(modifier)
     }
 
-    if (staticMods.length) {
+    // Collect all static expressions into a single object
+    // This must also happen when we hit the last element in the array
+    // And it also must ensure that an object always comes first in callArgs
+    if (
+      (!isStatic && (staticMods.length || i === 0)) ||
+      (isStatic && i === dir.modifiers.length - 1)
+    ) {
       callArgs.push(
         createObjectExpression(
           staticMods.map(modifier =>
             createObjectProperty(modifier, trueExpression),
           ),
-          loc,
+          dir.loc,
         ),
       )
     }
 
-    if (callArgs.length === 1) {
-      dirArgs.push(callArgs[0])
-    } else {
-      dirArgs.push(createCallExpression('Object.assign', callArgs))
+    if (!isStatic) {
+      callArgs.push(modifier)
+      // We only reset the array on hitting a dynamic modifier so we can check its length
+      // after the loop has finished
+      staticMods.length = 0
     }
   }
-  return createArrayExpression(dirArgs, dir.loc)
+
+  // Only static mods were passed. Use simple expression to avoid adding modelModidifiers to dynamic prop keys
+  if (staticMods.length === dir.modifiers.length) {
+    const modifiers = staticMods
+      .map(m => (m as SimpleExpressionNode).content)
+      .map(m => (isSimpleIdentifier(m) ? m : JSON.stringify(m)) + `: true`)
+      .join(`, `)
+
+    return createSimpleExpression(
+      `{ ${modifiers} }`,
+      false,
+      dir.loc,
+      ConstantTypes.CAN_CACHE,
+    )
+  }
+
+  return callArgs.length !== 1
+    ? createCallExpression('Object.assign', callArgs)
+    : callArgs[0]
 }
 
 function stringifyDynamicPropNames(props: string[]): string {

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -13,6 +13,7 @@ import {
   NodeTypes,
   type ObjectExpression,
   type Property,
+  type SimpleExpressionNode,
   type TemplateTextChildNode,
   type VNodeCall,
   createArrayExpression,
@@ -666,7 +667,10 @@ export function buildProps(
       }
 
       // force hydration for v-bind with .prop modifier
-      if (isVBind && modifiers.some(mod => mod.content === 'prop')) {
+      if (
+        isVBind &&
+        modifiers.some(mod => (mod as SimpleExpressionNode).content === 'prop')
+      ) {
         patchFlag |= PatchFlags.NEED_HYDRATION
       }
 
@@ -910,15 +914,51 @@ export function buildDirectiveArgs(
       }
       dirArgs.push(`void 0`)
     }
+
     const trueExpression = createSimpleExpression(`true`, false, loc)
-    dirArgs.push(
-      createObjectExpression(
-        dir.modifiers.map(modifier =>
-          createObjectProperty(modifier, trueExpression),
+
+    const staticMods: ExpressionNode[] = []
+    const callArgs: (ObjectExpression | ExpressionNode)[] = []
+
+    for (let i = 0; i < dir.modifiers.length; i++) {
+      const modifier = dir.modifiers[i]
+
+      if ((modifier as SimpleExpressionNode).isStatic) {
+        staticMods.push(modifier)
+      } else {
+        // Object expression must be first to avoid null or undefined
+        if (staticMods.length || i === 0) {
+          callArgs.push(
+            createObjectExpression(
+              staticMods.map(modifier =>
+                createObjectProperty(modifier, trueExpression),
+              ),
+              loc,
+            ),
+          )
+          staticMods.length = 0
+        }
+
+        callArgs.push(modifier)
+      }
+    }
+
+    if (staticMods.length) {
+      callArgs.push(
+        createObjectExpression(
+          staticMods.map(modifier =>
+            createObjectProperty(modifier, trueExpression),
+          ),
+          loc,
         ),
-        loc,
-      ),
-    )
+      )
+    }
+
+    if (callArgs.length === 1) {
+      dirArgs.push(callArgs[0])
+    } else {
+      dirArgs.push(createCallExpression('Object.assign', callArgs))
+    }
   }
   return createArrayExpression(dirArgs, dir.loc)
 }

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -51,6 +51,8 @@ import {
 } from '../runtimeHelpers'
 import {
   findProp,
+  hasDynamicModifier,
+  hasStaticModifier,
   isCoreComponent,
   isSimpleIdentifier,
   isStaticArgOf,
@@ -541,9 +543,20 @@ export function buildProps(
       )
     } else {
       // directives
-      const { name, arg, exp, loc, modifiers } = prop
+      const { name, arg, exp, loc } = prop
       const isVBind = name === 'bind'
       const isVOn = name === 'on'
+
+      if (!arg && isVBind && hasDynamicModifier(prop)) {
+        context.onError(
+          createCompilerError(
+            ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+            loc,
+            undefined,
+            ` v-bind only supports static modifiers.`,
+          ),
+        )
+      }
 
       // skip v-slot - it is handled by its dedicated transform.
       if (name === 'slot') {
@@ -668,10 +681,7 @@ export function buildProps(
       }
 
       // force hydration for v-bind with .prop modifier
-      if (
-        isVBind &&
-        modifiers.some(mod => (mod as SimpleExpressionNode).content === 'prop')
-      ) {
+      if (isVBind && hasStaticModifier(prop, 'prop')) {
         patchFlag |= PatchFlags.NEED_HYDRATION
       }
 
@@ -907,7 +917,7 @@ export function buildDirectiveArgs(
     }
     dirArgs.push(dir.arg)
   }
-  if (Object.keys(dir.modifiers).length) {
+  if (dir.modifiers.length) {
     if (!dir.arg) {
       if (!dir.exp) {
         dirArgs.push(`void 0`)
@@ -931,8 +941,8 @@ export function transformModifiers(dir: DirectiveNode): Property['value'] {
   const callArgs: (ObjectExpression | ExpressionNode)[] = []
 
   for (let i = 0; i < dir.modifiers.length; i++) {
-    const modifier = dir.modifiers[i] as SimpleExpressionNode
-    const isStatic = modifier.isStatic
+    const modifier = dir.modifiers[i]
+    const isStatic = isStaticExp(modifier)
 
     if (isStatic) {
       staticMods.push(modifier)
@@ -963,7 +973,7 @@ export function transformModifiers(dir: DirectiveNode): Property['value'] {
     }
   }
 
-  // Only static mods were passed. Use simple expression to avoid adding modelModidifiers to dynamic prop keys
+  // Only static mods were passed. Use simple expression to avoid adding modelModifiers to dynamic prop keys
   if (staticMods.length === dir.modifiers.length) {
     const modifiers = staticMods
       .map(m => (m as SimpleExpressionNode).content)

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -62,6 +62,7 @@ export const transformExpression: NodeTransform = (node, context) => {
       if (dir.type === NodeTypes.DIRECTIVE && dir.name !== 'for') {
         const exp = dir.exp
         const arg = dir.arg
+        const mods = dir.modifiers
         // do not process exp if this is v-on:arg - we need special handling
         // for wrapping inline statements.
         if (
@@ -85,6 +86,12 @@ export const transformExpression: NodeTransform = (node, context) => {
         }
         if (arg && arg.type === NodeTypes.SIMPLE_EXPRESSION && !arg.isStatic) {
           dir.arg = processExpression(arg, context)
+        }
+        for (let j = 0; j < mods.length; j++) {
+          const mod = mods[j]
+          if (mod.type === NodeTypes.SIMPLE_EXPRESSION && !mod.isStatic) {
+            mods[j] = processExpression(mod, context)
+          }
         }
       }
     }

--- a/packages/compiler-core/src/transforms/vBind.ts
+++ b/packages/compiler-core/src/transforms/vBind.ts
@@ -45,7 +45,9 @@ export const transformBind: DirectiveTransform = (dir, _node, context) => {
   }
 
   // .sync is replaced by v-model:arg
-  if (modifiers.some(mod => mod.content === 'camel')) {
+  if (
+    modifiers.some(mod => (mod as SimpleExpressionNode).content === 'camel')
+  ) {
     if (arg.type === NodeTypes.SIMPLE_EXPRESSION) {
       if (arg.isStatic) {
         arg.content = camelize(arg.content)
@@ -59,10 +61,14 @@ export const transformBind: DirectiveTransform = (dir, _node, context) => {
   }
 
   if (!context.inSSR) {
-    if (modifiers.some(mod => mod.content === 'prop')) {
+    if (
+      modifiers.some(mod => (mod as SimpleExpressionNode).content === 'prop')
+    ) {
       injectPrefix(arg, '.')
     }
-    if (modifiers.some(mod => mod.content === 'attr')) {
+    if (
+      modifiers.some(mod => (mod as SimpleExpressionNode).content === 'attr')
+    ) {
       injectPrefix(arg, '^')
     }
   }

--- a/packages/compiler-core/src/transforms/vBind.ts
+++ b/packages/compiler-core/src/transforms/vBind.ts
@@ -8,15 +8,27 @@ import {
 import { ErrorCodes, createCompilerError } from '../errors'
 import { camelize } from '@vue/shared'
 import { CAMELIZE } from '../runtimeHelpers'
+import { hasDynamicModifier, hasStaticModifier } from '../utils'
 
 // v-bind without arg is handled directly in ./transformElement.ts due to its affecting
 // codegen for the entire props object. This transform here is only for v-bind
 // *with* args.
 export const transformBind: DirectiveTransform = (dir, _node, context) => {
-  const { modifiers, loc } = dir
+  const { loc } = dir
   const arg = dir.arg!
 
   let { exp } = dir
+
+  if (hasDynamicModifier(dir)) {
+    context.onError(
+      createCompilerError(
+        ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+        loc,
+        undefined,
+        ` v-bind only supports static modifiers.`,
+      ),
+    )
+  }
 
   // handle empty expression
   if (exp && exp.type === NodeTypes.SIMPLE_EXPRESSION && !exp.content.trim()) {
@@ -45,9 +57,7 @@ export const transformBind: DirectiveTransform = (dir, _node, context) => {
   }
 
   // .sync is replaced by v-model:arg
-  if (
-    modifiers.some(mod => (mod as SimpleExpressionNode).content === 'camel')
-  ) {
+  if (hasStaticModifier(dir, 'camel')) {
     if (arg.type === NodeTypes.SIMPLE_EXPRESSION) {
       if (arg.isStatic) {
         arg.content = camelize(arg.content)
@@ -61,14 +71,10 @@ export const transformBind: DirectiveTransform = (dir, _node, context) => {
   }
 
   if (!context.inSSR) {
-    if (
-      modifiers.some(mod => (mod as SimpleExpressionNode).content === 'prop')
-    ) {
+    if (hasStaticModifier(dir, 'prop')) {
       injectPrefix(arg, '.')
     }
-    if (
-      modifiers.some(mod => (mod as SimpleExpressionNode).content === 'attr')
-    ) {
+    if (hasStaticModifier(dir, 'attr')) {
       injectPrefix(arg, '^')
     }
   }

--- a/packages/compiler-core/src/transforms/vModel.ts
+++ b/packages/compiler-core/src/transforms/vModel.ts
@@ -1,15 +1,10 @@
 import type { DirectiveTransform } from '../transform'
 import {
-  ConstantTypes,
   ElementTypes,
   type ExpressionNode,
   NodeTypes,
-  type ObjectExpression,
   type Property,
-  type SimpleExpressionNode,
-  createCallExpression,
   createCompoundExpression,
-  createObjectExpression,
   createObjectProperty,
   createSimpleExpression,
 } from '../ast'
@@ -23,6 +18,7 @@ import {
 import { IS_REF } from '../runtimeHelpers'
 import { BindingTypes } from '../options'
 import { camelize, getModifierPropName } from '@vue/shared'
+import { transformModifiers } from './transformElement'
 
 export const transformModel: DirectiveTransform = (dir, node, context) => {
   const { exp, arg } = dir
@@ -143,80 +139,13 @@ export const transformModel: DirectiveTransform = (dir, node, context) => {
 
   // modelModifiers: { foo: true, "bar-baz": true }
   if (dir.modifiers.length && node.tagType === ElementTypes.COMPONENT) {
-    const trueExpression = createSimpleExpression(
-      `true`,
-      false,
-      dir.loc,
-      ConstantTypes.CAN_CACHE,
-    )
-
-    const staticMods: ExpressionNode[] = []
-    const callArgs: (ObjectExpression | ExpressionNode)[] = []
-
     const modifiersKey = arg
       ? isStaticExp(arg)
         ? getModifierPropName(arg.content)
         : createCompoundExpression([arg, ' + "Modifiers"'])
       : `modelModifiers`
 
-    for (let i = 0; i < dir.modifiers.length; i++) {
-      const modifier = dir.modifiers[i]
-
-      if ((modifier as SimpleExpressionNode).isStatic) {
-        staticMods.push(modifier)
-      } else {
-        // Object expression must be first to avoid null or undefined
-        if (staticMods.length || i === 0) {
-          callArgs.push(
-            createObjectExpression(
-              staticMods.map(modifier =>
-                createObjectProperty(modifier, trueExpression),
-              ),
-              dir.loc,
-            ),
-          )
-          staticMods.length = 0
-        }
-
-        callArgs.push(modifier)
-      }
-    }
-
-    let val: Property['value']
-
-    // Only static mods were passed. Use simple expression to avoid adding modelModidifiers to dynamic prop keys
-    if (callArgs.length === 0) {
-      const modifiers = staticMods
-        .map(m => (m as SimpleExpressionNode).content)
-        .map(m => (isSimpleIdentifier(m) ? m : JSON.stringify(m)) + `: true`)
-        .join(`, `)
-
-      val = createSimpleExpression(
-        `{ ${modifiers} }`,
-        false,
-        dir.loc,
-        ConstantTypes.CAN_CACHE,
-      )
-    } else {
-      // push remaining static mods that werent added in the loop
-      if (staticMods.length) {
-        callArgs.push(
-          createObjectExpression(
-            staticMods.map(modifier =>
-              createObjectProperty(modifier, trueExpression),
-            ),
-            dir.loc,
-          ),
-        )
-      }
-
-      val =
-        callArgs.length !== 1
-          ? createCallExpression('Object.assign', callArgs)
-          : callArgs[0]
-    }
-
-    props.push(createObjectProperty(modifiersKey, val))
+    props.push(createObjectProperty(modifiersKey, transformModifiers(dir)))
   }
 
   return createTransformProps(props)

--- a/packages/compiler-core/src/transforms/vModel.ts
+++ b/packages/compiler-core/src/transforms/vModel.ts
@@ -5,6 +5,7 @@ import {
   type ExpressionNode,
   NodeTypes,
   type Property,
+  type SimpleExpressionNode,
   createCompoundExpression,
   createObjectProperty,
   createSimpleExpression,
@@ -140,7 +141,7 @@ export const transformModel: DirectiveTransform = (dir, node, context) => {
   // modelModifiers: { foo: true, "bar-baz": true }
   if (dir.modifiers.length && node.tagType === ElementTypes.COMPONENT) {
     const modifiers = dir.modifiers
-      .map(m => m.content)
+      .map(m => (m as SimpleExpressionNode).content)
       .map(m => (isSimpleIdentifier(m) ? m : JSON.stringify(m)) + `: true`)
       .join(`, `)
     const modifiersKey = arg

--- a/packages/compiler-core/src/transforms/vModel.ts
+++ b/packages/compiler-core/src/transforms/vModel.ts
@@ -4,9 +4,12 @@ import {
   ElementTypes,
   type ExpressionNode,
   NodeTypes,
+  type ObjectExpression,
   type Property,
   type SimpleExpressionNode,
+  createCallExpression,
   createCompoundExpression,
+  createObjectExpression,
   createObjectProperty,
   createSimpleExpression,
 } from '../ast'
@@ -140,26 +143,80 @@ export const transformModel: DirectiveTransform = (dir, node, context) => {
 
   // modelModifiers: { foo: true, "bar-baz": true }
   if (dir.modifiers.length && node.tagType === ElementTypes.COMPONENT) {
-    const modifiers = dir.modifiers
-      .map(m => (m as SimpleExpressionNode).content)
-      .map(m => (isSimpleIdentifier(m) ? m : JSON.stringify(m)) + `: true`)
-      .join(`, `)
+    const trueExpression = createSimpleExpression(
+      `true`,
+      false,
+      dir.loc,
+      ConstantTypes.CAN_CACHE,
+    )
+
+    const staticMods: ExpressionNode[] = []
+    const callArgs: (ObjectExpression | ExpressionNode)[] = []
+
     const modifiersKey = arg
       ? isStaticExp(arg)
         ? getModifierPropName(arg.content)
         : createCompoundExpression([arg, ' + "Modifiers"'])
       : `modelModifiers`
-    props.push(
-      createObjectProperty(
-        modifiersKey,
-        createSimpleExpression(
-          `{ ${modifiers} }`,
-          false,
-          dir.loc,
-          ConstantTypes.CAN_CACHE,
-        ),
-      ),
-    )
+
+    for (let i = 0; i < dir.modifiers.length; i++) {
+      const modifier = dir.modifiers[i]
+
+      if ((modifier as SimpleExpressionNode).isStatic) {
+        staticMods.push(modifier)
+      } else {
+        // Object expression must be first to avoid null or undefined
+        if (staticMods.length || i === 0) {
+          callArgs.push(
+            createObjectExpression(
+              staticMods.map(modifier =>
+                createObjectProperty(modifier, trueExpression),
+              ),
+              dir.loc,
+            ),
+          )
+          staticMods.length = 0
+        }
+
+        callArgs.push(modifier)
+      }
+    }
+
+    let val: Property['value']
+
+    // Only static mods were passed. Use simple expression to avoid adding modelModidifiers to dynamic prop keys
+    if (callArgs.length === 0) {
+      const modifiers = staticMods
+        .map(m => (m as SimpleExpressionNode).content)
+        .map(m => (isSimpleIdentifier(m) ? m : JSON.stringify(m)) + `: true`)
+        .join(`, `)
+
+      val = createSimpleExpression(
+        `{ ${modifiers} }`,
+        false,
+        dir.loc,
+        ConstantTypes.CAN_CACHE,
+      )
+    } else {
+      // push remaining static mods that werent added in the loop
+      if (staticMods.length) {
+        callArgs.push(
+          createObjectExpression(
+            staticMods.map(modifier =>
+              createObjectProperty(modifier, trueExpression),
+            ),
+            dir.loc,
+          ),
+        )
+      }
+
+      val =
+        callArgs.length !== 1
+          ? createCallExpression('Object.assign', callArgs)
+          : callArgs[0]
+    }
+
+    props.push(createObjectProperty(modifiersKey, val))
   }
 
   return createTransformProps(props)

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -48,6 +48,18 @@ import { isWhitespace } from './tokenizer'
 export const isStaticExp = (p: JSChildNode): p is SimpleExpressionNode =>
   p.type === NodeTypes.SIMPLE_EXPRESSION && p.isStatic
 
+export const isStaticModifier = (
+  modifier: ExpressionNode,
+  name?: string,
+): modifier is SimpleExpressionNode =>
+  isStaticExp(modifier) && (name === undefined || modifier.content === name)
+
+export const hasStaticModifier = (dir: DirectiveNode, name: string): boolean =>
+  dir.modifiers.some(modifier => isStaticModifier(modifier, name))
+
+export const hasDynamicModifier = (dir: DirectiveNode): boolean =>
+  dir.modifiers.some(modifier => !isStaticModifier(modifier))
+
 export function isCoreComponent(tag: string): symbol | void {
   switch (tag) {
     case 'Teleport':

--- a/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
@@ -2,6 +2,7 @@ import {
   BindingTypes,
   type CompilerOptions,
   type ElementNode,
+  ErrorCodes,
   NodeTypes,
   type ObjectExpression,
   TO_HANDLER_KEY,
@@ -47,6 +48,20 @@ describe('compiler-dom: transform v-on', () => {
         arguments: [{ content: '_ctx.test' }, '["stop","prevent"]'],
       },
     })
+  })
+
+  it('should error on dynamic modifiers', () => {
+    const onError = vi.fn()
+    parseWithVOn(`<div @keyup.[key]="test"/>`, {
+      onError,
+      prefixIdentifiers: true,
+    })
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+      }),
+    )
   })
 
   it('should support multiple events and modifiers options w/ prefixIdentifiers: true', () => {

--- a/packages/compiler-dom/src/errors.ts
+++ b/packages/compiler-dom/src/errors.ts
@@ -21,7 +21,7 @@ export function createDOMCompilerError(
 }
 
 export enum DOMErrorCodes {
-  X_V_HTML_NO_EXPRESSION = 58 /* ErrorCodes.__EXTEND_POINT__ */,
+  X_V_HTML_NO_EXPRESSION = 59 /* ErrorCodes.__EXTEND_POINT__ */,
   X_V_HTML_WITH_CHILDREN,
   X_V_TEXT_NO_EXPRESSION,
   X_V_TEXT_WITH_CHILDREN,

--- a/packages/compiler-dom/src/errors.ts
+++ b/packages/compiler-dom/src/errors.ts
@@ -21,7 +21,7 @@ export function createDOMCompilerError(
 }
 
 export enum DOMErrorCodes {
-  X_V_HTML_NO_EXPRESSION = 54 /* ErrorCodes.__EXTEND_POINT__ */,
+  X_V_HTML_NO_EXPRESSION = 58 /* ErrorCodes.__EXTEND_POINT__ */,
   X_V_HTML_WITH_CHILDREN,
   X_V_TEXT_NO_EXPRESSION,
   X_V_TEXT_WITH_CHILDREN,

--- a/packages/compiler-dom/src/transforms/vOn.ts
+++ b/packages/compiler-dom/src/transforms/vOn.ts
@@ -1,6 +1,7 @@
 import {
   CompilerDeprecationTypes,
   type DirectiveTransform,
+  ErrorCodes,
   type ExpressionNode,
   NodeTypes,
   type SimpleExpressionNode,
@@ -9,6 +10,7 @@ import {
   transformOn as baseTransform,
   checkCompatEnabled,
   createCallExpression,
+  createCompilerError,
   createCompoundExpression,
   createObjectProperty,
   createSimpleExpression,
@@ -121,14 +123,23 @@ export const transformOn: DirectiveTransform = (dir, node, context) => {
     const { modifiers } = dir
     if (!modifiers.length) return baseResult
 
+    const staticModifiers = modifiers.filter(isStaticExp)
+    if (staticModifiers.length !== modifiers.length) {
+      context.onError(
+        createCompilerError(
+          ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+          dir.loc,
+          undefined,
+          ` v-on only supports static modifiers.`,
+        ),
+      )
+    }
+
+    if (!staticModifiers.length) return baseResult
+
     let { key, value: handlerExp } = baseResult.props[0]
     const { keyModifiers, nonKeyModifiers, eventOptionModifiers } =
-      resolveModifiers(
-        key,
-        modifiers as SimpleExpressionNode[],
-        context,
-        dir.loc,
-      )
+      resolveModifiers(key, staticModifiers, context, dir.loc)
 
     // normalize click.right and click.middle since they don't actually fire
     if (nonKeyModifiers.includes('right')) {

--- a/packages/compiler-dom/src/transforms/vOn.ts
+++ b/packages/compiler-dom/src/transforms/vOn.ts
@@ -123,7 +123,12 @@ export const transformOn: DirectiveTransform = (dir, node, context) => {
 
     let { key, value: handlerExp } = baseResult.props[0]
     const { keyModifiers, nonKeyModifiers, eventOptionModifiers } =
-      resolveModifiers(key, modifiers, context, dir.loc)
+      resolveModifiers(
+        key,
+        modifiers as SimpleExpressionNode[],
+        context,
+        dir.loc,
+      )
 
     // normalize click.right and click.middle since they don't actually fire
     if (nonKeyModifiers.includes('right')) {

--- a/packages/compiler-ssr/src/errors.ts
+++ b/packages/compiler-ssr/src/errors.ts
@@ -17,7 +17,7 @@ export function createSSRCompilerError(
 }
 
 export enum SSRErrorCodes {
-  X_SSR_UNSAFE_ATTR_NAME = 65 /* DOMErrorCodes.__EXTEND_POINT__ */,
+  X_SSR_UNSAFE_ATTR_NAME = 70 /* DOMErrorCodes.__EXTEND_POINT__ */,
   X_SSR_NO_TELEPORT_TARGET,
   X_SSR_INVALID_AST_NODE,
 }

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -136,6 +136,17 @@ describe('compile', () => {
         expect(code).matchSnapshot()
       })
 
+      test('dynamic modifiers', () => {
+        const code = compile(`<div v-example.bar.[mods]="msg"></div>`, {
+          prefixIdentifiers: true,
+          bindingMetadata: {
+            msg: BindingTypes.SETUP_REF,
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).contains(`Object.assign({ bar: true }, _ctx.mods)`)
+      })
+
       test('modifiers w/o binding', () => {
         const code = compile(`<div v-example.foo-bar></div>`, {
           bindingMetadata: {

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -289,6 +289,17 @@ describe('compiler v-bind', () => {
     expect(code).contains('_setProp(n0, "fooBar", _ctx.id)')
   })
 
+  test('dynamic modifier should error', () => {
+    const onError = vi.fn()
+    compileWithVBind(`<div v-bind:foo.[mods]="id"/>`, { onError })
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+      }),
+    )
+  })
+
   test('.camel modifier w/ no expression', () => {
     const { ir, code } = compileWithVBind(`<div v-bind:foo-bar.camel />`)
 

--- a/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
@@ -166,6 +166,17 @@ describe('compiler: vModel transform', () => {
 
       expect(code).toMatchSnapshot()
     })
+
+    test('dynamic modifiers', () => {
+      const { code } = compileWithVModel(
+        '<input v-model.trim.[mods]="model" />',
+        {
+          prefixIdentifiers: true,
+        },
+      )
+
+      expect(code).contains(`Object.assign({ trim: true }, _ctx.mods)`)
+    })
   })
 
   test('should support member expression', () => {
@@ -286,7 +297,10 @@ describe('compiler: vModel transform', () => {
               key: { content: 'modelValue', isStatic: true },
               values: [{ content: 'foo', isStatic: false }],
               model: true,
-              modelModifiers: ['trim', 'bar-baz'],
+              modelModifiers: [
+                { content: 'trim', isStatic: true },
+                { content: 'bar-baz', isStatic: true },
+              ],
             },
           ],
         ],
@@ -309,13 +323,13 @@ describe('compiler: vModel transform', () => {
               key: { content: 'foo', isStatic: true },
               values: [{ content: 'foo', isStatic: false }],
               model: true,
-              modelModifiers: ['trim'],
+              modelModifiers: [{ content: 'trim', isStatic: true }],
             },
             {
               key: { content: 'bar', isStatic: true },
               values: [{ content: 'bar', isStatic: false }],
               model: true,
-              modelModifiers: ['number'],
+              modelModifiers: [{ content: 'number', isStatic: true }],
             },
           ],
         ],
@@ -337,7 +351,7 @@ describe('compiler: vModel transform', () => {
               key: { content: 'model', isStatic: true },
               values: [{ content: 'foo', isStatic: false }],
               model: true,
-              modelModifiers: ['trim'],
+              modelModifiers: [{ content: 'trim', isStatic: true }],
             },
           ],
         ],
@@ -365,14 +379,43 @@ describe('compiler: vModel transform', () => {
             key: { content: 'foo', isStatic: false },
             values: [{ content: 'foo', isStatic: false }],
             model: true,
-            modelModifiers: ['trim'],
+            modelModifiers: [{ content: 'trim', isStatic: true }],
           },
           {
             key: { content: 'bar', isStatic: false },
             values: [{ content: 'bar', isStatic: false }],
             model: true,
-            modelModifiers: ['number'],
+            modelModifiers: [{ content: 'number', isStatic: true }],
           },
+        ],
+      })
+    })
+
+    test('v-model for component should generate dynamic modelModifiers', () => {
+      const { code, ir } = compileWithVModel(
+        '<Comp v-model.trim.[mods]="foo" />',
+        {
+          prefixIdentifiers: true,
+        },
+      )
+      expect(code).contains(
+        `modelModifiers: () => (Object.assign({ trim: true }, _ctx.mods))`,
+      )
+      expect(ir.block.dynamic.children[0].operation).toMatchObject({
+        type: IRNodeTypes.CREATE_COMPONENT_NODE,
+        tag: 'Comp',
+        props: [
+          [
+            {
+              key: { content: 'modelValue', isStatic: true },
+              values: [{ content: 'foo', isStatic: false }],
+              model: true,
+              modelModifiers: [
+                { content: 'trim', isStatic: true },
+                { content: 'mods', isStatic: false },
+              ],
+            },
+          ],
         ],
       })
     })

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -402,6 +402,19 @@ describe('v-on', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
+  test('should error on dynamic modifiers', () => {
+    const onError = vi.fn()
+    compileWithVOn(`<div @keyup.[key]="handler" />`, {
+      onError,
+      prefixIdentifiers: true,
+    })
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+      }),
+    )
+  })
+
   test('should support multiple modifiers and event options w/ prefixIdentifiers: true', () => {
     const { code, ir, helpers } = compileWithVOn(
       `<div @click.stop.prevent.capture.once="test"/>`,

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -314,8 +314,8 @@ function genStaticProps(
         const modifiersKey = key.isStatic
           ? [getModifierPropName(key.content)]
           : ['[', ...genExpression(key, context), ' + "Modifiers"]']
-        const modifiersVal = genDirectiveModifiers(modelModifiers)
-        args.push([...modifiersKey, `: () => ({ ${modifiersVal} })`])
+        const modifiersVal = genDirectiveModifiers(modelModifiers, context)
+        args.push([...modifiersKey, `: () => (`, ...modifiersVal, `)`])
       }
     }
   }
@@ -382,8 +382,8 @@ function genDynamicProps(
                   ...genExpression(p.key, context),
                   ' + "Modifiers"]',
                 ] as CodeFragment[])
-            const modifiersVal = genDirectiveModifiers(modelModifiers)
-            entries.push([...modifiersKey, `: () => ({ ${modifiersVal} })`])
+            const modifiersVal = genDirectiveModifiers(modelModifiers, context)
+            entries.push([...modifiersKey, `: () => (`, ...modifiersVal, `)`])
           }
 
           expr = genMulti(DELIMITERS_OBJECT_NEWLINE, ...entries)

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -1,6 +1,9 @@
 import {
+  type ExpressionNode,
+  type SimpleExpressionNode,
   createSimpleExpression,
   isSimpleIdentifier,
+  isStaticExp,
   toValidAssetId,
 } from '@vue/compiler-dom'
 import { extend } from '@vue/shared'
@@ -71,11 +74,8 @@ function genCustomDirectives(
         )
     const value = dir.exp && ['() => ', ...genExpression(dir.exp, context)]
     const argument = dir.arg && genExpression(dir.arg, context)
-    const modifiers = !!dir.modifiers.length && [
-      '{ ',
-      genDirectiveModifiers(dir.modifiers.map(m => m.content)),
-      ' }',
-    ]
+    const modifiers =
+      !!dir.modifiers.length && genDirectiveModifiers(dir.modifiers, context)
 
     return genMulti(
       DELIMITERS_ARRAY.concat('void 0') as CodeFragmentDelimiters,
@@ -87,13 +87,64 @@ function genCustomDirectives(
   }
 }
 
-export function genDirectiveModifiers(modifiers: string[]): string {
-  return modifiers
-    .map(
-      value =>
-        `${isSimpleIdentifier(value) ? value : JSON.stringify(value)}: true`,
-    )
-    .join(', ')
+export function genDirectiveModifiers(
+  modifiers: ExpressionNode[],
+  context: CodegenContext,
+): CodeFragment[] {
+  const staticMods: SimpleExpressionNode[] = []
+  const callArgs: CodeFragment[][] = []
+
+  for (let i = 0; i < modifiers.length; i++) {
+    const modifier = modifiers[i]
+    const isStatic = isStaticExp(modifier)
+
+    if (isStatic) {
+      staticMods.push(modifier)
+    }
+
+    if (
+      (!isStatic && (staticMods.length || i === 0)) ||
+      (isStatic && i === modifiers.length - 1)
+    ) {
+      callArgs.push(genStaticDirectiveModifiers(staticMods))
+    }
+
+    if (!isStatic) {
+      callArgs.push(
+        genExpression(modifier as unknown as SimpleExpressionNode, context),
+      )
+      staticMods.length = 0
+    }
+  }
+
+  if (staticMods.length === modifiers.length) {
+    return genStaticDirectiveModifiers(staticMods)
+  }
+
+  return callArgs.length !== 1
+    ? genCall('Object.assign', ...callArgs)
+    : callArgs[0]
+}
+
+function genStaticDirectiveModifiers(
+  modifiers: SimpleExpressionNode[],
+): CodeFragment[] {
+  if (!modifiers.length) {
+    return ['{}']
+  }
+
+  return [
+    '{ ',
+    modifiers
+      .map(({ content }) => {
+        const key = isSimpleIdentifier(content)
+          ? content
+          : JSON.stringify(content)
+        return `${key}: true`
+      })
+      .join(', '),
+    ' }',
+  ]
 }
 
 function filterCustomDirectives(

--- a/packages/compiler-vapor/src/generators/vModel.ts
+++ b/packages/compiler-vapor/src/generators/vModel.ts
@@ -3,6 +3,7 @@ import type { DirectiveIRNode } from '../ir'
 import { type CodeFragment, NEWLINE, genCall } from './utils'
 import { genExpression } from './expression'
 import type { SimpleExpressionNode } from '@vue/compiler-dom'
+import { genDirectiveModifiers } from './directive'
 
 const helperMap = {
   text: 'applyTextModel',
@@ -33,9 +34,7 @@ export function genVModel(
       // setter
       genModelHandler(exp!, context),
       // modifiers
-      modifiers.length
-        ? `{ ${modifiers.map(e => e.content + ': true').join(',')} }`
-        : undefined,
+      modifiers.length ? genDirectiveModifiers(modifiers, context) : undefined,
     ),
   ]
 }

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -5,6 +5,7 @@ import {
   type CompilerCompatOptions,
   type ElementNode,
   ElementTypes,
+  type ExpressionNode,
   NodeTypes,
   type RootNode,
   type SimpleExpressionNode,
@@ -58,7 +59,7 @@ export interface DirectiveTransformResult {
   handler?: boolean
   handlerModifiers?: SetEventIRNode['modifiers']
   model?: boolean
-  modelModifiers?: string[]
+  modelModifiers?: ExpressionNode[]
 }
 
 // A structural directive transform is technically also a NodeTransform;

--- a/packages/compiler-vapor/src/transforms/vBind.ts
+++ b/packages/compiler-vapor/src/transforms/vBind.ts
@@ -5,6 +5,8 @@ import {
   type SimpleExpressionNode,
   createCompilerError,
   createSimpleExpression,
+  hasDynamicModifier,
+  hasStaticModifier,
 } from '@vue/compiler-dom'
 import { camelize, extend } from '@vue/shared'
 import type { DirectiveTransform, TransformContext } from '../transform'
@@ -34,10 +36,20 @@ export function normalizeBindShorthand(
 }
 
 export const transformVBind: DirectiveTransform = (dir, node, context) => {
-  const { loc, modifiers } = dir
+  const { loc } = dir
   let { exp } = dir
   let arg = dir.arg!
-  const modifiersString = modifiers.map(s => s.content)
+
+  if (hasDynamicModifier(dir)) {
+    context.options.onError(
+      createCompilerError(
+        ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+        loc,
+        undefined,
+        ` v-bind only supports static modifiers.`,
+      ),
+    )
+  }
 
   if (!exp) exp = normalizeBindShorthand(arg, context)
   if (!exp.content.trim()) {
@@ -54,7 +66,7 @@ export const transformVBind: DirectiveTransform = (dir, node, context) => {
   if (arg.isStatic && isReservedProp(arg.content)) return
 
   let camel = false
-  if (modifiersString.includes('camel')) {
+  if (hasStaticModifier(dir, 'camel')) {
     if (arg.isStatic) {
       arg = extend({}, arg, { content: camelize(arg.content) })
     } else {
@@ -67,9 +79,9 @@ export const transformVBind: DirectiveTransform = (dir, node, context) => {
     value: exp,
     loc,
     runtimeCamelize: camel,
-    modifier: modifiersString.includes('prop')
+    modifier: hasStaticModifier(dir, 'prop')
       ? '.'
-      : modifiersString.includes('attr')
+      : hasStaticModifier(dir, 'attr')
         ? '^'
         : undefined,
   }

--- a/packages/compiler-vapor/src/transforms/vModel.ts
+++ b/packages/compiler-vapor/src/transforms/vModel.ts
@@ -66,7 +66,7 @@ export const transformVModel: DirectiveTransform = (dir, node, context) => {
       key: arg ? arg : createSimpleExpression('modelValue', true),
       value: exp,
       model: true,
-      modelModifiers: dir.modifiers.map(m => m.content),
+      modelModifiers: dir.modifiers,
     }
   }
 

--- a/packages/compiler-vapor/src/transforms/vOn.ts
+++ b/packages/compiler-vapor/src/transforms/vOn.ts
@@ -27,6 +27,18 @@ export const transformVOn: DirectiveTransform = (dir, node, context) => {
   const isComponent = node.tagType === ElementTypes.COMPONENT
   const isSlotOutlet = node.tag === 'slot'
 
+  const staticModifiers = modifiers.filter(isStaticExp)
+  if (staticModifiers.length !== modifiers.length) {
+    context.options.onError(
+      createCompilerError(
+        ErrorCodes.X_DYNAMIC_DIRECTIVE_MODIFIER_NOT_SUPPORTED,
+        loc,
+        undefined,
+        ` v-on only supports static modifiers.`,
+      ),
+    )
+  }
+
   if (!exp && !modifiers.length) {
     context.options.onError(
       createCompilerError(ErrorCodes.X_V_ON_NO_EXPRESSION, loc),
@@ -43,7 +55,7 @@ export const transformVOn: DirectiveTransform = (dir, node, context) => {
   const { keyModifiers, nonKeyModifiers, eventOptionModifiers } =
     resolveModifiers(
       arg.isStatic ? `on${arg.content}` : arg,
-      modifiers,
+      staticModifiers,
       null,
       loc,
     )
@@ -155,7 +167,7 @@ function hasStopHandlerForStaticEvent(node: ElementNode, eventName: string) {
 
     const { nonKeyModifiers } = resolveModifiers(
       `on${arg.content}`,
-      prop.modifiers,
+      prop.modifiers.filter(isStaticExp),
       null,
       prop.loc,
     )


### PR DESCRIPTION
fix #8281

This PR adds dynamic modifiers for directives 

```vue
<div v-foo.[myModifiers]="5" />

const myModifiers = {
  mod1: true,
  mod2: false
}
```

It also adds error states for empty modifiers (`v-foo.="5"`) and handles empty dynamic modifiers or invalid values e.g. `v-foo.[]="5"`, `v-foo.[123]="5"`.

I skipped modifiers with invalid values. I am not sure if that is a problem. Otherwise codegen would be corrupted (it was before for empty values already. That's also fixed with that).

I also had to change modifiers to be an Expression instead of SimpleExpression so that I can use parseExpression with it. That means I had to cast to SimpleExpression at a few places
