### PR TITLE
fix(runtime-vapor): render slot fallback if no content is provided

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1,0 +1,29 @@
+import { h } from 'vue'
+import { createSlot, defineVaporComponent, template } from '../src'
+import { makeInteropRender } from './_utils'
+
+const define = makeInteropRender()
+
+describe('vdomInterop', () => {
+  describe('slots', () => {
+    test('should render slot fallback if no slot content is provided', () => {
+      const VaporChild = defineVaporComponent({
+        setup() {
+          const n0 = createSlot('default', null, () => {
+            const n2 = template('<div>hi</div>')()
+            return n2
+          })
+          return n0
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporChild as any)
+        },
+      }).render()
+
+      expect(html()).toBe('<div>hi</div>')
+    })
+  })
+})

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -236,24 +236,26 @@ function renderVDOMSlot(
   frag.insert = (parentNode, anchor) => {
     if (!isMounted) {
       renderEffect(() => {
-        const vnode = renderSlot(
-          slotsRef.value,
-          isFunction(name) ? name() : name,
-          props,
-        )
-        if ((vnode.children as any[]).length) {
-          if (fallbackNodes) {
-            remove(fallbackNodes, parentNode)
-            fallbackNodes = undefined
-          }
-          internals.p(
-            oldVNode,
-            vnode,
-            parentNode,
-            anchor,
-            parentComponent as any,
+        if (slotsRef.value) {
+          const vnode = renderSlot(
+            slotsRef.value,
+            isFunction(name) ? name() : name,
+            props,
           )
-          oldVNode = vnode
+          if ((vnode.children as any[]).length) {
+            if (fallbackNodes) {
+              remove(fallbackNodes, parentNode)
+              fallbackNodes = undefined
+            }
+            internals.p(
+              oldVNode,
+              vnode,
+              parentNode,
+              anchor,
+              parentComponent as any,
+            )
+            oldVNode = vnode
+          }
         } else {
           if (fallback && !fallbackNodes) {
             // mount fallback


### PR DESCRIPTION
- [Playground](https://deploy-preview-12359--vapor-repl.netlify.app/#eNp9UT1PwzAQ/SuWly5VMsBUQiRAHWAABIjJS0guqYtjW/4Ikar8d86OkqaIdsq79xE93x3ondZJ54FuaGZLw7UjFpzXOZO81co48lng50G1mtRGtWSVpDMTgqsbJrN0jGIIBwetFoUDnAjJZvM4HsM4Z+nCS9fU2VLJmjfJ3iqJjQ4hwmiJbi7AvGjHlbSMbkhUglYIoX6eIueMh/XElzsov//h97YPHKOvBiyYDhidNVeYBtwob9+foUc8i62qvED3BfENrBI+dBxt915WWHvhi20f4165bD7stncg7fSoUDQ4h+hnFLcbFnXu6ce6V8l1zDE54BZPzvP3rqQLan7pYhXvIkBohXL5jqM7gAVJZNHCLaO1UoymkxKSX4XJ0ukXEzo99PAL8d7Rug==)