### PR TITLE
 fix(runtime-vapor): prevent passing null slots to renderSlot

### DIFF
--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -236,12 +236,10 @@ function renderVDOMSlot(
   frag.insert = (parentNode, anchor) => {
     if (!isMounted) {
       renderEffect(() => {
-        const vnode = renderSlot(
-          slotsRef.value,
-          isFunction(name) ? name() : name,
-          props,
-        )
-        if ((vnode.children as any[]).length) {
+        const vnode = slotsRef.value
+          ? renderSlot(slotsRef.value, isFunction(name) ? name() : name, props)
+          : null
+        if (vnode && (vnode.children as any[]).length) {
           if (fallbackNodes) {
             remove(fallbackNodes, parentNode)
             fallbackNodes = undefined


### PR DESCRIPTION
[REPL](https://deploy-preview-13558--vapor-repl.netlify.app/#eNp9kTFPwzAQhf+K5aVLlQwwVVElQB1gAASIyUuUXouLY1v2OUSq8t+5c2jaIuiU5H3vOc93e3njfdElkAtZxSZojyICJr9UVrfeBRTvNT3uXOvFJrhWzIpyUjg4U7YqxyRl6AOh9aZGoC8hqmO6JKEqT6icS4yNsxu9LXbRWaqw54ySDfm1gfDkUTsblVyITJjVxrivh6xhSDA/6M0HNJ9/6LvYs6bkc4AIoQMlJ4Z12AKOePX6CD29T7B162TIfQG+QHQmccfRdpvsmmqf+HLb+zxIbbdvcdUj2Hi4FBdl55D9StI4eVT/Xf1Y96q4zjllB5ri2T5+L1J0TJeXdhSNY51/ko8SfFYm5Q8639vwDbXAvaY=)