### PR TITLE
fix(renderList): handle readonly reactive arrays in renderList

### DIFF
--- a/packages/runtime-core/__tests__/helpers/renderList.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/renderList.spec.ts
@@ -1,4 +1,10 @@
-import { isReactive, reactive, shallowReactive } from '../../src/index'
+import {
+  isReactive,
+  reactive,
+  readonly,
+  ref,
+  shallowReactive,
+} from '../../src/index'
 import { renderList } from '../../src/helpers/renderList'
 
 describe('renderList', () => {
@@ -64,5 +70,15 @@ describe('renderList', () => {
 
     const shallowReactiveArray = shallowReactive([{ foo: 1 }])
     expect(renderList(shallowReactiveArray, isReactive)).toEqual([false])
+  })
+
+  it('should warn when attempting to mutate a readonly reactive array', () => {
+    const reactiveArray = readonly(ref([{ x: 1 }])) as any
+    renderList(reactiveArray.value, m => {
+      m.x = 0
+    })
+    expect(
+      `Set operation on key "x" failed: target is readonly.`,
+    ).toHaveBeenWarned()
   })
 })

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -68,9 +68,10 @@ export function renderList(
   const sourceIsArray = isArray(source)
 
   if (sourceIsArray || isString(source)) {
-    const sourceIsReactiveArray = sourceIsArray && isReactive(source)
+    const sourceIsReactiveArray =
+      sourceIsArray && !isReadonly(source) && isReactive(source)
     let needsWrap = false
-    if (!isReadonly(source) && sourceIsReactiveArray) {
+    if (sourceIsReactiveArray) {
       needsWrap = !isShallow(source)
       source = shallowReadArray(source)
     }

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,6 +1,7 @@
 import type { VNode, VNodeChild } from '../vnode'
 import {
   isReactive,
+  isReadonly,
   isShallow,
   shallowReadArray,
   toReactive,
@@ -69,7 +70,7 @@ export function renderList(
   if (sourceIsArray || isString(source)) {
     const sourceIsReactiveArray = sourceIsArray && isReactive(source)
     let needsWrap = false
-    if (sourceIsReactiveArray) {
+    if (!isReadonly(source) && sourceIsReactiveArray) {
       needsWrap = !isShallow(source)
       source = shallowReadArray(source)
     }


### PR DESCRIPTION
close #13087

In version [3.4](https://play.vuejs.org/#eNp9UUFOwzAQ/MrKF1qppFTlgEpbCVAPcAAE3DBCIdmkLolt2U5IFeXvrB21tBKqfPHOzI7Huy270TqqK2QzNreJEdqBRVfpJZei1Mo4aMFgnCpZbKGDzKgSzkh/dn0kyI44LlP8qvIcDZeJktZBovQWFnunAXUM3ltoZjCB7mM4JDd/5uM+A71OhcNSF7FDqgDmqaihPs+UWXBWgpDBk7Nl20IZNWR+AV03H5Os168nngoPe5xK73/gyUbMWYqXiTzaWCVpBK3v5CxRpRYFmiftBMXnbAaB8VxcFOrnIWDOVDja4ckak+9/8I1tPMbZs0GLpkbO9pyLTY6up1evj9jQfU+WKq0KUp8gX9CqovIZe9ltJVOKfaALae/DnoTM3+yqcSjt7lM+qFd2Qc8Z7e7uxNf/4k6jy9DHZUdT/KzReE8aIBHR9Ip1v4lWxn8=) the runtime will throw a warning and the "array item" will not be modified, so this should be a bug
