### PR TITLE
feat(lint): add performance-related rules

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run eslint
         run: pnpm run lint --fix
 
+      - name: Run tsslint
+        run: pnpm run tsslint --fix
+
       - name: Run prettier
         run: pnpm run format
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-replace": "5.0.4",
     "@swc/core": "^1.11.12",
+    "@tsslint/cli": "~1.5.11",
+    "@tsslint/config": "~1.5.11",
     "@types/hash-sum": "^1.0.2",
     "@types/node": "^22.13.13",
     "@types/semver": "^7.5.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "size-esm": "node scripts/build.js runtime-dom runtime-core reactivity shared -f esm-bundler",
     "check": "tsc --incremental --noEmit",
     "lint": "eslint --cache .",
+    "tsslint": "tsslint --project tsconfig.json",
     "format": "prettier --write --cache .",
     "format-check": "prettier --check --cache .",
     "test": "vitest",

--- a/packages/compiler-core/src/babelUtils.ts
+++ b/packages/compiler-core/src/babelUtils.ts
@@ -95,7 +95,7 @@ export function walkIdentifiers(
       if (node !== rootExp && node.scopeIds) {
         for (const id of node.scopeIds) {
           knownIds[id]--
-          if (knownIds[id] === 0) {
+          if (!knownIds[id]) {
             delete knownIds[id]
           }
         }
@@ -113,7 +113,7 @@ export function isReferencedIdentifier(
     return false
   }
 
-  if (!parent) {
+  if (parent === null) {
     return true
   }
 
@@ -376,7 +376,7 @@ function isReferenced(node: Node, parent: Node, grandparent?: Node): boolean {
         return !!parent.computed
       }
       // parent.value === node
-      return !grandparent || grandparent.type !== 'ObjectPattern'
+      return grandparent === undefined || grandparent.type !== 'ObjectPattern'
     // no: class { NODE = value; }
     // yes: class { [NODE] = value; }
     // yes: class { key = NODE; }

--- a/packages/compiler-core/src/compile.ts
+++ b/packages/compiler-core/src/compile.ts
@@ -96,7 +96,10 @@ export function baseCompile(
 
   if (!__BROWSER__ && options.isTS) {
     const { expressionPlugins } = options
-    if (!expressionPlugins || !expressionPlugins.includes('typescript')) {
+    if (
+      expressionPlugins === undefined ||
+      !expressionPlugins.includes('typescript')
+    ) {
       options.expressionPlugins = [...(expressionPlugins || []), 'typescript']
     }
   }

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -497,7 +497,7 @@ function parseForExpression(
   const loc = input.loc
   const exp = input.content
   const inMatch = exp.match(forAliasRE)
-  if (!inMatch) return
+  if (inMatch === null) return
 
   const [, LHS, RHS] = inMatch
 
@@ -1056,7 +1056,7 @@ export function baseParse(input: string, options?: ParserOptions): RootNode {
         `[@vue/compiler-core] decodeEntities option is passed but will be ` +
           `ignored in non-browser builds.`,
       )
-    } else if (__BROWSER__ && !currentOptions.decodeEntities) {
+    } else if (__BROWSER__ && currentOptions.decodeEntities === undefined) {
       throw new Error(
         `[@vue/compiler-core] decodeEntities option is required in browser builds.`,
       )

--- a/packages/compiler-core/src/tokenizer.ts
+++ b/packages/compiler-core/src/tokenizer.ts
@@ -259,7 +259,7 @@ export default class Tokenizer {
 
   public mode: ParseMode = ParseMode.BASE
   public get inSFCRoot(): boolean {
-    return this.mode === ParseMode.SFC && this.stack.length === 0
+    return this.mode === ParseMode.SFC && !this.stack.length
   }
 
   constructor(
@@ -430,7 +430,7 @@ export default class Tokenizer {
 
     if ((c | 0x20) === this.currentSequence[this.sequenceIndex]) {
       this.sequenceIndex += 1
-    } else if (this.sequenceIndex === 0) {
+    } else if (!this.sequenceIndex) {
       if (
         this.currentSequence === Sequences.TitleEnd ||
         (this.currentSequence === Sequences.TextareaEnd && !this.inSFCRoot)
@@ -518,7 +518,7 @@ export default class Tokenizer {
         this.sectionStart = this.index + 1
         this.state = State.Text
       }
-    } else if (this.sequenceIndex === 0) {
+    } else if (!this.sequenceIndex) {
       // Fast-forward to the first character of the sequence
       if (this.fastForwardTo(this.currentSequence[0])) {
         this.sequenceIndex = 1
@@ -910,7 +910,7 @@ export default class Tokenizer {
       if (length >= 0) {
         this.state = this.baseState
 
-        if (length === 0) {
+        if (!length) {
           this.index = this.entityStart
         }
       } else {
@@ -1084,7 +1084,7 @@ export default class Tokenizer {
     if (this.sectionStart !== this.index) {
       if (
         this.state === State.Text ||
-        (this.state === State.InRCDATA && this.sequenceIndex === 0)
+        (this.state === State.InRCDATA && !this.sequenceIndex)
       ) {
         this.cbs.ontext(this.sectionStart, this.index)
         this.sectionStart = this.index

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -223,10 +223,10 @@ export function createTransformContext(
     replaceNode(node) {
       /* v8 ignore start */
       if (__DEV__) {
-        if (!context.currentNode) {
+        if (context.currentNode === null) {
           throw new Error(`Node being replaced is already removed.`)
         }
-        if (!context.parent) {
+        if (context.parent === null) {
           throw new Error(`Cannot replace root node.`)
         }
       }
@@ -235,7 +235,7 @@ export function createTransformContext(
     },
     removeNode(node) {
       /* v8 ignore next 3 */
-      if (__DEV__ && !context.parent) {
+      if (__DEV__ && context.parent === null) {
         throw new Error(`Cannot remove root node.`)
       }
       const list = context.parent!.children
@@ -248,7 +248,7 @@ export function createTransformContext(
       if (__DEV__ && removalIndex < 0) {
         throw new Error(`node being removed is not a child of current parent`)
       }
-      if (!node || node === context.currentNode) {
+      if (node === undefined || node === context.currentNode) {
         // current node removed
         context.currentNode = null
         context.onNodeRemoved()

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -213,7 +213,7 @@ export const transformElement: NodeTransform = (node, context) => {
       vnodeTag,
       vnodeProps,
       vnodeChildren,
-      patchFlag === 0 ? undefined : patchFlag,
+      !patchFlag ? undefined : patchFlag,
       vnodeDynamicProps,
       vnodeDirectives,
       !!shouldUseBlock,
@@ -248,7 +248,7 @@ export function resolveComponentType(
         exp = isProp.value && createSimpleExpression(isProp.value.content, true)
       } else {
         exp = isProp.exp
-        if (!exp) {
+        if (exp === undefined) {
           // #10469 handle :is shorthand
           exp = createSimpleExpression(`is`, false, isProp.arg!.loc)
           if (!__BROWSER__) {
@@ -590,7 +590,7 @@ export function buildProps(
       }
 
       // special case for v-bind and v-on with no argument
-      if (!arg && (isVBind || isVOn)) {
+      if (arg === undefined && (isVBind || isVOn)) {
         hasDynamicKeys = true
         if (exp) {
           if (isVBind) {
@@ -739,7 +739,7 @@ export function buildProps(
   }
   if (
     !shouldUseBlock &&
-    (patchFlag === 0 || patchFlag === PatchFlags.NEED_HYDRATION) &&
+    (!patchFlag || patchFlag === PatchFlags.NEED_HYDRATION) &&
     (hasRef || hasVnodeHook || runtimeDirectives.length > 0)
   ) {
     patchFlag |= PatchFlags.NEED_PATCH
@@ -897,14 +897,14 @@ export function buildDirectiveArgs(
   const { loc } = dir
   if (dir.exp) dirArgs.push(dir.exp)
   if (dir.arg) {
-    if (!dir.exp) {
+    if (dir.exp === undefined) {
       dirArgs.push(`void 0`)
     }
     dirArgs.push(dir.arg)
   }
   if (Object.keys(dir.modifiers).length) {
-    if (!dir.arg) {
-      if (!dir.exp) {
+    if (dir.arg === undefined) {
+      if (dir.exp === undefined) {
         dirArgs.push(`void 0`)
       }
       dirArgs.push(`void 0`)

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -242,7 +242,7 @@ export function processExpression(
     return node
   }
 
-  if (ast === null || (!ast && isSimpleIdentifier(rawExp))) {
+  if (ast === null || (ast === undefined && isSimpleIdentifier(rawExp))) {
     const isScopeVarReference = context.identifiers[rawExp]
     const isAllowedGlobal = isGloballyAllowed(rawExp)
     const isLiteral = isLiteralWhitelisted(rawExp)
@@ -268,7 +268,7 @@ export function processExpression(
     return node
   }
 
-  if (!ast) {
+  if (ast === undefined) {
     // exp needs to be parsed differently:
     // 1. Multiple inline statements (v-on, with presence of `;`): parse as raw
     //    exp, but make sure to pad with spaces for consistent ranges
@@ -325,7 +325,7 @@ export function processExpression(
         // local scope variable (a v-for alias, or a v-slot prop)
         if (
           !(needPrefix && isLocal) &&
-          (!parent ||
+          (parent === null ||
             (parent.type !== 'CallExpression' &&
               parent.type !== 'NewExpression' &&
               parent.type !== 'MemberExpression'))

--- a/packages/compiler-core/src/transforms/transformText.ts
+++ b/packages/compiler-core/src/transforms/transformText.ts
@@ -36,7 +36,7 @@ export const transformText: NodeTransform = (node, context) => {
           for (let j = i + 1; j < children.length; j++) {
             const next = children[j]
             if (isText(next)) {
-              if (!currentContainer) {
+              if (currentContainer === undefined) {
                 currentContainer = children[i] = createCompoundExpression(
                   [child],
                   child.loc,
@@ -72,7 +72,7 @@ export const transformText: NodeTransform = (node, context) => {
               !node.props.find(
                 p =>
                   p.type === NodeTypes.DIRECTIVE &&
-                  !context.directiveTransforms[p.name],
+                  context.directiveTransforms[p.name] === undefined,
               ) &&
               // in compat mode, <template> tags with no special directives
               // will be rendered as a fragment so its children must be

--- a/packages/compiler-core/src/transforms/transformText.ts
+++ b/packages/compiler-core/src/transforms/transformText.ts
@@ -69,11 +69,11 @@ export const transformText: NodeTransform = (node, context) => {
               // we need to avoid setting textContent of the element at runtime
               // to avoid accidentally overwriting the DOM elements added
               // by the user through custom directives.
-              !node.props.find(
+              node.props.find(
                 p =>
                   p.type === NodeTypes.DIRECTIVE &&
                   context.directiveTransforms[p.name] === undefined,
-              ) &&
+              ) === undefined &&
               // in compat mode, <template> tags with no special directives
               // will be rendered as a fragment so its children must be
               // converted into vnodes.

--- a/packages/compiler-core/src/transforms/vBind.ts
+++ b/packages/compiler-core/src/transforms/vBind.ts
@@ -41,7 +41,7 @@ export const transformBind: DirectiveTransform = (dir, _node, context) => {
   }
 
   // same-name shorthand - :arg is expanded to :arg="arg"
-  if (!exp) {
+  if (exp === undefined) {
     if (arg.type !== NodeTypes.SIMPLE_EXPRESSION || !arg.isStatic) {
       // only simple expression is allowed for same-name shorthand
       context.onError(

--- a/packages/compiler-core/src/transforms/vFor.ts
+++ b/packages/compiler-core/src/transforms/vFor.ts
@@ -64,7 +64,7 @@ export const transformFor: NodeTransform = createStructuralDirectiveTransform(
       const memo = findDir(node, 'memo')
       const keyProp = findProp(node, `key`, false, true)
       const isDirKey = keyProp && keyProp.type === NodeTypes.DIRECTIVE
-      if (isDirKey && !keyProp.exp) {
+      if (isDirKey && keyProp.exp === undefined) {
         // resolve :key shorthand #10882
         transformBindShorthand(keyProp, context)
       }
@@ -264,7 +264,7 @@ export function processFor(
   context: TransformContext,
   processCodegen?: (forNode: ForNode) => (() => void) | undefined,
 ) {
-  if (!dir.exp) {
+  if (dir.exp === undefined) {
     context.onError(
       createCompilerError(ErrorCodes.X_V_FOR_NO_EXPRESSION, dir.loc),
     )
@@ -273,7 +273,7 @@ export function processFor(
 
   const parseResult = dir.forParseResult
 
-  if (!parseResult) {
+  if (parseResult === undefined) {
     context.onError(
       createCompilerError(ErrorCodes.X_V_FOR_MALFORMED_EXPRESSION, dir.loc),
     )

--- a/packages/compiler-core/src/transforms/vIf.ts
+++ b/packages/compiler-core/src/transforms/vIf.ts
@@ -88,7 +88,7 @@ export function processIf(
 ): (() => void) | undefined {
   if (
     dir.name !== 'else' &&
-    (!dir.exp || !(dir.exp as SimpleExpressionNode).content.trim())
+    (dir.exp === undefined || !(dir.exp as SimpleExpressionNode).content.trim())
   ) {
     const loc = dir.exp ? dir.exp.loc : node.loc
     context.onError(
@@ -211,7 +211,10 @@ function createIfBranch(node: ElementNode, dir: DirectiveNode): IfBranchNode {
     type: NodeTypes.IF_BRANCH,
     loc: node.loc,
     condition: dir.name === 'else' ? undefined : dir.exp,
-    children: isTemplateIf && !findDir(node, 'for') ? node.children : [node],
+    children:
+      isTemplateIf && findDir(node, 'for') === undefined
+        ? node.children
+        : [node],
     userKey: findProp(node, `key`),
     isTemplateIf,
   }
@@ -308,7 +311,7 @@ function isSameKey(
   a: AttributeNode | DirectiveNode | undefined,
   b: AttributeNode | DirectiveNode,
 ): boolean {
-  if (!a || a.type !== b.type) {
+  if (a === undefined || a.type !== b.type) {
     return false
   }
   if (a.type === NodeTypes.ATTRIBUTE) {

--- a/packages/compiler-core/src/transforms/vMemo.ts
+++ b/packages/compiler-core/src/transforms/vMemo.ts
@@ -16,7 +16,7 @@ const seen = new WeakSet()
 export const transformMemo: NodeTransform = (node, context) => {
   if (node.type === NodeTypes.ELEMENT) {
     const dir = findDir(node, 'memo')
-    if (!dir || seen.has(node)) {
+    if (dir === undefined || seen.has(node)) {
       return
     }
     seen.add(node)

--- a/packages/compiler-core/src/transforms/vModel.ts
+++ b/packages/compiler-core/src/transforms/vModel.ts
@@ -22,7 +22,7 @@ import { camelize } from '@vue/shared'
 
 export const transformModel: DirectiveTransform = (dir, node, context) => {
   const { exp, arg } = dir
-  if (!exp) {
+  if (exp === undefined) {
     context.onError(
       createCompilerError(ErrorCodes.X_V_MODEL_NO_EXPRESSION, dir.loc),
     )

--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -33,7 +33,7 @@ export const transformOn: DirectiveTransform = (
   augmentor,
 ) => {
   const { loc, modifiers, arg } = dir as VOnDirectiveNode
-  if (!dir.exp && !modifiers.length) {
+  if (dir.exp === undefined && !modifiers.length) {
     context.onError(createCompilerError(ErrorCodes.X_V_ON_NO_EXPRESSION, loc))
   }
   let eventName: ExpressionNode
@@ -79,7 +79,8 @@ export const transformOn: DirectiveTransform = (
   if (exp && !exp.content.trim()) {
     exp = undefined
   }
-  let shouldCache: boolean = context.cacheHandlers && !exp && !context.inVOnce
+  let shouldCache: boolean =
+    context.cacheHandlers && exp === undefined && !context.inVOnce
   if (exp) {
     const isMemberExp = isMemberExpression(exp, context)
     const isInlineStatement = !(isMemberExp || isFnExpression(exp, context))

--- a/packages/compiler-core/src/transforms/vSlot.ts
+++ b/packages/compiler-core/src/transforms/vSlot.ts
@@ -166,7 +166,7 @@ export function buildSlots(
 
     if (
       !isTemplateNode(slotElement) ||
-      !(slotDir = findDir(slotElement, 'slot', true))
+      (slotDir = findDir(slotElement, 'slot', true)) === undefined
     ) {
       // not a <template v-slot>, skip.
       if (slotElement.type !== NodeTypes.COMMENT) {
@@ -299,7 +299,7 @@ export function buildSlots(
     }
   }
 
-  if (!onComponentSlot) {
+  if (onComponentSlot === undefined) {
     const buildDefaultSlotProperty = (
       props: ExpressionNode | undefined,
       children: TemplateChildNode[],

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -112,7 +112,7 @@ export const isMemberExpressionBrowser = (exp: ExpressionNode): boolean => {
           state = MemberExpLexState.inParens
           currentOpenParensCount++
         } else if (
-          !(i === 0 ? validFirstIdentCharRE : validIdentCharRE).test(char)
+          !(!i ? validFirstIdentCharRE : validIdentCharRE).test(char)
         ) {
           return false
         }
@@ -331,7 +331,7 @@ export function hasDynamicKeyVBind(node: ElementNode): boolean {
     p =>
       p.type === NodeTypes.DIRECTIVE &&
       p.name === 'bind' &&
-      (!p.arg || // v-bind="obj"
+      (p.arg === undefined || // v-bind="obj"
         p.arg.type !== NodeTypes.SIMPLE_EXPRESSION || // v-bind:[_ctx.foo]
         !p.arg.isStatic), // v-bind:[foo]
   )
@@ -434,7 +434,7 @@ export function injectProp(
         props.arguments.unshift(createObjectExpression([prop]))
       }
     }
-    !propsWithInjection && (propsWithInjection = props)
+    propsWithInjection === undefined && (propsWithInjection = props)
   } else if (props.type === NodeTypes.JS_OBJECT_EXPRESSION) {
     if (!hasProp(prop, props)) {
       props.properties.unshift(prop)
@@ -502,7 +502,7 @@ export function hasScopeRef(
     | undefined,
   ids: TransformContext['identifiers'],
 ): boolean {
-  if (!node || Object.keys(ids).length === 0) {
+  if (node === undefined || !Object.keys(ids).length) {
     return false
   }
   switch (node.type) {

--- a/packages/compiler-dom/src/transforms/vHtml.ts
+++ b/packages/compiler-dom/src/transforms/vHtml.ts
@@ -7,7 +7,7 @@ import { DOMErrorCodes, createDOMCompilerError } from '../errors'
 
 export const transformVHtml: DirectiveTransform = (dir, node, context) => {
   const { exp, loc } = dir
-  if (!exp) {
+  if (exp === undefined) {
     context.onError(
       createDOMCompilerError(DOMErrorCodes.X_V_HTML_NO_EXPRESSION, loc),
     )

--- a/packages/compiler-dom/src/transforms/vShow.ts
+++ b/packages/compiler-dom/src/transforms/vShow.ts
@@ -4,7 +4,7 @@ import { V_SHOW } from '../runtimeHelpers'
 
 export const transformShow: DirectiveTransform = (dir, node, context) => {
   const { exp, loc } = dir
-  if (!exp) {
+  if (exp === undefined) {
     context.onError(
       createDOMCompilerError(DOMErrorCodes.X_V_SHOW_NO_EXPRESSION, loc),
     )

--- a/packages/compiler-dom/src/transforms/vText.ts
+++ b/packages/compiler-dom/src/transforms/vText.ts
@@ -10,7 +10,7 @@ import { DOMErrorCodes, createDOMCompilerError } from '../errors'
 
 export const transformVText: DirectiveTransform = (dir, node, context) => {
   const { exp, loc } = dir
-  if (!exp) {
+  if (exp === undefined) {
     context.onError(
       createDOMCompilerError(DOMErrorCodes.X_V_TEXT_NO_EXPRESSION, loc),
     )

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -165,13 +165,13 @@ export function compileScript(
 
   const ctx = new ScriptCompileContext(sfc, options)
   const { script, scriptSetup, source, filename } = sfc
-  const hoistStatic = options.hoistStatic !== false && !script
+  const hoistStatic = options.hoistStatic !== false && script === null
   const scopeId = options.id ? options.id.replace(/^data-v-/, '') : ''
   const scriptLang = script && script.lang
   const scriptSetupLang = scriptSetup && scriptSetup.lang
 
-  if (!scriptSetup) {
-    if (!script) {
+  if (scriptSetup === null) {
+    if (script === null) {
       throw new Error(`[@vue/compiler-sfc] SFC contains no <script> tags.`)
     }
     // normal <script> only
@@ -256,7 +256,7 @@ export function compileScript(
   }
 
   function checkInvalidScopeReference(node: Node | undefined, method: string) {
-    if (!node) return
+    if (node === undefined) return
     walkIdentifiers(node, id => {
       const binding = setupBindings[id.name]
       if (binding && binding !== BindingTypes.LITERAL_CONST) {
@@ -599,7 +599,7 @@ export function compileScript(
         setupBindings,
         vueImportAliases,
         hoistStatic,
-        !!ctx.propsDestructureDecl,
+        ctx.propsDestructureDecl !== undefined,
       )
     }
 
@@ -783,7 +783,7 @@ export function compileScript(
         startOffset + ctx.propsDestructureDecl!.end!,
         ctx.propsDestructureRestId,
       )
-    } else if (!ctx.propsDestructureDecl) {
+    } else if (ctx.propsDestructureDecl === undefined) {
       ctx.s.overwrite(
         startOffset + ctx.propsCall!.start!,
         startOffset + ctx.propsCall!.end!,
@@ -813,7 +813,7 @@ export function compileScript(
   let returned
   if (
     !options.inlineTemplate ||
-    (!sfc.template && ctx.hasDefaultExportRender)
+    (sfc.template === null && ctx.hasDefaultExportRender)
   ) {
     // non-inline mode, or has manual render in normal <script>
     // return bindings from script and script setup

--- a/packages/compiler-sfc/src/compileStyle.ts
+++ b/packages/compiler-sfc/src/compileStyle.ts
@@ -223,7 +223,10 @@ function preprocess(
   options: SFCStyleCompileOptions,
   preprocessor: StylePreprocessor,
 ): StylePreprocessorResults {
-  if ((__ESM_BROWSER__ || __GLOBAL__) && !options.preprocessCustomRequire) {
+  if (
+    (__ESM_BROWSER__ || __GLOBAL__) &&
+    options.preprocessCustomRequire === undefined
+  ) {
     throw new Error(
       `[@vue/compiler-sfc] Style preprocessing in the browser build must ` +
         `provide the \`preprocessCustomRequire\` option to return the in-browser ` +

--- a/packages/compiler-sfc/src/compileTemplate.ts
+++ b/packages/compiler-sfc/src/compileTemplate.ts
@@ -112,7 +112,7 @@ export function compileTemplate(
   if (
     (__ESM_BROWSER__ || __GLOBAL__) &&
     preprocessLang &&
-    !preprocessCustomRequire
+    preprocessCustomRequire === undefined
   ) {
     throw new Error(
       `[@vue/compiler-sfc] Template preprocessing in the browser build must ` +
@@ -188,7 +188,7 @@ function doCompileTemplate({
     nodeTransforms = [transformAssetUrl, transformSrcset]
   }
 
-  if (ssr && !ssrCssVars) {
+  if (ssr && ssrCssVars === undefined) {
     warnOnce(
       `compileTemplate is called with \`ssr: true\` but no ` +
         `corresponding \`cssVars\` option.`,
@@ -250,7 +250,7 @@ function doCompileTemplate({
   // inMap should be the map produced by ./parse.ts which is a simple line-only
   // mapping. If it is present, we need to adjust the final map and errors to
   // reflect the original line numbers.
-  if (inMap && !inAST) {
+  if (inMap && inAST === undefined) {
     if (map) {
       map = mapLines(inMap, map)
     }

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -165,7 +165,7 @@ export function parse(
     }
     switch (node.tag) {
       case 'template':
-        if (!descriptor.template) {
+        if (descriptor.template === null) {
           const templateBlock = (descriptor.template = createBlock(
             node,
             source,
@@ -196,11 +196,11 @@ export function parse(
       case 'script':
         const scriptBlock = createBlock(node, source, pad) as SFCScriptBlock
         const isSetup = !!scriptBlock.attrs.setup
-        if (isSetup && !descriptor.scriptSetup) {
+        if (isSetup && descriptor.scriptSetup === null) {
           descriptor.scriptSetup = scriptBlock
           break
         }
-        if (!isSetup && !descriptor.script) {
+        if (!isSetup && descriptor.script === null) {
           descriptor.script = scriptBlock
           break
         }
@@ -223,7 +223,11 @@ export function parse(
         break
     }
   })
-  if (!descriptor.template && !descriptor.script && !descriptor.scriptSetup) {
+  if (
+    descriptor.template === null &&
+    descriptor.script === null &&
+    descriptor.scriptSetup === null
+  ) {
     errors.push(
       new SyntaxError(
         `At least one <template> or <script> is required in a single file component. ${descriptor.filename}`,
@@ -437,7 +441,7 @@ export function hmrShouldReload(
   next: SFCDescriptor,
 ): boolean {
   if (
-    !next.scriptSetup ||
+    next.scriptSetup === null ||
     (next.scriptSetup.lang !== 'ts' && next.scriptSetup.lang !== 'tsx')
   ) {
     return false
@@ -471,7 +475,7 @@ function dedent(s: string): [string, number] {
     const indent = line.match(/^\s*/)?.[0]?.length || 0
     return Math.min(indent, minIndent)
   }, Infinity)
-  if (minIndent === 0) {
+  if (!minIndent) {
     return [s, minIndent]
   }
   return [

--- a/packages/compiler-sfc/src/script/context.ts
+++ b/packages/compiler-sfc/src/script/context.ts
@@ -178,7 +178,7 @@ export function resolveParserPlugins(
 ): ParserPlugin[] {
   const plugins: ParserPlugin[] = []
   if (
-    !userPlugins ||
+    userPlugins === undefined ||
     !userPlugins.some(
       p =>
         p === 'importAssertions' ||
@@ -197,7 +197,7 @@ export function resolveParserPlugins(
   }
   if (lang === 'ts' || lang === 'mts' || lang === 'tsx' || lang === 'mtsx') {
     plugins.push(['typescript', { dts }], 'explicitResourceManagement')
-    if (!userPlugins || !userPlugins.includes('decorators')) {
+    if (userPlugins === undefined || !userPlugins.includes('decorators')) {
       plugins.push('decorators-legacy')
     }
   }

--- a/packages/compiler-sfc/src/script/defineProps.ts
+++ b/packages/compiler-sfc/src/script/defineProps.ts
@@ -354,7 +354,7 @@ function genDestructuredDefaultValue(
     // destructure w/ runtime declaration since we cannot safely infer
     // whether the expected runtime prop type is `Function`.
     const needSkipFactory =
-      !inferredType &&
+      inferredType === undefined &&
       (isFunctionType(unwrapped) || unwrapped.type === 'Identifier')
 
     const needFactoryWrap =

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -146,7 +146,7 @@ export function resolveTypeElements(
   scope?: TypeScope,
   typeParameters?: Record<string, Node>,
 ): ResolvedElements {
-  const canCache = !typeParameters
+  const canCache = typeParameters === undefined
   if (canCache && node._resolvedElements) {
     return node._resolvedElements
   }
@@ -234,7 +234,7 @@ function innerResolveTypeElements(
           typeParams = Object.create(null)
           resolved.typeParameters.params.forEach((p, i) => {
             let param = typeParameters && typeParameters[p.name]
-            if (!param) param = node.typeParameters!.params[i]
+            if (param === undefined) param = node.typeParameters!.params[i]
             typeParams![p.name] = param
           })
         }
@@ -808,7 +808,7 @@ function qualifiedNameToPath(node: Identifier | TSQualifiedName): string[] {
 function resolveGlobalScope(ctx: TypeResolveContext): TypeScope[] | undefined {
   if (ctx.options.globalTypeFiles) {
     const fs = resolveFS(ctx)
-    if (!fs) {
+    if (fs === undefined) {
       throw new Error('[vue/compiler-sfc] globalTypeFiles requires fs access.')
     }
     return ctx.options.globalTypeFiles.map(file =>
@@ -851,11 +851,11 @@ function resolveFS(ctx: TypeResolveContext): FS | undefined {
   if (ctx.fs) {
     return ctx.fs
   }
-  if (!ts && loadTS) {
+  if (ts === undefined && loadTS) {
     ts = loadTS()
   }
   const fs = ctx.options.fs || ts?.sys
-  if (!fs) {
+  if (fs === undefined) {
     return
   }
   return (ctx.fs = {
@@ -898,7 +898,7 @@ function importSourceToScope(
   } catch (err: any) {
     return ctx.error(err.message, node, scope)
   }
-  if (!fs) {
+  if (fs === undefined) {
     return ctx.error(
       `No fs option provided to \`compileScript\` in non-Node environment. ` +
         `File system access is required for resolving imported types.`,
@@ -927,9 +927,9 @@ function importSourceToScope(
           scope,
         )
       }
-      if (!ts) {
+      if (ts === undefined) {
         if (loadTS) ts = loadTS()
-        if (!ts) {
+        if (ts === undefined) {
           return ctx.error(
             `Failed to resolve import source ${JSON.stringify(source)}. ` +
               `typescript is required as a peer dep for vue in order ` +
@@ -1000,7 +1000,7 @@ function resolveWithTS(
     let configs: CachedConfig[]
     const normalizedConfigPath = normalizePath(configPath)
     const cached = tsConfigCache.get(normalizedConfigPath)
-    if (!cached) {
+    if (cached === undefined) {
       configs = loadTSConfig(configPath, ts, fs).map(config => ({ config }))
       tsConfigCache.set(normalizedConfigPath, configs)
     } else {
@@ -1019,7 +1019,8 @@ function resolveWithTS(
         const included: string[] | undefined = c.config.raw?.include
         const excluded: string[] | undefined = c.config.raw?.exclude
         if (
-          (!included && (!base || containingFile.startsWith(base))) ||
+          (included === undefined &&
+            (!base || containingFile.startsWith(base))) ||
           included?.some(p => isMatch(containingFile, joinPaths(base, p)))
         ) {
           if (
@@ -1032,7 +1033,7 @@ function resolveWithTS(
           break
         }
       }
-      if (!matchedConfig) {
+      if (matchedConfig === undefined) {
         matchedConfig = configs[configs.length - 1]
       }
     }
@@ -1155,7 +1156,7 @@ function parseFile(
     const {
       descriptor: { script, scriptSetup },
     } = parse(content)
-    if (!script && !scriptSetup) {
+    if (script === null && scriptSetup === null) {
       return []
     }
 
@@ -1434,7 +1435,7 @@ function attachNamespace(
   to: Node & { _ns?: TSModuleDeclaration },
   ns: TSModuleDeclaration,
 ) {
-  if (!to._ns) {
+  if (to._ns === undefined) {
     to._ns = ns
   } else {
     mergeNamespaces(to._ns, ns)
@@ -1913,7 +1914,7 @@ function resolveReturnType(
   ) {
     resolved = resolveTypeReference(ctx, arg, scope)
   }
-  if (!resolved) return
+  if (resolved === undefined) return
   if (resolved.type === 'TSFunctionType') {
     return resolved.typeAnnotation?.typeAnnotation
   }

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -224,7 +224,7 @@ function rewriteSelector(
       (n.type !== 'pseudo' && n.type !== 'combinator') ||
       (n.type === 'pseudo' &&
         (n.value === ':is' || n.value === ':where') &&
-        !node)
+        node === null)
     ) {
       node = n
     }
@@ -282,7 +282,7 @@ function isSpaceCombinator(node: selectorParser.Node) {
 }
 
 function extractAndWrapNodes(parentNode: Rule | AtRule) {
-  if (!parentNode.nodes) return
+  if (parentNode.nodes === undefined) return
   const nodes = parentNode.nodes.filter(
     node => node.type === 'decl' || node.type === 'comment',
   )

--- a/packages/compiler-sfc/src/style/preprocessors.ts
+++ b/packages/compiler-sfc/src/style/preprocessors.ts
@@ -38,7 +38,7 @@ const scss: StylePreprocessor = (source, map, options, load = require) => {
       const result = compileString(data, {
         ...options,
         url: pathToFileURL(options.filename),
-        sourceMap: !!map,
+        sourceMap: map !== undefined,
       })
       css = result.css
       dependencies = result.loadedUrls.map(url => fileURLToPath(url))
@@ -49,7 +49,7 @@ const scss: StylePreprocessor = (source, map, options, load = require) => {
         data,
         file: options.filename,
         outFile: options.filename,
-        sourceMap: !!map,
+        sourceMap: map !== undefined,
       })
       css = result.css.toString()
       dependencies = result.stats.includedFiles

--- a/packages/compiler-sfc/src/template/transformAssetUrl.ts
+++ b/packages/compiler-sfc/src/template/transformAssetUrl.ts
@@ -104,7 +104,7 @@ export const transformAssetUrl: NodeTransform = (
       if (
         attr.type !== NodeTypes.ATTRIBUTE ||
         !assetAttrs.includes(attr.name) ||
-        !attr.value ||
+        attr.value === undefined ||
         isExternalUrl(attr.value.content) ||
         isDataUrl(attr.value.content) ||
         attr.value.content[0] === '#' ||

--- a/packages/compiler-sfc/src/template/transformSrcset.ts
+++ b/packages/compiler-sfc/src/template/transformSrcset.ts
@@ -45,7 +45,7 @@ export const transformSrcset: NodeTransform = (
     if (srcsetTags.includes(node.tag) && node.props.length) {
       node.props.forEach((attr, index) => {
         if (attr.name === 'srcset' && attr.type === NodeTypes.ATTRIBUTE) {
-          if (!attr.value) return
+          if (attr.value === undefined) return
           const value = attr.value.content
           if (!value) return
           const imageCandidates: ImageCandidate[] = value.split(',').map(s => {

--- a/packages/compiler-ssr/__tests__/utils.ts
+++ b/packages/compiler-ssr/__tests__/utils.ts
@@ -9,7 +9,7 @@ export function getCompiledString(src: string): string {
     /_push\(\`<div\${\s*_ssrRenderAttrs\(_attrs\)\s*}>([^]*)<\/div>\`\)/,
   )
 
-  if (!match) {
+  if (match === null) {
     throw new Error(`Unexpected compile result:\n${code}`)
   }
 

--- a/packages/compiler-ssr/src/ssrCodegenTransform.ts
+++ b/packages/compiler-ssr/src/ssrCodegenTransform.ts
@@ -112,7 +112,7 @@ function createSSRTransformContext(
       return name
     },
     pushStringPart(part) {
-      if (!currentString) {
+      if (currentString === null) {
         const currentCall = createCallExpression(`_push`)
         body.push(currentCall)
         currentString = createTemplateLiteral([])

--- a/packages/compiler-ssr/src/transforms/ssrInjectCssVars.ts
+++ b/packages/compiler-ssr/src/transforms/ssrInjectCssVars.ts
@@ -22,7 +22,7 @@ export const ssrInjectCssVars: NodeTransform = (node, context) => {
   }
 
   const parent = context.parent
-  if (!parent || parent.type !== NodeTypes.ROOT) {
+  if (parent === null || parent.type !== NodeTypes.ROOT) {
     return
   }
 
@@ -40,7 +40,7 @@ function injectCssVars(node: RootNode | TemplateChildNode) {
     node.type === NodeTypes.ELEMENT &&
     (node.tagType === ElementTypes.ELEMENT ||
       node.tagType === ElementTypes.COMPONENT) &&
-    !findDir(node, 'for')
+    findDir(node, 'for') === undefined
   ) {
     if (node.tag === 'suspense' || node.tag === 'Suspense') {
       for (const child of node.children) {

--- a/packages/compiler-ssr/src/transforms/ssrInjectFallthroughAttrs.ts
+++ b/packages/compiler-ssr/src/transforms/ssrInjectFallthroughAttrs.ts
@@ -42,7 +42,7 @@ export const ssrInjectFallthroughAttrs: NodeTransform = (node, context) => {
   }
 
   const parent = context.parent
-  if (!parent || parent.type !== NodeTypes.ROOT) {
+  if (parent === null || parent.type !== NodeTypes.ROOT) {
     return
   }
 
@@ -77,7 +77,7 @@ function injectFallthroughAttrs(node: RootNode | TemplateChildNode) {
     node.type === NodeTypes.ELEMENT &&
     (node.tagType === ElementTypes.ELEMENT ||
       node.tagType === ElementTypes.COMPONENT) &&
-    !findDir(node, 'for')
+    findDir(node, 'for') === undefined
   ) {
     node.props.push({
       type: NodeTypes.DIRECTIVE,

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -207,7 +207,7 @@ export function ssrProcessComponent(
   parent: { children: TemplateChildNode[] },
 ): void {
   const component = componentTypeMap.get(node)!
-  if (!node.ssrCodegenNode) {
+  if (node.ssrCodegenNode === undefined) {
     // this is a built-in component that fell-through.
     if (component === TELEPORT) {
       return ssrProcessTeleport(node, context)

--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -112,7 +112,10 @@ export const ssrTransformElement: NodeTransform = (node, context) => {
             | undefined
           // If interpolation, this is dynamic <textarea> content, potentially
           // injected by v-model and takes higher priority than v-bind value
-          if (!existingText || existingText.type !== NodeTypes.INTERPOLATION) {
+          if (
+            existingText === undefined ||
+            existingText.type !== NodeTypes.INTERPOLATION
+          ) {
             // <textarea> with dynamic v-bind. We don't know if the final props
             // will contain .value, so we will have to do something special:
             // assign the merged props to a temp variable, and check whether
@@ -167,7 +170,7 @@ export const ssrTransformElement: NodeTransform = (node, context) => {
         } else if (directives.length && !node.children.length) {
           // v-text directive has higher priority than the merged props
           const vText = findDir(node, 'text')
-          if (!vText) {
+          if (vText === undefined) {
             const tempId = `_temp${context.temps++}`
             propsExp.arguments = [
               createAssignmentExpression(

--- a/packages/compiler-ssr/src/transforms/ssrTransformSuspense.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformSuspense.ts
@@ -65,7 +65,7 @@ export function ssrProcessSuspense(
 ): void {
   // complete wip slots with ssr code
   const wipEntry = wipMap.get(node)
-  if (!wipEntry) {
+  if (wipEntry === undefined) {
     return
   }
   const { slotsExp, wipSlots } = wipEntry

--- a/packages/compiler-ssr/src/transforms/ssrTransformTeleport.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformTeleport.ts
@@ -20,7 +20,7 @@ export function ssrProcessTeleport(
   context: SSRTransformContext,
 ): void {
   const targetProp = findProp(node, 'to')
-  if (!targetProp) {
+  if (targetProp === undefined) {
     context.onError(
       createSSRCompilerError(SSRErrorCodes.X_SSR_NO_TELEPORT_TARGET, node.loc),
     )
@@ -34,7 +34,7 @@ export function ssrProcessTeleport(
   } else {
     target = targetProp.exp
   }
-  if (!target) {
+  if (target === undefined) {
     context.onError(
       createSSRCompilerError(
         SSRErrorCodes.X_SSR_NO_TELEPORT_TARGET,

--- a/packages/compiler-ssr/src/transforms/ssrTransformTransition.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformTransition.ts
@@ -17,7 +17,7 @@ export function ssrTransformTransition(
 ) {
   return (): void => {
     const appear = findProp(node, 'appear', false, true)
-    wipMap.set(node, !!appear)
+    wipMap.set(node, appear !== undefined)
   }
 }
 

--- a/packages/compiler-ssr/src/transforms/ssrVIf.ts
+++ b/packages/compiler-ssr/src/transforms/ssrVIf.ts
@@ -56,7 +56,7 @@ export function ssrProcessIf(
     }
   }
 
-  if (!currentIf.alternate && !disableComment) {
+  if (currentIf.alternate === undefined && !disableComment) {
     currentIf.alternate = createBlockStatement([
       createCallExpression(`_push`, ['`<!---->`']),
     ])

--- a/packages/compiler-ssr/src/transforms/ssrVShow.ts
+++ b/packages/compiler-ssr/src/transforms/ssrVShow.ts
@@ -9,7 +9,7 @@ import {
 } from '@vue/compiler-dom'
 
 export const ssrTransformShow: DirectiveTransform = (dir, node, context) => {
-  if (!dir.exp) {
+  if (dir.exp === undefined) {
     context.onError(
       createDOMCompilerError(DOMErrorCodes.X_V_SHOW_NO_EXPRESSION),
     )

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -107,7 +107,7 @@ export class ComputedRefImpl<T = any> implements Subscriber {
     private readonly setter: ComputedSetter<T> | undefined,
     isSSR: boolean,
   ) {
-    this[ReactiveFlags.IS_READONLY] = !setter
+    this[ReactiveFlags.IS_READONLY] = setter === undefined
     this.isSSR = isSSR
   }
 

--- a/packages/reactivity/src/dep.ts
+++ b/packages/reactivity/src/dep.ts
@@ -100,7 +100,11 @@ export class Dep {
   }
 
   track(debugInfo?: DebuggerEventExtraInfo): Link | undefined {
-    if (!activeSub || !shouldTrack || activeSub === this.computed) {
+    if (
+      activeSub === undefined ||
+      !shouldTrack ||
+      activeSub === this.computed
+    ) {
       return
     }
 
@@ -109,7 +113,7 @@ export class Dep {
       link = this.activeLink = new Link(activeSub, this)
 
       // add the link to the activeEffect as a dep (as tail)
-      if (!activeSub.deps) {
+      if (activeSub.deps === undefined) {
         activeSub.deps = activeSub.depsTail = link
       } else {
         link.prevDep = activeSub.depsTail
@@ -204,7 +208,7 @@ function addSub(link: Link) {
     const computed = link.dep.computed
     // computed getting its first subscriber
     // enable tracking + lazily subscribe to all its deps
-    if (computed && !link.dep.subs) {
+    if (computed && link.dep.subs === undefined) {
       computed.flags |= EffectFlags.TRACKING | EffectFlags.DIRTY
       for (let l = computed.deps; l; l = l.nextDep) {
         addSub(l)
@@ -256,11 +260,11 @@ export const ARRAY_ITERATE_KEY: unique symbol = Symbol(
 export function track(target: object, type: TrackOpTypes, key: unknown): void {
   if (shouldTrack && activeSub) {
     let depsMap = targetMap.get(target)
-    if (!depsMap) {
+    if (depsMap === undefined) {
       targetMap.set(target, (depsMap = new Map()))
     }
     let dep = depsMap.get(key)
-    if (!dep) {
+    if (dep === undefined) {
       depsMap.set(key, (dep = new Dep()))
       dep.map = depsMap
       dep.key = key
@@ -294,7 +298,7 @@ export function trigger(
   oldTarget?: Map<unknown, unknown> | Set<unknown>,
 ): void {
   const depsMap = targetMap.get(target)
-  if (!depsMap) {
+  if (depsMap === undefined) {
     // never been tracked
     globalVersion++
     return

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -401,7 +401,7 @@ export function refreshComputed(computed: ComputedRefImpl): undefined {
   try {
     prepareDeps(computed)
     const value = computed.fn(computed._value)
-    if (dep.version === 0 || hasChanged(value, computed._value)) {
+    if (!dep.version || hasChanged(value, computed._value)) {
       computed._value = value
       dep.version++
     }
@@ -435,7 +435,7 @@ function removeSub(link: Link, soft = false) {
     // was previous tail, point new tail to prev
     dep.subs = prevSub
 
-    if (!prevSub && dep.computed) {
+    if (prevSub === undefined && dep.computed) {
       // if computed, unsubscribe it from all its deps so this computed and its
       // value can be GCed
       dep.computed.flags &= ~EffectFlags.TRACKING

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -120,7 +120,7 @@ export class EffectScope {
    * @internal
    */
   off(): void {
-    if (this._on > 0 && --this._on === 0) {
+    if (this._on > 0 && !--this._on) {
       activeEffectScope = this.prevScope
       this.prevScope = undefined
     }

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -107,7 +107,7 @@ export function onWatcherCleanup(
 ): void {
   if (owner) {
     let cleanups = cleanupMap.get(owner)
-    if (!cleanups) cleanupMap.set(owner, (cleanups = []))
+    if (cleanups === undefined) cleanupMap.set(owner, (cleanups = []))
     cleanups.push(cleanupFn)
   } else if (__DEV__ && !failSilently) {
     warn(

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -40,7 +40,7 @@ export interface AsyncComponentOptions<T = any> {
 }
 
 export const isAsyncWrapper = (i: ComponentInternalInstance | VNode): boolean =>
-  !!(i.type as ComponentOptions).__asyncLoader
+  (i.type as ComponentOptions).__asyncLoader !== undefined
 
 /*! #__NO_SIDE_EFFECTS__ */
 export function defineAsyncComponent<

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -345,7 +345,7 @@ export function createAppAPI<HostElement>(
           validateDirectiveName(name)
         }
 
-        if (!directive) {
+        if (directive === undefined) {
           return context.directives[name] as any
         }
         if (__DEV__ && context.directives[name]) {

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -12,7 +12,7 @@ export function provide<T, K = InjectionKey<T> | string | number>(
   key: K,
   value: K extends InjectionKey<infer V> ? V : T,
 ): void {
-  if (!currentInstance) {
+  if (currentInstance === null) {
     if (__DEV__) {
       warn(`provide() can only be used inside setup().`)
     }
@@ -88,5 +88,5 @@ export function inject(
  * user. One example is `useRoute()` in `vue-router`.
  */
 export function hasInjectionContext(): boolean {
-  return !!(currentInstance || currentRenderingInstance || currentApp)
+  return (currentInstance || currentRenderingInstance || currentApp) !== null
 }

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -145,7 +145,7 @@ function doWatch(
 ): WatchHandle {
   const { immediate, deep, flush, once } = options
 
-  if (__DEV__ && !cb) {
+  if (__DEV__ && cb === null) {
     if (immediate !== undefined) {
       warn(
         `watch() "immediate" option is only respected when using the ` +
@@ -171,7 +171,7 @@ function doWatch(
   if (__DEV__) baseWatchOptions.onWarn = warn
 
   // immediate watcher or watchEffect
-  const runsImmediately = (cb && immediate) || (!cb && flush !== 'post')
+  const runsImmediately = (cb && immediate) || (cb === null && flush !== 'post')
   let ssrCleanup: (() => void)[] | undefined
   if (__SSR__ && isInSSRComponentSetup) {
     if (flush === 'sync') {

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -353,7 +353,7 @@ function installFilterMethod(app: App, context: AppContext) {
   context.filters = {}
   app.filter = (name: string, filter?: Function): any => {
     assertCompatEnabled(DeprecationTypes.FILTERS, null)
-    if (!filter) {
+    if (filter === undefined) {
       return context.filters![name]
     }
     if (__DEV__ && context.filters![name]) {
@@ -467,7 +467,9 @@ function installCompatMount(
     vnode.appContext = context
 
     const hasNoRender =
-      !isFunction(component) && !component.render && !component.template
+      !isFunction(component) &&
+      component.render === undefined &&
+      !component.template
     const emptyRender = () => {}
 
     // create root instance
@@ -497,7 +499,7 @@ function installCompatMount(
       if (typeof selectorOrEl === 'string') {
         // eslint-disable-next-line
         const result = document.querySelector(selectorOrEl)
-        if (!result) {
+        if (result === null) {
           __DEV__ &&
             warn(
               `Failed to mount root instance: selector "${selectorOrEl}" returned null.`,

--- a/packages/runtime-core/src/compat/instanceEventEmitter.ts
+++ b/packages/runtime-core/src/compat/instanceEventEmitter.ts
@@ -17,7 +17,7 @@ export function getRegistry(
   instance: ComponentInternalInstance,
 ): EventRegistry {
   let events = eventRegistryMap.get(instance)
-  if (!events) {
+  if (events === undefined) {
     eventRegistryMap.set(instance, (events = Object.create(null)))
   }
   return events!
@@ -80,10 +80,10 @@ export function off(
   // specific event
   const events = getRegistry(instance)
   const cbs = events[event!]
-  if (!cbs) {
+  if (cbs === undefined) {
     return vm
   }
-  if (!fn) {
+  if (fn === undefined) {
     events[event!] = undefined
     return vm
   }

--- a/packages/runtime-core/src/compat/renderFn.ts
+++ b/packages/runtime-core/src/compat/renderFn.ts
@@ -46,7 +46,12 @@ export function convertLegacyRenderFn(
   const render = Component.render as InternalRenderFunction | undefined
 
   // v3 runtime compiled, or already checked / wrapped
-  if (!render || render._rc || render._compatChecked || render._compatWrapped) {
+  if (
+    render === undefined ||
+    render._rc ||
+    render._compatChecked ||
+    render._compatWrapped
+  ) {
     return
   }
 
@@ -180,7 +185,7 @@ function convertLegacyProps(
   legacyProps: LegacyVNodeProps | undefined,
   type: any,
 ): (Data & VNodeProps) | null {
-  if (!legacyProps) {
+  if (legacyProps === undefined) {
     return null
   }
 

--- a/packages/runtime-core/src/compat/renderHelpers.ts
+++ b/packages/runtime-core/src/compat/renderHelpers.ts
@@ -124,7 +124,7 @@ export function legacyRenderStatic(
   index: number,
 ): any {
   let cache = staticCacheMap.get(instance)
-  if (!cache) {
+  if (cache === undefined) {
     staticCacheMap.set(instance, (cache = []))
   }
   if (cache[index]) {

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -893,7 +893,7 @@ function setupStatefulComponent(
         // async setup returned Promise.
         // bail here and wait for re-entry.
         instance.asyncDep = setupResult
-        if (__DEV__ && !instance.suspense) {
+        if (__DEV__ && instance.suspense === null) {
           const name = Component.name ?? 'Anonymous'
           warn(
             `Component <${name}>: setup function returned a promise, but no ` +
@@ -978,7 +978,7 @@ export function registerRuntimeCompiler(_compile: any): void {
 }
 
 // dev only
-export const isRuntimeOnly = (): boolean => !compile
+export const isRuntimeOnly = (): boolean => compile === undefined
 
 export function finishComponentSetup(
   instance: ComponentInternalInstance,
@@ -997,10 +997,10 @@ export function finishComponentSetup(
 
   // template / render function normalization
   // could be already set when returned from setup()
-  if (!instance.render) {
+  if (instance.render === null) {
     // only do on-the-fly compile if not in SSR - SSR on-the-fly compilation
     // is done by server-renderer
-    if (!isSSR && compile && !Component.render) {
+    if (!isSSR && compile && Component.render === undefined) {
       const template =
         (__COMPAT__ &&
           instance.vnode.props &&
@@ -1063,8 +1063,13 @@ export function finishComponentSetup(
 
   // warn missing template/render
   // the runtime compilation of template in SSR is done by server-render
-  if (__DEV__ && !Component.render && instance.render === NOOP && !isSSR) {
-    if (!compile && Component.template) {
+  if (
+    __DEV__ &&
+    Component.render === undefined &&
+    instance.render === NOOP &&
+    !isSSR
+  ) {
+    if (compile === undefined && Component.template) {
       /* v8 ignore start */
       warn(
         `Component provided template option but ` +

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -130,7 +130,10 @@ export function emit(
             event.startsWith(compatModelEventPrefix))
         )
       ) {
-        if (!propsOptions || !(toHandlerKey(camelize(event)) in propsOptions)) {
+        if (
+          propsOptions === undefined ||
+          !(toHandlerKey(camelize(event)) in propsOptions)
+        ) {
           warn(
             `Component emitted event "${event}" but it is neither declared in ` +
               `the emits option nor as an "${toHandlerKey(camelize(event))}" prop.`,
@@ -208,7 +211,7 @@ export function emit(
 
   const onceHandler = props[handlerName + `Once`]
   if (onceHandler) {
-    if (!instance.emitted) {
+    if (instance.emitted === null) {
       instance.emitted = {}
     } else if (instance.emitted[handlerName]) {
       return
@@ -289,7 +292,7 @@ export function isEmitListener(
   options: ObjectEmitsOptions | null,
   key: string,
 ): boolean {
-  if (!options || !isOn(key)) {
+  if (options === null || !isOn(key)) {
     return false
   }
 

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -758,7 +758,7 @@ export function applyOptions(instance: ComponentInternalInstance): void {
           set: val => (publicThis[key] = val),
         })
       })
-    } else if (!instance.exposed) {
+    } else if (instance.exposed === null) {
       instance.exposed = {}
     }
   }
@@ -937,7 +937,7 @@ export function resolveMergedOptions(
 
   if (cached) {
     resolved = cached
-  } else if (!globalMixins.length && !mixins && !extendsOptions) {
+  } else if (!globalMixins.length && mixins === undefined && !extendsOptions) {
     if (
       __COMPAT__ &&
       isCompatEnabled(DeprecationTypes.PRIVATE_APIS, instance)
@@ -1112,8 +1112,8 @@ function mergeWatchOptions(
   to: ComponentWatchOptions | undefined,
   from: ComponentWatchOptions | undefined,
 ) {
-  if (!to) return from
-  if (!from) return to
+  if (to === undefined) return from
+  if (from === undefined) return to
   const merged = extend(Object.create(null), to)
   for (const key in from) {
     merged[key] = mergeAsArray(to[key], from[key])

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -314,7 +314,7 @@ export function updateProps(
     let kebabKey: string
     for (const key in rawCurrentProps) {
       if (
-        !rawProps ||
+        rawProps === null ||
         // for camelCase
         (!hasOwn(rawProps, key) &&
           // it's possible the original props was passed in as kebab-case
@@ -348,7 +348,7 @@ export function updateProps(
     if (attrs !== rawCurrentProps) {
       for (const key in attrs) {
         if (
-          !rawProps ||
+          rawProps === null ||
           (!hasOwn(rawProps, key) &&
             (!__COMPAT__ || !hasOwn(rawProps, key + 'Native')))
         ) {
@@ -403,7 +403,7 @@ function setFullProps(
       // kebab -> camel conversion here we need to camelize the key.
       let camelKey
       if (options && hasOwn(options, (camelKey = camelize(key)))) {
-        if (!needCastKeys || !needCastKeys.includes(camelKey)) {
+        if (needCastKeys === undefined || !needCastKeys.includes(camelKey)) {
           props[camelKey] = value
         } else {
           ;(rawCastValues || (rawCastValues = {}))[camelKey] = value
@@ -758,7 +758,7 @@ function getInvalidTypeMessage(
   value: unknown,
   expectedTypes: string[],
 ): string {
-  if (expectedTypes.length === 0) {
+  if (!expectedTypes.length) {
     return (
       `Prop type [] for prop "${name}" won't match anything.` +
       ` Did you mean to use type Array instead?`

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -357,7 +357,7 @@ export type PublicPropertiesMap = Record<
 const getPublicInstance = (
   i: ComponentInternalInstance | null,
 ): ComponentPublicInstance | ComponentInternalInstance['exposed'] | null => {
-  if (!i) return null
+  if (i === null) return null
   if (isStatefulComponent(i)) return getComponentPublicInstance(i)
   return getPublicInstance(i.parent)
 }

--- a/packages/runtime-core/src/componentRenderContext.ts
+++ b/packages/runtime-core/src/componentRenderContext.ts
@@ -72,7 +72,7 @@ export function withCtx(
   ctx: ComponentInternalInstance | null = currentRenderingInstance,
   isNonScopedSlot?: boolean, // __COMPAT__ only
 ): Function {
-  if (!ctx) return fn
+  if (ctx === null) return fn
 
   // already normalized
   if ((fn as ContextualRenderFn)._n) {

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -277,7 +277,7 @@ const getChildRoot = (vnode: VNode): [VNode, SetRootFn] => {
   const rawChildren = vnode.children as VNodeArrayChildren
   const dynamicChildren = vnode.dynamicChildren
   const childRoot = filterSingleRoot(rawChildren, false)
-  if (!childRoot) {
+  if (childRoot === undefined) {
     return [vnode, undefined]
   } else if (
     __DEV__ &&

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -154,7 +154,7 @@ const BaseTransitionImpl: ComponentOptions = {
     return () => {
       const children =
         slots.default && getTransitionRawChildren(slots.default(), true)
-      if (!children || !children.length) {
+      if (children === undefined || !children.length) {
         return
       }
 
@@ -181,7 +181,7 @@ const BaseTransitionImpl: ComponentOptions = {
       // in the case of <transition><keep-alive/></transition>, we need to
       // compare the type of the kept-alive children.
       const innerChild = getInnerChild(child)
-      if (!innerChild) {
+      if (innerChild === undefined) {
         return emptyPlaceholder(child)
       }
 

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -211,7 +211,7 @@ const KeepAliveImpl: ComponentOptions = {
 
     function pruneCacheEntry(key: CacheKey) {
       const cached = cache.get(key) as VNode
-      if (cached && (!current || !isSameVNodeType(cached, current))) {
+      if (cached && (current === null || !isSameVNodeType(cached, current))) {
         unmount(cached)
       } else if (current) {
         // current active instance should no longer be kept-alive.
@@ -271,7 +271,7 @@ const KeepAliveImpl: ComponentOptions = {
     return () => {
       pendingCacheKey = null
 
-      if (!slots.default) {
+      if (slots.default === undefined) {
         return (current = null)
       }
 

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -45,7 +45,7 @@ const resolveTarget = <T = RendererElement>(
 ): T | null => {
   const targetSelector = props && props.to
   if (isString(targetSelector)) {
-    if (!select) {
+    if (select === undefined) {
       __DEV__ &&
         warn(
           `Current renderer does not support string target for Teleports. ` +
@@ -54,7 +54,7 @@ const resolveTarget = <T = RendererElement>(
       return null
     } else {
       const target = select(targetSelector)
-      if (__DEV__ && !target && !isTeleportDisabled(props)) {
+      if (__DEV__ && target === null && !isTeleportDisabled(props)) {
         warn(
           `Failed to locate Teleport target with selector "${targetSelector}". ` +
             `Note the target element must exist before the component is mounted - ` +
@@ -453,7 +453,7 @@ function hydrateTeleport(
         // correct position on the final page during SSR. the targetAnchor will
         // always be null, we need to manually add targetAnchor to ensure
         // Teleport it can properly unmount or move
-        if (!vnode.targetAnchor) {
+        if (vnode.targetAnchor === null) {
           prepareAnchor(target, vnode, createText, insert)
         }
 

--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -181,7 +181,7 @@ export function invokeDirectiveHook(
       binding.oldValue = oldBindings[i].value
     }
     let hook = binding.dir[name] as DirectiveHook | DirectiveHook[] | undefined
-    if (__COMPAT__ && !hook) {
+    if (__COMPAT__ && hook === undefined) {
       hook = mapCompatDirectiveHook(name, binding.dir, instance)
     }
     if (hook) {

--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -107,7 +107,7 @@ export function ensureValidVNode(
     if (child.type === Comment) return false
     if (
       child.type === Fragment &&
-      !ensureValidVNode(child.children as VNodeArrayChildren)
+      ensureValidVNode(child.children as VNodeArrayChildren) === null
     )
       return false
     return true

--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -52,7 +52,7 @@ const map: Map<
 export function registerHMR(instance: ComponentInternalInstance): void {
   const id = instance.type.__hmrId!
   let record = map.get(id)
-  if (!record) {
+  if (record === undefined) {
     createRecord(id, instance.type as HMRComponent)
     record = map.get(id)!
   }
@@ -80,7 +80,7 @@ function normalizeClassComponent(component: HMRComponent): ComponentOptions {
 
 function rerender(id: string, newRender?: Function): void {
   const record = map.get(id)
-  if (!record) {
+  if (record === undefined) {
     return
   }
 
@@ -103,7 +103,7 @@ function rerender(id: string, newRender?: Function): void {
 
 function reload(id: string, newComp: HMRComponent): void {
   const record = map.get(id)
-  if (!record) return
+  if (record === undefined) return
 
   newComp = normalizeClassComponent(newComp)
   // update initial def (for not-yet-rendered components)
@@ -117,7 +117,7 @@ function reload(id: string, newComp: HMRComponent): void {
     const oldComp = normalizeClassComponent(instance.type as HMRComponent)
 
     let dirtyInstances = hmrDirtyComponents.get(oldComp)
-    if (!dirtyInstances) {
+    if (dirtyInstances === undefined) {
       // 1. Update existing comp definition to match new one
       if (oldComp !== record.initialDef) {
         updateComponentDef(oldComp, newComp)

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -740,7 +740,7 @@ export function createHydrationFunctions(
       if (node && isComment(node)) {
         if (node.data === open) match++
         if (node.data === close) {
-          if (match === 0) {
+          if (!match) {
             return nextSibling(node)
           } else {
             match--

--- a/packages/runtime-core/src/hydrationStrategies.ts
+++ b/packages/runtime-core/src/hydrationStrategies.ts
@@ -126,7 +126,7 @@ export function forEachElement(
         }
       } else if (isComment(next)) {
         if (next.data === ']') {
-          if (--depth === 0) break
+          if (!--depth) break
         } else if (next.data === '[') {
           depth++
         }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1219,7 +1219,7 @@ function baseCreateRenderer(
 
       // Give it a placeholder if this is not hydration
       // TODO handle self-defined fallback
-      if (!initialVNode.el) {
+      if (initialVNode.el === null) {
         const placeholder = (instance.subTree = createVNode(Comment))
         processCommentNode(null, placeholder, container!, anchor)
       }
@@ -2318,7 +2318,7 @@ function baseCreateRenderer(
       instance.suspenseId === parentSuspense.pendingId
     ) {
       parentSuspense.deps--
-      if (parentSuspense.deps === 0) {
+      if (!parentSuspense.deps) {
         parentSuspense.resolve()
       }
     }
@@ -2442,7 +2442,8 @@ export function needTransition(
   transition: TransitionHooks | null,
 ): boolean | null {
   return (
-    (!parentSuspense || (parentSuspense && !parentSuspense.pendingBranch)) &&
+    (parentSuspense === null ||
+      (parentSuspense && parentSuspense.pendingBranch === null)) &&
     transition &&
     !transition.persisted
   )
@@ -2486,7 +2487,7 @@ export function traverseStaticChildren(
       }
       // also inherit for comment nodes, but not placeholders (e.g. v-if which
       // would have received .el during block patch)
-      if (__DEV__ && c2.type === Comment && !c2.el) {
+      if (__DEV__ && c2.type === Comment && c2.el === null) {
         c2.el = c1.el
       }
     }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -112,7 +112,7 @@ export function queueJob(job: SchedulerJob): void {
 }
 
 function queueFlush() {
-  if (!currentFlushPromise) {
+  if (currentFlushPromise === null) {
     currentFlushPromise = resolvedPromise.then(flushJobs)
   }
 }

--- a/packages/runtime-core/src/warning.ts
+++ b/packages/runtime-core/src/warning.ts
@@ -111,7 +111,7 @@ export function getComponentTrace(): ComponentTraceStack {
 function formatTrace(trace: ComponentTraceStack): any[] {
   const logs: any[] = []
   trace.forEach((entry, i) => {
-    logs.push(...(i === 0 ? [] : [`\n`]), ...formatTraceEntry(entry))
+    logs.push(...(!i ? [] : [`\n`]), ...formatTraceEntry(entry))
   })
   return logs
 }

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -270,7 +270,7 @@ export class VueElement
       }
     }
 
-    if (!(this._def as ComponentOptions).__asyncLoader) {
+    if ((this._def as ComponentOptions).__asyncLoader === undefined) {
       // for sync component defs we can immediately resolve props
       this._resolveProps(this._def)
     }
@@ -280,7 +280,7 @@ export class VueElement
     // avoid resolving component if it's not connected
     if (!this.isConnected) return
 
-    if (!this.shadowRoot) {
+    if (this.shadowRoot === null) {
       this._parseSlots()
     }
     this._connected = true
@@ -296,7 +296,7 @@ export class VueElement
       }
     }
 
-    if (!this._instance) {
+    if (this._instance === null) {
       if (this._resolved) {
         this._setParent()
         this._update()
@@ -425,7 +425,7 @@ export class VueElement
 
     // apply expose after mount
     const exposed = this._instance && this._instance.exposed
-    if (!exposed) return
+    if (exposed === null) return
     for (const key in exposed) {
       if (!hasOwn(this, key)) {
         // exposed properties are readonly
@@ -525,12 +525,12 @@ export class VueElement
 
   private _createVNode(): VNode<any, any> {
     const baseProps: VNodeProps = {}
-    if (!this.shadowRoot) {
+    if (this.shadowRoot === null) {
       baseProps.onVnodeMounted = baseProps.onVnodeUpdated =
         this._renderSlots.bind(this)
     }
     const vnode = createVNode(this._def, extend(baseProps, this._props))
-    if (!this._instance) {
+    if (this._instance === null) {
       vnode.ce = instance => {
         this._instance = instance
         instance.ce = this
@@ -580,7 +580,7 @@ export class VueElement
     styles: string[] | undefined,
     owner?: ConcreteComponent,
   ) {
-    if (!styles) return
+    if (styles === undefined) return
     if (owner) {
       if (owner === this._def || this._styleChildren.has(owner)) {
         return
@@ -597,9 +597,9 @@ export class VueElement
       if (__DEV__) {
         if (owner) {
           if (owner.__hmrId) {
-            if (!this._childStyles) this._childStyles = new Map()
+            if (this._childStyles === undefined) this._childStyles = new Map()
             let entry = this._childStyles.get(owner.__hmrId)
-            if (!entry) {
+            if (entry === undefined) {
               this._childStyles.set(owner.__hmrId, (entry = []))
             }
             entry.push(s)
@@ -688,7 +688,7 @@ export function useHost(caller?: string): VueElement | null {
   if (el) {
     return el
   } else if (__DEV__) {
-    if (!instance) {
+    if (instance === null) {
       warn(
         `${caller || 'useHost'} called without an active component instance.`,
       )

--- a/packages/runtime-dom/src/helpers/useCssModule.ts
+++ b/packages/runtime-dom/src/helpers/useCssModule.ts
@@ -9,7 +9,7 @@ export function useCssModule(name = '$style'): Record<string, string> {
       return EMPTY_OBJ
     }
     const modules = instance.type.__cssModules
-    if (!modules) {
+    if (modules === undefined) {
       __DEV__ && warn(`Current instance does not have CSS modules injected.`)
       return EMPTY_OBJ
     }

--- a/packages/runtime-dom/src/helpers/useCssVars.ts
+++ b/packages/runtime-dom/src/helpers/useCssVars.ts
@@ -22,7 +22,7 @@ export function useCssVars(getter: (ctx: any) => Record<string, string>): void {
 
   const instance = getCurrentInstance()
   /* v8 ignore start */
-  if (!instance) {
+  if (instance === null) {
     __DEV__ &&
       warn(`useCssVars is called without current active component instance.`)
     return

--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -106,10 +106,14 @@ export const createApp = ((...args) => {
   const { mount } = app
   app.mount = (containerOrSelector: Element | ShadowRoot | string): any => {
     const container = normalizeContainer(containerOrSelector)
-    if (!container) return
+    if (container === null) return
 
     const component = app._component
-    if (!isFunction(component) && !component.render && !component.template) {
+    if (
+      !isFunction(component) &&
+      component.render === undefined &&
+      !component.template
+    ) {
       // __UNSAFE__
       // Reason: potential execution of JS expressions in in-DOM template.
       // The user must make sure the in-DOM template is trusted. If it's
@@ -230,7 +234,7 @@ function normalizeContainer(
 ): Element | ShadowRoot | null {
   if (isString(container)) {
     const res = document.querySelector(container)
-    if (__DEV__ && !res) {
+    if (__DEV__ && res === null) {
       warn(
         `Failed to mount app: mount target selector "${container}" returned null.`,
       )

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -106,7 +106,7 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
       // cached
       while (true) {
         parent.insertBefore(start!.cloneNode(true), anchor)
-        if (start === end || !(start = start!.nextSibling)) break
+        if (start === end || (start = start!.nextSibling) === null) break
       }
     } else {
       // fresh insert

--- a/packages/runtime-test/src/nodeOps.ts
+++ b/packages/runtime-test/src/nodeOps.ts
@@ -221,7 +221,7 @@ function parentNode(node: TestNode): TestElement | null {
 
 function nextSibling(node: TestNode): TestNode | null {
   const parent = node.parentNode
-  if (!parent) {
+  if (parent === null) {
     return null
   }
   const i = parent.children.indexOf(node)

--- a/packages/server-renderer/__tests__/createBuffer.bench.ts
+++ b/packages/server-renderer/__tests__/createBuffer.bench.ts
@@ -29,7 +29,7 @@ describe('createBuffer', () => {
     'string with nested',
     () => {
       for (let i = 0; i < 10; i += 1) {
-        if (i % 3 === 0) {
+        if (!(i % 3)) {
           stringNestedBuffer.push('hello')
         } else {
           const buffer = createBuffer()
@@ -49,7 +49,7 @@ describe('createBuffer', () => {
     'string with nested async',
     () => {
       for (let i = 0; i < 10; i += 1) {
-        if (i % 3 === 0) {
+        if (!(i % 3)) {
           const buffer = createBuffer()
           buffer.push('hello')
           stringNestedBuffer.push(Promise.resolve(buffer.getBuffer()))

--- a/packages/server-renderer/__tests__/unrollBuffer.bench.ts
+++ b/packages/server-renderer/__tests__/unrollBuffer.bench.ts
@@ -30,7 +30,7 @@ function createMixedBuffer(levels: number, itemsPerLevel: number): SSRBuffer {
 
   function addItems(buf: ReturnType<typeof createBuffer>, level: number) {
     for (let i = 1; i <= levels * itemsPerLevel; i++) {
-      if (i % 3 === 0) {
+      if (!(i % 3)) {
         // @ts-expect-error testing...
         buf.push(Promise.resolve(`async${level}.${i}`))
       } else {

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -133,7 +133,7 @@ function renderComponentSubTree(
     let root = renderComponentRoot(instance)
     // #5817 scope ID attrs not falling through if functional component doesn't
     // have props
-    if (!(comp as FunctionalComponent).props) {
+    if ((comp as FunctionalComponent).props === undefined) {
       for (const key in instance.attrs) {
         if (key.startsWith(`data-v-`)) {
           ;(root.props || (root.props = {}))[key] = ``
@@ -143,9 +143,9 @@ function renderComponentSubTree(
     renderVNode(push, (instance.subTree = root), instance, slotScopeId)
   } else {
     if (
-      (!instance.render || instance.render === NOOP) &&
+      (instance.render === null || instance.render === NOOP) &&
       !instance.ssrRender &&
-      !comp.ssrRender &&
+      comp.ssrRender === undefined &&
       isString(comp.template)
     ) {
       comp.ssrRender = ssrCompile(comp.template, instance)

--- a/packages/shared/src/codeframe.ts
+++ b/packages/shared/src/codeframe.ts
@@ -19,7 +19,7 @@ export function generateCodeFrame(
 
   // Separate the lines and newline sequences into separate arrays for easier referencing
   const newlineSequences = lines.filter((_, idx) => idx % 2 === 1)
-  lines = lines.filter((_, idx) => idx % 2 === 0)
+  lines = lines.filter((_, idx) => !(idx % 2))
 
   let count = 0
   const res: string[] = []

--- a/packages/shared/src/escapeHtml.ts
+++ b/packages/shared/src/escapeHtml.ts
@@ -4,7 +4,7 @@ export function escapeHtml(string: unknown): string {
   const str = '' + string
   const match = escapeRE.exec(str)
 
-  if (!match) {
+  if (match === null) {
     return str
   }
 

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -84,7 +84,7 @@ export function normalizeClass(value: unknown): string {
 export function normalizeProps(
   props: Record<string, any> | null,
 ): Record<string, any> | null {
-  if (!props) return null
+  if (props === null) return null
   let { class: klass, style } = props
   if (klass && !isString(klass)) {
     props.class = normalizeClass(klass)

--- a/packages/vue-compat/src/index.ts
+++ b/packages/vue-compat/src/index.ts
@@ -49,7 +49,7 @@ function compileToFunction(
 
   if (template[0] === '#') {
     const el = document.querySelector(template)
-    if (__DEV__ && !el) {
+    if (__DEV__ && el === null) {
       warn(`Template element not found or is empty: ${template}`)
     }
     // __UNSAFE__

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -48,7 +48,7 @@ function compileToFunction(
 
   if (template[0] === '#') {
     const el = document.querySelector(template)
-    if (__DEV__ && !el) {
+    if (__DEV__ && el === null) {
       warn(`Template element not found or is empty: ${template}`)
     }
     // __UNSAFE__
@@ -68,7 +68,7 @@ function compileToFunction(
   )
 
   if (!opts.isCustomElement && typeof customElements !== 'undefined') {
-    opts.isCustomElement = tag => !!customElements.get(tag)
+    opts.isCustomElement = tag => customElements.get(tag) !== undefined
   }
 
   const { code } = compile(template, opts)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       '@swc/core':
         specifier: ^1.11.12
         version: 1.11.12
+      '@tsslint/cli':
+        specifier: ~1.5.11
+        version: 1.5.11(typescript@5.6.2)
+      '@tsslint/config':
+        specifier: ~1.5.11
+        version: 1.5.11(typescript@5.6.2)
       '@types/hash-sum':
         specifier: ^1.0.2
         version: 1.0.2
@@ -479,6 +485,12 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@clack/core@0.3.5':
+    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+
+  '@clack/prompts@0.8.2':
+    resolution: {integrity: sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==}
 
   '@conventional-changelog/git-client@1.0.1':
     resolution: {integrity: sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==}
@@ -1344,6 +1356,21 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@tsslint/cli@1.5.11':
+    resolution: {integrity: sha512-Sm/h2p2i8Cuq58NrJKJTwKM8eHZ+3NhfS6I6VFSmMAfCRXHV2pHhJF/dPvIENWByxYo4lMt2n6wJYHbVOyyxAg==}
+    hasBin: true
+    peerDependencies:
+      typescript: '*'
+
+  '@tsslint/config@1.5.11':
+    resolution: {integrity: sha512-Ksk+jkvDk1P8Q7jQB8RbzbEEuftzImHz1K9oTuJQI9pjLII6ba2Wa8uSJqJ1NIkuS+OWxNHcy+o1SyoLErAshg==}
+
+  '@tsslint/core@1.5.11':
+    resolution: {integrity: sha512-QRpMLM4gE61PuDOIR1Wn1kD0A+Sw5R+i+11EoQomF22CqPUFKPKAxL3/YBtTGKjaH3fKdBHV9gbk84KXoEZzZQ==}
+
+  '@tsslint/types@1.5.11':
+    resolution: {integrity: sha512-bPmik238B6yS03DH7hcdhl37D4HBzDJl0dTFLjgGOd3ekj6qe6V/f0QC1u8EwRqID4j0W132nH/5h5Rj88XZ1A==}
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
@@ -1539,6 +1566,15 @@ packages:
 
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
+
+  '@volar/language-core@2.4.12':
+    resolution: {integrity: sha512-RLrFdXEaQBWfSnYGVxvR2WrO6Bub0unkdHYIdC31HzIEqATIuuhRRzYu76iGPZ6OtA4Au1SnW0ZwIqPP217YhA==}
+
+  '@volar/source-map@2.4.12':
+    resolution: {integrity: sha512-bUFIKvn2U0AWojOaqf63ER0N/iHIBYZPpNGogfLPQ68F5Eet6FnLlyho7BS0y2HJ1jFhSif7AcuTx1TqsCzRzw==}
+
+  '@volar/typescript@2.4.12':
+    resolution: {integrity: sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==}
 
   '@vue/consolidate@1.0.0':
     resolution: {integrity: sha512-oTyUE+QHIzLw2PpV14GD/c7EohDyP64xCniWTcqcEmTd699eFqTIwOmtDYjcO1j3QgdXoJEoWv1/cCdLrRoOfg==}
@@ -2032,6 +2068,9 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-define-property@1.0.0:
     resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
@@ -2564,6 +2603,11 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
@@ -2853,6 +2897,9 @@ packages:
 
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3215,6 +3262,9 @@ packages:
     resolution: {integrity: sha512-NB3V4XyCOrWTIhjh85DyEoVlM3adHWwqQXKYHmuegy/108bJPP6YxuPGm4ZKBq1+GVKRbKJuzNY//09cMJYp+A==}
     hasBin: true
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -3263,6 +3313,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
@@ -3541,6 +3594,9 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -3712,6 +3768,17 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@clack/core@0.3.5':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.8.2':
+    dependencies:
+      '@clack/core': 0.3.5
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@conventional-changelog/git-client@1.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.0.0)':
     dependencies:
@@ -4307,6 +4374,33 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
+  '@tsslint/cli@1.5.11(typescript@5.6.2)':
+    dependencies:
+      '@clack/prompts': 0.8.2
+      '@tsslint/config': 1.5.11(typescript@5.6.2)
+      '@tsslint/core': 1.5.11
+      '@volar/language-core': 2.4.12
+      '@volar/typescript': 2.4.12
+      glob: 10.4.5
+      json5: 2.2.3
+      typescript: 5.6.2
+
+  '@tsslint/config@1.5.11(typescript@5.6.2)':
+    dependencies:
+      '@tsslint/types': 1.5.11
+      ts-api-utils: 2.0.1(typescript@5.6.2)
+    transitivePeerDependencies:
+      - typescript
+
+  '@tsslint/core@1.5.11':
+    dependencies:
+      '@tsslint/types': 1.5.11
+      error-stack-parser: 2.1.4
+      esbuild: 0.25.1
+      minimatch: 10.0.1
+
+  '@tsslint/types@1.5.11': {}
+
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
@@ -4523,6 +4617,18 @@ snapshots:
       '@vitest/pretty-format': 3.0.9
       loupe: 3.1.3
       tinyrainbow: 2.0.0
+
+  '@volar/language-core@2.4.12':
+    dependencies:
+      '@volar/source-map': 2.4.12
+
+  '@volar/source-map@2.4.12': {}
+
+  '@volar/typescript@2.4.12':
+    dependencies:
+      '@volar/language-core': 2.4.12
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
 
   '@vue/consolidate@1.0.0': {}
 
@@ -4990,6 +5096,10 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
 
   es-define-property@1.0.0:
     dependencies:
@@ -5614,6 +5724,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json5@2.2.3: {}
+
   jsonfile@6.1.0:
     dependencies:
       universalify: 2.0.1
@@ -5905,6 +6017,8 @@ snapshots:
   parse5@7.2.1:
     dependencies:
       entities: 4.5.0
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -6378,6 +6492,8 @@ snapshots:
 
   simple-git-hooks@2.12.1: {}
 
+  sisteransi@1.0.5: {}
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -6426,6 +6542,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  stackframe@1.3.4: {}
 
   std-env@3.8.0: {}
 
@@ -6680,6 +6798,8 @@ snapshots:
       - terser
 
   void-elements@3.1.0: {}
+
+  vscode-uri@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/tsslint.config.ts
+++ b/tsslint.config.ts
@@ -1,0 +1,134 @@
+import { defineConfig } from '@tsslint/config'
+import type * as ts from 'typescript'
+
+export default defineConfig({
+  exclude: ['**/*.spec.ts'],
+  rules: {
+    'number-equality'({
+      typescript: ts,
+      sourceFile,
+      reportWarning,
+      languageService,
+    }) {
+      const checker = languageService.getProgram()!.getTypeChecker()
+      ts.forEachChild(sourceFile, function visit(node) {
+        if (
+          ts.isBinaryExpression(node) &&
+          node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken &&
+          ts.isNumericLiteral(node.right) &&
+          node.right.text === '0'
+        ) {
+          const type = checker.getTypeAtLocation(node.left)
+          if (type.flags & ts.TypeFlags.Number) {
+            reportWarning(
+              `Replace "x === 0" with "!x" for numeric variables to clarify boolean usage.`,
+              node.getStart(sourceFile),
+              node.getEnd(),
+            ).withFix('Use exclamation instead', () => [
+              {
+                fileName: sourceFile.fileName,
+                textChanges: [
+                  {
+                    newText: `!(${node.left.getText(sourceFile)})`,
+                    span: {
+                      start: node.getStart(sourceFile),
+                      length: node.getWidth(),
+                    },
+                  },
+                ],
+              },
+            ])
+          }
+        }
+        ts.forEachChild(node, visit)
+      })
+    },
+    'object-equality'({
+      typescript: ts,
+      sourceFile,
+      reportWarning,
+      languageService,
+    }) {
+      const checker = languageService.getProgram()!.getTypeChecker()
+      const checkFlags = [ts.TypeFlags.Undefined, ts.TypeFlags.Null]
+      ts.forEachChild(sourceFile, function visit(node) {
+        if (
+          ts.isPrefixUnaryExpression(node) &&
+          node.operator === ts.SyntaxKind.ExclamationToken
+        ) {
+          const type = checker.getTypeAtLocation(node.operand)
+          for (const checkFlag of checkFlags) {
+            if (isObjectOrNullableUnion(type, checkFlag)) {
+              const flagText =
+                checkFlag === ts.TypeFlags.Undefined ? 'undefined' : 'null'
+              if (
+                ts.isPrefixUnaryExpression(node.parent) &&
+                node.parent.operator === ts.SyntaxKind.ExclamationToken
+              ) {
+                reportWarning(
+                  `Do not use "!!" for a variable of type "object | ${flagText}". Replace with "!== ${flagText}" for clarity.`,
+                  node.parent.getStart(sourceFile),
+                  node.getEnd(),
+                ).withFix(`Replace with !== ${flagText}`, () => [
+                  {
+                    fileName: sourceFile.fileName,
+                    textChanges: [
+                      {
+                        newText: `${node.operand.getText(sourceFile)} !== ${flagText}`,
+                        span: {
+                          start: node.parent.getStart(sourceFile),
+                          length:
+                            node.getEnd() - node.parent.getStart(sourceFile),
+                        },
+                      },
+                    ],
+                  },
+                ])
+              } else {
+                reportWarning(
+                  `Do not use "!" for a variable of type "object | ${flagText}". Replace with "=== ${flagText}" for clarity.`,
+                  node.getStart(sourceFile),
+                  node.getEnd(),
+                ).withFix(`Replace with === ${flagText}`, () => [
+                  {
+                    fileName: sourceFile.fileName,
+                    textChanges: [
+                      {
+                        newText: `${node.operand.getText(sourceFile)} === ${flagText}`,
+                        span: {
+                          start: node.getStart(sourceFile),
+                          length: node.getWidth(),
+                        },
+                      },
+                    ],
+                  },
+                ])
+              }
+            }
+          }
+        }
+        ts.forEachChild(node, visit)
+      })
+
+      function isObjectOrNullableUnion(
+        type: ts.Type,
+        nullableFlag: ts.TypeFlags,
+      ) {
+        if (!(type.flags & ts.TypeFlags.Union)) return false
+        const unionType = type
+        let hasObject = false
+        let hasNullable = false
+        for (const sub of (unionType as ts.UnionType).types) {
+          if (sub.flags & nullableFlag) {
+            hasNullable = true
+          } else if (sub.flags & ts.TypeFlags.Object) {
+            hasObject = true
+          } else {
+            return false
+          }
+        }
+        return hasObject && hasNullable
+      }
+    },
+  },
+})


### PR DESCRIPTION
Add 2 performance-related linting rules.

1. Numeric types should avoid `!== 0` comparisons.
2. Nullable object types should be compared using `=== undefined`/`!== undefined`/`=== null`/` !== null`.

#### Benchmark

`number !== 0`: 153.250917 ms
`!number`: 204.387375 ms
`object === undefined`: 184.250917 ms
`!object`: 358.422708 ms
