### PR TITLE
fix(compiler-vapor): remove types for expressions

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
@@ -123,6 +123,18 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 }"
 `;
 
+exports[`v-on > expression with type 1`] = `
+"import { delegateEvents as _delegateEvents, template as _template } from 'vue';
+const t0 = _template("<div></div>", true)
+_delegateEvents("click")
+
+export function render(_ctx, $props, $emit, $attrs, $slots) {
+  const n0 = t0()
+  n0.$evtclick = e => (_ctx.handleClick as any)(e)
+  return n0
+}"
+`;
+
 exports[`v-on > function expression w/ prefixIdentifiers: true 1`] = `
 "import { delegateEvents as _delegateEvents, template as _template } from 'vue';
 const t0 = _template("<div></div>", true)

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
@@ -130,7 +130,7 @@ _delegateEvents("click")
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  n0.$evtclick = e => (_ctx.handleClick as any)(e)
+  n0.$evtclick = e => _ctx.handleClick(e)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -684,12 +684,15 @@ describe('v-on', () => {
   })
 
   test('expression with type', () => {
-    const { code } = compileWithVOn(`<div @click="handleClick as any"></div>`, {
-      bindingMetadata: {
-        handleClick: BindingTypes.SETUP_CONST,
+    const { code } = compileWithVOn(
+      `<div @click="(<number>handleClick as any)"></div>`,
+      {
+        bindingMetadata: {
+          handleClick: BindingTypes.SETUP_CONST,
+        },
       },
-    })
+    )
     expect(code).matchSnapshot()
-    expect(code).include('n0.$evtclick = e => (_ctx.handleClick as any)(e)')
+    expect(code).include('n0.$evtclick = e => _ctx.handleClick(e)')
   })
 })

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -682,4 +682,14 @@ describe('v-on', () => {
       '_delegate(n0, "click", _withModifiers(e => _ctx.test(e), ["stop"]))',
     )
   })
+
+  test('expression with type', () => {
+    const { code } = compileWithVOn(`<div @click="handleClick as any"></div>`, {
+      bindingMetadata: {
+        handleClick: BindingTypes.SETUP_CONST,
+      },
+    })
+    expect(code).matchSnapshot()
+    expect(code).include('n0.$evtclick = e => (_ctx.handleClick as any)(e)')
+  })
 })

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -65,8 +65,7 @@ export function genExpression(
   let hasMemberExpression = false
   if (ids.length) {
     const [frag, push] = buildCodeFragment()
-    const shouldWrap = ast && TS_NODE_TYPES.includes(ast.type)
-    if (shouldWrap) push('(')
+    const isTSNode = ast && TS_NODE_TYPES.includes(ast.type)
     ids
       .sort((a, b) => a.start! - b.start!)
       .forEach((id, i) => {
@@ -75,8 +74,10 @@ export function genExpression(
         const end = id.end! - 1
         const last = ids[i - 1]
 
-        const leadingText = content.slice(last ? last.end! - 1 : 0, start)
-        if (leadingText.length) push([leadingText, NewlineType.Unknown])
+        if (!(isTSNode && i === 0)) {
+          const leadingText = content.slice(last ? last.end! - 1 : 0, start)
+          if (leadingText.length) push([leadingText, NewlineType.Unknown])
+        }
 
         const source = content.slice(start, end)
         const parentStack = parentStackMap.get(id)!
@@ -103,11 +104,10 @@ export function genExpression(
           ),
         )
 
-        if (i === ids.length - 1 && end < content.length) {
+        if (i === ids.length - 1 && end < content.length && !isTSNode) {
           push([content.slice(end), NewlineType.Unknown])
         }
       })
-    if (shouldWrap) push(')')
 
     if (assignment && hasMemberExpression) {
       push(` = ${assignment}`)

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -49,7 +49,6 @@ export function genExpression(
     return genIdentifier(content, context, loc, assignment)
   }
 
-  const shouldWrap = ast && TS_NODE_TYPES.includes(ast.type)
   const ids: Identifier[] = []
   const parentStackMap = new Map<Identifier, Node[]>()
   const parentStack: Node[] = []
@@ -66,6 +65,8 @@ export function genExpression(
   let hasMemberExpression = false
   if (ids.length) {
     const [frag, push] = buildCodeFragment()
+    const shouldWrap = ast && TS_NODE_TYPES.includes(ast.type)
+    if (shouldWrap) push('(')
     ids
       .sort((a, b) => a.start! - b.start!)
       .forEach((id, i) => {
@@ -87,7 +88,6 @@ export function genExpression(
             parent.type === 'OptionalMemberExpression')
 
         push(
-          shouldWrap ? '(' : '',
           ...genIdentifier(
             source,
             context,
@@ -106,8 +106,8 @@ export function genExpression(
         if (i === ids.length - 1 && end < content.length) {
           push([content.slice(end), NewlineType.Unknown])
         }
-        push(shouldWrap ? ')' : '')
       })
+    if (shouldWrap) push(')')
 
     if (assignment && hasMemberExpression) {
       push(` = ${assignment}`)

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -10,6 +10,7 @@ import {
   NewlineType,
   type SimpleExpressionNode,
   type SourceLocation,
+  TS_NODE_TYPES,
   advancePositionWithClone,
   createSimpleExpression,
   isInDestructureAssignment,
@@ -48,6 +49,7 @@ export function genExpression(
     return genIdentifier(content, context, loc, assignment)
   }
 
+  const shouldWrap = ast && TS_NODE_TYPES.includes(ast.type)
   const ids: Identifier[] = []
   const parentStackMap = new Map<Identifier, Node[]>()
   const parentStack: Node[] = []
@@ -85,6 +87,7 @@ export function genExpression(
             parent.type === 'OptionalMemberExpression')
 
         push(
+          shouldWrap ? '(' : '',
           ...genIdentifier(
             source,
             context,
@@ -103,6 +106,7 @@ export function genExpression(
         if (i === ids.length - 1 && end < content.length) {
           push([content.slice(end), NewlineType.Unknown])
         }
+        push(shouldWrap ? ')' : '')
       })
 
     if (assignment && hasMemberExpression) {


### PR DESCRIPTION
## Before
```ts
<div @click="handleClick as any" /> 
// convert to
n0.$evtclick = e => _ctx.handleClick as any(e) // syntax error
```

## After
```ts
<div @click="handleClick as any" /> 
// convert to
n0.$evtclick = e => _ctx.handleClick(e) // correct
```
