### PR TITLE
feat(reactivity): introducing persistent Dep

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -199,7 +199,7 @@ class MutableReactiveHandler extends BaseReactiveHandler {
 
   has(target: Record<string | symbol, unknown>, key: string | symbol): boolean {
     const result = Reflect.has(target, key)
-    if (!isSymbol(key) || !builtInSymbols.has(key)) {
+    if (result && (!isSymbol(key) || !builtInSymbols.has(key))) {
       track(target, TrackOpTypes.HAS, key)
     }
     return result

--- a/packages/reactivity/src/dep.ts
+++ b/packages/reactivity/src/dep.ts
@@ -1,6 +1,6 @@
 import { extend, isArray, isIntegerKey, isMap, isSymbol } from '@vue/shared'
 import type { ComputedRefImpl } from './computed'
-import { type TrackOpTypes, TriggerOpTypes } from './constants'
+import { TrackOpTypes, TriggerOpTypes } from './constants'
 import {
   type DebuggerEventExtraInfo,
   EffectFlags,
@@ -92,6 +92,12 @@ export class Dep {
    * Subscriber counter
    */
   sc: number = 0
+
+  /**
+   * Indicates whether this Dep instance can be deleted
+   * When set to true, the Dep should be preserved
+   */
+  permanent: boolean = false
 
   constructor(public computed?: ComputedRefImpl | undefined) {
     if (__DEV__) {
@@ -264,6 +270,10 @@ export function track(target: object, type: TrackOpTypes, key: unknown): void {
       depsMap.set(key, (dep = new Dep()))
       dep.map = depsMap
       dep.key = key
+
+      if (type === TrackOpTypes.HAS) {
+        dep.permanent = true
+      }
     }
     if (__DEV__) {
       dep.track({

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -316,10 +316,11 @@ function cleanupDeps(sub: Subscriber) {
   let link = tail
   while (link) {
     const prev = link.prevDep
-    if (link.version === -1) {
+    const isPermanentDep = link.dep.permanent
+    if (link.version === -1 && !isPermanentDep) {
       if (link === tail) tail = prev
       // unused - remove it from the dep's subscribing effect list
-      removeSub(link)
+      removeSub(link, isPermanentDep)
       // also remove it from this effect's dep list
       removeDep(link)
     } else {


### PR DESCRIPTION
Fixes: #12924.

```typescript
<script setup>
import { ref, reactive } from 'vue'

const msg = ref('Hello World!')
function getTestData1() {
  const data = reactive({}); // The issue lies in the fact that each function execution will create a new {}.
  console.log('use in operator', 'label' in data); // Then this will create Dep Links without limits.
  data.label = 'set data after in';
  return data;
}
</script>

<template>
  <h1>{{ msg }}</h1>
  <input v-model="msg" />
  <div>{{ getTestData1() }}</div>
</template>
```