### PR TITLE
feat(compiler-vapor): support custom generate operation

### DIFF
--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -19,7 +19,14 @@ import {
 } from './generators/utils'
 import { setTemplateRefIdent } from './generators/templateRef'
 
-export type CodegenOptions = Omit<BaseCodegenOptions, 'optimizeImports'>
+type CustomGenOperation = (
+  opers: any,
+  context: CodegenContext,
+) => CodeFragment[] | void
+
+export type CodegenOptions = Omit<BaseCodegenOptions, 'optimizeImports'> & {
+  customGenOperation?: CustomGenOperation | null
+}
 
 export class CodegenContext {
   options: Required<CodegenOptions>
@@ -87,6 +94,7 @@ export class CodegenContext {
       inline: false,
       bindingMetadata: {},
       expressionPlugins: [],
+      customGenOperation: null,
     }
     this.options = extend(defaultOptions, options)
     this.block = ir.block

--- a/packages/compiler-vapor/src/generators/operation.ts
+++ b/packages/compiler-vapor/src/generators/operation.ts
@@ -88,6 +88,11 @@ export function genOperation(
     case IRNodeTypes.GET_TEXT_CHILD:
       return genGetTextChild(oper, context)
     default:
+      if (context.options.customGenOperation) {
+        const result = context.options.customGenOperation(oper, context)
+        if (result) return result
+      }
+
       const exhaustiveCheck: never = oper
       throw new Error(
         `Unhandled operation type in genOperation: ${exhaustiveCheck}`,

--- a/packages/compiler-vapor/src/generators/text.ts
+++ b/packages/compiler-vapor/src/generators/text.ts
@@ -10,8 +10,8 @@ export function genSetText(
   context: CodegenContext,
 ): CodeFragment[] {
   const { helper } = context
-  const { element, values, generated, jsx } = oper
-  const texts = combineValues(values, context, jsx)
+  const { element, values, generated } = oper
+  const texts = combineValues(values, context)
   return [
     NEWLINE,
     ...genCall(helper('setText'), `${generated ? 'x' : 'n'}${element}`, texts),
@@ -21,16 +21,15 @@ export function genSetText(
 function combineValues(
   values: SimpleExpressionNode[],
   context: CodegenContext,
-  jsx?: boolean,
 ): CodeFragment[] {
   return values.flatMap((value, i) => {
     let exp = genExpression(value, context)
-    if (!jsx && getLiteralExpressionValue(value) == null) {
+    if (getLiteralExpressionValue(value) == null) {
       // dynamic, wrap with toDisplayString
       exp = genCall(context.helper('toDisplayString'), exp)
     }
     if (i > 0) {
-      exp.unshift(jsx ? ', ' : ' + ')
+      exp.unshift(' + ')
     }
     return exp
   })

--- a/packages/compiler-vapor/src/generators/utils.ts
+++ b/packages/compiler-vapor/src/generators/utils.ts
@@ -10,6 +10,8 @@ import {
 import { isArray, isString } from '@vue/shared'
 import type { CodegenContext } from '../generate'
 
+export { genExpression } from './expression'
+
 export const NEWLINE: unique symbol = Symbol(__DEV__ ? `newline` : ``)
 /** increase offset but don't push actual code */
 export const LF: unique symbol = Symbol(__DEV__ ? `line feed` : ``)

--- a/packages/compiler-vapor/src/index.ts
+++ b/packages/compiler-vapor/src/index.ts
@@ -13,13 +13,7 @@ export {
   type CodegenOptions,
   type VaporCodegenResult,
 } from './generate'
-export {
-  genCall,
-  genMulti,
-  buildCodeFragment,
-  codeFragmentToString,
-  type CodeFragment,
-} from './generators/utils'
+export * from './generators/utils'
 export {
   wrapTemplate,
   compile,

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -124,7 +124,6 @@ export interface SetTextIRNode extends BaseIRNode {
   element: number
   values: SimpleExpressionNode[]
   generated?: boolean // whether this is a generated empty text node by `processTextLikeContainer`
-  jsx?: boolean
 }
 
 export type KeyOverride = [find: string, replacement: string]


### PR DESCRIPTION
I added `setNodes` and `createNodes` IR for vue-jsx-vapor, so remove the `setText`'s `jsx` flag.

This is my custom IR https://github.com/vuejs/vue-jsx-vapor/blob/main/packages/compiler/src/generate.ts