### PR TITLE
dx(runtime-core): fix warning message for useSlots, useAttrs invocation with missing instance

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -382,17 +382,17 @@ export function withDefaults<
 }
 
 export function useSlots(): SetupContext['slots'] {
-  return getContext().slots
+  return getContext('useSlots').slots
 }
 
 export function useAttrs(): SetupContext['attrs'] {
-  return getContext().attrs
+  return getContext('useAttrs').attrs
 }
 
-function getContext(): SetupContext {
+function getContext(calledFunctionName: string): SetupContext {
   const i = getCurrentInstance()!
   if (__DEV__ && !i) {
-    warn(`useContext() called without active instance.`)
+    warn(`${calledFunctionName}() called without active instance.`)
   }
   return i.setupContext || (i.setupContext = createSetupContext(i))
 }


### PR DESCRIPTION
`useContext` no longer exists; make the warning message of `useAttrs` or `useSlots` being used outside of an active component instance more accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning messages to specify which function was called without an active instance, making it easier to identify issues when using certain features in development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->