### PR TITLE
feat(compiler-core): add `tagLoc` and `closeTagLoc` to element ast node

### DIFF
--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -130,6 +130,8 @@ export interface BaseElementNode extends Node {
   type: NodeTypes.ELEMENT
   ns: Namespace
   tag: string
+  tagLoc: SourceLocation
+  closeTagLoc?: SourceLocation
   tagType: ElementTypes
   props: Array<AttributeNode | DirectiveNode>
   children: TemplateChildNode[]

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -140,6 +140,7 @@ const tokenizer = new Tokenizer(stack, {
       type: NodeTypes.ELEMENT,
       tag: name,
       ns: currentOptions.getNamespace(name, stack[0], currentOptions.ns),
+      tagLoc: getLoc(start, end),
       tagType: ElementTypes.ELEMENT, // will be refined on tag close
       props: [],
       children: [],
@@ -165,6 +166,9 @@ const tokenizer = new Tokenizer(stack, {
           }
           for (let j = 0; j <= i; j++) {
             const el = stack.shift()!
+            if (j === i) {
+              el.closeTagLoc = getLoc(start, end)
+            }
             onCloseTag(el, end, j < i)
           }
           break


### PR DESCRIPTION
Nowadays, language tools rely on string search to determine the offset of tags, which is not reliable and may cause some issues, like:

```html
<img v-bind="imgAttrs">
        <!-- ^^^ -->
```