### PR TITLE
chore: update side effect annotations to use standardized format

### DIFF
--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -43,7 +43,7 @@ export interface AsyncComponentOptions<T = any> {
 export const isAsyncWrapper = (i: ComponentInternalInstance | VNode): boolean =>
   !!(i.type as ComponentOptions).__asyncLoader
 
-/*! #__NO_SIDE_EFFECTS__ */
+/*@__NO_SIDE_EFFECTS__*/
 export function defineAsyncComponent<
   T extends Component = { new (): ComponentPublicInstance },
 >(source: AsyncComponentLoader<T> | AsyncComponentOptions<T>): T {

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -301,7 +301,7 @@ export function defineComponent<
 >
 
 // implementation, close to no-op
-/*! #__NO_SIDE_EFFECTS__ */
+/*@__NO_SIDE_EFFECTS__*/
 export function defineComponent(
   options: unknown,
   extraOptions?: ComponentOptions,

--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -125,7 +125,7 @@ export const devtoolsComponentRemoved = (
 
 type DevtoolsComponentHook = (component: ComponentInternalInstance) => void
 
-/*! #__NO_SIDE_EFFECTS__ */
+/*@__NO_SIDE_EFFECTS__*/
 function createDevtoolsComponentHook(
   hook: DevtoolsHooks,
 ): DevtoolsComponentHook {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -163,7 +163,7 @@ export function defineCustomElement<
   T extends DefineComponent<infer P, any, any, any> ? P : unknown
 >
 
-/*! #__NO_SIDE_EFFECTS__ */
+/*@__NO_SIDE_EFFECTS__*/
 export function defineCustomElement(
   options: any,
   extraOptions?: ComponentOptions,
@@ -184,7 +184,7 @@ export function defineCustomElement(
   return VueCustomElement
 }
 
-/*! #__NO_SIDE_EFFECTS__ */
+/*@__NO_SIDE_EFFECTS__*/
 export const defineSSRCustomElement = ((
   options: any,
   extraOptions?: ComponentOptions,

--- a/packages/shared/src/makeMap.ts
+++ b/packages/shared/src/makeMap.ts
@@ -6,7 +6,7 @@
  * So that rollup can tree-shake them if necessary.
  */
 
-/*! #__NO_SIDE_EFFECTS__ */
+/*@__NO_SIDE_EFFECTS__*/
 export function makeMap(str: string): (key: string) => boolean {
   const map = Object.create(null)
   for (const key of str.split(',')) map[key] = 1


### PR DESCRIPTION
Fix the following warning while running `nr build`
https://github.com/vuejs/core/blob/a28794edfabe403f4c595f48d150894c5c6c1ed4/packages/runtime-dom/src/apiCustomElement.ts#L187-L194

 ```bash
(!) packages/runtime-dom/src/apiCustomElement.ts (32:0): A comment

"/*! #__NO_SIDE_EFFECTS__ */"

in "packages/runtime-dom/src/apiCustomElement.ts" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
```

esbuild supports the `/* @__NO_SIDE_EFFECTS__ */` from v.0.18.1. (https://github.com/evanw/esbuild/commit/cf687c94d9458b6286786850babeefd3e77ff9fb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized no-side-effects directive annotations across the codebase to a consistent format.
  - No changes to behavior, performance, or public APIs.
- Chores
  - Internal cleanup to align comment directives; no user-facing impact.
  - No functional differences; existing features and compatibility remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->