### PR TITLE
refactor: replace inline type checks with shared utils

### DIFF
--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -6,7 +6,7 @@ import {
   currentInstance,
   isInSSRComponentSetup,
 } from './component'
-import { isFunction, isObject } from '@vue/shared'
+import { isFunction, isNullish, isObject } from '@vue/shared'
 import type { ComponentPublicInstance } from './componentPublicInstance'
 import { type VNode, createVNode } from './vnode'
 import { defineComponent } from './apiDefineComponent'
@@ -191,7 +191,7 @@ export function defineAsyncComponent<
         }, delay)
       }
 
-      if (timeout != null) {
+      if (!isNullish(timeout)) {
         setTimeout(() => {
           if (!loaded.value && !error.value) {
             const err = new Error(

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -22,7 +22,7 @@ import { warn } from './warning'
 import { type VNode, cloneVNode, createVNode } from './vnode'
 import type { RootHydrateFunction } from './hydration'
 import { devtoolsInitApp, devtoolsUnmountApp } from './devtools'
-import { NO, extend, isFunction, isObject } from '@vue/shared'
+import { NO, extend, isFunction, isNullish, isObject } from '@vue/shared'
 import { version } from '.'
 import { installAppCompatProperties } from './compat/global'
 import type { NormalizedPropsOptions } from './componentProps'
@@ -259,7 +259,7 @@ export function createAppAPI<HostElement>(
       rootComponent = extend({}, rootComponent)
     }
 
-    if (rootProps != null && !isObject(rootProps)) {
+    if (!isNullish(rootProps) && !isObject(rootProps)) {
       __DEV__ && warn(`root props passed to app.mount() must be an object.`)
       rootProps = null
     }

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -1,4 +1,4 @@
-import { isFunction } from '@vue/shared'
+import { isFunction, isNullish } from '@vue/shared'
 import { currentInstance } from './component'
 import { currentRenderingInstance } from './componentRenderContext'
 import { currentApp } from './apiCreateApp'
@@ -62,7 +62,7 @@ export function inject(
     const provides = currentApp
       ? currentApp._context.provides
       : instance
-        ? instance.parent == null
+        ? isNullish(instance.parent)
           ? instance.vnode.appContext && instance.vnode.appContext.provides
           : instance.parent.provides
         : undefined

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -68,6 +68,7 @@ import {
   getGlobalThis,
   isArray,
   isFunction,
+  isNullish,
   isObject,
   isPromise,
   makeMap,
@@ -1127,7 +1128,7 @@ export function createSetupContext(
       if (instance.exposed) {
         warn(`expose() should be called only once per setup().`)
       }
-      if (exposed != null) {
+      if (!isNullish(exposed)) {
         let exposedType: string = typeof exposed
         if (exposedType === 'object') {
           if (isArray(exposed)) {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -15,6 +15,7 @@ import {
   extend,
   isArray,
   isFunction,
+  isNullish,
   isObject,
   isPromise,
   isString,
@@ -768,7 +769,7 @@ export function applyOptions(instance: ComponentInternalInstance): void {
   if (render && instance.render === NOOP) {
     instance.render = render as InternalRenderFunction
   }
-  if (inheritAttrs != null) {
+  if (!isNullish(inheritAttrs)) {
     instance.inheritAttrs = inheritAttrs
   }
 

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -17,6 +17,7 @@ import {
   hyphenate,
   isArray,
   isFunction,
+  isNullish,
   isObject,
   isOn,
   isReservedProp,
@@ -455,7 +456,7 @@ function resolvePropValue(
   isAbsent: boolean,
 ) {
   const opt = options[key]
-  if (opt != null) {
+  if (!isNullish(opt)) {
     const hasDefault = hasOwn(opt, 'default')
     // default values
     if (hasDefault && value === undefined) {
@@ -631,7 +632,7 @@ function getType(ctor: Prop<any> | null): string {
   }
 
   // Avoid using regex for common cases by checking the type directly
-  if (typeof ctor === 'function') {
+  if (isFunction(ctor)) {
     // Using name property to avoid converting function to string
     return ctor.name || ''
   } else if (typeof ctor === 'object') {
@@ -657,7 +658,7 @@ function validateProps(
   const camelizePropsKey = Object.keys(rawProps).map(key => camelize(key))
   for (const key in options) {
     let opt = options[key]
-    if (opt == null) continue
+    if (isNullish(opt)) continue
     validateProp(
       key,
       resolvedValues[key],
@@ -685,11 +686,11 @@ function validateProp(
     return
   }
   // missing but optional
-  if (value == null && !required) {
+  if (isNullish(value) && !required) {
     return
   }
   // type check
-  if (type != null && type !== true && !skipCheck) {
+  if (!isNullish(type) && type !== true && !skipCheck) {
     let isValid = false
     const types = isArray(type) ? type : [type]
     const expectedTypes = []

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -22,6 +22,7 @@ import {
   hasOwn,
   isFunction,
   isGloballyAllowed,
+  isNullish,
   isString,
 } from '@vue/shared'
 import {
@@ -596,7 +597,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     key: string,
     descriptor: PropertyDescriptor,
   ) {
-    if (descriptor.get != null) {
+    if (!isNullish(descriptor.get)) {
       // invalidate key cache of a getter based property #5417
       target._.accessCache![key] = 0
     } else if (hasOwn(descriptor, 'value')) {

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -14,6 +14,7 @@ import {
   def,
   isArray,
   isFunction,
+  isNullish,
 } from '@vue/shared'
 import { warn } from './warning'
 import { isKeepAlive } from './components/KeepAlive'
@@ -133,7 +134,7 @@ const normalizeObjectSlots = (
     const value = rawSlots[key]
     if (isFunction(value)) {
       slots[key] = normalizeSlot(key, value, ctx)
-    } else if (value != null) {
+    } else if (!isNullish(value)) {
       if (
         __DEV__ &&
         !(
@@ -248,7 +249,7 @@ export const updateSlots = (
   // delete stale slots
   if (needDeletionCheck) {
     for (const key in slots) {
-      if (!isInternalKey(key) && deletionComparisonTarget[key] == null) {
+      if (!isInternalKey(key) && isNullish(deletionComparisonTarget[key])) {
         delete slots[key]
       }
     }

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -16,7 +16,13 @@ import { warn } from '../warning'
 import { isKeepAlive } from './KeepAlive'
 import { toRaw } from '@vue/reactivity'
 import { ErrorCodes, callWithAsyncErrorHandling } from '../errorHandling'
-import { PatchFlags, ShapeFlags, isArray, isFunction } from '@vue/shared'
+import {
+  PatchFlags,
+  ShapeFlags,
+  isArray,
+  isFunction,
+  isNullish,
+} from '@vue/shared'
 import { onBeforeUnmount, onMounted } from '../apiLifecycle'
 import { isTeleport } from './Teleport'
 import type { RendererElement } from '../renderer'
@@ -545,10 +551,9 @@ export function getTransitionRawChildren(
   for (let i = 0; i < children.length; i++) {
     let child = children[i]
     // #5360 inherit parent key in case of <template v-for>
-    const key =
-      parentKey == null
-        ? child.key
-        : String(parentKey) + String(child.key != null ? child.key : i)
+    const key = isNullish(parentKey)
+      ? child.key
+      : String(parentKey) + String(!isNullish(child.key) ? child.key : i)
     // handle fragment children case, e.g. v-for
     if (child.type === Fragment) {
       if (child.patchFlag & PatchFlags.KEYED_FRAGMENT) keyedFragmentCount++
@@ -558,7 +563,7 @@ export function getTransitionRawChildren(
     }
     // comment placeholders should be skipped, e.g. v-if
     else if (keepComment || child.type !== Comment) {
-      ret.push(key != null ? cloneVNode(child, { key }) : child)
+      ret.push(!isNullish(key) ? cloneVNode(child, { key }) : child)
     }
   }
   // #1126 if a transition children list contains multiple sub fragments, these

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -28,6 +28,7 @@ import {
   ShapeFlags,
   invokeArrayFns,
   isArray,
+  isNullish,
   isRegExp,
   isString,
   remove,
@@ -237,7 +238,7 @@ const KeepAliveImpl: ComponentOptions = {
     let pendingCacheKey: CacheKey | null = null
     const cacheSubtree = () => {
       // fix #1621, the pendingCacheKey could be 0
-      if (pendingCacheKey != null) {
+      if (!isNullish(pendingCacheKey)) {
         // if KeepAlive child is a Suspense, it needs to be cached after Suspense resolves
         // avoid caching vnode that not been mounted
         if (isSuspense(instance.subTree.type)) {
@@ -321,7 +322,7 @@ const KeepAliveImpl: ComponentOptions = {
         return rawVNode
       }
 
-      const key = vnode.key == null ? comp : vnode.key
+      const key = isNullish(vnode.key) ? comp : vnode.key
       const cachedVNode = cache.get(key)
 
       // clone vnode if it's reused because we are going to mutate it

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -10,7 +10,14 @@ import {
   normalizeVNode,
   openBlock,
 } from '../vnode'
-import { ShapeFlags, isArray, isFunction, toNumber } from '@vue/shared'
+import {
+  ShapeFlags,
+  isArray,
+  isFunction,
+  isNullish,
+  isNumber,
+  toNumber,
+} from '@vue/shared'
 import { type ComponentInternalInstance, handleSetupResult } from '../component'
 import type { Slots } from '../componentSlots'
 import {
@@ -78,7 +85,7 @@ export const SuspenseImpl = {
     // platform-specific impl passed from renderer
     rendererInternals: RendererInternals,
   ): void {
-    if (n1 == null) {
+    if (isNullish(n1)) {
       mountSuspense(
         n2,
         container,
@@ -501,7 +508,7 @@ function createSuspenseBoundary(
     hiddenContainer,
     deps: 0,
     pendingId: suspenseId++,
-    timeout: typeof timeout === 'number' ? timeout : -1,
+    timeout: isNumber(timeout) ? timeout : -1,
     activeBranch: null,
     pendingBranch: null,
     isInFallback: !isHydrating,
@@ -900,5 +907,5 @@ function setActiveBranch(suspense: SuspenseBoundary, branch: VNode) {
 
 function isVNodeSuspensible(vnode: VNode) {
   const suspensible = vnode.props && vnode.props.suspensible
-  return suspensible != null && suspensible !== false
+  return !isNullish(suspensible) && suspensible !== false
 }

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -11,7 +11,7 @@ import {
   traverseStaticChildren,
 } from '../renderer'
 import type { VNode, VNodeArrayChildren, VNodeProps } from '../vnode'
-import { ShapeFlags, isString } from '@vue/shared'
+import { ShapeFlags, isFunction, isNullish, isString } from '@vue/shared'
 import { warn } from '../warning'
 import { isHmrUpdating } from '../hmr'
 
@@ -37,7 +37,7 @@ const isTargetSVG = (target: RendererElement): boolean =>
   typeof SVGElement !== 'undefined' && target instanceof SVGElement
 
 const isTargetMathML = (target: RendererElement): boolean =>
-  typeof MathMLElement === 'function' && target instanceof MathMLElement
+  isFunction(MathMLElement) && target instanceof MathMLElement
 
 const resolveTarget = <T = RendererElement>(
   props: TeleportProps | null,
@@ -104,7 +104,7 @@ export const TeleportImpl = {
       dynamicChildren = null
     }
 
-    if (n1 == null) {
+    if (isNullish(n1)) {
       // insert anchors in the main view
       const placeholder = (n2.el = __DEV__
         ? createComment('teleport start')

--- a/packages/runtime-core/src/customFormatter.ts
+++ b/packages/runtime-core/src/customFormatter.ts
@@ -8,7 +8,16 @@ import {
   resetTracking,
   toRaw,
 } from '@vue/reactivity'
-import { EMPTY_OBJ, extend, isArray, isFunction, isObject } from '@vue/shared'
+import {
+  EMPTY_OBJ,
+  extend,
+  isArray,
+  isBoolean,
+  isFunction,
+  isNumber,
+  isObject,
+  isString,
+} from '@vue/shared'
 import type { ComponentInternalInstance, ComponentOptions } from './component'
 import type { ComponentPublicInstance } from './componentPublicInstance'
 
@@ -151,11 +160,11 @@ export function initCustomFormatter(): void {
   }
 
   function formatValue(v: unknown, asRaw = true) {
-    if (typeof v === 'number') {
+    if (isNumber(v)) {
       return ['span', numberStyle, v]
-    } else if (typeof v === 'string') {
+    } else if (isString(v)) {
       return ['span', stringStyle, JSON.stringify(v)]
-    } else if (typeof v === 'boolean') {
+    } else if (isBoolean(v)) {
       return ['span', keywordStyle, v]
     } else if (isObject(v)) {
       return ['object', { object: asRaw ? toRaw(v) : v }]

--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -2,6 +2,7 @@
 import type { App } from './apiCreateApp'
 import { Comment, Fragment, Static, Text } from './vnode'
 import type { ComponentInternalInstance } from './component'
+import { isFunction } from '@vue/shared'
 
 interface AppRecord {
   id: number
@@ -115,7 +116,7 @@ export const devtoolsComponentRemoved = (
 ): void => {
   if (
     devtools &&
-    typeof devtools.cleanupBuffer === 'function' &&
+    isFunction(devtools.cleanupBuffer) &&
     // remove the component if it wasn't buffered
     !devtools.cleanupBuffer(component)
   ) {

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -7,7 +7,7 @@ import {
   toReactive,
   toReadonly,
 } from '@vue/reactivity'
-import { isArray, isObject, isString } from '@vue/shared'
+import { isArray, isNumber, isObject, isString } from '@vue/shared'
 import { warn } from '../warning'
 
 /**
@@ -90,7 +90,7 @@ export function renderList(
         cached && cached[i],
       )
     }
-  } else if (typeof source === 'number') {
+  } else if (isNumber(source)) {
     if (__DEV__ && !Number.isInteger(source)) {
       warn(`The v-for range expect an integer value but got ${source}.`)
     }

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -23,6 +23,7 @@ import {
   isBooleanAttr,
   isKnownHtmlAttr,
   isKnownSvgAttr,
+  isNullish,
   isOn,
   isRenderableAttrValue,
   isReservedProp,
@@ -357,7 +358,7 @@ export function createHydrationFunctions(
         }
     }
 
-    if (ref != null) {
+    if (!isNullish(ref)) {
       setRef(ref, null, parentSuspense, vnode)
     }
 
@@ -838,7 +839,7 @@ function propHasMismatch(
     if (isBooleanAttr(key)) {
       actual = el.hasAttribute(key)
       expected = includeBooleanAttr(clientValue)
-    } else if (clientValue == null) {
+    } else if (isNullish(clientValue)) {
       actual = el.hasAttribute(key)
       expected = false
     } else {
@@ -860,7 +861,7 @@ function propHasMismatch(
     }
   }
 
-  if (mismatchType != null && !isMismatchAllowed(el, mismatchType)) {
+  if (!isNullish(mismatchType) && !isMismatchAllowed(el, mismatchType)) {
     const format = (v: any) =>
       v === false ? `(not rendered)` : `${mismatchKey}="${v}"`
     const preSegment = `Hydration ${MismatchTypeString[mismatchType]} mismatch on`
@@ -980,7 +981,7 @@ function isMismatchAllowed(
     }
   }
   const allowedAttr = el && el.getAttribute(allowMismatchAttr)
-  if (allowedAttr == null) {
+  if (isNullish(allowedAttr)) {
     return false
   } else if (allowedAttr === '') {
     return true

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -37,6 +37,7 @@ import {
   getGlobalThis,
   invokeArrayFns,
   isArray,
+  isNullish,
   isReservedProp,
 } from '@vue/shared'
 import {
@@ -406,7 +407,7 @@ function baseCreateRenderer(
         processCommentNode(n1, n2, container, anchor)
         break
       case Static:
-        if (n1 == null) {
+        if (isNullish(n1)) {
           mountStaticNode(n2, container, anchor, namespace)
         } else if (__DEV__) {
           patchStaticNode(n1, n2, container, namespace)
@@ -482,13 +483,13 @@ function baseCreateRenderer(
     }
 
     // set ref
-    if (ref != null && parentComponent) {
+    if (!isNullish(ref) && parentComponent) {
       setRef(ref, n1 && n1.ref, parentSuspense, n2 || n1, !n2)
     }
   }
 
   const processText: ProcessTextOrCommentFn = (n1, n2, container, anchor) => {
-    if (n1 == null) {
+    if (isNullish(n1)) {
       hostInsert(
         (n2.el = hostCreateText(n2.children as string)),
         container,
@@ -508,7 +509,7 @@ function baseCreateRenderer(
     container,
     anchor,
   ) => {
-    if (n1 == null) {
+    if (isNullish(n1)) {
       hostInsert(
         (n2.el = hostCreateComment((n2.children as string) || '')),
         container,
@@ -606,7 +607,7 @@ function baseCreateRenderer(
       namespace = 'mathml'
     }
 
-    if (n1 == null) {
+    if (isNullish(n1)) {
       mountElement(
         n2,
         container,
@@ -837,8 +838,8 @@ function baseCreateRenderer(
     // #9135 innerHTML / textContent unset needs to happen before possible
     // new children mount
     if (
-      (oldProps.innerHTML && newProps.innerHTML == null) ||
-      (oldProps.textContent && newProps.textContent == null)
+      (oldProps.innerHTML && isNullish(newProps.innerHTML)) ||
+      (oldProps.textContent && isNullish(newProps.textContent))
     ) {
       hostSetElementText(el, '')
     }
@@ -923,7 +924,7 @@ function baseCreateRenderer(
           hostSetElementText(el, n2.children as string)
         }
       }
-    } else if (!optimized && dynamicChildren == null) {
+    } else if (!optimized && isNullish(dynamicChildren)) {
       // unoptimized, full diff
       patchProps(el, oldProps, newProps, parentComponent, namespace)
     }
@@ -1052,7 +1053,7 @@ function baseCreateRenderer(
         : fragmentSlotScopeIds
     }
 
-    if (n1 == null) {
+    if (isNullish(n1)) {
       hostInsert(fragmentStartAnchor, container, anchor)
       hostInsert(fragmentEndAnchor, container, anchor)
       // a fragment can only have array children
@@ -1100,7 +1101,7 @@ function baseCreateRenderer(
           //  get moved around. Make sure all root level vnodes inherit el.
           // #2134 or if it's a component root, it may also get moved around
           // as the component is being moved.
-          n2.key != null ||
+          !isNullish(n2.key) ||
           (parentComponent && n2 === parentComponent.subTree)
         ) {
           traverseStaticChildren(n1, n2, true /* shallow */)
@@ -1137,7 +1138,7 @@ function baseCreateRenderer(
     optimized: boolean,
   ) => {
     n2.slotScopeIds = slotScopeIds
-    if (n1 == null) {
+    if (isNullish(n1)) {
       if (n2.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
         ;(parentComponent!.ctx as KeepAliveContext).activate(
           n2,
@@ -1887,7 +1888,7 @@ function baseCreateRenderer(
         const nextChild = (c2[i] = optimized
           ? cloneIfMounted(c2[i] as VNode)
           : normalizeVNode(c2[i]))
-        if (nextChild.key != null) {
+        if (!isNullish(nextChild.key)) {
           if (__DEV__ && keyToNewIndexMap.has(nextChild.key)) {
             warn(
               `Duplicate keys found during update:`,
@@ -1923,7 +1924,7 @@ function baseCreateRenderer(
           continue
         }
         let newIndex
-        if (prevChild.key != null) {
+        if (!isNullish(prevChild.key)) {
           newIndex = keyToNewIndexMap.get(prevChild.key)
         } else {
           // key-less node, try to locate a key-less node of the same type
@@ -2097,14 +2098,14 @@ function baseCreateRenderer(
     }
 
     // unset ref
-    if (ref != null) {
+    if (!isNullish(ref)) {
       pauseTracking()
       setRef(ref, null, parentSuspense, vnode, true)
       resetTracking()
     }
 
     // #6593 should clean memo cache when unmount
-    if (cacheIndex != null) {
+    if (!isNullish(cacheIndex)) {
       parentComponent!.renderCache[cacheIndex] = undefined
     }
 
@@ -2377,7 +2378,7 @@ function baseCreateRenderer(
 
   let isFlushing = false
   const render: RootRenderFunction = (vnode, container, namespace) => {
-    if (vnode == null) {
+    if (isNullish(vnode)) {
       if (container._vnode) {
         unmount(container._vnode, null, null, true)
       }

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -6,6 +6,7 @@ import {
   hasOwn,
   isArray,
   isFunction,
+  isNullish,
   isString,
   remove,
 } from '@vue/shared'
@@ -95,7 +96,7 @@ export function setRef(
         }
 
   // dynamic ref changed. unset old ref
-  if (oldRef != null && oldRef !== ref) {
+  if (!isNullish(oldRef) && oldRef !== ref) {
     if (isString(oldRef)) {
       refs[oldRef] = null
       if (canSetSetupRef(oldRef)) {

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -1,5 +1,5 @@
 import { ErrorCodes, callWithErrorHandling, handleError } from './errorHandling'
-import { NOOP, isArray } from '@vue/shared'
+import { NOOP, isArray, isNullish } from '@vue/shared'
 import { type ComponentInternalInstance, getComponentName } from './component'
 
 export enum SchedulerJobFlags {
@@ -204,7 +204,11 @@ export function flushPostFlushCbs(seen?: CountMap): void {
 }
 
 const getId = (job: SchedulerJob): number =>
-  job.id == null ? (job.flags! & SchedulerJobFlags.PRE ? -1 : Infinity) : job.id
+  isNullish(job.id)
+    ? job.flags! & SchedulerJobFlags.PRE
+      ? -1
+      : Infinity
+    : job.id
 
 function flushJobs(seen?: CountMap) {
   if (__DEV__) {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -5,7 +5,10 @@ import {
   SlotFlags,
   extend,
   isArray,
+  isBoolean,
   isFunction,
+  isNullish,
+  isNumber,
   isObject,
   isOn,
   isString,
@@ -432,18 +435,18 @@ const createVNodeWithArgsTransform = (
 }
 
 const normalizeKey = ({ key }: VNodeProps): VNode['key'] =>
-  key != null ? key : null
+  !isNullish(key) ? key : null
 
 const normalizeRef = ({
   ref,
   ref_key,
   ref_for,
 }: VNodeProps): VNodeNormalizedRefAtom | null => {
-  if (typeof ref === 'number') {
+  if (isNumber(ref)) {
     ref = '' + ref
   }
   return (
-    ref != null
+    !isNullish(ref)
       ? isString(ref) || isRef(ref) || isFunction(ref)
         ? { i: currentRenderingInstance, r: ref, k: ref_key, f: !!ref_for }
         : ref
@@ -782,7 +785,7 @@ export function createCommentVNode(
 }
 
 export function normalizeVNode(child: VNodeChild): VNode {
-  if (child == null || typeof child === 'boolean') {
+  if (isNullish(child) || isBoolean(child)) {
     // empty placeholder
     return createVNode(Comment)
   } else if (isArray(child)) {
@@ -814,7 +817,7 @@ export function cloneIfMounted(child: VNode): VNode {
 export function normalizeChildren(vnode: VNode, children: unknown): void {
   let type = 0
   const { shapeFlag } = vnode
-  if (children == null) {
+  if (isNullish(children)) {
     children = null
   } else if (isArray(children)) {
     type = ShapeFlags.ARRAY_CHILDREN

--- a/packages/runtime-core/src/warning.ts
+++ b/packages/runtime-core/src/warning.ts
@@ -5,7 +5,13 @@ import {
   type Data,
   formatComponentName,
 } from './component'
-import { isFunction, isString } from '@vue/shared'
+import {
+  isBoolean,
+  isFunction,
+  isNullish,
+  isNumber,
+  isString,
+} from '@vue/shared'
 import { isRef, pauseTracking, resetTracking, toRaw } from '@vue/reactivity'
 import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 
@@ -119,7 +125,7 @@ function formatTrace(trace: ComponentTraceStack): any[] {
 function formatTraceEntry({ vnode, recurseCount }: TraceEntry): any[] {
   const postfix =
     recurseCount > 0 ? `... (${recurseCount} recursive calls)` : ``
-  const isRoot = vnode.component ? vnode.component.parent == null : false
+  const isRoot = vnode.component ? isNullish(vnode.component.parent) : false
   const open = ` at <${formatComponentName(
     vnode.component,
     vnode.type,
@@ -149,11 +155,7 @@ function formatProp(key: string, value: unknown, raw?: boolean): any {
   if (isString(value)) {
     value = JSON.stringify(value)
     return raw ? value : [`${key}=${value}`]
-  } else if (
-    typeof value === 'number' ||
-    typeof value === 'boolean' ||
-    value == null
-  ) {
+  } else if (isNumber(value) || isBoolean(value) || isNullish(value)) {
     return raw ? value : [`${key}=${value}`]
   } else if (isRef(value)) {
     value = formatProp(key, toRaw(value.value), true)

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -38,7 +38,9 @@ import {
   hasOwn,
   hyphenate,
   isArray,
+  isNumber,
   isPlainObject,
+  isString,
   toNumber,
 } from '@vue/shared'
 import { createApp, createSSRApp, render } from '.'
@@ -509,7 +511,7 @@ export class VueElement
         ob && ob.disconnect()
         if (val === true) {
           this.setAttribute(hyphenate(key), '')
-        } else if (typeof val === 'string' || typeof val === 'number') {
+        } else if (isString(val) || isNumber(val)) {
           this.setAttribute(hyphenate(key), val + '')
         } else if (!val) {
           this.removeAttribute(hyphenate(key))

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -8,7 +8,7 @@ import {
   compatUtils,
   h,
 } from '@vue/runtime-core'
-import { extend, isArray, isObject, toNumber } from '@vue/shared'
+import { extend, isArray, isNullish, isObject, toNumber } from '@vue/shared'
 
 const TRANSITION = 'transition'
 const ANIMATION = 'animation'
@@ -300,7 +300,7 @@ export function resolveTransitionProps(
 function normalizeDuration(
   duration: TransitionProps['duration'],
 ): [number, number] | null {
-  if (duration == null) {
+  if (isNullish(duration)) {
     return null
   } else if (isObject(duration)) {
     return [NumberOf(duration.enter), NumberOf(duration.leave)]
@@ -358,7 +358,7 @@ function whenTransitionEnds(
     }
   }
 
-  if (explicitTimeout != null) {
+  if (!isNullish(explicitTimeout)) {
     return setTimeout(resolveIfNotStale, explicitTimeout)
   }
 

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -27,7 +27,7 @@ import {
   useTransitionState,
   warn,
 } from '@vue/runtime-core'
-import { extend } from '@vue/shared'
+import { extend, isNullish } from '@vue/shared'
 
 const positionMap = new WeakMap<VNode, DOMRect>()
 const newPositionMap = new WeakMap<VNode, DOMRect>()
@@ -157,7 +157,7 @@ const TransitionGroupImpl: ComponentOptions = /*@__PURE__*/ decorate({
 
       for (let i = 0; i < children.length; i++) {
         const child = children[i]
-        if (child.key != null) {
+        if (!isNullish(child.key)) {
           setTransitionHooks(
             child,
             resolveTransitionHooks(child, cssTransitionProps, state, instance),

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -10,6 +10,7 @@ import { addEventListener } from '../modules/events'
 import {
   invokeArrayFns,
   isArray,
+  isNullish,
   isSet,
   looseEqual,
   looseIndexOf,
@@ -83,7 +84,7 @@ export const vModelText: ModelDirective<
   },
   // set value on mounted so it's after min/max for type="range"
   mounted(el, { value }) {
-    el.value = value == null ? '' : value
+    el.value = isNullish(value) ? '' : value
   },
   beforeUpdate(
     el,
@@ -97,7 +98,7 @@ export const vModelText: ModelDirective<
       (number || el.type === 'number') && !/^0\d/.test(el.value)
         ? looseToNumber(el.value)
         : el.value
-    const newValue = value == null ? '' : value
+    const newValue = isNullish(value) ? '' : value
 
     if (elValue === newValue) {
       return

--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -170,10 +170,7 @@ function resolveRootNamespace(
   if (container instanceof SVGElement) {
     return 'svg'
   }
-  if (
-    typeof MathMLElement === 'function' &&
-    container instanceof MathMLElement
-  ) {
+  if (isFunction(MathMLElement) && container instanceof MathMLElement) {
     return 'mathml'
   }
 }

--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -1,6 +1,7 @@
 import {
   NOOP,
   includeBooleanAttr,
+  isNullish,
   isSpecialBooleanAttr,
   isSymbol,
   makeMap,
@@ -22,7 +23,7 @@ export function patchAttr(
   isBoolean: boolean = isSpecialBooleanAttr(key),
 ): void {
   if (isSVG && key.startsWith('xlink:')) {
-    if (value == null) {
+    if (isNullish(value)) {
       el.removeAttributeNS(xlinkNS, key.slice(6, key.length))
     } else {
       el.setAttributeNS(xlinkNS, key, value)
@@ -34,7 +35,7 @@ export function patchAttr(
 
     // note we are only checking boolean attributes that don't have a
     // corresponding dom prop of the same name here.
-    if (value == null || (isBoolean && !includeBooleanAttr(value))) {
+    if (isNullish(value) || (isBoolean && !includeBooleanAttr(value))) {
       el.removeAttribute(key)
     } else {
       // attribute value is a string https://html.spec.whatwg.org/multipage/dom.html#attributes

--- a/packages/runtime-dom/src/modules/class.ts
+++ b/packages/runtime-dom/src/modules/class.ts
@@ -1,3 +1,4 @@
+import { isNullish } from '@vue/shared'
 import { type ElementWithTransition, vtcKey } from '../components/Transition'
 
 // compiler should normalize class + :class bindings on the same element
@@ -16,7 +17,7 @@ export function patchClass(
       value ? [value, ...transitionClasses] : [...transitionClasses]
     ).join(' ')
   }
-  if (value == null) {
+  if (isNullish(value)) {
     el.removeAttribute('class')
   } else if (isSVG) {
     el.setAttribute('class', value)

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -1,4 +1,10 @@
-import { capitalize, hyphenate, isArray, isString } from '@vue/shared'
+import {
+  capitalize,
+  hyphenate,
+  isArray,
+  isNullish,
+  isString,
+} from '@vue/shared'
 import { camelize, warn } from '@vue/runtime-core'
 import {
   type VShowElement,
@@ -19,14 +25,14 @@ export function patchStyle(el: Element, prev: Style, next: Style): void {
     if (prev) {
       if (!isString(prev)) {
         for (const key in prev) {
-          if (next[key] == null) {
+          if (isNullish(next[key])) {
             setStyle(style, key, '')
           }
         }
       } else {
         for (const prevStyle of prev.split(';')) {
           const key = prevStyle.slice(0, prevStyle.indexOf(':')).trim()
-          if (next[key] == null) {
+          if (isNullish(next[key])) {
             setStyle(style, key, '')
           }
         }
@@ -75,7 +81,7 @@ function setStyle(
   if (isArray(val)) {
     val.forEach(v => setStyle(style, name, v))
   } else {
-    if (val == null) val = ''
+    if (isNullish(val)) val = ''
     if (__DEV__) {
       if (semicolonRE.test(val)) {
         warn(

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -1,5 +1,6 @@
 import { warn } from '@vue/runtime-core'
 import type { RendererOptions } from '@vue/runtime-core'
+import { isNullish } from '@vue/shared'
 import type {
   TrustedHTML,
   TrustedTypePolicy,
@@ -63,7 +64,7 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
             ? doc.createElement(tag, { is })
             : doc.createElement(tag)
 
-    if (tag === 'select' && props && props.multiple != null) {
+    if (tag === 'select' && props && !isNullish(props.multiple)) {
       ;(el as HTMLSelectElement).setAttribute('multiple', props.multiple)
     }
 

--- a/packages/shared/src/domAttrConfig.ts
+++ b/packages/shared/src/domAttrConfig.ts
@@ -1,3 +1,4 @@
+import { isNullish } from './general'
 import { makeMap } from './makeMap'
 
 /**
@@ -146,7 +147,7 @@ export const isKnownMathMLAttr: (key: string) => boolean =
  * Shared between server-renderer and runtime-core hydration logic
  */
 export function isRenderableAttrValue(value: unknown): boolean {
-  if (value == null) {
+  if (isNullish(value)) {
     return false
   }
   const type = typeof value

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -49,9 +49,14 @@ export const isRegExp = (val: unknown): val is RegExp =>
 export const isFunction = (val: unknown): val is Function =>
   typeof val === 'function'
 export const isString = (val: unknown): val is string => typeof val === 'string'
+export const isNumber = (val: unknown): val is number => typeof val === 'number'
+export const isBoolean = (val: unknown): val is boolean =>
+  typeof val === 'boolean'
 export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
 export const isObject = (val: unknown): val is Record<any, any> =>
   val !== null && typeof val === 'object'
+
+export const isNullish = (val: unknown): val is null | undefined => val == null
 
 export const isPromise = <T = any>(val: unknown): val is Promise<T> => {
   return (
@@ -213,7 +218,7 @@ export function genCacheKey(source: string, options: any): string {
   return (
     source +
     JSON.stringify(options, (_, val) =>
-      typeof val === 'function' ? val.toString() : val,
+      isFunction(val) ? val.toString() : val,
     )
   )
 }

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -1,4 +1,4 @@
-import { hyphenate, isArray, isObject, isString } from './general'
+import { hyphenate, isArray, isNumber, isObject, isString } from './general'
 
 export type NormalizedStyle = Record<string, string | number>
 
@@ -51,7 +51,7 @@ export function stringifyStyle(
   let ret = ''
   for (const key in styles) {
     const value = styles[key]
-    if (isString(value) || typeof value === 'number') {
+    if (isString(value) || isNumber(value)) {
       const normalizedKey = key.startsWith(`--`) ? key : hyphenate(key)
       // only render valid values
       ret += `${normalizedKey}:${value};`

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -4,6 +4,7 @@ import {
   isArray,
   isFunction,
   isMap,
+  isNullish,
   isObject,
   isPlainObject,
   isSet,
@@ -24,7 +25,7 @@ const isRef = (val: any): val is { value: unknown } => {
 export const toDisplayString = (val: unknown): string => {
   return isString(val)
     ? val
-    : val == null
+    : isNullish(val)
       ? ''
       : isArray(val) ||
           (isObject(val) &&


### PR DESCRIPTION
This PR refactors several inline type checks across the codebase to use existing utility functions from `@vue/shared` (such as `isString`, `isFunction`, etc.) in order to improve consistency.

It also adds a few additional utility functions:

- `isNumber`
- `isBoolean`
- `isNullish`

These utility functions are now available in `@vue/shared` and have been applied where appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized null, undefined, and type checks throughout the codebase by introducing and using new utility functions (`isNullish`, `isNumber`, `isBoolean`, etc.).
  - Improved consistency for value checks in various features, including component options, transitions, directives, and DOM attribute handling.

- **New Features**
  - Added utility functions for detecting nullish values, numbers, and booleans.

- **Style**
  - Enhanced code clarity and maintainability by unifying type and nullish checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->