### PR TITLE
perf(compiler): remove regx for removeStaticBinding

### DIFF
--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -39,6 +39,7 @@ import {
   isBooleanAttr,
   isBuiltInDirective,
   isSSRSafeAttrName,
+  isString,
   propsToAttrMap,
 } from '@vue/shared'
 import { SSRErrorCodes, createSSRCompilerError } from '../errors'
@@ -423,9 +424,16 @@ function removeStaticBinding(
   tag: TemplateLiteral['elements'],
   binding: string,
 ) {
-  const regExp = new RegExp(`^ ${binding}=".+"$`)
-
-  const i = tag.findIndex(e => typeof e === 'string' && regExp.test(e))
+  const bindingStart = ` ${binding}="`
+  // tag must end with at least one character and "
+  const minLen = bindingStart.length + 2
+  const i = tag.findIndex(
+    e =>
+      isString(e) &&
+      e.length >= minLen &&
+      e.startsWith(bindingStart) &&
+      e[e.length - 1] === '"',
+  )
 
   if (i > -1) {
     tag.splice(i, 1)


### PR DESCRIPTION
Regular expression ``new RegExp(`^ ${binding}=".+"$`)`` is easily replaced using string methods.

For example, the binding is `'class'`

1. Tag item must startsWith `` class="`` and endsWith `"`
2. The length of the tag must be greater than or equal to 10 (` class=“` + `"` + At least one character)

[Benchmark](https://stackblitz.com/edit/vitest-dev-vitest-p5ndun5g?file=index.bench.ts) shows 2x faster than before.