### PR TITLE
chore: remove `warnRecursiveComputed`

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -119,12 +119,6 @@ export class ComputedRefImpl<T = any> implements Dependency, Subscriber {
   // dev only
   onTrigger?: (event: DebuggerEvent) => void
 
-  /**
-   * Dev only
-   * @internal
-   */
-  _warnRecursive?: boolean
-
   constructor(
     public fn: ComputedGetter<T>,
     private readonly setter: ComputedSetter<T> | undefined,

--- a/packages/runtime-core/src/apiComputed.ts
+++ b/packages/runtime-core/src/apiComputed.ts
@@ -1,17 +1,10 @@
-import { type ComputedRefImpl, computed as _computed } from '@vue/reactivity'
-import { getCurrentInstance, isInSSRComponentSetup } from './component'
+import { computed as _computed } from '@vue/reactivity'
+import { isInSSRComponentSetup } from './component'
 
 export const computed: typeof _computed = (
   getterOrOptions: any,
   debugOptions?: any,
 ) => {
   // @ts-expect-error
-  const c = _computed(getterOrOptions, debugOptions, isInSSRComponentSetup)
-  if (__DEV__) {
-    const i = getCurrentInstance()
-    if (i && i.appContext.config.warnRecursiveComputed) {
-      ;(c as unknown as ComputedRefImpl<any>)._warnRecursive = true
-    }
-  }
-  return c as any
+  return _computed(getterOrOptions, debugOptions, isInSSRComponentSetup) as any
 }

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -150,12 +150,6 @@ export interface AppConfig {
   isCustomElement?: (tag: string) => boolean
 
   /**
-   * TODO document for 3.5
-   * Enable warnings for computed getters that recursively trigger itself.
-   */
-  warnRecursiveComputed?: boolean
-
-  /**
    * Whether to throw unhandled errors in production.
    * Default is `false` to avoid crashing on any error (and only logs it)
    * But in some cases, e.g. SSR, throwing might be more desirable.


### PR DESCRIPTION
It's no longer needed in 3.6.

close https://github.com/vuejs/core/pull/12225
close https://github.com/vuejs/core/issues/12845
close https://github.com/vuejs/core/pull/12179
close https://github.com/vuejs/docs/pull/3072