### PR TITLE
fix(types): Type 'enter' and 'tab' is not assignable to type 'VOnModifiers'

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vOn.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vOn.spec.ts
@@ -163,4 +163,16 @@ describe('runtime-dom: v-on directive', () => {
     triggerEvent(el2, 'click', e => (e.shiftKey = true))
     expect(fn).toBeCalledTimes(2)
   })
+
+  it('it should support "enter" and "tab" key modifiers', () => {
+    const el = document.createElement('input')
+    const fn = vi.fn()
+
+    const enterHandler = withModifiers(fn, ['enter', 'tab'])
+    patchEvent(el, 'onKeyup', null, enterHandler, null)
+    triggerEvent(el, 'keyup', e => (e.key = 'Enter'))
+    expect(fn).toBeCalledTimes(1)
+    triggerEvent(el, 'keyup', e => (e.key = 'Tab'))
+    expect(fn).toBeCalledTimes(2)
+  })
 })

--- a/packages/runtime-dom/src/directives/vOn.ts
+++ b/packages/runtime-dom/src/directives/vOn.ts
@@ -72,7 +72,15 @@ export const withModifiers = <
 // Kept for 2.x compat.
 // Note: IE11 compat for `spacebar` and `del` is removed for now.
 const keyNames: Record<
-  'esc' | 'space' | 'up' | 'left' | 'right' | 'down' | 'delete',
+  | 'esc'
+  | 'space'
+  | 'up'
+  | 'left'
+  | 'right'
+  | 'down'
+  | 'delete'
+  | 'enter'
+  | 'tab',
   string
 > = {
   esc: 'escape',
@@ -82,6 +90,8 @@ const keyNames: Record<
   right: 'arrow-right',
   down: 'arrow-down',
   delete: 'backspace',
+  enter: 'enter',
+  tab: 'tab',
 }
 
 /**


### PR DESCRIPTION
close #13336 
| before | after |
| ------- | ----- |
| ![966521e38159034cb123e4a3bddc812e](https://github.com/user-attachments/assets/e757e2d4-3bad-49b1-9fec-1b126128b2bb) | ![3ee2dcbe02e389659e9677c65f1dc4ac](https://github.com/user-attachments/assets/36ebc55a-3a94-4ca7-a92a-a09ec1d5b2a8) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for “enter” and “tab” key modifiers in event handling.
  - Event handlers can now respond specifically to Enter and Tab key presses, including when both modifiers are configured together.

- **Tests**
  - Added coverage verifying that combined “enter” and “tab” key modifiers correctly trigger event handlers for each key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->