### PR TITLE
fix(ssr): ensure empty slots render as a comment node in Transition

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1677,6 +1677,24 @@ describe('SSR hydration', () => {
     expect(`mismatch`).not.toHaveBeenWarned()
   })
 
+  // #13394
+  test('transition appear work with empty content', () => {
+    const { vnode, container } = mountWithHydration(
+      `<template></template>`,
+      () =>
+        h(
+          Transition,
+          { appear: true },
+          {
+            default: () => null,
+          },
+        ),
+    )
+    expect(container.firstChild).toBe(null)
+    expect(vnode.el).toBe(container.firstChild)
+    expect(`mismatch`).not.toHaveBeenWarned()
+  })
+
   test('transition appear with v-if', () => {
     const show = false
     const { vnode, container } = mountWithHydration(

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1681,7 +1681,7 @@ describe('SSR hydration', () => {
   test('transition appear work with empty content', async () => {
     const show = ref(true)
     const { vnode, container } = mountWithHydration(
-      `<template></template>`,
+      `<template><!----></template>`,
       function (this: any) {
         return h(
           Transition,
@@ -1696,7 +1696,7 @@ describe('SSR hydration', () => {
       },
     )
 
-    // expect empty slot render as a comment node
+    // empty slot render as a comment node
     expect(container.firstChild!.nodeType).toBe(Node.COMMENT_NODE)
     expect(vnode.el).toBe(container.firstChild)
     expect(`mismatch`).not.toHaveBeenWarned()

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -202,9 +202,7 @@ export function createHydrationFunctions(
           // wrapped <transition appear>
           // replace <template> node with inner child
           replaceNode(
-            // #13394, the server may render an empty <template>, a comment node
-            // needs to be created to be consistent with the client's behavior
-            (vnode.el = node.content.firstChild || createComment('')),
+            (vnode.el = node.content.firstChild!),
             node,
             parentComponent,
           )
@@ -399,11 +397,10 @@ export function createHydrationFunctions(
           parentComponent.vnode.props &&
           parentComponent.vnode.props.appear
 
-        let content =
-          (el.content.firstChild as Element & { $cls?: string }) ||
-          createComment('')
+        const content = (el as HTMLTemplateElement).content
+          .firstChild as Element & { $cls?: string }
 
-        if (needCallTransitionHooks && content instanceof Element) {
+        if (needCallTransitionHooks) {
           const cls = content.getAttribute('class')
           if (cls) content.$cls = cls
           transition!.beforeEnter(content)

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -761,7 +761,8 @@ export function createHydrationFunctions(
     // replace node
     const parentNode = oldNode.parentNode
     if (parentNode) {
-      parentNode.replaceChild(newNode, oldNode)
+      if (newNode) parentNode.replaceChild(newNode, oldNode)
+      else remove(oldNode)
     }
 
     // update vnode

--- a/packages/server-renderer/__tests__/ssrSlot.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSlot.spec.ts
@@ -127,6 +127,22 @@ describe('ssr: slot', () => {
     expect(
       await renderToString(
         createApp({
+          template: `<transition><slot/></transition>`,
+        }),
+      ),
+    ).toBe(`<!---->`)
+
+    expect(
+      await renderToString(
+        createApp({
+          template: `<transition appear><slot/></transition>`,
+        }),
+      ),
+    ).toBe(`<template><!----></template>`)
+
+    expect(
+      await renderToString(
+        createApp({
           components: {
             one: {
               template: `<transition><slot/></transition>`,

--- a/packages/server-renderer/__tests__/ssrSlot.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSlot.spec.ts
@@ -135,7 +135,33 @@ describe('ssr: slot', () => {
     expect(
       await renderToString(
         createApp({
+          components: {
+            one: {
+              template: `<transition><slot/></transition>`,
+            },
+          },
+          template: `<one><slot/></one>`,
+        }),
+      ),
+    ).toBe(`<!---->`)
+
+    expect(
+      await renderToString(
+        createApp({
           template: `<transition appear><slot/></transition>`,
+        }),
+      ),
+    ).toBe(`<template><!----></template>`)
+
+    expect(
+      await renderToString(
+        createApp({
+          components: {
+            one: {
+              template: `<transition appear><slot/></transition>`,
+            },
+          },
+          template: `<one><slot/></one>`,
         }),
       ),
     ).toBe(`<template><!----></template>`)

--- a/packages/server-renderer/__tests__/ssrSlot.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSlot.spec.ts
@@ -111,34 +111,36 @@ describe('ssr: slot', () => {
   })
 
   test('transition slot', async () => {
+    const ReusableTransition = {
+      template: `<transition><slot/></transition>`,
+    }
+
+    const ReusableTransitionWithAppear = {
+      template: `<transition appear><slot/></transition>`,
+    }
+
     expect(
       await renderToString(
         createApp({
           components: {
-            one: {
-              template: `<transition><slot/></transition>`,
-            },
+            one: ReusableTransition,
           },
           template: `<one><div v-if="false">foo</div></one>`,
         }),
       ),
     ).toBe(`<!---->`)
 
-    expect(
-      await renderToString(
-        createApp({
-          template: `<transition><slot/></transition>`,
-        }),
-      ),
-    ).toBe(`<!---->`)
+    expect(await renderToString(createApp(ReusableTransition))).toBe(`<!---->`)
+
+    expect(await renderToString(createApp(ReusableTransitionWithAppear))).toBe(
+      `<template><!----></template>`,
+    )
 
     expect(
       await renderToString(
         createApp({
           components: {
-            one: {
-              template: `<transition><slot/></transition>`,
-            },
+            one: ReusableTransition,
           },
           template: `<one><slot/></one>`,
         }),
@@ -148,18 +150,8 @@ describe('ssr: slot', () => {
     expect(
       await renderToString(
         createApp({
-          template: `<transition appear><slot/></transition>`,
-        }),
-      ),
-    ).toBe(`<template><!----></template>`)
-
-    expect(
-      await renderToString(
-        createApp({
           components: {
-            one: {
-              template: `<transition appear><slot/></transition>`,
-            },
+            one: ReusableTransitionWithAppear,
           },
           template: `<one><slot/></one>`,
         }),
@@ -169,10 +161,56 @@ describe('ssr: slot', () => {
     expect(
       await renderToString(
         createApp({
+          render() {
+            return h(ReusableTransition, null, {
+              default: () => null,
+            })
+          },
+        }),
+      ),
+    ).toBe(`<!---->`)
+
+    expect(
+      await renderToString(
+        createApp({
+          render() {
+            return h(ReusableTransitionWithAppear, null, {
+              default: () => null,
+            })
+          },
+        }),
+      ),
+    ).toBe(`<template><!----></template>`)
+
+    expect(
+      await renderToString(
+        createApp({
+          render() {
+            return h(ReusableTransitionWithAppear, null, {
+              default: () => [],
+            })
+          },
+        }),
+      ),
+    ).toBe(`<template><!----></template>`)
+
+    expect(
+      await renderToString(
+        createApp({
+          render() {
+            return h(ReusableTransition, null, {
+              default: () => [],
+            })
+          },
+        }),
+      ),
+    ).toBe(`<!---->`)
+
+    expect(
+      await renderToString(
+        createApp({
           components: {
-            one: {
-              template: `<transition><slot/></transition>`,
-            },
+            one: ReusableTransition,
           },
           template: `<one><div v-if="true">foo</div></one>`,
         }),

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -117,6 +117,8 @@ export function ssrRenderSlotInner(
     }
   } else if (fallbackRenderFn) {
     fallbackRenderFn()
+  } else if (transition) {
+    push(`<!---->`)
   }
 }
 

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -74,6 +74,8 @@ export function ssrRenderSlotInner(
         )
       } else if (fallbackRenderFn) {
         fallbackRenderFn()
+      } else if (transition) {
+        push(`<!---->`)
       }
     } else {
       // ssr slot.

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -110,8 +110,12 @@ export function ssrRenderSlotInner(
           end--
         }
 
-        for (let i = start; i < end; i++) {
-          push(slotBuffer[i])
+        if (start < end) {
+          for (let i = start; i < end; i++) {
+            push(slotBuffer[i])
+          }
+        } else if (transition) {
+          push(`<!---->`)
         }
       }
     }


### PR DESCRIPTION
close #13394 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved server-side rendering to correctly handle transition components with empty slots, ensuring a placeholder comment is emitted when no content is present.
- **Tests**
  - Added new test cases to verify correct hydration and SSR output for transitions with initially empty content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->