### PR TITLE
chore: add `<search>` to known HTML elements

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -1176,6 +1176,7 @@ export interface IntrinsicElementAttributes {
   s: HTMLAttributes
   samp: HTMLAttributes
   script: ScriptHTMLAttributes
+  search: HTMLAttributes
   section: HTMLAttributes
   select: SelectHTMLAttributes
   small: HTMLAttributes

--- a/packages/shared/src/domTagConfig.ts
+++ b/packages/shared/src/domTagConfig.ts
@@ -12,7 +12,7 @@ const HTML_TAGS =
   'canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,' +
   'th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,' +
   'option,output,progress,select,textarea,details,dialog,menu,' +
-  'summary,template,blockquote,iframe,tfoot'
+  'search,summary,template,blockquote,iframe,tfoot'
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element
 const SVG_TAGS =


### PR DESCRIPTION
Add `<search>` to known HTML elements.

Spec:

- https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `<search>` HTML element in JSX, allowing it to accept standard HTML attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->