### PR TITLE
fix(compiler-sfc): don't inject scope id before child combinator >

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -520,5 +520,12 @@ describe('SFC style preprocessors', () => {
       "[data-v-test]:last-child [data-v-test]:active { color: red;
       }"
     `)
+    expect(compileScoped(`main { > * { background-color: yellow; } }`))
+      .toMatchInlineSnapshot(`
+        "main {
+        > [data-v-test] { background-color: yellow;
+        }
+        }"
+      `)
   })
 })

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -257,9 +257,9 @@ function rewriteSelector(
     }
   } else {
     // #13387 don't inject [id] at the selector start if node is null
-    // and the selector starts with `>`
+    // and the selector starts with a non-empty combinator
     const { type, value } = selector.first
-    if (type === 'combinator' && value === '>') {
+    if (type === 'combinator' && value !== ' ') {
       shouldInject = false
     }
   }


### PR DESCRIPTION
close #13387 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scoped CSS handling to correctly apply attribute selectors with child combinators (e.g., `main > *`), ensuring accurate style scoping.

- **Tests**
  - Added a test verifying proper scoping behavior for nested child selectors using combinators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->