### PR TITLE
fix(compat): ensure false value on input value retains attribute

### DIFF
--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -79,6 +79,7 @@ export function compatCoerceAttr(
     }
   } else if (
     value === false &&
+    !(el.tagName === 'INPUT' && key === 'value') &&
     !isSpecialBooleanAttr(key) &&
     compatUtils.isCompatEnabled(DeprecationTypes.ATTR_FALSE_VALUE, instance)
   ) {

--- a/packages/vue-compat/__tests__/misc.spec.ts
+++ b/packages/vue-compat/__tests__/misc.spec.ts
@@ -208,6 +208,20 @@ test('ATTR_FALSE_VALUE', () => {
   ).toHaveBeenWarned()
 })
 
+test('ATTR_FALSE_VALUE with false on input value', () => {
+  const vm = new Vue({
+    template: `<input :value="false"/>`,
+  }).$mount()
+  expect(vm.$el).toBeInstanceOf(HTMLInputElement)
+  expect(vm.$el.hasAttribute('value')).toBe(true)
+  expect(vm.$el.getAttribute('value')).toBe('false')
+  expect(
+    (deprecationData[DeprecationTypes.ATTR_FALSE_VALUE].message as Function)(
+      'value',
+    ),
+  ).not.toHaveBeenWarned()
+})
+
 test("ATTR_FALSE_VALUE with false value shouldn't throw warning", () => {
   const vm = new Vue({
     template: `<div :id="false" :foo="false"/>`,


### PR DESCRIPTION
close #13205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented removal of the `value` attribute from `<input>` elements when bound to `false`, ensuring it remains as `"false"` and no warning is shown.

- **Tests**
  - Added a test to confirm that binding `false` to the `value` attribute on `<input>` elements behaves correctly and does not trigger a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->