### PR TITLE
feat(KeepAlive): pause deactivated components with freeze prop

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -55,6 +55,7 @@ export interface KeepAliveProps {
   include?: MatchPattern
   exclude?: MatchPattern
   max?: number | string
+  freeze?: boolean | string
 }
 
 type CacheKey = PropertyKey | ConcreteComponent
@@ -88,6 +89,7 @@ const KeepAliveImpl: ComponentOptions = {
     include: [String, RegExp, Array],
     exclude: [String, RegExp, Array],
     max: [String, Number],
+    freeze: [String, Boolean],
   },
 
   setup(props: KeepAliveProps, { slots }: SetupContext) {
@@ -160,6 +162,10 @@ const KeepAliveImpl: ComponentOptions = {
         }
       }, parentSuspense)
 
+      if (props.freeze) {
+        instance.scope.resume()
+      }
+
       if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
         // Update components tree
         devtoolsComponentAdded(instance)
@@ -182,6 +188,10 @@ const KeepAliveImpl: ComponentOptions = {
         }
         instance.isDeactivated = true
       }, parentSuspense)
+
+      if (props.freeze) {
+        instance.scope.resume()
+      }
 
       if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
         // Update components tree


### PR DESCRIPTION
Fixes #5386

As described in the issue, when a component is deactivated, the effects of that component will still be running. In the same way the `defer` attribute was added to `Teleport` to keep backwards-compat, a `freeze` prop has been added here, so users can opt-in to this new behavior.

Requires # so there's a walkable tree of effect scopes when pausing/resuming, hence a draft PR. Tests and docs will be created once that PR is merged.