### PR TITLE
fix(custom-element): prevent parse slot when custom element move in DOM

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -280,7 +280,7 @@ export class VueElement
     // avoid resolving component if it's not connected
     if (!this.isConnected) return
 
-    if (!this.shadowRoot) {
+    if (!this.shadowRoot && !this._instance) {
       this._parseSlots()
     }
     this._connected = true


### PR DESCRIPTION
## Bug Report: Component Disappears When Moved in DOM Using Custom Element with Slot

### Description

I'm using a **Custom Element** to wrap a Vue component that includes a `slot`. In this setup, `shadowRoot` is set to `false`.

The issue I'm encountering is that when I move this element within the DOM — either by dragging it or using `appendChild` to insert it elsewhere — the `disconnectedCallback` is triggered.

Inside the `disconnectedCallback`, `nextTick` is used. However, before `nextTick` gets a chance to execute, the `connectedCallback` is triggered again. As a result, `_parseSlots` is called before the component is fully re-initialized, and all `childNodes` inside the element are removed. This causes the component to suddenly disappear from the DOM.

### Temporary Fix

To resolve this issue, I added a check to ensure `_instance` is not `null` before calling `_parseSlots`. This workaround prevents the unexpected removal of slot content.

### Reproduction

If needed, I can provide a minimal reproduction of the problem.

### Environment

- Vue version: [your version]
- Custom Element setup: `shadowRoot: false`
- Browser: [your browser name and version]

### Expected Behavior

Moving the component in the DOM should not cause it to lose its slotted children or disappear.

### Actual Behavior

Slotted content is removed when the component is reconnected before `nextTick` executes.

---

Let me know if a repro is needed — I’d be happy to provide one.
