### PR TITLE
fix(runtime-vapor): should not fallthrough emit handlers to vdom child

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -557,3 +557,7 @@ export { startMeasure, endMeasure } from './profiling'
  * @internal
  */
 export { initFeatureFlags } from './featureFlags'
+/**
+ * @internal
+ */
+export { createInternalObject } from './internalObject'

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1,4 +1,11 @@
-import { type Ref, nextTick, ref } from '@vue/runtime-dom'
+import {
+  type Ref,
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+} from '@vue/runtime-dom'
 import {
   createComponent,
   defineVaporComponent,
@@ -8,6 +15,7 @@ import {
   setProp,
   setStyle,
   template,
+  vaporInteropPlugin,
 } from '../src'
 import { makeRender } from './_utils'
 import { stringifyStyle } from '@vue/shared'
@@ -360,5 +368,43 @@ describe('attribute fallthrough', () => {
 
     const el = host.children[0]
     expect(el.classList.length).toBe(0)
+  })
+
+  it('should not fallthrough emit handlers to vdom child', () => {
+    const VDomChild = defineComponent({
+      emits: ['click'],
+      setup(_, { emit }) {
+        return () => h('button', { onClick: () => emit('click') }, 'click me')
+      },
+    })
+
+    const fn = vi.fn()
+    const VaporChild = defineVaporComponent({
+      emits: ['click'],
+      setup() {
+        return createComponent(
+          VDomChild as any,
+          { onClick: () => fn },
+          null,
+          true,
+        )
+      },
+    })
+
+    const App = {
+      setup() {
+        return () => h(VaporChild as any)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe('<button>click me</button>')
+    const button = root.querySelector('button')!
+    button.dispatchEvent(new Event('click'))
+
+    // fn should be called once
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -9,9 +9,11 @@ import {
   type Slots,
   type VNode,
   type VaporInteropInterface,
+  createInternalObject,
   createVNode,
   currentInstance,
   ensureRenderer,
+  isEmitListener,
   onScopeDispose,
   renderSlot,
   shallowRef,
@@ -162,7 +164,14 @@ function createVDOMComponent(
   // overwrite how the vdom instance handles props
   vnode.vi = (instance: ComponentInternalInstance) => {
     instance.props = wrapper.props
-    instance.attrs = wrapper.attrs
+
+    const attrs = (instance.attrs = createInternalObject())
+    for (const key in wrapper.attrs) {
+      if (!isEmitListener(instance.emitsOptions, key)) {
+        attrs[key] = wrapper.attrs[key]
+      }
+    }
+
     instance.slots =
       wrapper.slots === EMPTY_OBJ
         ? EMPTY_OBJ


### PR DESCRIPTION
- [Playground with vapor branch](https://deploy-preview-12359--vapor-repl.netlify.app/#eNqFkkFPgzAUx79K05jAkgUOekJc1GUHPahR46kXhAfrVlpCCy5Z9t19LcKYm/PU9v3/r/2997qld1UVtA3QiMY6rXlliAbTVDMmeVmp2pCPBJe5KiuS16okXhAOEZvoXTMZh10qJuHBQFmJxACeCIkHc4jnOByJdEqNTpXMeRGstJKIsLUpjKZo5wLq58pwJTWjEXGK1RIh1Neji5m6gWkfT5eQrk/EV3pjY4y+1KChboHRQTNJXYDp5MXbE2xwP4ilyhqB7jPiK2glGsvY2e4bmSH2yOdoH1wjuSze9WJjQOq+KAtqnTvnZxTbaTv1V+l73MvgyuUxucMuHszj9yBJa9XRODNVHk7zJ9APM29kat8my8RWMxc8XfsTB4HDwoIhEKrwvdQK3gQR/vkA/YO3LuOG0dHFjJ76FmOko3pEIgu8xGBv0J1BziUsSm507Bh9iEjPFpFW8QwJZz5ynoP8bIzBkgfEC8Ab9zXSmdvFYec7Qt59A8E9HjM=)