### PR TITLE
Fix toHaveBeenWarnedTimes type definition in setup-vitest.ts

### DIFF
--- a/scripts/setup-vitest.ts
+++ b/scripts/setup-vitest.ts
@@ -8,7 +8,7 @@ declare module 'vitest' {
 interface CustomMatchers<R = unknown> {
   toHaveBeenWarned(): R
   toHaveBeenWarnedLast(): R
-  toHaveBeenWarnedTimes(n: number): R
+  toHaveBeenWarnedTimes(received: string, n: number): R
 }
 
 vi.stubGlobal('MathMLElement', class MathMLElement {})


### PR DESCRIPTION
This PR fixes a mismatch between the interface definition and implementation of the `toHaveBeenWarnedTimes` custom matcher. The interface was missing the `received` parameter that is used in the implementation.

- Before: `toHaveBeenWarnedTimes(n: number): R`
- After: `toHaveBeenWarnedTimes(received: string, n: number): R`

This change ensures type correctness and better developer experience when using this custom matcher.