### PR TITLE
fix(runtime-dom): Vapor `useCssModules` support

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -105,6 +105,11 @@ export {
 // plugins
 export { getCurrentInstance } from './component'
 
+/**
+ * @internal
+ */
+export { getCurrentGenericInstance } from './component'
+
 // For raw render function users
 export { h } from './h'
 // Advanced render function utilities

--- a/packages/runtime-dom/src/helpers/useCssModule.ts
+++ b/packages/runtime-dom/src/helpers/useCssModule.ts
@@ -1,9 +1,9 @@
-import { getCurrentInstance, warn } from '@vue/runtime-core'
+import { getCurrentGenericInstance, warn } from '@vue/runtime-core'
 import { EMPTY_OBJ } from '@vue/shared'
 
 export function useCssModule(name = '$style'): Record<string, string> {
   if (!__GLOBAL__) {
-    const instance = getCurrentInstance()!
+    const instance = getCurrentGenericInstance()
     if (!instance) {
       __DEV__ && warn(`useCssModule must be called inside setup()`)
       return EMPTY_OBJ

--- a/packages/runtime-vapor/__tests__/helpers/useCssModule.spec.ts
+++ b/packages/runtime-vapor/__tests__/helpers/useCssModule.spec.ts
@@ -1,0 +1,55 @@
+import { useCssModule } from '@vue/runtime-dom'
+import { makeRender } from '../_utils'
+import { defineVaporComponent, template } from '@vue/runtime-vapor'
+
+const define = makeRender<any>()
+
+describe('useCssModule', () => {
+  function mountWithModule(modules: any, name?: string) {
+    let res
+    define(
+      defineVaporComponent({
+        __cssModules: modules,
+        setup() {
+          res = useCssModule(name)
+          const n0 = template('<div></div>')()
+          return n0
+        },
+      }),
+    ).render()
+    return res
+  }
+
+  test('basic usage', () => {
+    const modules = {
+      $style: {
+        red: 'red',
+      },
+    }
+    expect(mountWithModule(modules)).toMatchObject(modules.$style)
+  })
+
+  test('basic usage', () => {
+    const modules = {
+      foo: {
+        red: 'red',
+      },
+    }
+    expect(mountWithModule(modules, 'foo')).toMatchObject(modules.foo)
+  })
+
+  test('warn out of setup usage', () => {
+    useCssModule()
+    expect('must be called inside setup').toHaveBeenWarned()
+  })
+
+  test('warn missing injection', () => {
+    mountWithModule(undefined)
+    expect('instance does not have CSS modules').toHaveBeenWarned()
+  })
+
+  test('warn missing injection', () => {
+    mountWithModule({ $style: { red: 'red' } }, 'foo')
+    expect('instance does not have CSS module named "foo"').toHaveBeenWarned()
+  })
+})


### PR DESCRIPTION
Allow `useCssModules` to be used in vapor mode.

Example:
```
<script setup vapor>
import { useCssModule } from 'vue'

const classes = useCssModule()
</script>

<template>
  <p :class="classes.red">This text is red</p>
</template>

<style module>
.red {
  color: red;
}
</style>
```

Rendered output:
<img width="280" height="88" alt="Screenshot From 2025-07-26 16-00-36" src="https://github.com/user-attachments/assets/a365bdd9-ba18-4398-8e05-856b2041e7c5" />
