### PR TITLE
fix(reactivity): properly cleanup effectScope

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -271,12 +271,12 @@ export function resetTracking(): void {
 export function cleanup(
   sub: ReactiveNode & { cleanups: (() => void)[]; cleanupsLength: number },
 ): void {
-  const l = sub.cleanupsLength
+  const l = sub.cleanups.length
   if (l) {
     for (let i = 0; i < l; i++) {
       sub.cleanups[i]()
     }
-    sub.cleanupsLength = 0
+    sub.cleanups.length = sub.cleanupsLength = 0
   }
 }
 


### PR DESCRIPTION
fix https://github.com/vuejs/ecosystem-ci/actions/runs/16184909715/job/45688573287#step:9:404

`useEventBus` directly operated on cleanups, causing the `cleanupsLength` value to remain at 0 all the time

```js
export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): UseEventBusReturn<T, P> {
  const scope = getCurrentScope()
  function on(listener: EventBusListener<T, P>) {
    const listeners = (events.get(key) || new Set())
    listeners.add(listener)
    events.set(key, listeners)

    const _off = () => off(listener)
    // auto unsubscribe when scope get disposed
    // @ts-expect-error vue3 and vue2 mis-align
    scope?.cleanups?.push(_off)
    return _off
  }
```

---
NOTE:

`cleanups` is an internal property and should not be used directly. `vueuse` needs to use `onScopeDispose` instead