### PR TITLE
feat(runtime-vapor): hydration with node draft

### DIFF
--- a/packages/runtime-vapor/src/dom/node.ts
+++ b/packages/runtime-vapor/src/dom/node.ts
@@ -1,29 +1,59 @@
 /*! #__NO_SIDE_EFFECTS__ */
-export function createTextNode(value = ''): Text {
+
+import { isHydrating } from './hydration'
+import {
+  CommentDraft,
+  NodeRef,
+  TextNodeDraft,
+  type VaporNode,
+  type VaporParentNode,
+  isUnresolvedNode,
+  toNode,
+} from './nodeDraft'
+
+export function createTextNode(value = ''): VaporNode<Text, TextNodeDraft> {
+  if (isHydrating) {
+    const node = new NodeRef<boolean, Text, TextNodeDraft>(TextNodeDraft)
+    node.ref.textContent
+    return node
+  }
   return document.createTextNode(value)
 }
 
 /*! #__NO_SIDE_EFFECTS__ */
-export function createComment(data: string): Comment {
+export function createComment(data: string): VaporNode<Comment, CommentDraft> {
+  if (isHydrating) {
+    const node = new NodeRef<boolean, Comment, CommentDraft>(CommentDraft)
+    node.ref.data
+    return node
+  }
   return document.createComment(data)
 }
 
 /*! #__NO_SIDE_EFFECTS__ */
-export function querySelector(selectors: string): Element | null {
-  return document.querySelector(selectors)
+export function child(node: VaporParentNode): VaporNode {
+  if (isUnresolvedNode(node) && !node.ref.childNodes[0]) {
+    return (node.ref.childNodes[0] = new NodeRef())
+  }
+
+  return toNode(node).firstChild!
 }
 
 /*! #__NO_SIDE_EFFECTS__ */
-export function child(node: ParentNode): Node {
-  return node.firstChild!
+export function nthChild(node: ParentNode, i: number): VaporNode {
+  if (isUnresolvedNode(node) && !node.ref.childNodes[i]) {
+    return (node.ref.childNodes[i] = new NodeRef())
+  }
+
+  return toNode(node).childNodes[i]
 }
 
 /*! #__NO_SIDE_EFFECTS__ */
-export function nthChild(node: Node, i: number): Node {
-  return node.childNodes[i]
-}
+export function next(node: VaporParentNode): VaporNode {
+  if (isUnresolvedNode(node) && !node.ref.nextSibling) {
+    const childNodes = node.ref.childNodes
+    return (childNodes[childNodes.indexOf(node) + 1] = new NodeRef())
+  }
 
-/*! #__NO_SIDE_EFFECTS__ */
-export function next(node: Node): Node {
-  return node.nextSibling!
+  return toNode(node).nextSibling!
 }

--- a/packages/runtime-vapor/src/dom/nodeDraft.ts
+++ b/packages/runtime-vapor/src/dom/nodeDraft.ts
@@ -1,0 +1,100 @@
+export type VaporNode<N extends Node = Node, D extends NodeDraft = NodeDraft> =
+  | N
+  | NodeRef<boolean, N, D>
+
+export type VaporParentNode<
+  N extends ParentNode = ParentNode,
+  D extends NodeDraft = NodeDraft,
+> = N | NodeRef<boolean, N, D>
+
+export type MaybeNodeDraft = Node | NodeDraft
+
+function unenumerable(obj: any, key: string | symbol) {
+  Object.defineProperty(obj, key, {
+    enumerable: false,
+  })
+}
+
+type Constructor<T> = new (ref: NodeRef) => T
+
+export class NodeRef<
+  T extends boolean = boolean,
+  N extends Node = Node,
+  D extends NodeDraft = NodeDraft,
+> {
+  get ref(): T extends true ? N : D {
+    return this.resolved ? (this.source! as any) : (this.draft as any)
+  }
+  private source?: N
+  private draft?: D
+
+  constructor(NodeDraftClass: Constructor<D> = NodeDraft as Constructor<D>) {
+    this.draft = new NodeDraftClass(this)
+  }
+
+  get resolved(): T {
+    return (this.draft === undefined) as T
+  }
+
+  resolve(theRef: N): void {
+    if (this.resolved) {
+      throw new Error('HydrationNode has already been resolved')
+    }
+    this.source = theRef
+    ;(Object.keys(this.ref) as Array<keyof NodeDraft>).forEach(key => {
+      const newValue = this.draft![key]
+      const oldValue = theRef[key]
+      if (newValue !== oldValue) {
+        ;(theRef as any)[key] = newValue
+      }
+    })
+    this.draft = undefined
+  }
+}
+
+export class NodeDraft {
+  constructor(
+    private __v_nodeRef: NodeRef,
+    private __v_childNodes: NodeRef<false>[] = [],
+    private __v_parentNode: NodeRef<false> | null = null,
+  ) {
+    unenumerable(this, '__v_nodeRef')
+    unenumerable(this, '__v_childNodes')
+    unenumerable(this, '__v_parentNode')
+  }
+
+  get parentNode(): NodeRef | null {
+    return this.__v_parentNode
+  }
+
+  get childNodes(): NodeRef[] {
+    return this.__v_childNodes
+  }
+
+  get firstChild(): NodeRef | null {
+    return this.childNodes[0] || null
+  }
+
+  get nextSibling(): NodeRef | null {
+    const parent = this.__v_parentNode
+    if (!parent) return null
+    const index = parent.ref.childNodes.indexOf(this.__v_nodeRef)
+    return parent.ref.childNodes[index + 1] || null
+  }
+}
+
+export class TextNodeDraft extends NodeDraft {
+  public textContent: string = ''
+}
+
+export class CommentDraft extends NodeDraft {
+  public data: string = ''
+}
+
+export function toNode(node: VaporNode): MaybeNodeDraft {
+  return node instanceof NodeRef ? node.ref : node
+}
+
+export function isUnresolvedNode(node: VaporNode): node is NodeRef<false> {
+  return node instanceof NodeRef && !node.resolved
+}


### PR DESCRIPTION
## Overview

This PR attempts to build Vapor's Hydration architecture based on "ref" and "draft". When hydrating, operations in the Render function will only create drafts and delay actual application until mounting, and update draft nodes to real nodes.

## Chart

<img width="2661" height="2554" alt="image" src="https://github.com/user-attachments/assets/742bbb94-a387-427d-a620-30b661cabf2b" />

