### PR TITLE
types(compiler-sfc): add explicit return type to genModelProps

### DIFF
--- a/packages/compiler-sfc/src/script/defineModel.ts
+++ b/packages/compiler-sfc/src/script/defineModel.ts
@@ -114,7 +114,7 @@ export function processDefineModel(
   return true
 }
 
-export function genModelProps(ctx: ScriptCompileContext) {
+export function genModelProps(ctx: ScriptCompileContext): string | undefined {
   if (!ctx.hasDefineModelCall) return
 
   const isProd = !!ctx.options.isProd


### PR DESCRIPTION
This PR adds an explicit return type to the `genModelProps` function to improve type clarity and satisfy the `isolatedDeclarations` requirement.