### PR TITLE
fix(runtime-vapor): add __vapor flag for dynamic component

### DIFF
--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -1,4 +1,4 @@
-import { resolveDynamicComponent } from '@vue/runtime-dom'
+import { currentInstance, resolveDynamicComponent } from '@vue/runtime-dom'
 import { DynamicFragment, type VaporFragment, insert } from './block'
 import { createComponentWithFallback } from './component'
 import { renderEffect } from './renderEffect'
@@ -31,6 +31,9 @@ export function createDynamicComponent(
 
   renderEffect(() => {
     const value = getter()
+    if (currentInstance && currentInstance.appContext.vapor) {
+      value.__vapor = true
+    }
     frag.update(
       () =>
         createComponentWithFallback(


### PR DESCRIPTION
In interop mode, the dynamic component's functional will be as a vdom, so i add a __vapor flag to prevent it.

```vue

<script setup vapor>
const text = document.createTextNode('123')
const fn = () => text
// fn.__vapor = true // add __vapor flag to fix
</script>

<template>
  <component :is="fn"></component>
</template>

```

[REPL](https://play.vuejs.org/#eNp9kUFvwjAMhf9KlAsgsXSDaQdUkLaJw3Zg08YxEopaF8rSJErcrhLiv88pKnCYOOa9Z/uzc+DPzommBj7jach86ZAFwNqxRjnrF9Jk1gRkCC2yOcttVldgUGQeFMKa1JXNYTh4mEwHoz5cGIoOR2y+6OqkSRLSxGbT9SQPfQ2MRJXnrFcLrbYMLSvKVpo0ObHQfHogVE7TOHoxlma2ctYQBJuVYS55YSRfpMlZplSaXJXwMcdAYEW5FftgDW16iI0kjyWlBv/hsCRwyWesc6KntLa/750Wace9nu0g+/lH34c2apJ/egjgG5D87KHyW8CTvfxexZNczMrmtab0DfMLgtV1ZDzFXmqTE/ZVrqN9owN4LM12HZYtggn9UhE0Jo9dXnL67tcbq19wp+Kxq5PmSFfcNOBjTzrgVDyJ+zul3U6JCT/+AQcywEI=)