### PR TITLE
fix(runtime-vapor): properly mount component when using setInsertionState

### DIFF
--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -2,6 +2,7 @@ import {
   type Ref,
   inject,
   nextTick,
+  onMounted,
   onUpdated,
   provide,
   ref,
@@ -13,6 +14,7 @@ import {
   createIf,
   createTextNode,
   renderEffect,
+  setInsertionState,
   template,
 } from '../src'
 import { makeRender } from './_utils'
@@ -264,6 +266,29 @@ describe('component', () => {
     await nextTick()
     expect(host.innerHTML).toBe('<h1>1</h1>')
     expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('properly mount child component when using setInsertionState', async () => {
+    const spy = vi.fn()
+
+    const { component: Comp } = define({
+      setup() {
+        onMounted(spy)
+        return template('<h1>hi</h1>')()
+      },
+    })
+
+    const { host } = define({
+      setup() {
+        const n2 = template('<div></div>', true)()
+        setInsertionState(n2 as any)
+        createComponent(Comp)
+        return n2
+      },
+    }).render()
+
+    expect(host.innerHTML).toBe('<div><h1>hi</h1></div>')
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it('unmount component', async () => {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -270,7 +270,7 @@ export function createComponent(
   onScopeDispose(() => unmountComponent(instance), true)
 
   if (!isHydrating && _insertionParent) {
-    insert(instance.block, _insertionParent, _insertionAnchor)
+    mountComponent(instance, _insertionParent, _insertionAnchor)
   }
 
   return instance


### PR DESCRIPTION
- open [local playground with vapor branch](http://localhost:5173/#eNqNUk1PwzAM/StWLh3S1B7gNMokQDuAxIeAYw6rWq/LSJMoScukqf8dJ+3GkNjEoarj9xy/+HnHbo1JuxbZjOWutMJ46Aqj7Zwr0dDfw71uDKysbiBJs3AI9OSaqzwbCohKB4+NkYVHOgHklehiQGEoGWMAhwilVk5LBKnrFPwaoUHnihphWa6FrKDRrfJYLZcgHCjtA7HGKh3vixqGLtnQJs+OmrMp845arESdbpxW9LBdIHNWUp2QaF+MFySBsxlEJGCFlPrrMea8bXG6z5drLD//yG/cNuQ4e7Xo0HbI2QHzha3RD/Di/Rm3FB/ARletJPYZ8A1pPG3QONDuWlWR7CNeVPsQ7RGq/nCLrUfl9o8KQgOzj3zOyK4wslNP/5F7mV7FOq56muLe6tObsQOtngazoB9XZNyNAzCZXNzMY6/R9pTcnCS/nE4uqCN9/1woJ2knsjMb0H8DuMLxZQ==)
- observe the console; the message `child mounted` is not logged.