### PR TITLE
refactor(runtime-vapor): allow non-instance for setRef

### DIFF
--- a/packages/runtime-vapor/__tests__/apiExpose.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiExpose.spec.ts
@@ -23,7 +23,7 @@ describe('api: expose', () => {
     define({
       setup: () => {
         const n0 = (i = createComponent(Child))
-        setRef(currentInstance as VaporComponentInstance, n0, childRef)
+        setRef(n0, childRef)
         return n0
       },
     }).render()
@@ -46,7 +46,7 @@ describe('api: expose', () => {
     define({
       setup: () => {
         const n0 = createComponent(Child)
-        setRef(currentInstance as VaporComponentInstance, n0, childRef)
+        setRef(n0, childRef)
         return n0
       },
     }).render()

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -34,26 +34,32 @@ export type setRefFn = (
 
 export function createTemplateRefSetter(): setRefFn {
   const instance = currentInstance as VaporComponentInstance
-  return (...args) => setRef(instance, ...args)
+  return (el, ref, oldRef, refFor) => setRef(el, ref, oldRef, refFor, instance)
 }
 
 /**
  * Function for handling a template ref
  */
 export function setRef(
-  instance: VaporComponentInstance,
   el: RefEl,
   ref: NodeRef,
   oldRef?: NodeRef,
   refFor = false,
+  instance?: VaporComponentInstance,
 ): NodeRef | undefined {
-  if (!instance || instance.isUnmounted) return
+  const _isString = isString(ref)
+  if (_isString && (!instance || instance.isUnmounted)) return
 
-  const setupState: any = __DEV__ ? instance.setupState || {} : null
+  const setupState: any = __DEV__
+    ? (instance && instance.setupState) || {}
+    : null
   const refValue = getRefValue(el)
 
-  const refs =
-    instance.refs === EMPTY_OBJ ? (instance.refs = {}) : instance.refs
+  const refs = instance
+    ? instance.refs === EMPTY_OBJ
+      ? (instance.refs = {})
+      : instance.refs
+    : {}
 
   // dynamic ref changed. unset old ref
   if (oldRef != null && oldRef !== ref) {
@@ -79,7 +85,6 @@ export function setRef(
     // TODO this gets called repeatedly in renderEffect when it's dynamic ref?
     onScopeDispose(() => invokeRefSetter())
   } else {
-    const _isString = isString(ref)
     const _isRef = isRef(ref)
     let existing: unknown
 


### PR DESCRIPTION
The instance of setRef only used for strings ref: `ref="comp"`,
But for `jsx-vapor` don't support strings ref, and i want to implement a `h` function to use setRef simply.

So can we remove the requirement for the instance to support functional ref?

```jsx
import { useRef } from 'vue-jsx-vapor'

export default ({ count = 1 }) => {
  const compRef = useRef(null)
  return (
    <div>
       { h('h' + count, { ref: compRef }) }
     </div>
  )
}
```