### PR TITLE
perf(shared): use loose equality in isObject for better performance

### DIFF
--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -51,7 +51,7 @@ export const isFunction = (val: unknown): val is Function =>
 export const isString = (val: unknown): val is string => typeof val === 'string'
 export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
 export const isObject = (val: unknown): val is Record<any, any> =>
-  val !== null && typeof val === 'object'
+  val != null && typeof val === 'object'
 
 export const isPromise = <T = any>(val: unknown): val is Promise<T> => {
   return (


### PR DESCRIPTION
This PR changes the null check in `isObject` from `val !== null` to `val != null` to achieve a slight performance improvement.

During the validation process, this approach allows us to filter out both `null` and `undefined` values in a single comparison before proceeding with the `typeof` check, making the overall validation more efficient.