### PR TITLE
fix(runtime-vapor): VNode render cannot be executed in vapor mode

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -290,18 +290,21 @@ export let isApplyingFallthroughProps = false
 export function devRender(instance: VaporComponentInstance): void {
   instance.block =
     (instance.type.render
-      ? callWithErrorHandling(
-          instance.type.render,
-          instance,
-          ErrorCodes.RENDER_FUNCTION,
-          [
-            instance.setupState,
-            instance.props,
-            instance.emit,
-            instance.attrs,
-            instance.slots,
-          ],
-        )
+      ? instance.type.__file && !instance.type.__vapor
+        ? // TODO
+          (warn('Need to activate vapor mode to compile SFC!'), [])
+        : callWithErrorHandling(
+            instance.type.render,
+            instance,
+            ErrorCodes.RENDER_FUNCTION,
+            [
+              instance.setupState,
+              instance.props,
+              instance.emit,
+              instance.attrs,
+              instance.slots,
+            ],
+          )
       : callWithErrorHandling(
           isFunction(instance.type) ? instance.type : instance.type.setup!,
           instance,


### PR DESCRIPTION
VNode render cannot be executed in vapor mode;

steps: 
App: 
```js
<template>
    <Page />
</template>

<script setup lang="ts" vapor>
import Page from './Page.vue';
</script>
```
Page: 
```js
<template>
    test
</template>

<script lang="ts" setup>
</script>
```

console print:  
`Uncaught TypeError: Cannot read properties of undefined (reading 'insert')`