### PR TITLE
feat(compiler-sfc): support Node subpath imports for type resolution

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1198,6 +1198,42 @@ describe('resolveType', () => {
       expect(deps && [...deps]).toStrictEqual(['/user.ts'])
     })
 
+    test('node subpath imports', () => {
+      const files = {
+        '/package.json': JSON.stringify({
+          imports: {
+            '#t1': './t1.ts',
+            '#t2': '/t2.ts',
+            '#o/*.ts': './other/*.ts',
+          },
+        }),
+        '/t1.ts': 'export type T1 = { foo: string }',
+        '/t2.ts': 'export type T2 = { bar: number }',
+        '/other/t3.ts': 'export type T3 = { baz: string }',
+      }
+
+      const { props, deps } = resolve(
+        `
+        import type { T1 } from '#t1'
+        import type { T2 } from '#t2'
+        import type { T3 } from '#o/t3.ts'
+        defineProps<T1 & T2 & T3>()
+        `,
+        files,
+      )
+
+      expect(props).toStrictEqual({
+        foo: ['String'],
+        bar: ['Number'],
+        baz: ['String'],
+      })
+      expect(deps && [...deps]).toStrictEqual([
+        '/t1.ts',
+        '/t2.ts',
+        '/other/t3.ts',
+      ])
+    })
+
     test('ts module resolve w/ project reference folder', () => {
       const files = {
         '/tsconfig.json': JSON.stringify({

--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -62,6 +62,7 @@
     "postcss-modules": "^6.0.1",
     "postcss-selector-parser": "^7.1.0",
     "pug": "^3.0.3",
+    "resolve.exports": "^2.0.3",
     "sass": "^1.90.0"
   }
 }

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -39,9 +39,10 @@ import { parse as babelParse } from '@babel/parser'
 import { parse } from '../parse'
 import { createCache } from '../cache'
 import type TS from 'typescript'
-import { dirname, extname, join } from 'path'
+import { dirname, extname, join, resolve } from 'path'
 import { minimatch as isMatch } from 'minimatch'
 import * as process from 'process'
+import { imports as resolveImports } from 'resolve.exports'
 
 export type SimpleTypeResolveOptions = Partial<
   Pick<
@@ -958,7 +959,9 @@ function importSourceToScope(
           )
         }
       }
-      resolved = resolveWithTS(scope.filename, source, ts, fs)
+      resolved =
+        resolveWithTS(scope.filename, source, ts, fs) ||
+        resolveWithNodeSubpathImports(source, fs)
     }
     if (resolved) {
       resolved = scope.resolvedImportSources[source] = normalizePath(resolved)
@@ -1121,6 +1124,52 @@ function loadTSConfig(
     }
   }
   return res
+}
+
+function resolveWithNodeSubpathImports(
+  source: string,
+  fs: FS,
+): string | undefined {
+  if (!__CJS__) return
+
+  try {
+    const pkgPath = findPackageJsonFile(fs)
+    if (!pkgPath) {
+      return
+    }
+
+    const pkgStr = fs.readFile(pkgPath)
+    if (!pkgStr) {
+      return
+    }
+
+    const pkg = JSON.parse(pkgStr)
+    const resolvedImports = resolveImports(pkg, source)
+    if (!resolvedImports || !resolvedImports.length) {
+      return
+    }
+
+    const resolved = resolve(dirname(pkgPath), resolvedImports[0])
+
+    return fs.realpath ? fs.realpath(resolved) : resolved
+  } catch (e) {}
+}
+
+function findPackageJsonFile(fs: FS): string | undefined {
+  let currDir = process.cwd()
+  while (true) {
+    const filePath = joinPaths(currDir, 'package.json')
+    if (fs.fileExists(filePath)) {
+      return filePath
+    }
+
+    const parentDir = dirname(currDir)
+    if (parentDir === currDir) {
+      return
+    }
+
+    currDir = parentDir
+  }
 }
 
 const fileToScopeCache = createCache<TypeScope>()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,9 @@ importers:
       pug:
         specifier: ^3.0.3
         version: 3.0.3
+      resolve.exports:
+        specifier: ^2.0.3
+        version: 2.0.3
       sass:
         specifier: ^1.90.0
         version: 1.90.0
@@ -3024,6 +3027,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
 
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
@@ -6083,6 +6090,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@1.22.8:
     dependencies:


### PR DESCRIPTION
close #13586

Support reading user-defined Node.js subpath imports for type resolution.

Example:

`Comp1.vue`
```vue
<script setup lang="ts">
import type { MyProps } from '#comp2'
const props = defineProps<MyProps>()
</script>

<template>
  {{ props.abc }}
</template>
```

`Comp2.vue`
```vue
<script setup lang="ts">
export interface MyProps {
  abc: number;
}
</script>

<template>
  Hello
</template>
```

`package.json`
```
{
  ...
  "imports": {
    "#comp2": "./Comp2.vue"
  }
}
```