### PR TITLE
fix(runtime-vapor): mark the instance of createComponent as mounted

### DIFF
--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -13,6 +13,7 @@ import {
   createIf,
   createTextNode,
   renderEffect,
+  setInsertionState,
   template,
 } from '../src'
 import { makeRender } from './_utils'
@@ -326,5 +327,26 @@ describe('component', () => {
     expect(
       'Vapor component setup() returned non-block value, and has no render function',
     ).toHaveBeenWarned()
+  })
+
+  it('should mark instance of createComponent as mounted', async () => {
+    const { component: Child } = define({
+      setup() {
+        return []
+      },
+    })
+
+    let instance!: VaporComponentInstance
+    createComponent(
+      define({
+        setup() {
+          const n1 = template('<div></div>', true)()
+          setInsertionState(n1 as ParentNode)
+          instance = createComponent(Child)
+          return n1
+        },
+      }).component,
+    )
+    expect(instance.isMounted).toBe(true)
   })
 })

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -270,7 +270,7 @@ export function createComponent(
   onScopeDispose(() => unmountComponent(instance), true)
 
   if (!isHydrating && _insertionParent) {
-    insert(instance.block, _insertionParent, _insertionAnchor)
+    insert(instance, _insertionParent, _insertionAnchor)
   }
 
   return instance


### PR DESCRIPTION
## Description
The insert operation of createComponent is only passed a instance.block, so can't emit mountComponent hook.

## Before:
[REPL](https://deploy-preview-13347--vapor-repl.netlify.app/#eNp9UktPg0AQ/iuTvQBJQw96aoBETQ+a+Ih6cz0QGJAKu2Qf2ITw351dpG0a9cLMfN88vpllZFd9Hw8W2YYlulBNb0CjsT0MeS9VxkXTkTUwQolVI/BGUixQmBVIcS+tMFjCBJWSHQTUJzipUFidUVwUUmgDna4hdXwYBNECutaQno0JRy5glrSBMII0A4/AcXwYRmn2A4JrHQ95a5EGBN2cQZMdNdEoZxV1UwLe3l04ARdTRB8ukvV8AdqaAoNd3+YGKQJIymbwDrlOW5asvfHceiHH0W82Ta7XST1bMaNpyaqp452Wgo7t9XJWUJOmRfXYm4aOwNlmWY+zvG3l153HjLK4WvDiA4vPX/Cd3juMsyeFGtWAnB04k6sazUxvXx5wT/6B7GRpW8r+h3xGLVvrNM5p11aUJPskz6u99U/fiPpVb/cGhV6WckL9tX0+Z/Q7uPv9tfpR7kV86evokdj0DTVq4jA=)

## After:
[REPL](https://deploy-preview-13359--vapor-repl.netlify.app/#eNp9UktPg0AQ/iuTvQBJQw96aoBETQ+a+Ih6cz0QGJAKu2Qf2ITw351dpG0a9cLMfN88vpllZFd9Hw8W2YYlulBNb0CjsT0MeS9VxkXTkTUwQolVI/BGUixQmBVIcS+tMFjCBJWSHQTUJzipUFidUVwUUmgDna4hdXwYBNECutaQno0JRy5glrSBMII0A4/AcXwYRmn2A4JrHQ95a5EGBN2cQZMdNdEoZxV1UwLe3l04ARdTRB8ukvV8AdqaAoNd3+YGKQJIymbwDrlOW5asvfHceiHH0W82Ta7XST1bMaNpyaqp452Wgo7t9XJWUJOmRfXYm4aOwNlmWY+zvG3l153HjLK4WvDiA4vPX/Cd3juMsyeFGtWAnB04k6sazUxvXx5wT/6B7GRpW8r+h3xGLVvrNM5p11aUJPskz6u99U/fiPpVb/cGhV6WckL9tX0+Z/Q7uPv9tfpR7kV86evokdj0DTVq4jA=)