### PR TITLE
fix(compiler-sfc): simulate `allowArbitraryExtensions` on resolving type (fix #13295)

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1434,6 +1434,29 @@ describe('resolveType', () => {
         colsLg: ['Number'],
       })
     })
+
+    test('allowArbitraryExtensions', () => {
+      const files = {
+        '/foo.d.vue.ts': 'export type Foo = number;',
+        '/foo.vue': '<template><div /></template>',
+        '/bar.d.css.ts': 'export type Bar = string;',
+        '/bar.css': ':root { --color: red; }',
+      }
+
+      const { props } = resolve(
+        `
+        import { Foo } from './foo.vue'
+        import { Bar } from './bar.css'
+        defineProps<{ foo: Foo; bar: Bar }>()
+        `,
+        files,
+      )
+
+      expect(props).toStrictEqual({
+        foo: ['Number'],
+        bar: ['String'],
+      })
+    })
   })
 })
 


### PR DESCRIPTION
resolve #13295

Currently, Vue only analyzes types from known type sources such as `.ts` files and Vue SFCs (`.vue` files). This PR enables Vue to mimic TypeScript 5.0's [`allowArbitraryExtensions`](https://www.typescriptlang.org/tsconfig/#allowArbitraryExtensions) option behavior, allowing type imports from type definitions of unknown type sources (e.g., `.css` files).

Following TypeScript's documentation, when encountering files from unknown type sources, we will attempt to locate their type definitions in:
- `./foo.vue`: `./foo.d.vue.ts`
- `./bar.css`: `./bar.d.css.ts`

### Link to minimal reproduction

https://github.com/Teages/vue-allow-arbitrary-extensions

### Related issues

https://github.com/nuxt/module-builder/issues/597
https://github.com/unjs/mkdist/issues/270
https://github.com/unjs/mkdist/pull/268#discussion_r1885496778

https://github.com/microsoft/TypeScript/issues/50133



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for TypeScript's `allowArbitraryExtensions` feature, allowing type imports from files with unconventional extensions (e.g., `.d.vue.ts`, `.d.css.ts`).
- **Tests**
  - Added test coverage for importing types from files with arbitrary extensions to ensure correct type resolution and runtime inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->