### PR TITLE
fix(runtime-dom): map kebab attributes to camelCase props (fix #13055)

### DIFF
--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -47,7 +47,9 @@ export const patchProp: DOMRendererOptions['patchProp'] = (
         ? ((key = key.slice(1)), false)
         : shouldSetAsProp(el, key, nextValue, isSVG)
   ) {
-    patchDOMProp(el, key, nextValue, parentComponent)
+    const camelKey = camelize(key)
+    const propKey = camelKey in el ? camelKey : key
+    patchDOMProp(el, propKey, nextValue, parentComponent, key)
     // #6007 also set form state as attributes so they work with
     // <input type="reset"> or libs / extensions that expect attributes
     // #11163 custom elements may use value as an prop and set it as object
@@ -140,5 +142,5 @@ function shouldSetAsProp(
     return false
   }
 
-  return key in el
+  return camelize(key) in el || key in el
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where kebab-case attributes are not correctly being set as DOM properties.

The problem is happening because there is no conversion from kebab-case to camelCase in the [patchProp function](https://github.com/vuejs/core/blob/e16e9a7341e7cfb3c443da4e5e5b06e8158712c3/packages/runtime-dom/src/patchProp.ts#L25) when checking if a property exists on the given element when using the `in` operator.

The problem also happens when using the `.prop` modifier, since the `patchDOMProp` function is called with the given `key` argument, without checking first for the existence of the camelCase DOM property:

https://github.com/vuejs/core/blob/e16e9a7341e7cfb3c443da4e5e5b06e8158712c3/packages/runtime-dom/src/patchProp.ts#L50

The changes in this PR addresses the issue in these two places, by checking first if the camelCase version of the `key` exists in the Element and using the original `key` argument as fallback.

## Fixes

* close #13055 

## Notes

Because of how the current version of `patchProp` and `shouldSetAsProp` are structured, it was not possible to avoid making the check with the `in` operator **twice** for the cases where `shouldSetAsProp` was called and executed entirely (or at least I couldn't figure out a way).

I understand this is performance sensitive part of the code so I refactored those functions in a [separate branch](https://github.com/vonBrax/vuejs-core/blob/refactor/patch-props/packages/runtime-dom/src/patchProp.ts) to show-case a different version where the check is performed at most once per code branch.

I decided to use my first solution for this PR since it was smaller and it didn't introduce style changes, which are discouraged according to the [contribution guidelines](https://github.com/vuejs/core/blob/main/.github/contributing.md#advanced-pull-request-tips). But since the same guidelines also suggests attention to performance impacts, I decided to create the second version, which would **theoretically** be more performant (no benchmarks).

I'm happy to update this PR with the changes from my other branch, if that would so be preferred.