### PR TITLE
types(reactivity): resolve "object is not assignable to type ShallowUnwrapRef"

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -275,7 +275,7 @@ export function proxyRefs<T extends object>(
   objectWithRefs: T,
 ): ShallowUnwrapRef<T> {
   return isReactive(objectWithRefs)
-    ? objectWithRefs
+    ? (objectWithRefs as ShallowUnwrapRef<T>)
     : new Proxy(objectWithRefs, shallowUnwrapHandlers)
 }
 


### PR DESCRIPTION
It shows a type error in my editor.
Strangely, `pnpm run check` does not report an error, but if I change it as follows, running `pnpm run check` will produce an error.

```ts
export function proxyRefs<T extends object>(
  objectWithRefs: T,
): ShallowUnwrapRef<T> {
  if (isReactive(objectWithRefs)) {
    return objectWithRefs
  }
  return new Proxy(objectWithRefs, shallowUnwrapHandlers)
}
```

<img width="1800" height="710" alt="ad2c3246b3ca307f372333a2c26e3835" src="https://github.com/user-attachments/assets/3334594f-2c6e-4b07-a0d7-addb8a1a7812" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.

- Refactor
  - Improved TypeScript type safety for ref unwrapping in reactive proxies to better align with declared return types. This enhances developer tooling, autocomplete, and error checking without changing runtime behavior.

- Bug Fixes
  - None.

- Chores
  - No action required for users; APIs and behavior remain unchanged. No migration needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->