### PR TITLE
fix(compiler-core): prevent incorrect entity parsing with logical AND

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -1264,6 +1264,17 @@ describe('compiler: parse', () => {
       })
     })
 
+    // #13361
+    test('directive with multiline value', () => {
+      const ast = baseParse(
+        `<div v-if="
+          foo &&
+          bar
+        "></div>`,
+      )
+      expect(ast.loc.end.line).toBe(4)
+    })
+
     test('directive with argument', () => {
       const ast = baseParse('<div v-on:click/>')
       const directive = (ast.children[0] as ElementNode).props[0]

--- a/packages/compiler-core/src/tokenizer.ts
+++ b/packages/compiler-core/src/tokenizer.ts
@@ -322,7 +322,7 @@ export default class Tokenizer {
       }
       this.state = State.BeforeTagName
       this.sectionStart = this.index
-    } else if (!__BROWSER__ && c === CharCodes.Amp) {
+    } else if (!__BROWSER__ && c === CharCodes.Amp && !this.isLogicalAnd()) {
       this.startEntity()
     } else if (!this.inVPre && c === this.delimiterOpen[0]) {
       this.state = State.InterpolationOpen
@@ -436,7 +436,7 @@ export default class Tokenizer {
         (this.currentSequence === Sequences.TextareaEnd && !this.inSFCRoot)
       ) {
         // We have to parse entities in <title> and <textarea> tags.
-        if (!__BROWSER__ && c === CharCodes.Amp) {
+        if (!__BROWSER__ && c === CharCodes.Amp && !this.isLogicalAnd()) {
           this.startEntity()
         } else if (!this.inVPre && c === this.delimiterOpen[0]) {
           // We also need to handle interpolation
@@ -795,7 +795,7 @@ export default class Tokenizer {
         this.index + 1,
       )
       this.state = State.BeforeAttrName
-    } else if (!__BROWSER__ && c === CharCodes.Amp) {
+    } else if (!__BROWSER__ && c === CharCodes.Amp && !this.isLogicalAnd()) {
       this.startEntity()
     }
   }
@@ -823,7 +823,7 @@ export default class Tokenizer {
         ErrorCodes.UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE,
         this.index,
       )
-    } else if (!__BROWSER__ && c === CharCodes.Amp) {
+    } else if (!__BROWSER__ && c === CharCodes.Amp && !this.isLogicalAnd()) {
       this.startEntity()
     }
   }
@@ -1177,5 +1177,12 @@ export default class Tokenizer {
         )
       }
     }
+  }
+
+  private isLogicalAnd(): boolean {
+    return (
+      this.buffer.charCodeAt(this.index - 1) === CharCodes.Amp ||
+      this.buffer.charCodeAt(this.index + 1) === CharCodes.Amp
+    )
   }
 }


### PR DESCRIPTION
close #13361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing to correctly handle logical AND (`&&`) operators in directive attribute values, preventing them from being misinterpreted as HTML entities.
- **Tests**
  - Added a test to verify correct parsing of multiline directive values containing logical operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->