### PR TITLE
feat(types): Add Exposed template to SetupContext

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -278,12 +278,13 @@ export type LifecycleHook<TFn = Function> = (TFn & SchedulerJob)[] | null
 export type SetupContext<
   E = EmitsOptions,
   S extends SlotsType = {},
+  EX extends Record<string, any> = Record<string, any>,
 > = E extends any
   ? {
       attrs: Data
       slots: UnwrapSlotsType<S>
       emit: EmitFn<E>
-      expose: <Exposed extends Record<string, any> = Record<string, any>>(
+      expose: <Exposed extends Record<string, any> = EX>(
         exposed?: Exposed,
       ) => void
     }


### PR DESCRIPTION
This PR allows the possibility to type `expose` when using `defineComponent` with composition api
```ts
export const UseVirtualList = defineComponent(
  <T = any>(props: {msg: T}, { slots, expose }: SetupContext<EmitsOptions, SlotsType<{}>, { index: number }>,
  ) => {
        ...
        const index = 2
        expose({index})
})
```