### PR TITLE
chore(compiler-vapor): use compiler-dom instead of compiler-core

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -12,7 +12,7 @@ import {
   type BindingMetadata,
   BindingTypes,
   NodeTypes,
-} from '@vue/compiler-core'
+} from '@vue/compiler-dom'
 
 const compileWithElementTransform = makeCompile({
   nodeTransforms: [transformElement, transformChildren, transformText],

--- a/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, NodeTypes } from '@vue/compiler-core'
+import { ErrorCodes, NodeTypes } from '@vue/compiler-dom'
 import {
   IRNodeTypes,
   transformChildren,

--- a/packages/compiler-vapor/__tests__/transforms/vIf.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vIf.spec.ts
@@ -10,7 +10,7 @@ import {
   transformVOnce,
   transformVText,
 } from '../../src'
-import { NodeTypes } from '@vue/compiler-core'
+import { NodeTypes } from '@vue/compiler-dom'
 
 const compileWithVIf = makeCompile({
   nodeTransforms: [

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, NodeTypes } from '@vue/compiler-core'
+import { ErrorCodes, NodeTypes } from '@vue/compiler-dom'
 import {
   IRNodeTypes,
   IRSlotType,

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -34,7 +34,7 @@ import {
   isMemberExpression,
   toValidAssetId,
   walkIdentifiers,
-} from '@vue/compiler-core'
+} from '@vue/compiler-dom'
 import { genEventHandler } from './event'
 import { genDirectiveModifiers, genDirectivesForElement } from './directive'
 import { genBlock } from './block'

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -2,7 +2,7 @@ import {
   NewlineType,
   type SimpleExpressionNode,
   isSimpleIdentifier,
-} from '@vue/compiler-core'
+} from '@vue/compiler-dom'
 import type { CodegenContext } from '../generate'
 import {
   IRDynamicPropsKind,

--- a/packages/compiler-vapor/src/transforms/transformSlotOutlet.ts
+++ b/packages/compiler-vapor/src/transforms/transformSlotOutlet.ts
@@ -9,7 +9,7 @@ import {
   createSimpleExpression,
   isStaticArgOf,
   isStaticExp,
-} from '@vue/compiler-core'
+} from '@vue/compiler-dom'
 import type { NodeTransform, TransformContext } from '../transform'
 import {
   type BlockIRNode,

--- a/packages/compiler-vapor/src/transforms/vSlot.ts
+++ b/packages/compiler-vapor/src/transforms/vSlot.ts
@@ -8,7 +8,7 @@ import {
   createCompilerError,
   isTemplateNode,
   isVSlot,
-} from '@vue/compiler-core'
+} from '@vue/compiler-dom'
 import type { NodeTransform, TransformContext } from '../transform'
 import { newBlock } from './utils'
 import {


### PR DESCRIPTION
https://github.com/vuejs/core/blob/vapor/packages/compiler-vapor/package.json#L45-L47
`compiler-core` is not in `compiler-vapor`'s dependencies, we should use `compiler-dom` instead.
 And the bundler size has been reduced by 15KB.
   - Before
     <img width="576" alt="41341747838339_ pic" src="https://github.com/user-attachments/assets/eda40fe4-a801-47c3-b867-da73149b4794" />
    - After
      <img width="561" alt="41331747838263_ pic" src="https://github.com/user-attachments/assets/8f75b062-69b2-45c1-ba42-679d46ba829f" />