### PR TITLE
build(tsconfig): Add vueCompilerOptions configuration and the inclusion path of global.d.ts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "vueCompilerOptions": {
+      "globalTypesPath": "./packages-private/global.d.ts"
+    },
     "baseUrl": ".",
     "outDir": "temp",
     "sourceMap": false,
@@ -30,6 +33,7 @@
     "composite": true
   },
   "include": [
+    "packages-private/global.d.ts",
     "packages/global.d.ts",
     "packages/*/src",
     "packages/*/__tests__",


### PR DESCRIPTION
Add the `globalTypesPath` configuration of `vueCompilerOptions` to support Vue global type definitions. Include the `packages - private/global.d.ts` file in the compilation path.Should can fix it.