### PR TITLE
chore(shared): Call an existing simpler function to determine the raw type

### DIFF
--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -38,14 +38,12 @@ export const hasOwn = (
 
 export const isArray: typeof Array.isArray = Array.isArray
 export const isMap = (val: unknown): val is Map<any, any> =>
-  toTypeString(val) === '[object Map]'
-export const isSet = (val: unknown): val is Set<any> =>
-  toTypeString(val) === '[object Set]'
+  toRawType(val) === 'Map'
+export const isSet = (val: unknown): val is Set<any> => toRawType(val) === 'Set'
 
-export const isDate = (val: unknown): val is Date =>
-  toTypeString(val) === '[object Date]'
+export const isDate = (val: unknown): val is Date => toRawType(val) === 'Date'
 export const isRegExp = (val: unknown): val is RegExp =>
-  toTypeString(val) === '[object RegExp]'
+  toRawType(val) === 'RegExp'
 export const isFunction = (val: unknown): val is Function =>
   typeof val === 'function'
 export const isString = (val: unknown): val is string => typeof val === 'string'
@@ -72,7 +70,7 @@ export const toRawType = (value: unknown): string => {
 }
 
 export const isPlainObject = (val: unknown): val is object =>
-  toTypeString(val) === '[object Object]'
+  toRawType(val) === 'Object'
 
 export const isIntegerKey = (key: unknown): boolean =>
   isString(key) &&


### PR DESCRIPTION
A simpler function exists to determine the raw type of a value, replacing `toTypeString()` with `toRawType()`.