### PR TITLE
feat(runtime-vapor): support functional slot in vdom component

### DIFF
--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -35,7 +35,7 @@ export function renderSlot(
   let slot = slots[name]
 
   // vapor slots rendered in vdom
-  if (slot && slots._vapor) {
+  if (slot && (slot as any).__vapor) {
     const ret = (openBlock(), createBlock(VaporSlot, props))
     ret.vs = { slot, fallback }
     return ret

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h } from '@vue/runtime-dom'
+import { defineComponent, h, renderSlot } from '@vue/runtime-dom'
 import { makeInteropRender } from './_utils'
 import { createComponent, defineVaporComponent } from '../src'
 
@@ -9,7 +9,36 @@ describe('vdomInterop', () => {
 
   describe.todo('emit', () => {})
 
-  describe.todo('slots', () => {})
+  describe('slots', () => {
+    test('functional slot', () => {
+      const VDomChild = defineComponent({
+        setup(_, { slots }) {
+          return () => renderSlot(slots, 'default')
+        },
+      })
+
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return createComponent(
+            VDomChild as any,
+            null,
+            {
+              default: () => document.createTextNode('default slot'),
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporChild as any)
+        },
+      }).render()
+
+      expect(html()).toBe('default slot')
+    })
+  })
 
   describe.todo('provide', () => {})
 

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, renderSlot } from '@vue/runtime-dom'
+import { createVNode, defineComponent, h, renderSlot } from '@vue/runtime-dom'
 import { makeInteropRender } from './_utils'
 import { createComponent, defineVaporComponent } from '../src'
 
@@ -10,10 +10,40 @@ describe('vdomInterop', () => {
   describe.todo('emit', () => {})
 
   describe('slots', () => {
-    test('functional slot', () => {
+    test('basic', () => {
       const VDomChild = defineComponent({
         setup(_, { slots }) {
           return () => renderSlot(slots, 'default')
+        },
+      })
+
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return createComponent(
+            VDomChild as any,
+            null,
+            {
+              default: () => document.createTextNode('default slot'),
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporChild as any)
+        },
+      }).render()
+
+      expect(html()).toBe('default slot')
+    })
+
+    test('functional slot', () => {
+      const VDomChild = defineComponent({
+        setup(_, { slots }) {
+          console.log(slots.default)
+          return () => createVNode(slots.default!)
         },
       })
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -186,7 +186,7 @@ export function getAttrFromRawProps(rawProps: RawProps, key: string): unknown {
       source = dynamicSources[i]
       isDynamic = isFunction(source)
       source = isDynamic ? (source as Function)() : source
-      if (hasOwn(source, key)) {
+      if (source && hasOwn(source, key)) {
         const value = isDynamic ? source[key] : source[key]()
         if (merged) {
           merged.push(value)

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -134,11 +134,17 @@ const vaporSlotPropsProxyHandler: ProxyHandler<
 
 const vaporSlotsProxyHandler: ProxyHandler<any> = {
   get(target, key) {
-    if (key === '_vapor') {
-      return target
-    } else {
-      return target[key]
-    }
+    const fn = target[key]
+    return isFunction(fn)
+      ? new Proxy(fn, {
+          get(fnTarget, fnKey) {
+            if (fnKey === '__vapor') {
+              return true
+            }
+            return fnTarget[fnKey]
+          },
+        })
+      : fn
   },
 }
 


### PR DESCRIPTION
Use `__vapor` flag of slot instead of `_vapor` flag of slots to determine if it is a vapor slot, so that can support functional slot.

```vue
<script setup>
const slots = useSlots()
</script>

<template>
  <slots.default />
</template>
```

[REPL](https://deploy-preview-13563--vapor-repl.netlify.app/#eNqNkk1PwzAMhv9KlMtAmtoDnKYyiY8d4ACIoZ1yqVp3dORLiTMmTf3vOCnrpmlMOyXx+9h6Y3vL763N1gH4hBe+cq1F5gGDnQrdKmscsi1z0LCONc4oNiJ0NEiPRtm/eJYvSoo9GRWrEVLkfTkqRA8EZWWJQC/Gipg3LfJ0RPJA5WOOvjK6aZfZyhtNvrYxR/CK6FaCe7PYGu0Fn7CkRK2U0vy8pBi6AONdvPqC6vtEfOU3MSb4uwMPbg2CDxqWbgnYy7P5K2zoPojK1EESfUb8AG9kiB577CHommwfcMntc2phq5effrZB0H73qWg0kl3iBad2xkb99/W93ZvsNuUJ3VEXD8dxPFy2juJ+xAvi9nO8bIYRSzfWV2O1UUlIBU6MdVf33KYFD3Np0B+tG+2DJzopdwN0dX3eYeKzGpoySGT5sSUy1f0CwuIEJg==)


Includes https://github.com/vuejs/core/pull/13564 to mark test pass.
 