### PR TITLE
chore: export `jsxs` type

### DIFF
--- a/packages/vue/jsx-runtime/index.d.ts
+++ b/packages/vue/jsx-runtime/index.d.ts
@@ -6,7 +6,7 @@ import type { NativeElements, ReservedProps, VNode } from '@vue/runtime-dom'
  * when ts compilerOptions.jsx is 'react-jsx' or 'react-jsxdev'
  * https://www.typescriptlang.org/tsconfig#jsxImportSource
  */
-export { h as jsx, h as jsxDEV, Fragment } from '@vue/runtime-dom'
+export { h as jsx, h as jsxDEV, Fragment, h as jsxs } from '@vue/runtime-dom'
 
 export namespace JSX {
   export interface Element extends VNode {}


### PR DESCRIPTION
According to this PR https://github.com/vuejs/core/pull/7959, I think we should export `jsxs type` to avoid type errors in ts

For example, a type error will occur when using it like this
https://www.typescriptlang.org/play/?ts=5.8.3#code/JYWwDg9gTgLgBAbzgCzgXzgMyhEcDkyAhgM4wkDGUwYM+AUKJLInDBAFIkAeASgK4A7GKACm6LDjyFSMALT8RAGzns5AKx5yoQkSFEMm0eEgBiUIgHN9wgDRxN3e45ITsuAgDd+ogPSPtXTF8OF9fOABBTyJgJSIAIyVxEmBBCnEAA29RAAEAZgA6PIyC+np2Lj4g-QAKZBrCAEZ8e0JgAEJ8AEp7BHo4OHMrGxhbfoceMYGXKbhRJJGImBhqeMVRADkifQBhUlEALgJkGBAlBjQuoA
