### PR TITLE
refactor(runtime-core): check `props` rather than `propsOptions[0]`

### DIFF
--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -430,7 +430,6 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     // is the multiple hasOwn() calls. It's much faster to do a simple property
     // access on a plain object, so we use an accessCache object (with null
     // prototype) to memoize what access type a key corresponds to.
-    let normalizedProps
     if (key[0] !== '$') {
       const n = accessCache![key]
       if (n !== undefined) {
@@ -451,12 +450,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
       } else if (data !== EMPTY_OBJ && hasOwn(data, key)) {
         accessCache![key] = AccessTypes.DATA
         return data[key]
-      } else if (
-        // only cache other properties when instance has declared (thus stable)
-        // props
-        (normalizedProps = instance.propsOptions[0]) &&
-        hasOwn(normalizedProps, key)
-      ) {
+      } else if (hasOwn(props, key)) {
         accessCache![key] = AccessTypes.PROPS
         return props![key]
       } else if (ctx !== EMPTY_OBJ && hasOwn(ctx, key)) {
@@ -575,16 +569,15 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
 
   has(
     {
-      _: { data, setupState, accessCache, ctx, appContext, propsOptions },
+      _: { data, setupState, accessCache, ctx, appContext, props },
     }: ComponentRenderContext,
     key: string,
   ) {
-    let normalizedProps
     return (
       !!accessCache![key] ||
       (data !== EMPTY_OBJ && hasOwn(data, key)) ||
       hasSetupBinding(setupState, key) ||
-      ((normalizedProps = propsOptions[0]) && hasOwn(normalizedProps, key)) ||
+      hasOwn(props, key) ||
       hasOwn(ctx, key) ||
       hasOwn(publicPropertiesMap, key) ||
       hasOwn(appContext.config.globalProperties, key)


### PR DESCRIPTION
This is minor refactoring of the logic for handling props in `PublicInstanceProxyHandlers.get` and `PublicInstanceProxyHandlers.has`, switching it from checking `propsOptions[0]` to checking `props`. The new version is simpler and leads to a smaller build.

In Vue 3.0, props could be missing from the `props` object. Props were only included if they were passed in by the parent or had a default value. The logic in `PublicInstanceProxyHandlers` couldn't rely on checking `props`, so it checked `propsOptions[0]` instead.

That changed in 3.1.0. See #3288 for more details, but `props` now contains all the props.

Some other notes about what I changed and why...

- The code for `set` hasn't been changed as that was already using `props`.
- I did consider adding a check for `EMPTY_OBJ` (as used for other sources of properties, e.g. `data`), but `props` won't be an `EMPTY_OBJ` by the time this code runs, even for components that don't declare any props.
- `propsOptions` is populated before `props`, so there is potentially a timing issue introduced by this change. However, in practice, the only user-facing 'hook' that runs between the population of those two objects is the `default` function for a prop. The `default` function doesn't have access to the relevant proxy, so it could only encounter a problem if it called `getCurrentInstance().proxy` (which it shouldn't be doing anyway) and then did some very strange things with it. I don't think this is a realistic case.
- I've also removed an adjacent comment that seems to be referring to a much older implementation and is no longer relevant.
- The existing tests all pass, but I don't think they're actually testing this specific aspect. I did try to add some extra tests, but it's quite difficult to test because dev builds expose all props via `ctx` (see `exposePropsOnRenderContext` in the same file). Even if the logic for props is wrong it still 'works' because they're accessed via `ctx` instead. If the logic were wrong it would likely only fail in a production build.