### PR TITLE
types: enhance plugin type inference for better IDE support

### DIFF
--- a/packages-private/dts-test/appUse.test-d.ts
+++ b/packages-private/dts-test/appUse.test-d.ts
@@ -110,7 +110,15 @@ const PluginTyped: Plugin<PluginOptions> = (app, options) => {}
 
 // @ts-expect-error: needs options
 app.use(PluginTyped)
-app.use(PluginTyped, { option2: 2, option3: true })
+app.use(
+  PluginTyped,
+  // Test autocomplete for options
+  {
+    option1: '',
+    option2: 2,
+    option3: true,
+  },
+)
 
 const functionPluginOptional = (app: App, options?: PluginOptions) => {}
 app.use(functionPluginOptional)
@@ -123,17 +131,6 @@ const functionPluginOptional2: Plugin<[options?: PluginOptions]> = (
 ) => {}
 app.use(functionPluginOptional2)
 app.use(functionPluginOptional2, { option2: 2, option3: true })
-
-const functionPluginOptional3: Plugin<PluginOptions> = (app, options) => {}
-app.use(
-  functionPluginOptional3,
-  // Test autocomplete for options
-  {
-    option1: 'foo',
-    option2: 1,
-    option3: true,
-  },
-)
 
 // vuetify usage
 const key: string = ''

--- a/packages-private/dts-test/appUse.test-d.ts
+++ b/packages-private/dts-test/appUse.test-d.ts
@@ -32,7 +32,6 @@ const objectPluginOptional = {
   install(app: App, options?: PluginOptions) {},
 }
 app.use(objectPluginOptional)
-
 app.use(
   objectPluginOptional,
   // Test JSDoc and `go to definition` for options

--- a/packages-private/dts-test/appUse.test-d.ts
+++ b/packages-private/dts-test/appUse.test-d.ts
@@ -12,8 +12,11 @@ app.use(PluginWithoutType, 2)
 app.use(PluginWithoutType, { anything: 'goes' }, true)
 
 type PluginOptions = {
+  /** option1 */
   option1?: string
+  /** option2 */
   option2: number
+  /** option3 */
   option3: boolean
 }
 
@@ -24,6 +27,21 @@ const PluginWithObjectOptions = {
     options.option3
   },
 }
+
+const objectPluginOptional = {
+  install(app: App, options?: PluginOptions) {},
+}
+app.use(objectPluginOptional)
+
+app.use(
+  objectPluginOptional,
+  // Test JSDoc and `go to definition` for options
+  {
+    option1: 'foo',
+    option2: 1,
+    option3: true,
+  },
+)
 
 for (const Plugin of [
   PluginWithObjectOptions,
@@ -93,6 +111,29 @@ const PluginTyped: Plugin<PluginOptions> = (app, options) => {}
 // @ts-expect-error: needs options
 app.use(PluginTyped)
 app.use(PluginTyped, { option2: 2, option3: true })
+
+const functionPluginOptional = (app: App, options?: PluginOptions) => {}
+app.use(functionPluginOptional)
+app.use(functionPluginOptional, { option2: 2, option3: true })
+
+// type optional params
+const functionPluginOptional2: Plugin<[options?: PluginOptions]> = (
+  app,
+  options,
+) => {}
+app.use(functionPluginOptional2)
+app.use(functionPluginOptional2, { option2: 2, option3: true })
+
+const functionPluginOptional3: Plugin<PluginOptions> = (app, options) => {}
+app.use(
+  functionPluginOptional3,
+  // Test autocomplete for options
+  {
+    option1: 'foo',
+    option2: 1,
+    option3: true,
+  },
+)
 
 // vuetify usage
 const key: string = ''

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -36,9 +36,9 @@ export interface App<HostElement = any> {
 
   use<Options extends unknown[]>(
     plugin: Plugin<Options>,
-    ...options: Options
+    ...options: NoInfer<Options>
   ): this
-  use<Options>(plugin: Plugin<Options>, options: Options): this
+  use<Options>(plugin: Plugin<Options>, options: NoInfer<Options>): this
 
   mixin(mixin: ComponentOptions): this
   component(name: string): Component | undefined
@@ -215,9 +215,10 @@ export type ObjectPlugin<Options = any[]> = {
 export type FunctionPlugin<Options = any[]> = PluginInstallFunction<Options> &
   Partial<ObjectPlugin<Options>>
 
-export type Plugin<Options = any[]> =
-  | FunctionPlugin<Options>
-  | ObjectPlugin<Options>
+export type Plugin<
+  Options = any[],
+  P extends unknown[] = Options extends unknown[] ? Options : [Options],
+> = FunctionPlugin<P> | ObjectPlugin<P>
 
 export function createAppContext(): AppContext {
   return {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -217,6 +217,7 @@ export type FunctionPlugin<Options = any[]> = PluginInstallFunction<Options> &
 
 export type Plugin<
   Options = any[],
+  // TODO: in next major Options extends unknown[] and remove P
   P extends unknown[] = Options extends unknown[] ? Options : [Options],
 > = FunctionPlugin<P> | ObjectPlugin<P>
 


### PR DESCRIPTION
- JSDoc comments for `options` are preserved and visible in IDEs.
- `Go to definition` functionality works for plugin options.
- Autocomplete for `options` fields is fully supported.