### PR TITLE
fix(custom-element): component styles are not merged with 2nd argument styles

### DIFF
--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -852,12 +852,13 @@ describe('defineCustomElement', () => {
           return h('div', 'hello')
         },
       })
-      const Foo = defineCustomElement(def)
+      const Foo = defineCustomElement(def, {
+        extraStyles: [`div { color: green; }`],
+      })
       customElements.define('my-el-with-styles', Foo)
       container.innerHTML = `<my-el-with-styles></my-el-with-styles>`
       const el = container.childNodes[0] as VueElement
-      const style = el.shadowRoot?.querySelector('style')!
-      expect(style.textContent).toBe(`div { color: red; }`)
+      assertStyles(el, [`div { color: red; }`, `div { color: green; }`])
 
       // hmr
       __VUE_HMR_RUNTIME__.reload('foo', {
@@ -866,7 +867,11 @@ describe('defineCustomElement', () => {
       } as any)
 
       await nextTick()
-      assertStyles(el, [`div { color: blue; }`, `div { color: yellow; }`])
+      assertStyles(el, [
+        `div { color: blue; }`,
+        `div { color: yellow; }`,
+        `div { color: green; }`,
+      ])
     })
 
     test("child components should inject styles to root element's shadow root", async () => {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -52,6 +52,7 @@ export type VueElementConstructor<P = {}> = {
 
 export interface CustomElementOptions {
   styles?: string[]
+  extraStyles?: string[]
   shadowRoot?: boolean
   nonce?: string
   configureApp?: (app: App) => void
@@ -220,6 +221,10 @@ export class VueElement
    * @internal
    */
   _nonce: string | undefined = this._def.nonce
+  /**
+   * @internal
+   */
+  _extraStyles?: string[] = this._def.extraStyles
 
   /**
    * @internal
@@ -391,7 +396,7 @@ export class VueElement
       // apply CSS
       if (this.shadowRoot) {
         this._applyStyles(styles)
-      } else if (__DEV__ && styles) {
+      } else if (__DEV__ && (styles || this._extraStyles)) {
         warn(
           'Custom element style injection is not supported when using ' +
             'shadowRoot: false',
@@ -586,7 +591,13 @@ export class VueElement
     styles: string[] | undefined,
     owner?: ConcreteComponent,
   ) {
-    if (!styles) return
+    const fullStyles: string[] = []
+    styles && fullStyles.push(...styles)
+    const { _extraStyles } = this
+    _extraStyles && fullStyles.push(..._extraStyles)
+    if (!fullStyles.length) return
+
+    if (!fullStyles) return
     if (owner) {
       if (owner === this._def || this._styleChildren.has(owner)) {
         return
@@ -594,10 +605,10 @@ export class VueElement
       this._styleChildren.add(owner)
     }
     const nonce = this._nonce
-    for (let i = styles.length - 1; i >= 0; i--) {
+    for (let i = fullStyles.length - 1; i >= 0; i--) {
       const s = document.createElement('style')
       if (nonce) s.setAttribute('nonce', nonce)
-      s.textContent = styles[i]
+      s.textContent = fullStyles[i]
       this.shadowRoot!.prepend(s)
       // record for HMR
       if (__DEV__) {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -597,7 +597,6 @@ export class VueElement
     _extraStyles && fullStyles.push(..._extraStyles)
     if (!fullStyles.length) return
 
-    if (!fullStyles) return
     if (owner) {
       if (owner === this._def || this._styleChildren.has(owner)) {
         return


### PR DESCRIPTION
This pr fixes an issue where component styles are not merged with second argument styles. It also fixes an issue where HMR causes style errors when modifying the contents of a component's `<style>` tag.

To avoid breaking changes, this pr adds a new `extraStyles` property to replace the original `styles` property. I recommend renaming the `styles` property in documentation to `extraStyles`, as the `styles` property has existed for nearly a year.

https://vuejs.org/api/custom-elements.html
<img width="753" height="455" alt="image" src="https://github.com/user-attachments/assets/6642118d-ce2c-4e2a-8f49-273105b255f6" />
