### PR TITLE
Add `undefined` to `NativeType` type

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -319,7 +319,7 @@ type InferDefaults<T> = {
   [K in keyof T]?: InferDefault<T, T[K]>
 }
 
-type NativeType = null | number | string | boolean | symbol | Function
+type NativeType = null | undefined | number | string | boolean | symbol | Function
 
 type InferDefault<P, T> =
   | ((props: P) => T & {})


### PR DESCRIPTION
Fixes: https://github.com/vuejs/core/issues/13593

See that issue for more information

The `InferDefault` type filters out any type that isn't listed in `NativeType`, and instead requests a function that returns the type intersected with an empty object (`{}`). However, the intersection with an empty object discards `null` and `undefined` ([According to the docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#improved-intersection-reduction-union-compatibility-and-narrowing)). This isn't an issue for `null`, because it is explicitly listed as a `NativeType`, however this causes an issue for `undefined`.

Currently, when `exactOptionalPropertyTypes` and `strictNullChecks` are true, you cannot set a prop's default value to `undefined` even if it's listed as a possible type. This fixes the issue by explicitly letting it be a default value