### PR TITLE
fix(runtime-vapor): prevent mounting functional components as virtual DOM

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -144,8 +144,9 @@ export function createComponent(
     locateHydrationNode()
   }
 
+  const isFnComponent = isFunction(component)
   // vdom interop enabled and component is not an explicit vapor component
-  if (appContext.vapor && !component.__vapor) {
+  if (appContext.vapor && !isFnComponent && !component.__vapor) {
     const frag = appContext.vapor.vdomMount(
       component as any,
       rawProps,
@@ -199,7 +200,7 @@ export function createComponent(
     setupPropsValidation(instance)
   }
 
-  const setupFn = isFunction(component) ? component : component.setup
+  const setupFn = isFnComponent ? component : component.setup
   const setupResult = setupFn
     ? callWithErrorHandling(setupFn, instance, ErrorCodes.SETUP_FUNCTION, [
         instance.props,
@@ -208,7 +209,7 @@ export function createComponent(
     : EMPTY_OBJ
 
   if (__DEV__ && !isBlock(setupResult)) {
-    if (isFunction(component)) {
+    if (isFnComponent) {
       warn(`Functional vapor component must return a block directly.`)
       instance.block = []
     } else if (!component.render) {


### PR DESCRIPTION
For interop mode of createVaporApp, The functional component will be as vdom to mount.
Such as the <slots.default /> will be render to `[object Text]`.

I think in a Vapor component, the functional component should be compile to Vapor DOM.
And in a VDom component, the functional component should be compile to Virtual DOM

```tsx
defineVaporComponent(() => {
  const slots = useSlots()
  return <slots.default />
})
```

[REPL](https://repl.zmjs.dev/vuejs/virtual-dom-in-vapor)