### PR TITLE
fix(compiler-core): do not increase newlines in `InEntity` state

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2271,6 +2271,12 @@ describe('compiler: parse', () => {
       expect(span.loc.start.offset).toBe(0)
       expect(span.loc.end.offset).toBe(27)
     })
+
+    test('correct loc when a line in attribute value ends with &', () => {
+      const [span] = baseParse(`<span v-if="foo &&\nbar"></span>`).children
+
+      expect(span.loc.end.line).toBe(2)
+    })
   })
 
   describe('decodeEntities option', () => {

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2274,7 +2274,6 @@ describe('compiler: parse', () => {
 
     test('correct loc when a line in attribute value ends with &', () => {
       const [span] = baseParse(`<span v-if="foo &&\nbar"></span>`).children
-
       expect(span.loc.end.line).toBe(2)
     })
   })

--- a/packages/compiler-core/src/tokenizer.ts
+++ b/packages/compiler-core/src/tokenizer.ts
@@ -929,7 +929,7 @@ export default class Tokenizer {
     this.buffer = input
     while (this.index < this.buffer.length) {
       const c = this.buffer.charCodeAt(this.index)
-      if (c === CharCodes.NewLine) {
+      if (c === CharCodes.NewLine && this.state !== State.InEntity) {
         this.newlines.push(this.index)
       }
       switch (this.state) {


### PR DESCRIPTION
fix #13361 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a test to ensure correct line number tracking for elements with multiline attribute values ending with an ampersand.

- **Bug Fixes**
  - Improved handling of newline tracking during parsing to ensure accurate location metadata for multiline attribute values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->