### PR TITLE
fix(scripts): add error handling to verify-treeshaking script

### DIFF
--- a/scripts/verify-treeshaking.js
+++ b/scripts/verify-treeshaking.js
@@ -46,4 +46,7 @@ exec('pnpm', ['build', 'vue', '-f', 'global-runtime']).then(() => {
       `Found the following treeshaking errors:\n\n- ${errors.join('\n\n- ')}`,
     )
   }
+}).catch(error => {
+  console.error(`Treeshaking verification failed: ${error.message}`)
+  process.exit(1)
 })


### PR DESCRIPTION
This PR adds basic error handling to the verify-treeshaking.js script to ensure build failures are properly caught and reported.