### PR TITLE
fix: make generics with runtime props in defineComponent work (fix #11374)

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1373,7 +1373,7 @@ describe('function syntax w/ emits', () => {
 describe('function syntax w/ runtime props', () => {
   // with runtime props, the runtime props must match
   // manual type declaration
-  defineComponent(
+  const Comp1 = defineComponent(
     (_props: { msg: string }) => {
       return () => {}
     },
@@ -1382,7 +1382,34 @@ describe('function syntax w/ runtime props', () => {
     },
   )
 
+  // @ts-expect-error bar isn't specified in props definition
   defineComponent(
+    (_props: { msg: string }) => {
+      return () => {}
+    },
+    {
+      props: ['msg', 'bar'],
+    },
+  )
+
+  defineComponent(
+    (_props: { msg: string; bar: string }) => {
+      return () => {}
+    },
+    {
+      props: ['msg'],
+    },
+  )
+
+  expectType<JSX.Element>(<Comp1 msg="1" />)
+  // @ts-expect-error msg type is incorrect
+  expectType<JSX.Element>(<Comp1 msg={1} />)
+  // @ts-expect-error msg is missing
+  expectType<JSX.Element>(<Comp1 />)
+  // @ts-expect-error bar doesn't exist
+  expectType<JSX.Element>(<Comp1 msg="1" bar="2" />)
+
+  const Comp2 = defineComponent(
     <T extends string>(_props: { msg: T }) => {
       return () => {}
     },
@@ -1391,7 +1418,36 @@ describe('function syntax w/ runtime props', () => {
     },
   )
 
+  // @ts-expect-error bar isn't specified in props definition
   defineComponent(
+    <T extends string>(_props: { msg: T }) => {
+      return () => {}
+    },
+    {
+      props: ['msg', 'bar'],
+    },
+  )
+
+  defineComponent(
+    <T extends string>(_props: { msg: T; bar: T }) => {
+      return () => {}
+    },
+    {
+      props: ['msg'],
+    },
+  )
+
+  expectType<JSX.Element>(<Comp2 msg="1" />)
+  expectType<JSX.Element>(<Comp2<string> msg="1" />)
+  // @ts-expect-error msg type is incorrect
+  expectType<JSX.Element>(<Comp2 msg={1} />)
+  // @ts-expect-error msg is missing
+  expectType<JSX.Element>(<Comp2 />)
+  // @ts-expect-error bar doesn't exist
+  expectType<JSX.Element>(<Comp2 msg="1" bar="2" />)
+
+  // Note: generics aren't supported with object runtime props
+  const Comp3 = defineComponent(
     <T extends string>(_props: { msg: T }) => {
       return () => {}
     },
@@ -1401,6 +1457,40 @@ describe('function syntax w/ runtime props', () => {
       },
     },
   )
+
+  defineComponent(
+    // @ts-expect-error bar isn't specified in props definition
+    <T extends string>(_props: { msg: T }) => {
+      return () => {}
+    },
+    {
+      props: {
+        bar: String,
+      },
+    },
+  )
+
+  defineComponent(
+    // @ts-expect-error generics aren't supported with object runtime props
+    <T extends string>(_props: { msg: T; bar: T }) => {
+      return () => {}
+    },
+    {
+      props: {
+        msg: String,
+      },
+    },
+  )
+
+  expectType<JSX.Element>(<Comp3 msg="1" />)
+  // @ts-expect-error generics aren't supported with object runtime props
+  expectType<JSX.Element>(<Comp3<string> msg="1" />)
+  // @ts-expect-error msg type is incorrect
+  expectType<JSX.Element>(<Comp3 msg={1} />)
+  // @ts-expect-error msg is missing
+  expectType<JSX.Element>(<Comp3 />)
+  // @ts-expect-error bar doesn't exist
+  expectType<JSX.Element>(<Comp3 msg="1" bar="2" />)
 
   // @ts-expect-error string prop names don't match
   defineComponent(
@@ -1420,19 +1510,6 @@ describe('function syntax w/ runtime props', () => {
       props: {
         // @ts-expect-error prop type mismatch
         msg: Number,
-      },
-    },
-  )
-
-  // @ts-expect-error prop keys don't match
-  defineComponent(
-    (_props: { msg: string }, ctx) => {
-      return () => {}
-    },
-    {
-      props: {
-        msg: String,
-        bar: String,
       },
     },
   )

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -157,7 +157,7 @@ export function defineComponent<
     ctx: SetupContext<E, S>,
   ) => RenderFunction | Promise<RenderFunction>,
   options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
-    props?: (keyof Props)[]
+    props?: (keyof NoInfer<Props>)[]
     emits?: E | EE[]
     slots?: S
   },


### PR DESCRIPTION
fixes #11374
relates to https://github.com/vuejs/core/issues/12761#issuecomment-2764608203, https://github.com/vuejs/core/pull/7963#issuecomment-2246825089

## Problem

In #7963 was introduced support for generics in defineComponent, but it doesn't work as everyone wants it to work. Specifically, if the `props` option passed, the generic type disappears and all the prop types become any

In other words, the simplest component with generics like shown below is impossible to make without losing types

```tsx
type Props<T> = {
  selected: T
  onChange: (option: T) => void
}

const Select= defineComponent(<T = string>(props: Props<T>) => {
  return () => <div>selected: {props.selected}</div>
}, {
  props: ['selected', 'onChange']
})
```

Why it doesn't work? Let's look at one of the overloads of the defineComponent:

```tsx
export function defineComponent<
  Props extends Record<string, any>,
  E extends EmitsOptions = {},
  EE extends string = string,
  S extends SlotsType = {},
>(
  setup: (
    props: Props,
    ctx: SetupContext<E, S>,
  ) => RenderFunction | Promise<RenderFunction>,
  options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
    props?: (keyof Props)[]
    emits?: E | EE[]
    slots?: S
  },
): DefineSetupFnComponent<Props, E, S>
```

Here we can see the `Props` generic type, the `setup` argument using `Props` and the `options` argument also using `Props`

I guess when we add a generic type to the `setup` function, it makes the function a less "explicit" variant to infer the `Props` type and typescript chooses `Props` from the `options.props` instead. But because it only contains names of the props, all values are preserved as `any` from `Props` extends

## Solution

We need to tell typescript not to infer `Props` from the `options.props` field, so we can use a native utility type `NoInfer`:

```tsx
props?: (keyof NoInfer<Props>)[]
```

Initially I've come up with another solution which doesn't rely on that new typescript `NoInfer` type.

It works by separating `Props` into two generics — original `Props` and `DeclaredProps` — and using them differently.
Type `DeclaredProps extends (keyof Props)[]` can have less keys than in `Props`, but not more

```tsx
export function defineComponent<
  Props extends Record<string, any>,
  ...,
  DeclaredProps extends (keyof Props)[] = (keyof Props)[],
>(
  setup: (props: Props, ...) => ...,
  options?: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
    props?: DeclaredProps
    ...
  },
): DefineSetupFnComponent<Props, E, S>
```

## Dealing with another format for passing props

Array of prop names isn't the only way to tell what props we want to use, there is also a format with objects and validations, which unfortunately I couldn't beat:

```tsx
props: {
  selected: String,
  onSelect: Function
}
```

Objects are much harder than arrays, you can't describe an object with no more fields than in another object using extends as easy as an array. Ok, maybe you can, but then you'll run into another problem: it's not easy (if even possible) to check if an object with primitive types matches another object with generic types

I tried hard and ended up with an idea that it just doesn't worth it and doesn't make enough sense to use this format with generics. So this format works as before: no generics and `any` instead of passed types