### PR TITLE
refactor(compat): rename legacyresolveScopedSlots to legacyResolveScopedSlots

### DIFF
--- a/packages/runtime-core/src/compat/instance.ts
+++ b/packages/runtime-core/src/compat/instance.ts
@@ -33,7 +33,7 @@ import {
   legacyPrependModifier,
   legacyRenderSlot,
   legacyRenderStatic,
-  legacyresolveScopedSlots,
+  legacyResolveScopedSlots,
 } from './renderHelpers'
 import { resolveFilter } from '../helpers/resolveAssets'
 import type { Slots } from '../componentSlots'
@@ -183,7 +183,7 @@ export function installCompatInstanceProperties(
     _b: () => legacyBindObjectProps,
     _v: () => createTextVNode,
     _e: () => createCommentVNode,
-    _u: () => legacyresolveScopedSlots,
+    _u: () => legacyResolveScopedSlots,
     _g: () => legacyBindObjectListeners,
     _d: () => legacyBindDynamicKeys,
     _p: () => legacyPrependModifier,

--- a/packages/runtime-core/src/compat/renderHelpers.ts
+++ b/packages/runtime-core/src/compat/renderHelpers.ts
@@ -87,7 +87,7 @@ type LegacyScopedSlotsData = Array<
   | LegacyScopedSlotsData
 >
 
-export function legacyresolveScopedSlots(
+export function legacyResolveScopedSlots(
   fns: LegacyScopedSlotsData,
   raw?: Record<string, Slot>,
   // the following are added in 2.6


### PR DESCRIPTION
This PR renames the function `legacyresolveScopedSlots` to`legacyResolveScopedSlots` to improve code readability and maintain consistency with existing naming patterns in the codebase.

This is a non-functional change and should not affect any logic or behavior.