### PR TITLE
chore(runtime-core): simplify block-tracking disabling in h function

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -202,35 +202,31 @@ export function h<P>(
 
 // Actual implementation
 export function h(type: any, propsOrChildren?: any, children?: any): VNode {
-  // #6913 disable tracking block in h function
-  const doCreateVNode = (type: any, props?: any, children?: any) => {
+  try {
+    // #6913 disable tracking block in h function
     setBlockTracking(-1)
-    try {
-      return createVNode(type, props, children)
-    } finally {
-      setBlockTracking(1)
-    }
-  }
-
-  const l = arguments.length
-  if (l === 2) {
-    if (isObject(propsOrChildren) && !isArray(propsOrChildren)) {
-      // single vnode without props
-      if (isVNode(propsOrChildren)) {
-        return doCreateVNode(type, null, [propsOrChildren])
+    const l = arguments.length
+    if (l === 2) {
+      if (isObject(propsOrChildren) && !isArray(propsOrChildren)) {
+        // single vnode without props
+        if (isVNode(propsOrChildren)) {
+          return createVNode(type, null, [propsOrChildren])
+        }
+        // props without children
+        return createVNode(type, propsOrChildren)
+      } else {
+        // omit props
+        return createVNode(type, null, propsOrChildren)
       }
-      // props without children
-      return doCreateVNode(type, propsOrChildren)
     } else {
-      // omit props
-      return doCreateVNode(type, null, propsOrChildren)
+      if (l > 3) {
+        children = Array.prototype.slice.call(arguments, 2)
+      } else if (l === 3 && isVNode(children)) {
+        children = [children]
+      }
+      return createVNode(type, propsOrChildren, children)
     }
-  } else {
-    if (l > 3) {
-      children = Array.prototype.slice.call(arguments, 2)
-    } else if (l === 3 && isVNode(children)) {
-      children = [children]
-    }
-    return doCreateVNode(type, propsOrChildren, children)
+  } finally {
+    setBlockTracking(1)
   }
 }


### PR DESCRIPTION
Avoid creating `doCreateVNode` every each call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified rendering helper control flow to a single consistent path per branch, improving maintainability.
  * Centralized VNode creation and streamlined argument handling for props and children while keeping the public API unchanged.

* **Reliability**
  * Ensures consistent behavior for props-only, single-child, and multiple-child call patterns.
  * Reduces edge-case inconsistencies in how single-child values are arrayified and interpreted.

* **Developer Impact**
  * No changes to exported function signatures; existing usage continues to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->