### PR TITLE
fix(compiler-core): ensure mapping is added only if node source is available

### DIFF
--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -188,7 +188,9 @@ function createCodegenContext(
               name = content
             }
           }
-          addMapping(node.loc.start, name)
+          if (node.loc.source) {
+            addMapping(node.loc.start, name)
+          }
         }
         if (newlineIndex === NewlineType.Unknown) {
           // multiple newlines, full iteration
@@ -225,7 +227,7 @@ function createCodegenContext(
             context.column = code.length - newlineIndex
           }
         }
-        if (node && node.loc !== locStub) {
+        if (node && node.loc !== locStub && node.loc.source) {
           addMapping(node.loc.end)
         }
       }

--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -157,6 +157,35 @@ test('source map', () => {
   ).toMatchObject(getPositionInCode(template.content, `foobar`))
 })
 
+test('source map: v-if generated comment should not have original position', () => {
+  const template = parse(
+    `
+      <template>
+        <div v-if="true"></div>
+      </template>
+    `,
+    { filename: 'example.vue', sourceMap: true },
+  ).descriptor.template!
+
+  const { code, map } = compile({
+    filename: 'example.vue',
+    source: template.content,
+  })
+
+  expect(map!.sources).toEqual([`example.vue`])
+  expect(map!.sourcesContent).toEqual([template.content])
+
+  const consumer = new SourceMapConsumer(map as RawSourceMap)
+  const commentNode = code.match(/_createCommentVNode\("v-if", true\)/)
+  expect(commentNode).not.toBeNull()
+  const commentPosition = getPositionInCode(code, commentNode![0])
+  const originalPosition = consumer.originalPositionFor(commentPosition)
+  // the comment node should not be mapped to the original source
+  expect(originalPosition.column).toBeNull()
+  expect(originalPosition.line).toBeNull()
+  expect(originalPosition.source).toBeNull()
+})
+
 test('should work w/ AST from descriptor', () => {
   const source = `
   <template>


### PR DESCRIPTION
close #13261
close https://github.com/vitejs/vite-plugin-vue/issues/368

- [before](https://evanw.github.io/source-map-visualization/#MTcxNABpbXBvcnQgeyBjcmVhdGVIb3RDb250ZXh0IGFzIF9fdml0ZV9fY3JlYXRlSG90Q29udGV4dCB9IGZyb20gIi9Adml0ZS9jbGllbnQiO2ltcG9ydC5tZXRhLmhvdCA9IF9fdml0ZV9fY3JlYXRlSG90Q29udGV4dCgiLi9maXh0dXJlcy9maWZ0aC52dWUiKTtpbXBvcnQgeyBkZWZpbmVDb21wb25lbnQgYXMgX2RlZmluZUNvbXBvbmVudCB9IGZyb20gIi9ub2RlX21vZHVsZXMvLnZpdGUvZGVwcy92dWUuanM/dj1mYjJkNmQxNSI7CmNvbnN0IGNvbmRpdGlvbiA9IGZhbHNlOwpjb25zdCBfc2ZjX21haW4gPSAvKiBAX19QVVJFX18gKi8gX2RlZmluZUNvbXBvbmVudCh7CiAgX19uYW1lOiAiZmlmdGgiLAogIHNldHVwKF9fcHJvcHMsIHsgZXhwb3NlOiBfX2V4cG9zZSB9KSB7CiAgICBfX2V4cG9zZSgpOwogICAgY29uc3QgX19yZXR1cm5lZF9fID0geyBjb25kaXRpb24gfTsKICAgIE9iamVjdC5kZWZpbmVQcm9wZXJ0eShfX3JldHVybmVkX18sICJfX2lzU2NyaXB0U2V0dXAiLCB7IGVudW1lcmFibGU6IGZhbHNlLCB2YWx1ZTogdHJ1ZSB9KTsKICAgIHJldHVybiBfX3JldHVybmVkX187CiAgfQp9KTsKaW1wb3J0IHsgb3BlbkJsb2NrIGFzIF9vcGVuQmxvY2ssIGNyZWF0ZUVsZW1lbnRCbG9jayBhcyBfY3JlYXRlRWxlbWVudEJsb2NrLCBjcmVhdGVDb21tZW50Vk5vZGUgYXMgX2NyZWF0ZUNvbW1lbnRWTm9kZSB9IGZyb20gIi9ub2RlX21vZHVsZXMvLnZpdGUvZGVwcy92dWUuanM/dj1mYjJkNmQxNSI7CmNvbnN0IF9ob2lzdGVkXzEgPSB7IGtleTogMCB9OwpmdW5jdGlvbiBfc2ZjX3JlbmRlcihfY3R4LCBfY2FjaGUsICRwcm9wcywgJHNldHVwLCAkZGF0YSwgJG9wdGlvbnMpIHsKICByZXR1cm4gJHNldHVwLmNvbmRpdGlvbiA/IChfb3BlbkJsb2NrKCksIF9jcmVhdGVFbGVtZW50QmxvY2soImgxIiwgX2hvaXN0ZWRfMSwgIiBIZWxsbyB3b3JsZCAiKSkgOiBfY3JlYXRlQ29tbWVudFZOb2RlKCJ2LWlmIiwgdHJ1ZSk7Cn0KX3NmY19tYWluLl9faG1ySWQgPSAiNGNhNDI2OGEiOwp0eXBlb2YgX19WVUVfSE1SX1JVTlRJTUVfXyAhPT0gInVuZGVmaW5lZCIgJiYgX19WVUVfSE1SX1JVTlRJTUVfXy5jcmVhdGVSZWNvcmQoX3NmY19tYWluLl9faG1ySWQsIF9zZmNfbWFpbik7CmltcG9ydC5tZXRhLmhvdC5vbigiZmlsZS1jaGFuZ2VkIiwgKHsgZmlsZSB9KSA9PiB7CiAgX19WVUVfSE1SX1JVTlRJTUVfXy5DSEFOR0VEX0ZJTEUgPSBmaWxlOwp9KTsKaW1wb3J0Lm1ldGEuaG90LmFjY2VwdCgobW9kKSA9PiB7CiAgaWYgKCFtb2QpIHJldHVybjsKICBjb25zdCB7IGRlZmF1bHQ6IHVwZGF0ZWQsIF9yZXJlbmRlcl9vbmx5IH0gPSBtb2Q7CiAgaWYgKF9yZXJlbmRlcl9vbmx5KSB7CiAgICBfX1ZVRV9ITVJfUlVOVElNRV9fLnJlcmVuZGVyKHVwZGF0ZWQuX19obXJJZCwgdXBkYXRlZC5yZW5kZXIpOwogIH0gZWxzZSB7CiAgICBfX1ZVRV9ITVJfUlVOVElNRV9fLnJlbG9hZCh1cGRhdGVkLl9faG1ySWQsIHVwZGF0ZWQpOwogIH0KfSk7CmltcG9ydCBfZXhwb3J0X3NmYyBmcm9tICIvQGlkL19feDAwX19wbHVnaW4tdnVlOmV4cG9ydC1oZWxwZXIiOwpleHBvcnQgZGVmYXVsdCAvKiBAX19QVVJFX18gKi8gX2V4cG9ydF9zZmMoX3NmY19tYWluLCBbWyJyZW5kZXIiLCBfc2ZjX3JlbmRlcl0sIFsiX19maWxlIiwgIi9Vc2Vycy9lZGlzb24vRG93bmxvYWRzL1Z1ZSBTb3VyY2UgTWFwcyBPZmYvZml4dHVyZXMvZmlmdGgudnVlIl1dKTsKMzg5AHsidmVyc2lvbiI6MywibWFwcGluZ3MiOiI7QUFDQSxNQUFNLFlBQVk7Ozs7Ozs7Ozs7O3FCQURsQjs7U0FLWSxrQ0FBVixvQkFFSyxNQVBQLFlBS3VCLGVBRXJCLEtBUEYiLCJuYW1lcyI6W10sImlnbm9yZUxpc3QiOltdLCJzb3VyY2VzIjpbImZpZnRoLnZ1ZSJdLCJzb3VyY2VzQ29udGVudCI6WyI8c2NyaXB0IHNldHVwIGxhbmc9XCJ0c1wiPlxuY29uc3QgY29uZGl0aW9uID0gZmFsc2U7XG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8aDEgdi1pZj1cImNvbmRpdGlvblwiPlxuICAgIEhlbGxvIHdvcmxkXG4gIDwvaDE+XG48L3RlbXBsYXRlPlxuIl0sImZpbGUiOiIvVXNlcnMvZWRpc29uL0Rvd25sb2Fkcy9WdWUgU291cmNlIE1hcHMgT2ZmL2ZpeHR1cmVzL2ZpZnRoLnZ1ZSJ9)
- [with this PR](https://evanw.github.io/source-map-visualization/#MTcxNABpbXBvcnQgeyBjcmVhdGVIb3RDb250ZXh0IGFzIF9fdml0ZV9fY3JlYXRlSG90Q29udGV4dCB9IGZyb20gIi9Adml0ZS9jbGllbnQiO2ltcG9ydC5tZXRhLmhvdCA9IF9fdml0ZV9fY3JlYXRlSG90Q29udGV4dCgiLi9maXh0dXJlcy9maWZ0aC52dWUiKTtpbXBvcnQgeyBkZWZpbmVDb21wb25lbnQgYXMgX2RlZmluZUNvbXBvbmVudCB9IGZyb20gIi9ub2RlX21vZHVsZXMvLnZpdGUvZGVwcy92dWUuanM/dj0wOTg5YTA0OSI7CmNvbnN0IGNvbmRpdGlvbiA9IGZhbHNlOwpjb25zdCBfc2ZjX21haW4gPSAvKiBAX19QVVJFX18gKi8gX2RlZmluZUNvbXBvbmVudCh7CiAgX19uYW1lOiAiZmlmdGgiLAogIHNldHVwKF9fcHJvcHMsIHsgZXhwb3NlOiBfX2V4cG9zZSB9KSB7CiAgICBfX2V4cG9zZSgpOwogICAgY29uc3QgX19yZXR1cm5lZF9fID0geyBjb25kaXRpb24gfTsKICAgIE9iamVjdC5kZWZpbmVQcm9wZXJ0eShfX3JldHVybmVkX18sICJfX2lzU2NyaXB0U2V0dXAiLCB7IGVudW1lcmFibGU6IGZhbHNlLCB2YWx1ZTogdHJ1ZSB9KTsKICAgIHJldHVybiBfX3JldHVybmVkX187CiAgfQp9KTsKaW1wb3J0IHsgb3BlbkJsb2NrIGFzIF9vcGVuQmxvY2ssIGNyZWF0ZUVsZW1lbnRCbG9jayBhcyBfY3JlYXRlRWxlbWVudEJsb2NrLCBjcmVhdGVDb21tZW50Vk5vZGUgYXMgX2NyZWF0ZUNvbW1lbnRWTm9kZSB9IGZyb20gIi9ub2RlX21vZHVsZXMvLnZpdGUvZGVwcy92dWUuanM/dj0wOTg5YTA0OSI7CmNvbnN0IF9ob2lzdGVkXzEgPSB7IGtleTogMCB9OwpmdW5jdGlvbiBfc2ZjX3JlbmRlcihfY3R4LCBfY2FjaGUsICRwcm9wcywgJHNldHVwLCAkZGF0YSwgJG9wdGlvbnMpIHsKICByZXR1cm4gJHNldHVwLmNvbmRpdGlvbiA/IChfb3BlbkJsb2NrKCksIF9jcmVhdGVFbGVtZW50QmxvY2soImgxIiwgX2hvaXN0ZWRfMSwgIiBIZWxsbyB3b3JsZCAiKSkgOiBfY3JlYXRlQ29tbWVudFZOb2RlKCJ2LWlmIiwgdHJ1ZSk7Cn0KX3NmY19tYWluLl9faG1ySWQgPSAiNGNhNDI2OGEiOwp0eXBlb2YgX19WVUVfSE1SX1JVTlRJTUVfXyAhPT0gInVuZGVmaW5lZCIgJiYgX19WVUVfSE1SX1JVTlRJTUVfXy5jcmVhdGVSZWNvcmQoX3NmY19tYWluLl9faG1ySWQsIF9zZmNfbWFpbik7CmltcG9ydC5tZXRhLmhvdC5vbigiZmlsZS1jaGFuZ2VkIiwgKHsgZmlsZSB9KSA9PiB7CiAgX19WVUVfSE1SX1JVTlRJTUVfXy5DSEFOR0VEX0ZJTEUgPSBmaWxlOwp9KTsKaW1wb3J0Lm1ldGEuaG90LmFjY2VwdCgobW9kKSA9PiB7CiAgaWYgKCFtb2QpIHJldHVybjsKICBjb25zdCB7IGRlZmF1bHQ6IHVwZGF0ZWQsIF9yZXJlbmRlcl9vbmx5IH0gPSBtb2Q7CiAgaWYgKF9yZXJlbmRlcl9vbmx5KSB7CiAgICBfX1ZVRV9ITVJfUlVOVElNRV9fLnJlcmVuZGVyKHVwZGF0ZWQuX19obXJJZCwgdXBkYXRlZC5yZW5kZXIpOwogIH0gZWxzZSB7CiAgICBfX1ZVRV9ITVJfUlVOVElNRV9fLnJlbG9hZCh1cGRhdGVkLl9faG1ySWQsIHVwZGF0ZWQpOwogIH0KfSk7CmltcG9ydCBfZXhwb3J0X3NmYyBmcm9tICIvQGlkL19feDAwX19wbHVnaW4tdnVlOmV4cG9ydC1oZWxwZXIiOwpleHBvcnQgZGVmYXVsdCAvKiBAX19QVVJFX18gKi8gX2V4cG9ydF9zZmMoX3NmY19tYWluLCBbWyJyZW5kZXIiLCBfc2ZjX3JlbmRlcl0sIFsiX19maWxlIiwgIi9Vc2Vycy9lZGlzb24vRG93bmxvYWRzL1Z1ZSBTb3VyY2UgTWFwcyBPZmYvZml4dHVyZXMvZmlmdGgudnVlIl1dKTsKMzc0AHsidmVyc2lvbiI6MywibWFwcGluZ3MiOiI7QUFDQSxNQUFNLFlBQVk7Ozs7Ozs7Ozs7Ozs7U0FJTixrQ0FBVixvQkFFSyxrQkFGZ0IsZUFFckIiLCJuYW1lcyI6W10sImlnbm9yZUxpc3QiOltdLCJzb3VyY2VzIjpbImZpZnRoLnZ1ZSJdLCJzb3VyY2VzQ29udGVudCI6WyI8c2NyaXB0IHNldHVwIGxhbmc9XCJ0c1wiPlxuY29uc3QgY29uZGl0aW9uID0gZmFsc2U7XG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICA8aDEgdi1pZj1cImNvbmRpdGlvblwiPlxuICAgIEhlbGxvIHdvcmxkXG4gIDwvaDE+XG48L3RlbXBsYXRlPlxuIl0sImZpbGUiOiIvVXNlcnMvZWRpc29uL0Rvd25sb2Fkcy9WdWUgU291cmNlIE1hcHMgT2ZmL2ZpeHR1cmVzL2ZpZnRoLnZ1ZSJ9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source map accuracy by ensuring mappings are only created for nodes with explicit source information.

- **Tests**
  - Added a test to confirm that generated comment nodes from v-if directives are correctly excluded from source maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->