### PR TITLE
fix(vdom): add null check in fragment removal  Add null check for 'cu…

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2260,7 +2260,7 @@ function baseCreateRenderer(
     // For fragments, directly remove all contained DOM nodes.
     // (fragment child nodes cannot have transition)
     let next
-    while (cur !== end) {
+    while (cur && cur !== end) {
       next = hostNextSibling(cur)!
       hostRemove(cur)
       cur = next


### PR DESCRIPTION
fix(vdom): add null check in fragment removal

Add null check for 'cur' in removeFragment function to prevent potential 
null reference errors when traversing DOM nodes. The while loop now 
verifies 'cur' exists before comparing with 'end'.

This makes the fragment removal more robust when dealing with edge cases.