### PR TITLE
fix(runtime-vapor): dynamic component fallback rendering with insertionState

### DIFF
--- a/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
@@ -1,6 +1,13 @@
-import { shallowRef } from '@vue/reactivity'
-import { nextTick } from '@vue/runtime-dom'
-import { createDynamicComponent } from '../src'
+import { ref, shallowRef } from '@vue/reactivity'
+import { nextTick, resolveDynamicComponent } from '@vue/runtime-dom'
+import {
+  createComponentWithFallback,
+  createDynamicComponent,
+  renderEffect,
+  setHtml,
+  setInsertionState,
+  template,
+} from '../src'
 import { makeRender } from './_utils'
 
 const define = makeRender()
@@ -53,5 +60,23 @@ describe('api: createDynamicComponent', () => {
     val.value = 'baz'
     await nextTick()
     expect(html()).toBe('<baz></baz><!--dynamic-component-->')
+  })
+
+  test('render fallback with insertionState', async () => {
+    const { html, mount } = define({
+      setup() {
+        const html = ref('hi')
+        const n1 = template('<div></div>', true)() as any
+        setInsertionState(n1)
+        const n0 = createComponentWithFallback(
+          resolveDynamicComponent('button') as any,
+        ) as any
+        renderEffect(() => setHtml(n0, html.value))
+        return n1
+      },
+    }).create()
+
+    mount()
+    expect(html()).toBe('<div><button>hi</button></div>')
   })
 })

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -476,6 +476,14 @@ export function createComponentWithFallback(
     return createComponent(comp, rawProps, rawSlots, isSingleRoot)
   }
 
+  const _insertionParent = insertionParent
+  const _insertionAnchor = insertionAnchor
+  if (isHydrating) {
+    locateHydrationNode()
+  } else {
+    resetInsertionState()
+  }
+
   const el = document.createElement(comp)
   // mark single root
   ;(el as any).$root = isSingleRoot
@@ -492,6 +500,10 @@ export function createComponentWithFallback(
     } else {
       insert(getSlot(rawSlots as RawSlots, 'default')!(), el)
     }
+  }
+
+  if (!isHydrating && _insertionParent) {
+    insert(el, _insertionParent, _insertionAnchor)
   }
 
   return el


### PR DESCRIPTION
- [Playground with vapor branch](https://deploy-preview-12359--vapor-repl.netlify.app/#eNp9Ub1OwzAQfpWTl4BUmgGmKkUC1AEGQMDoJaTX1sWxLfscIkV5d86OWjpUnXz3/ek7eRAPzs27iGIhqtB45QgCUnTQ1c76e2lUyy/BAB43MMLG2xYKNhTSNNYEgh21GpaJvip2qriWpiqnJHbzQtg6XRPyBlCtVZcHHhvL0QYNgQpLKb4jkTVSQHeTIhlJD+/l5Cwna1WeBIqZoMA1Nmo73wdr+IohiaVI4Uqjf3OkuKYUC8hM4mqt7e9LxshHnB3wZofNzxl8H/qESfHuMaDvUIojR7XfIk306vMVe56PZGvXUbP6AvmBweqYOk6yx2jWXPtEl9s+519QZvsVVj2hCYejUtGkHLNeCv6Zpwun/9e9nd9lnzSjGP8AigyrYg==)