### PR TITLE
feat(runtime-core): add generic option to getCurrentInstance

### DIFF
--- a/packages/runtime-core/src/componentCurrentInstance.ts
+++ b/packages/runtime-core/src/componentCurrentInstance.ts
@@ -16,10 +16,25 @@ export let currentInstance: GenericComponentInstance | null = null
 export const getCurrentGenericInstance: () => GenericComponentInstance | null =
   () => currentInstance || currentRenderingInstance
 
-export const getCurrentInstance: () => ComponentInternalInstance | null = () =>
-  currentInstance && !currentInstance.vapor
-    ? (currentInstance as ComponentInternalInstance)
+/**
+ * Retrieves the current component instance.
+ *
+ * @param generic - A boolean flag indicating whether to return a generic component instance.
+ *                  If `true`, returns a `GenericComponentInstance` including vapor instance.
+ *                  If `false` or unset, returns a `ComponentInternalInstance` if available.
+ * @returns The current component instance, or `null` if no instance is active.
+ */
+export function getCurrentInstance(
+  generic: true,
+): GenericComponentInstance | null
+export function getCurrentInstance(
+  generic?: boolean,
+): ComponentInternalInstance | null
+export function getCurrentInstance(generic?: boolean) {
+  return currentInstance && (generic || !currentInstance.vapor)
+    ? currentInstance
     : currentRenderingInstance
+}
 
 export let isInSSRComponentSetup = false
 


### PR DESCRIPTION
## Issue

In Vapor mode, getCurrentInstance returns null. Vue 3.6 will expose currentInstance for Vapor instances, but for users on Vue 3.5 or earlier, this causes a build error.

```ts
import { currentInstance } from 'vue'
```
will get error: 
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/8658ee37-7cee-4f14-9774-81709e743f19" />


## Proposed Solution

Add a generic option to getCurrentInstance that returns the Vapor instance when set to true. This allows plugins to retrieve the Vapor instance without affecting users on Vue 3.5 or earlier.

```ts
const i = getCurrentInstance(true) // VaporInstance | ComponentInternalInstance
```