### PR TITLE
feat(runtime-vapor): use shallow clone to support shallowRef in v-for

### DIFF
--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -410,12 +410,12 @@ describe('createFor', () => {
       '<li>0. 1</li><li>1. 2</li><li>2. 3</li><li>3. 4</li><!--for-->',
     )
 
-    // change deep value should not update
+    // change
     list.value[0].name = 'a'
     setList()
     await nextTick()
     expect(host.innerHTML).toBe(
-      '<li>0. 1</li><li>1. 2</li><li>2. 3</li><li>3. 4</li><!--for-->',
+      '<li>0. a</li><li>1. 2</li><li>2. 3</li><li>3. 4</li><!--for-->',
     )
 
     // remove
@@ -423,7 +423,7 @@ describe('createFor', () => {
     setList()
     await nextTick()
     expect(host.innerHTML).toBe(
-      '<li>0. 1</li><li>1. 3</li><li>2. 4</li><!--for-->',
+      '<li>0. a</li><li>1. 3</li><li>2. 4</li><!--for-->',
     )
 
     // clear

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -389,7 +389,7 @@ export function createForSlots(
   return slots
 }
 
-function normalizeSource(source: any, needsWrap?: boolean): ResolvedSource {
+function normalizeSource(source: any, needsWrap = false): ResolvedSource {
   let values = source
   let keys
   if (isArray(source)) {
@@ -416,7 +416,7 @@ function normalizeSource(source: any, needsWrap?: boolean): ResolvedSource {
       }
     }
   }
-  return { values, needsWrap: !!needsWrap, keys }
+  return { values, needsWrap, keys }
 }
 
 function shallowClone(val: any) {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -78,6 +78,7 @@ export const createFor = (
   // hydrationNode?: Node,
 ): VaporFragment => {
   let isMounted = false
+  let needsWrapCache: boolean
   let oldBlocks: ForBlock[] = []
   let newBlocks: ForBlock[]
   let parent: ParentNode | undefined | null
@@ -92,7 +93,10 @@ export const createFor = (
   }
 
   const renderList = () => {
-    const source = normalizeSource(src())
+    const source = normalizeSource(src(), needsWrapCache)
+    if (needsWrapCache === undefined) {
+      needsWrapCache = source.needsWrap
+    }
     const newLength = source.values.length
     const oldLength = oldBlocks.length
     newBlocks = new Array(newLength)
@@ -387,13 +391,14 @@ export function createForSlots(
   return slots
 }
 
-function normalizeSource(source: any): ResolvedSource {
+function normalizeSource(source: any, needsWrap?: boolean): ResolvedSource {
   let values = source
-  let needsWrap = false
   let keys
   if (isArray(source)) {
     if (isReactive(source)) {
-      needsWrap = !isShallow(source)
+      if (needsWrap === undefined) {
+        needsWrap = !isShallow(source)
+      }
       values = shallowReadArray(source)
     }
   } else if (isString(source)) {
@@ -415,7 +420,7 @@ function normalizeSource(source: any): ResolvedSource {
       }
     }
   }
-  return { values, needsWrap, keys }
+  return { values, needsWrap: !!needsWrap, keys }
 }
 
 function shallowClone(val: any) {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -78,7 +78,7 @@ export const createFor = (
   // hydrationNode?: Node,
 ): VaporFragment => {
   let isMounted = false
-  let needsWrapCache: boolean
+  let prevNeedsWrap: boolean
   let oldBlocks: ForBlock[] = []
   let newBlocks: ForBlock[]
   let parent: ParentNode | undefined | null
@@ -93,10 +93,8 @@ export const createFor = (
   }
 
   const renderList = () => {
-    const source = normalizeSource(src(), needsWrapCache)
-    if (needsWrapCache === undefined) {
-      needsWrapCache = source.needsWrap
-    }
+    const source = normalizeSource(src(), prevNeedsWrap)
+    prevNeedsWrap = source.needsWrap
     const newLength = source.values.length
     const oldLength = oldBlocks.length
     newBlocks = new Array(newLength)
@@ -396,9 +394,7 @@ function normalizeSource(source: any, needsWrap?: boolean): ResolvedSource {
   let keys
   if (isArray(source)) {
     if (isReactive(source)) {
-      if (needsWrap === undefined) {
-        needsWrap = !isShallow(source)
-      }
+      needsWrap = !isShallow(source)
       values = shallowReadArray(source)
     }
   } else if (isString(source)) {


### PR DESCRIPTION
[REPL](https://deploy-preview-12927--vapor-repl.netlify.app/#eNp9kstOwzAQRX9l5A0gIAHBqqQ8xQIWgAq7uovgOK3bxLb8SCtF+XfGjlpaqLqyPXPu+M7YLXnQOmk8JwOSWWaEdmC58xqaXCtzS6WocXXQgp3lVaWWI15CB6VRNRyh7uiGSiqZktaBUUsLwy3weNyKYnDRTU4CVHrJnFASvC5yx49PoKUSIE2jMGnyyvPxxQQrtICy3WgiCjiFS7waeesZ47wI6n/QcL8OVWUuqr+iHTyxlWDoi8qOyiztx4EjwIPjta7QNJ4Asm/vHPZxz5BfDCnpG6Lktt9kaQ9EKUDbxjvQzF1w02HxWKUQDTTnpTJYQYCQkcIiIRlVYo0jnCKNmSzdckLOiLM4+lJMk7lVEt8wTpQSpmqNzZp3HQaORQf9rEMuPs5rjDnj+dk6zmacLfbE53YVYpR8GG65abDPTc7lZspdn37+fOMr3G+StSp8hfSB5IhbVfngsccevSzQ9hYX3b7EPyjk9Ms+rxyXdt1UMBrILvKU4Id8OtD6r92r5Drq8KlJ9wPwUQK3)

Using the `rows.slice()` (shallow copy) to replaced the `rows`, only the content inside v-for hasn't changed, which is inconsistent with the behavior of the Virtual DOM.
So I created a shallow clone for the item when the source is a not a reactive object .

> This PR may not be the best solution, but I can’t find other solutions. If you can resolve it, you can turn it off at will.


