### PR TITLE
chore: add pnpm setting to pnpm-workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,22 +111,5 @@
     "typescript-eslint": "^8.31.1",
     "vite": "catalog:",
     "vitest": "^3.0.9"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "typescript-eslint>eslint": "^9.0.0",
-        "@typescript-eslint/eslint-plugin>eslint": "^9.0.0",
-        "@typescript-eslint/parser>eslint": "^9.0.0",
-        "@typescript-eslint/type-utils>eslint": "^9.0.0",
-        "@typescript-eslint/utils>eslint": "^9.0.0"
-      }
-    },
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild",
-      "puppeteer",
-      "simple-git-hooks"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,18 @@ catalog:
   'source-map-js': ^1.2.1
   'vite': ^5.4.15
   '@vitejs/plugin-vue': ^5.2.3
+
+onlyBuiltDependencies:
+  - '@swc/core'
+  - 'esbuild'
+  - 'puppeteer'
+  - 'simple-git-hooks'
+  - 'unrs-resolver'
+
+peerDependencyRules:
+  allowedVersions:
+    'typescript-eslint>eslint': '^9.0.0'
+    '@typescript-eslint/eslint-plugin>eslint': '^9.0.0'
+    '@typescript-eslint/parser>eslint': '^9.0.0'
+    '@typescript-eslint/type-utils>eslint': '^9.0.0'
+    '@typescript-eslint/utils>eslint': '^9.0.0'


### PR DESCRIPTION
To ease management and avoid conflicts with npm, pnpm supports moving all configurations to the pnpm-workspace.yaml file. For more [github.com/orgs/pnpm/discussions/9037](https://github.com/orgs/pnpm/discussions/9037)