### PR TITLE
refactor(hydration): reuse existing variable

### DIFF
--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -997,6 +997,6 @@ function isMismatchAllowed(
     if (allowedType === MismatchTypes.TEXT && list.includes('children')) {
       return true
     }
-    return allowedAttr.split(',').includes(MismatchTypeString[allowedType])
+    return list.includes(MismatchTypeString[allowedType])
   }
 }


### PR DESCRIPTION
Avoid calling `allowedAttr.split(',')` twice by using `list`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal performance by optimizing attribute handling during hydration. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->