### PR TITLE
fix(compiler-sfc): replace trailing universal selector with :where([id]) in scoped styles

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -493,7 +493,7 @@ describe('SFC style preprocessors', () => {
       }"
     `)
     expect(compileScoped(`.foo * { color: red; }`)).toMatchInlineSnapshot(`
-      ".foo[data-v-test] [data-v-test] { color: red;
+      ".foo[data-v-test] :where([data-v-test]) { color: red;
       }"
     `)
     expect(compileScoped(`.foo :active { color: red; }`))
@@ -503,7 +503,7 @@ describe('SFC style preprocessors', () => {
     `)
     expect(compileScoped(`.foo *:active { color: red; }`))
       .toMatchInlineSnapshot(`
-      ".foo[data-v-test] [data-v-test]:active { color: red;
+      ".foo[data-v-test] :where([data-v-test]):active { color: red;
       }"
     `)
     expect(compileScoped(`.foo * .bar { color: red; }`)).toMatchInlineSnapshot(`
@@ -512,12 +512,12 @@ describe('SFC style preprocessors', () => {
     `)
     expect(compileScoped(`:last-child * { color: red; }`))
       .toMatchInlineSnapshot(`
-      "[data-v-test]:last-child [data-v-test] { color: red;
+      "[data-v-test]:last-child :where([data-v-test]) { color: red;
       }"
     `)
     expect(compileScoped(`:last-child *:active { color: red; }`))
       .toMatchInlineSnapshot(`
-      "[data-v-test]:last-child [data-v-test]:active { color: red;
+      "[data-v-test]:last-child :where([data-v-test]):active { color: red;
       }"
     `)
   })

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -218,7 +218,7 @@ function rewriteSelector(
         }
       }
       // store the universal selector so it can be rewritten later
-      // .foo * -> .foo[xxxxxxx] [xxxxxxx]
+      // .foo * -> .foo[xxxxxxx] :where([xxxxxxx])
       starNode = n
     }
 
@@ -280,15 +280,20 @@ function rewriteSelector(
       }),
     )
     // Used for trailing universal selectors (#12906)
-    // `.foo * {}` -> `.foo[xxxxxxx] [xxxxxxx] {}`
+    // `.foo * {}` -> `.foo[xxxxxxx] :where([xxxxxxx]) {}`
     if (starNode) {
       selector.insertBefore(
         starNode,
-        selectorParser.attribute({
-          attribute: idToAdd,
-          value: idToAdd,
-          raws: {},
-          quoteMark: `"`,
+        selectorParser.pseudo({
+          value: ':where',
+          nodes: [
+            selectorParser.attribute({
+              attribute: idToAdd,
+              value: idToAdd,
+              raws: {},
+              quoteMark: `"`,
+            }),
+          ],
         }),
       )
       selector.removeChild(starNode)


### PR DESCRIPTION
close #13401
re-fix https://github.com/vuejs/core/issues/12906

#12918 replaced `*` with `[id]`, which indirectly increased the rule's specificity
`.row[data-v-e17ea971] > * {}` changed to `.row[data-v-e17ea971] > [data-v-e17ea971] {}`,
leading to the issue in #13401.

This PR changes `*` to `:where([id])` to maintain the same specificity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of scoped CSS for universal selectors, ensuring that attribute selectors are now wrapped in the `:where()` pseudo-class for more accurate and consistent styling in compiled CSS. This affects selectors such as `.foo *` and `*:active`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->