### PR TITLE
fix(runtime-vapor): ensure props are shallow reactive in VDOM component

### DIFF
--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -16,6 +16,7 @@ import {
   isEmitListener,
   onScopeDispose,
   renderSlot,
+  shallowReactive,
   shallowRef,
   simpleSetCurrentInstance,
 } from '@vue/runtime-dom'
@@ -163,7 +164,8 @@ function createVDOMComponent(
 
   // overwrite how the vdom instance handles props
   vnode.vi = (instance: ComponentInternalInstance) => {
-    instance.props = wrapper.props
+    // ensure props are shallow reactive to align with VDOM behavior.
+    instance.props = shallowReactive(wrapper.props)
 
     const attrs = (instance.attrs = createInternalObject())
     for (const key in wrapper.attrs) {


### PR DESCRIPTION
- [Playground with vapor branch](https://deploy-preview-12359--vapor-repl.netlify.app/#eNp9UctuwjAQ/JWVL4CEkkN7ogGprTi0hxa1PfoShQVME9uyN4CE8u/dNeUhVHqyd2ZWHs/s1aP32aZFNVJFrILxBBGp9bApvQsTbU3DJ8Gzazwsgmugl+UyyFLvQdsiP6yxlAfCxtclIU8Ahehyvhb5Ba6GimLl7MIss3V0ll/ei1qriuWmxvDuyTgbtRpBYoQr69ptXxNGocXhEa9WWH3/ga/jTjCtZgEjhg1qdeKoDEukAz39fMMd309k4+Ztzep/yA+Mrm7F40H21No5277QJbcvKTljl19xuiO08fgpMSrKLum14iQlqVtfP9u9y+7TnrYdp3hs4bq6c2l72JZUraD7bU4q05azjwQ+OB9hDHNcGIszmfoDbdNCP5FD6A9gPBEj/CBzN6u+brj7AZMQybs=)

There is a similar issue when directly watching props in the Vapor component. Related PR: #13384