### PR TITLE
add `Promise/setTimeout/setInterval` to GLOBALS_ALLOWED

### DIFF
--- a/packages/shared/src/globalsAllowList.ts
+++ b/packages/shared/src/globalsAllowList.ts
@@ -3,7 +3,8 @@ import { makeMap } from './makeMap'
 const GLOBALS_ALLOWED =
   'Infinity,undefined,NaN,isFinite,isNaN,parseFloat,parseInt,decodeURI,' +
   'decodeURIComponent,encodeURI,encodeURIComponent,Math,Number,Date,Array,' +
-  'Object,Boolean,String,RegExp,Map,Set,JSON,Intl,BigInt,console,Error,Symbol'
+  'Object,Boolean,String,RegExp,Map,Set,JSON,Intl,BigInt,console,Error,Symbol' +
+  'Promise,setTimeout,setInterval'
 
 export const isGloballyAllowed: (key: string) => boolean =
   /*@__PURE__*/ makeMap(GLOBALS_ALLOWED)

--- a/packages/shared/src/globalsAllowList.ts
+++ b/packages/shared/src/globalsAllowList.ts
@@ -3,7 +3,7 @@ import { makeMap } from './makeMap'
 const GLOBALS_ALLOWED =
   'Infinity,undefined,NaN,isFinite,isNaN,parseFloat,parseInt,decodeURI,' +
   'decodeURIComponent,encodeURI,encodeURIComponent,Math,Number,Date,Array,' +
-  'Object,Boolean,String,RegExp,Map,Set,JSON,Intl,BigInt,console,Error,Symbol' +
+  'Object,Boolean,String,RegExp,Map,Set,JSON,Intl,BigInt,console,Error,Symbol,' +
   'Promise,setTimeout,setInterval'
 
 export const isGloballyAllowed: (key: string) => boolean =


### PR DESCRIPTION
This scene was discovered when I temporarily wanted to debug some information
current i have to
```vue
<script setup lang="ts">
const P = Promise.bind(window)
const S = setTimeout.bind(window)
</script>

<template>
  <div @click="async()=>{
   doSomething()
   await new P(r=>S(r, 1000))
   doSomething()
  }">loading</div>
</template>

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Expanded the list of allowed global identifiers to include `Promise`, `setTimeout`, and `setInterval`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->