### PR TITLE
feat: handle nested defineEmits

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineEmits.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineEmits.spec.ts.snap
@@ -15,6 +15,22 @@ return { myEmit }
 }"
 `;
 
+exports[`defineEmits > nested call expression 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  emits: ['foo', 'bar'],
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+    const transformed = transform(__emit);
+    
+return { transformed }
+}
+
+})"
+`;
+
 exports[`defineEmits > w/ runtime options 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript/defineEmits.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineEmits.spec.ts
@@ -210,6 +210,20 @@ const emit = defineEmits(['a', 'b'])
     assertCode(content)
   })
 
+  test('nested call expression', () => {
+    const { content } = compile(`
+    <script setup>
+    const transformed = transform(defineEmits(['foo', 'bar']));
+    </script>
+    `)
+
+    // should remove defineEmits import and call
+    expect(content).not.toMatch('defineEmits')
+
+    assertCode(content)
+    expect(content).toMatch(`const transformed = transform(__emit);`)
+  })
+
   describe('errors', () => {
     test('w/ both type and non-type args', () => {
       expect(() => {

--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -211,38 +211,42 @@ color: red
     expect(
       compileScoped(`.div { color: red; } .div:where(:hover) { color: blue; }`),
     ).toMatchInlineSnapshot(`
-    ".div[data-v-test] { color: red;
-    }
-    .div[data-v-test]:where(:hover) { color: blue;
-    }"`)
+      ".div[data-v-test] { color: red;
+      }
+      .div[data-v-test]:where(:hover) { color: blue;
+      }"
+    `)
 
     expect(
       compileScoped(`.div { color: red; } .div:is(:hover) { color: blue; }`),
     ).toMatchInlineSnapshot(`
-    ".div[data-v-test] { color: red;
-    }
-    .div[data-v-test]:is(:hover) { color: blue;
-    }"`)
+      ".div[data-v-test] { color: red;
+      }
+      .div[data-v-test]:is(:hover) { color: blue;
+      }"
+    `)
 
     expect(
       compileScoped(
         `.div { color: red; } .div:where(.foo:hover) { color: blue; }`,
       ),
     ).toMatchInlineSnapshot(`
-    ".div[data-v-test] { color: red;
-    }
-    .div[data-v-test]:where(.foo:hover) { color: blue;
-    }"`)
+      ".div[data-v-test] { color: red;
+      }
+      .div[data-v-test]:where(.foo:hover) { color: blue;
+      }"
+    `)
 
     expect(
       compileScoped(
         `.div { color: red; } .div:is(.foo:hover) { color: blue; }`,
       ),
     ).toMatchInlineSnapshot(`
-    ".div[data-v-test] { color: red;
-    }
-    .div[data-v-test]:is(.foo:hover) { color: blue;
-    }"`)
+      ".div[data-v-test] { color: red;
+      }
+      .div[data-v-test]:is(.foo:hover) { color: blue;
+      }"
+    `)
   })
 
   test('media query', () => {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -46,6 +46,8 @@ import {
   DEFINE_EMITS,
   genRuntimeEmits,
   processDefineEmits,
+  processNestedDefineEmits,
+  replaceDefineEmits,
 } from './script/defineEmits'
 import { DEFINE_EXPOSE, processDefineExpose } from './script/defineExpose'
 import { DEFINE_OPTIONS, processDefineOptions } from './script/defineOptions'
@@ -544,7 +546,7 @@ export function compileScript(
 
           // defineEmits
           const isDefineEmits =
-            !isDefineProps && processDefineEmits(ctx, init, decl.id)
+            !isDefineProps && processNestedDefineEmits(ctx, init, decl.id)
           !isDefineEmits &&
             (processDefineSlots(ctx, init, decl.id) ||
               processDefineModel(ctx, init, decl.id))
@@ -572,11 +574,7 @@ export function compileScript(
               left--
             }
           } else if (isDefineEmits) {
-            ctx.s.overwrite(
-              startOffset + init.start!,
-              startOffset + init.end!,
-              '__emit',
-            )
+            replaceDefineEmits(ctx, init)
           } else {
             lastNonRemoved = i
           }

--- a/packages/compiler-sfc/src/script/defineEmits.ts
+++ b/packages/compiler-sfc/src/script/defineEmits.ts
@@ -16,6 +16,36 @@ import {
 
 export const DEFINE_EMITS = 'defineEmits'
 
+/**
+ * Detects if this node recursively contains a call to `defineEmits()`.
+ *
+ * @returns true If the given node itself is a call to `defineEmits()` and should be removed, false otherwise.
+ */
+export function processNestedDefineEmits(
+  ctx: ScriptCompileContext,
+  node: Node,
+  declId?: LVal,
+): boolean {
+  if (node.type !== 'CallExpression') {
+    return false
+  }
+  if (processDefineEmits(ctx, node, declId)) {
+    return true
+  }
+  for (const arg of node.arguments) {
+    if (processNestedDefineEmits(ctx, arg)) {
+      replaceDefineEmits(ctx, arg)
+    }
+  }
+
+  return false
+}
+
+/**
+ * Detects if the node is a call to `defineEmits()`.
+ *
+ * @returns true If the given node itself is a call to `defineEmits()` and should be removed, false otherwise.
+ */
 export function processDefineEmits(
   ctx: ScriptCompileContext,
   node: Node,
@@ -43,6 +73,17 @@ export function processDefineEmits(
   ctx.emitDecl = declId
 
   return true
+}
+
+export function replaceDefineEmits(
+  ctx: ScriptCompileContext,
+  node: Node,
+): void {
+  ctx.s.overwrite(
+    ctx.startOffset! + node.start!,
+    ctx.startOffset! + node.end!,
+    '__emit',
+  )
 }
 
 export function genRuntimeEmits(ctx: ScriptCompileContext): string | undefined {


### PR DESCRIPTION
I'm not sure whether this is a fix or a feature.

This PR allows calling `defineEmits` as an argument of another method.

````ts
const transformed = transform(defineEmits(['foo', 'bar']));
````

**My Usecase**

````ts
const { foo, bar } = toEmitFunctions(defineEmits(['foo', 'bar']));

foo(); // equivalent to emit('foo') including correct argument typing
````

<details>
<summary><code>toEmitFunctions</code> definition</summary>

````ts
import { getCurrentInstance } from 'vue';

type EmitterOverloads<T extends (event: string, ...args: unknown[]) => void> =
  T extends {
    (event: infer N0, ...args: infer A0): void;
    (event: infer N1, ...args: infer A1): void;
    (event: infer N2, ...args: infer A2): void;
    (event: infer N3, ...args: infer A3): void;
    (event: infer N4, ...args: infer A4): void;
    (event: infer N5, ...args: infer A5): void;
    (event: infer N6, ...args: infer A6): void;
    (event: infer N7, ...args: infer A7): void;
    (event: infer N8, ...args: infer A8): void;
    (event: infer N9, ...args: infer A9): void;
  }
    ? [
        [N0, (...args: A0) => void],
        [N1, A0 extends A1 ? never : (...args: A1) => void],
        [N2, A1 extends A2 ? never : (...args: A2) => void],
        [N3, A2 extends A3 ? never : (...args: A3) => void],
        [N4, A3 extends A4 ? never : (...args: A4) => void],
        [N5, A4 extends A5 ? never : (...args: A5) => void],
        [N6, A5 extends A6 ? never : (...args: A6) => void],
        [N7, A6 extends A7 ? never : (...args: A7) => void],
        [N8, A7 extends A8 ? never : (...args: A8) => void],
        [N9, A8 extends A9 ? never : (...args: A9) => void],
      ]
    : never;

type TupleToRecord<T extends ReadonlyArray<[string, unknown]>> = {
  [K in T[number] as K[0]]: K[1];
};

// eslint-disable-next-line @typescript-eslint/no-explicit-any
export function toEmitFunctions<T extends (...args: any) => void>(
  emit: T
): TupleToRecord<EmitterOverloads<T>> {
  const instance = getCurrentInstance();
  if (!instance) {
    throw new Error('useEmitters must be called within setup()');
  }

  return new Proxy(
    {},
    {
      get(_, key: string) {
        return (...args: unknown[]) => emit(key, ...args);
      },
    }
  ) as TupleToRecord<EmitterOverloads<T>>;
}
````

</details>

Without this patch, you have to use the following code:

````ts
const emit = defineEmits(['foo', 'bar']); // This must be on a separate line
const { foo, bar } = toEmitFunctions(emit); 

foo();
````

poluting the scope with the `emit` variable, that shouldn't be used after this.
