### PR TITLE
feat(compiler-dom): support customizable select

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/validateHtmlNesting.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/validateHtmlNesting.spec.ts
@@ -11,6 +11,13 @@ describe('validate html nesting', () => {
     expect(err!.message).toMatch(`<div> cannot be child of <p>`)
   })
 
+  it("Don't warn with customize select and option", () => {
+    let err: CompilerError | undefined
+    compile(`<select><option></option></select>`, { onWarn: e => (err = e) })
+    compile(`<option><p></p></option>`, { onWarn: e => (err = e) })
+    expect(err).toBeUndefined()
+  })
+
   it('should not warn with select > hr', () => {
     let err: CompilerError | undefined
     compile(`<select><hr></select>`, {

--- a/packages/compiler-dom/src/htmlNesting.ts
+++ b/packages/compiler-dom/src/htmlNesting.ts
@@ -62,8 +62,6 @@ const onlyValidChildren: Record<string, Set<string>> = {
     'script',
     'template',
   ]),
-  optgroup: new Set(['option']),
-  select: new Set(['optgroup', 'option', 'hr']),
   // table
   table: new Set(['caption', 'colgroup', 'tbody', 'tfoot', 'thead']),
   tr: new Set(['td', 'th']),
@@ -74,7 +72,6 @@ const onlyValidChildren: Record<string, Set<string>> = {
   // these elements can not have any children elements
   script: emptySet,
   iframe: emptySet,
-  option: emptySet,
   textarea: emptySet,
   style: emptySet,
   title: emptySet,


### PR DESCRIPTION
Related: #13608

- https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select

| Before | After |
| --- | --- |
|  <img width="3008" height="1258" alt="CleanShot 2025-07-11 at 11 29 01" src="https://github.com/user-attachments/assets/b017e510-c37b-4544-ab14-b27ca6699a97" />  | <img width="872" height="976" alt="CleanShot 2025-07-11 at 11 29 18" src="https://github.com/user-attachments/assets/41d1d0bd-0e41-45e6-8df4-7140c1e32328" /> |
