### PR TITLE
types(runtime-dom): improve event types

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -1296,15 +1296,15 @@ export interface Events {
 
   // form events
   onChange: Event
-  onBeforeinput: Event
-  onInput: Event
+  onBeforeinput: InputEvent
+  onInput: InputEvent
   onReset: Event
-  onSubmit: Event
+  onSubmit: SubmitEvent
   onInvalid: Event
 
   // image events
   onLoad: Event
-  onError: Event
+  onError: ErrorEvent
 
   // keyboard events
   onKeydown: KeyboardEvent
@@ -1330,7 +1330,7 @@ export interface Events {
   onCanplaythrough: Event
   onDurationchange: Event
   onEmptied: Event
-  onEncrypted: Event
+  onEncrypted: MediaEncryptedEvent
   onEnded: Event
   onLoadeddata: Event
   onLoadedmetadata: Event
@@ -1338,7 +1338,7 @@ export interface Events {
   onPause: Event
   onPlay: Event
   onPlaying: Event
-  onProgress: Event
+  onProgress: ProgressEvent
   onRatechange: Event
   onSeeked: Event
   onSeeking: Event


### PR DESCRIPTION
For the other events marked in 13796 but not modified in this PR, I’m not sure whether they should also be updated. According to MDN, they were previously typed as `MouseEvent`, and I’m uncertain if changing them to `PointerEvent` could cause compatibility issues. For example: [Click Event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event#event_type).

close #13796