### PR TITLE
fix(compiler-sfc): improve type inference for TSTypeAliasDeclaration with better runtime type detection

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -154,6 +154,27 @@ return {  }
 })"
 `;
 
+exports[`defineProps > w/ TSTypeAliasDeclaration 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+type FunFoo<O> = (item: O) => boolean;
+    type FunBar = FunFoo<number>;
+    
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    foo: { type: Function, required: false, default: () => true },
+    bar: { type: Function, required: false, default: () => true }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+    
+    
+return {  }
+}
+
+})"
+`;
+
 exports[`defineProps > w/ exported interface 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 export interface Props { x?: number }

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -808,4 +808,30 @@ const props = defineProps({ foo: String })
     expect(content).toMatch(`foo: { default: 5.5, type: Number }`)
     assertCode(content)
   })
+
+  test('w/ TSTypeAliasDeclaration', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+    type FunFoo<O> = (item: O) => boolean;
+    type FunBar = FunFoo<number>;
+    withDefaults(
+      defineProps<{
+        foo?: FunFoo<number>;
+        bar?: FunBar;
+      }>(),
+      {
+        foo: () => true,
+        bar: () => true,
+      },
+    );
+    </script>
+      `)
+    assertCode(content)
+    expect(content).toMatch(
+      `foo: { type: Function, required: false, default: () => true }`,
+    )
+    expect(content).toMatch(
+      `bar: { type: Function, required: false, default: () => true }`,
+    )
+  })
 })

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1554,6 +1554,14 @@ export function inferRuntimeType(
       case 'TSTypeReference': {
         const resolved = resolveTypeReference(ctx, node, scope)
         if (resolved) {
+          if (resolved.type === 'TSTypeAliasDeclaration') {
+            return inferRuntimeType(
+              ctx,
+              resolved.typeAnnotation,
+              resolved._ownerScope,
+              isKeyOf,
+            )
+          }
           return inferRuntimeType(ctx, resolved, resolved._ownerScope, isKeyOf)
         }
 


### PR DESCRIPTION
close #13240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type inference to correctly handle type aliases, ensuring more accurate runtime type detection.

- **Tests**
  - Added a new test case to validate prop definitions using TypeScript type aliases with default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->