### PR TITLE
ci(pkg-pr-new): add 'vapor' branch for pull-request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - minor
+      - vapor
 
 jobs:
   test:


### PR DESCRIPTION
pnpm patch don't support `pkg-pr-new`'s package. 
Can we add the vapor branch for pull requests so that I can use those PRs #12893 and #12890 before they are merged?