### PR TITLE
fix(compiler-vapor): properly cache variable with optional chaining

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -113,6 +113,20 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`cache multiple access > optional chaining 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div></div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => {
+    const _obj = _ctx.obj
+    _setProp(n0, "id", _obj?.foo + _obj?.bar)
+  })
+  return n0
+}"
+`;
+
 exports[`cache multiple access > repeated expression in expressions 1`] = `
 "import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div></div>")

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -794,6 +794,13 @@ describe('cache multiple access', () => {
     expect(code).contains('_setStyle(n0, {color: _color})')
   })
 
+  test('optional chaining', () => {
+    const { code } = compileWithVBind(`<div :id="obj?.foo + obj?.bar"></div>`)
+    expect(code).matchSnapshot()
+    expect(code).contains('const _obj = _ctx.obj')
+    expect(code).contains('_setProp(n0, "id", _obj?.foo + _obj?.bar)')
+  })
+
   test('not cache variable only used in property shorthand', () => {
     const { code } = compileWithVBind(`
         <div :style="{color}" />

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -588,6 +588,7 @@ function extractMemberExpression(
     case 'CallExpression': // foo[bar(baz)]
       return `${extractMemberExpression(exp.callee, onIdentifier)}(${exp.arguments.map(arg => extractMemberExpression(arg, onIdentifier)).join(', ')})`
     case 'MemberExpression': // foo[bar.baz]
+    case 'OptionalMemberExpression': // foo?.bar
       const object = extractMemberExpression(exp.object, onIdentifier)
       const prop = exp.computed
         ? `[${extractMemberExpression(exp.property, onIdentifier)}]`


### PR DESCRIPTION
- [Playground with vapor branch](https://deploy-preview-12359--vapor-repl.netlify.app/#eNp9kTFPwzAQhf+KdStVOsAUpa0AdYABEDB6SZNrcHBsyz6HSFH+O+dELR1QN99735Pf2SPcO5f1ESGHIlReORIBKTrRl876rTSVNYGEPbRiI8ZJmmK9YGzxQNg5XRLyVNSqF7mqNxKY3mVHa8VNCu6yQ+klbIs1EwlcX6RgBRT4jqNqsjZYwz1GaYSQUNnOKY3+1ZHiDhJyMTvJK7W2P8+zRj7i6qRXX1h9/6O3YUiahDePAX2PEs4elb5BWuz9xwsOfD6bna2jZvqK+Y7B6pg6LthDNDXXvuDmtk8dvycp03yG/UBowmmpVDSR08xL4M94vLL6X93b7G7OSTPB9AvSMJbU)