### PR TITLE
fix(compiler-dom): handle v-model + v-bind shorthand type edge case

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -48,6 +48,22 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: transform v-model > input with v-bind shorthand type should use dynamic model 1`] = `
+"const _Vue = Vue
+
+return function render(_ctx, _cache) {
+  with (_ctx) {
+    const { vModelDynamic: _vModelDynamic, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = _Vue
+
+    return _withDirectives((_openBlock(), _createElementBlock("input", {
+      "onUpdate:modelValue": $event => ((model) = $event)
+    }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+      [_vModelDynamic, model]
+    ])
+  }
+}"
+`;
+
 exports[`compiler: transform v-model > modifiers > .lazy 1`] = `
 "const _Vue = Vue
 

--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -48,7 +48,7 @@ return function render(_ctx, _cache) {
 }"
 `;
 
-exports[`compiler: transform v-model > input with v-bind shorthand type should use dynamic model 1`] = `
+exports[`compiler: transform v-model > input with v-bind shorthand type after v-model should use dynamic model 1`] = `
 "const _Vue = Vue
 
 return function render(_ctx, _cache) {

--- a/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
@@ -63,8 +63,8 @@ describe('compiler: transform v-model', () => {
     expect(generate(root).code).toMatchSnapshot()
   })
 
-  test('input with v-bind shorthand type should use dynamic model', () => {
-    const root = transformWithModel('<input :type v-model="model" />')
+  test('input with v-bind shorthand type after v-model should use dynamic model', () => {
+    const root = transformWithModel('<input v-model="model" :type/>')
 
     expect(root.helpers).toContain(V_MODEL_DYNAMIC)
     expect(generate(root).code).toMatchSnapshot()

--- a/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
@@ -63,6 +63,13 @@ describe('compiler: transform v-model', () => {
     expect(generate(root).code).toMatchSnapshot()
   })
 
+  test('input with v-bind shorthand type should use dynamic model', () => {
+    const root = transformWithModel('<input :type v-model="model" />')
+
+    expect(root.helpers).toContain(V_MODEL_DYNAMIC)
+    expect(generate(root).code).toMatchSnapshot()
+  })
+
   test('input w/ dynamic v-bind', () => {
     const root = transformWithModel('<input v-bind="obj" v-model="model" />')
 

--- a/packages/compiler-dom/src/transforms/vModel.ts
+++ b/packages/compiler-dom/src/transforms/vModel.ts
@@ -56,7 +56,7 @@ export const transformModel: DirectiveTransform = (dir, node, context) => {
     let directiveToUse = V_MODEL_TEXT
     let isInvalidType = false
     if (tag === 'input' || isCustomElement) {
-      const type = findProp(node, `type`)
+      const type = findProp(node, `type`, false, true)
       if (type) {
         if (type.type === NodeTypes.DIRECTIVE) {
           // :type="foo"


### PR DESCRIPTION
close #13169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to ensure that input elements using shorthand dynamic type bindings with v-model correctly utilize the dynamic model helper.

- **Bug Fixes**
  - Improved detection of dynamic type bindings on input elements, ensuring proper handling when using shorthand syntax with v-model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->