### PR TITLE
fix(compiler-core): preserve start/end whitespace nodes in whitespace: 'preserve' mode

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2419,9 +2419,14 @@ describe('compiler: parse', () => {
         ...options,
       })
 
-    test('should still remove whitespaces at start/end inside an element', () => {
+    test('should preserve whitespaces at start/end inside a non-root element', () => {
       const ast = parse(`<div>   <span/>    </div>`)
-      expect((ast.children[0] as ElementNode).children.length).toBe(1)
+      expect((ast.children[0] as ElementNode).children.length).toBe(3)
+    })
+
+    test('should remove whitespaces at start/end inside a root element', () => {
+      const ast = parse(`   <span/>    `)
+      expect(ast.children).toMatchObject([{ type: NodeTypes.ELEMENT }])
     })
 
     test('should preserve whitespaces w/ newline between elements', () => {
@@ -2433,6 +2438,48 @@ describe('compiler: parse', () => {
         NodeTypes.ELEMENT,
         NodeTypes.TEXT,
         NodeTypes.ELEMENT,
+      ])
+    })
+
+    test('should preserve surrounding whitespace for element with text between comments', () => {
+      const ast = parse(`<div>   <!--comment-->Hi<!--comment--> </div>`)
+      expect(ast.children).toMatchObject([
+        {
+          type: NodeTypes.ELEMENT,
+          children: [
+            { type: NodeTypes.TEXT, content: ' ' },
+            { type: NodeTypes.COMMENT, content: 'comment' },
+            { type: NodeTypes.TEXT, content: 'Hi' },
+            { type: NodeTypes.COMMENT, content: 'comment' },
+            { type: NodeTypes.TEXT, content: ' ' },
+          ],
+        },
+      ])
+    })
+
+    test('should preserve surrounding whitespace for element with text between comments and newlines', () => {
+      const ast = parse(`<div>\n <!--comment-->Hi<!--comment-->\n</div>`)
+      expect(ast.children).toMatchObject([
+        {
+          type: NodeTypes.ELEMENT,
+          children: [
+            { type: NodeTypes.TEXT, content: ' ' },
+            { type: NodeTypes.COMMENT, content: 'comment' },
+            { type: NodeTypes.TEXT, content: 'Hi' },
+            { type: NodeTypes.COMMENT, content: 'comment' },
+            { type: NodeTypes.TEXT, content: ' ' },
+          ],
+        },
+      ])
+    })
+
+    test('should preserve whitespace for single element of only whitespace', () => {
+      const ast = parse(`<div> </div>`)
+      expect(ast.children).toMatchObject([
+        {
+          type: NodeTypes.ELEMENT,
+          children: [{ type: NodeTypes.TEXT, content: ' ' }],
+        },
       ])
     })
 

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -225,7 +225,30 @@ return function render(_ctx, _cache) {
     header: _withCtx(() => [" Header "]),
     default: _withCtx(() => [
       " ",
-      _createElementVNode("p")
+      " ",
+      _createElementVNode("p"),
+      " "
+    ]),
+    _: 1 /* STABLE */
+  }))
+}"
+`;
+
+exports[`compiler: transform component slots > with whitespace: 'preserve' > implicit default slot before and after template 1`] = `
+"const { createElementVNode: _createElementVNode, resolveComponent: _resolveComponent, withCtx: _withCtx, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+return function render(_ctx, _cache) {
+  const _component_Comp = _resolveComponent("Comp")
+
+  return (_openBlock(), _createBlock(_component_Comp, null, {
+    header: _withCtx(() => [" Header "]),
+    default: _withCtx(() => [
+      " ",
+      _createElementVNode("p"),
+      " ",
+      " ",
+      _createElementVNode("p"),
+      " "
     ]),
     _: 1 /* STABLE */
   }))

--- a/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
@@ -965,6 +965,24 @@ describe('compiler: transform component slots', () => {
       expect(generate(root, { prefixIdentifiers: true }).code).toMatchSnapshot()
     })
 
+    test('implicit default slot before and after template', () => {
+      const source = `
+      <Comp>
+        <p/>
+        <template #header> Header </template>
+        <p/>
+      </Comp>
+      `
+      const { root } = parseWithSlots(source, {
+        whitespace: 'preserve',
+      })
+
+      expect(
+        `Extraneous children found when component already has explicitly named default slot.`,
+      ).not.toHaveBeenWarned()
+      expect(generate(root, { prefixIdentifiers: true }).code).toMatchSnapshot()
+    })
+
     test('should not generate whitespace only default slot', () => {
       const source = `
       <Comp>


### PR DESCRIPTION
close #7789

This would solve the scenario highlighted in this issue of a single child whitespace-only text node being wiped, and would also more generically handle scenarios like: `<span> <!--comment-->Value<!--comment--> </span>` where the whitespace is currently wiped in `preserve` mode perhaps unexpectedly.

Furthermore, I think this behavior change would also closer align with the documented behavior: https://vuejs.org/api/application#app-config-compileroptions-whitespace

> 2. Whitespace characters between elements that contain newlines are removed.
> [...]
>
> Setting this option to 'preserve' will disable (2) and (3).

Notes/downsides:
1. This is a breaking change
2. This makes the `preserve` behavior different from Vue 2 `preserve` behavior (e.g. Vue 2.7.14 strips `<span> </span>` to `<span></span>` in preserve mode)
3. This will make user bundle sizes larger due to extra whitespace nodes