### PR TITLE
Revert "fix(compiler-sfc): add error handling for defineModel() without variable assignment"

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1007,7 +1007,7 @@ describe('SFC compile <script setup>', () => {
       expect(() =>
         compile(`<script setup>
         let bar = 1
-        const model = defineModel({
+        defineModel({
           default: () => bar
         })
         </script>`),
@@ -1017,7 +1017,7 @@ describe('SFC compile <script setup>', () => {
       expect(() =>
         compile(`<script setup>
         const bar = 1
-        const model = defineModel({
+        defineModel({
           default: () => bar
         })
         </script>`),
@@ -1027,7 +1027,7 @@ describe('SFC compile <script setup>', () => {
       expect(() =>
         compile(`<script setup>
         let bar = 1
-        const model = defineModel({
+        defineModel({
           get: () => bar,
           set: () => bar
         })

--- a/packages/compiler-sfc/__tests__/compileScript/defineModel.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineModel.spec.ts
@@ -269,16 +269,4 @@ describe('defineModel()', () => {
       modelValue: BindingTypes.SETUP_REF,
     })
   })
-
-  test('error when defineModel is not assigned to a variable', () => {
-    expect(() =>
-      compile(`
-        <script setup>
-        defineModel()
-        </script>
-      `),
-    ).toThrow(
-      'defineModel() must be assigned to a variable. For example: const model = defineModel()',
-    )
-  })
 })

--- a/packages/compiler-sfc/src/script/defineModel.ts
+++ b/packages/compiler-sfc/src/script/defineModel.ts
@@ -22,13 +22,6 @@ export function processDefineModel(
     return false
   }
 
-  if (!declId) {
-    ctx.error(
-      'defineModel() must be assigned to a variable. For example: const model = defineModel()',
-      node,
-    )
-  }
-
   ctx.hasDefineModelCall = true
 
   const type =


### PR DESCRIPTION
Reverts vuejs/core#13352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where calling `defineModel()` without assigning it to a variable would cause an error. Now, `defineModel()` can be used as a standalone call without assignment.
- **Tests**
  - Updated test cases to reflect the new behavior of `defineModel()`, removing assignment requirements and related error checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->