### PR TITLE
feat(runtime-vapor): expose isVaporComponent

### DIFF
--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -7,7 +7,11 @@ export type { VaporDirective } from './directives/custom'
 // compiler-use only
 export { insert, prepend, remove, isFragment, VaporFragment } from './block'
 export { setInsertionState } from './insertionState'
-export { createComponent, createComponentWithFallback } from './component'
+export {
+  createComponent,
+  createComponentWithFallback,
+  isVaporComponent,
+} from './component'
 export { renderEffect } from './renderEffect'
 export { createSlot } from './componentSlots'
 export { template } from './dom/template'


### PR DESCRIPTION
To determine if a node is a block for vue-jsx-vapor.
```ts
function normalizeNode(node: any): Block {
  if (node instanceof Node || isFragment(node) || isVaporComponent(node)){
    return node
  } else {
    // ...
  }
}
```
