### PR TITLE
fix(compat): correct deprecation message for v-bind.sync usage

### DIFF
--- a/packages/compiler-core/src/compat/compatConfig.ts
+++ b/packages/compiler-core/src/compat/compatConfig.ts
@@ -41,7 +41,7 @@ const deprecationData: Record<CompilerDeprecationTypes, DeprecationData> = {
   [CompilerDeprecationTypes.COMPILER_V_BIND_SYNC]: {
     message: key =>
       `.sync modifier for v-bind has been removed. Use v-model with ` +
-      `argument instead. \`v-bind:${key}.sync\` should be changed to ` +
+      `argument instead. \`v-bind:${key}\` should be changed to ` +
       `\`v-model:${key}\`.`,
     link: `https://v3-migration.vuejs.org/breaking-changes/v-model.html`,
   },

--- a/packages/compiler-core/src/compat/compatConfig.ts
+++ b/packages/compiler-core/src/compat/compatConfig.ts
@@ -41,7 +41,7 @@ const deprecationData: Record<CompilerDeprecationTypes, DeprecationData> = {
   [CompilerDeprecationTypes.COMPILER_V_BIND_SYNC]: {
     message: key =>
       `.sync modifier for v-bind has been removed. Use v-model with ` +
-      `argument instead. \`v-bind:${key}\` should be changed to ` +
+      `argument instead. \`v-bind:${key}.sync\` should be changed to ` +
       `\`v-model:${key}\`.`,
     link: `https://v3-migration.vuejs.org/breaking-changes/v-model.html`,
   },

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -388,7 +388,7 @@ const tokenizer = new Tokenizer(stack, {
               CompilerDeprecationTypes.COMPILER_V_BIND_SYNC,
               currentOptions,
               currentProp.loc,
-              currentProp.rawName,
+              currentProp.loc.source,
             )
           ) {
             currentProp.name = 'model'

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -388,7 +388,7 @@ const tokenizer = new Tokenizer(stack, {
               CompilerDeprecationTypes.COMPILER_V_BIND_SYNC,
               currentOptions,
               currentProp.loc,
-              currentProp.loc.source,
+              (currentProp.arg as SimpleExpressionNode).content,
             )
           ) {
             currentProp.name = 'model'

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -388,7 +388,7 @@ const tokenizer = new Tokenizer(stack, {
               CompilerDeprecationTypes.COMPILER_V_BIND_SYNC,
               currentOptions,
               currentProp.loc,
-              (currentProp.arg as SimpleExpressionNode).content,
+              currentProp.arg!.loc.source,
             )
           ) {
             currentProp.name = 'model'


### PR DESCRIPTION
close #13133

According to this
https://github.com/vuejs/core/blob/069f838691b2238f31f4237e8412d9ff12921995/packages/compiler-core/src/parse.ts#L885