### PR TITLE
feat(compiler-core): warn instead of assign for v-model on reactive on reactive objects (fix #13693)

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -26,6 +26,36 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: transform v-model > errors > used on reactive const generates warning 1`] = `
+"const _Vue = Vue
+
+return function render(_ctx, _cache) {
+  with (_ctx) {
+    const { warn: _warn, openBlock: _openBlock, createElementBlock: _createElementBlock } = _Vue
+
+    return (_openBlock(), _createElementBlock("input", {
+      modelValue: reactiveVar,
+      "onUpdate:modelValue": $event => (_warn("v-model cannot be used on reactive objects directly. ","Detected v-model on reactive variable 'reactiveVar'. Consider using a reactive property or ref instead."), reactiveVar)
+    }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
+  }
+}"
+`;
+
+exports[`compiler: transform v-model > errors > used on reactive const member expression should not generate warning 1`] = `
+"const _Vue = Vue
+
+return function render(_ctx, _cache) {
+  with (_ctx) {
+    const { openBlock: _openBlock, createElementBlock: _createElementBlock } = _Vue
+
+    return (_openBlock(), _createElementBlock("input", {
+      modelValue: reactiveVar.foo,
+      "onUpdate:modelValue": $event => ((reactiveVar.foo) = $event)
+    }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
+  }
+}"
+`;
+
 exports[`compiler: transform v-model > simple expression (with multilines) 1`] = `
 "const _Vue = Vue
 

--- a/packages/compiler-core/src/runtimeHelpers.ts
+++ b/packages/compiler-core/src/runtimeHelpers.ts
@@ -80,6 +80,7 @@ export const UNREF: unique symbol = Symbol(__DEV__ ? `unref` : ``)
 export const IS_REF: unique symbol = Symbol(__DEV__ ? `isRef` : ``)
 export const WITH_MEMO: unique symbol = Symbol(__DEV__ ? `withMemo` : ``)
 export const IS_MEMO_SAME: unique symbol = Symbol(__DEV__ ? `isMemoSame` : ``)
+export const WARN: unique symbol = Symbol(__DEV__ ? `warn` : ``)
 
 // Name mapping for runtime helpers that need to be imported from 'vue' in
 // generated code. Make sure these are correctly exported in the runtime!
@@ -123,6 +124,7 @@ export const helperNameMap: Record<symbol, string> = {
   [IS_REF]: `isRef`,
   [WITH_MEMO]: `withMemo`,
   [IS_MEMO_SAME]: `isMemoSame`,
+  [WARN]: `warn`,
 }
 
 export function registerRuntimeHelpers(helpers: Record<symbol, string>): void {


### PR DESCRIPTION
This PR fixes a compatibility issue with rolldown bundler and prevents potential runtime errors by replacing assignment statements with warnings when `v-model` is used directly on reactive objects.

## Problem Statement

When using `v-model` directly on reactive objects in `<script setup>`, Vue's compiler generates assignment code that attempts to reassign `const` variables:

```vue
<script setup>
const form = reactive({ name: 'John', age: 25 })
</script>

<template>
  <!-- This generates: $event => ((form) = $event) -->
  <Form v-model="form" />
</template>
```

**Generated problematic code:**
```js
"onUpdate:modelValue": $event => ((form) = $event)
```

This causes several issues:

1. **Rolldown Build Failures**: Triggers `ILLEGAL_REASSIGNMENT` errors in rolldown-based Vite builds
2. **Potential Runtime Errors**: If the assignment were executed, it would fail at runtime
3. **Silent Bugs**: The pattern "works" only because child components use `useModel()` proxies instead of the parent's update handler

**Why this worked before:**
- Rollup only checks const reassignment within the same scope
- Vue's compilation separates variable declaration and update handlers into different scopes
- Child components bypass the problematic assignment via `useModel()` proxies

**Why it fails now:**
- Rolldown performs stricter cross-scope const reassignment checks
- The generated assignment code is technically invalid, even if not executed

## Solution

Replace the problematic assignment with a warning that guides developers toward correct usage:

**Before:**
```js
"onUpdate:modelValue": $event => ((form) = $event)
```

**After:**
```js  
"onUpdate:modelValue": $event => (_warn("v-model cannot be used on reactive objects directly.", "Detected v-model on reactive variable 'form'. Consider using a reactive property or ref instead."), form)
```

## Examples

```vue
<Form v-model="reactiveState" />  <!-- Generates warning -->
```

```vue
<Form v-model="reactiveState.field" />  <!-- Normal assignment -->
<input v-model="reactiveState['key']" />  <!-- Normal assignment -->
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runtime warning when using `v-model` directly on reactive constant variables, guiding users to use a reactive property or ref instead.

* **Bug Fixes**
  * Ensured that using `v-model` on a property of a reactive constant variable does not trigger the new warning.

* **Tests**
  * Introduced tests to verify the new warning behavior and confirm correct handling of member expressions with `v-model`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->