### PR TITLE
Update Suspense.ts

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -462,9 +462,6 @@ function createSuspenseBoundary(
     hasWarned = true
     // @ts-expect-error `console.info` cannot be null error
     // eslint-disable-next-line no-console
-    console[console.info ? 'info' : 'log'](
-      `<Suspense> is an experimental feature and its API will likely change.`,
-    )
   }
   /* v8 ignore stop */
 


### PR DESCRIPTION
Remove annoying Suspense message, as there is no other way to silence it. It messes with unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the development-only console warning about the experimental status of the `<Suspense>` feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->