### PR TITLE
fix(compiler-vapor): add missing dependency for @babel/parser

### DIFF
--- a/packages/compiler-vapor/package.json
+++ b/packages/compiler-vapor/package.json
@@ -42,6 +42,7 @@
   },
   "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-vapor#readme",
   "dependencies": {
+    "@babel/parser": "catalog:",
     "@vue/compiler-dom": "workspace:*",
     "@vue/shared": "workspace:*",
     "source-map-js": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
 
   packages/compiler-vapor:
     dependencies:
+      '@babel/parser':
+        specifier: 'catalog:'
+        version: 7.28.0
       '@vue/compiler-dom':
         specifier: workspace:*
         version: link:../compiler-dom


### PR DESCRIPTION
fix https://github.com/vuejs/ecosystem-ci/actions/runs/16107157715/job/45444649085