### PR TITLE
fix(compiler-sfc): enhance inferRuntimeType to support TSMappedType with indexed access

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -731,6 +731,22 @@ describe('resolveType', () => {
     })
   })
 
+  test('TSMappedType with indexed access', () => {
+    const { props } = resolve(
+      `
+      type Prettify<T> = { [K in keyof T]: T[K] } & {}
+      type Side = 'top' | 'right' | 'bottom' | 'left'
+      type AlignedPlacement = \`\${Side}-\${Alignment}\`
+      type Alignment = 'start' | 'end'
+      type Placement = Prettify<Side | AlignedPlacement>
+      defineProps<{placement?: Placement}>()
+    `,
+    )
+    expect(props).toStrictEqual({
+      placement: ['String', 'Object'],
+    })
+  })
+
   describe('type alias declaration', () => {
     // #13240
     test('function type', () => {

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -728,6 +728,13 @@ function resolveTypeReference(
   name?: string,
   onlyExported = false,
 ): ScopeTypeNode | undefined {
+  if (
+    node.leadingComments &&
+    node.leadingComments.some(c => c.value.includes('@vue-ignore'))
+  ) {
+    return undefined
+  }
+
   const canCache = !scope?.isGenericScope
   if (canCache && node._resolvedReference) {
     return node._resolvedReference

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -728,13 +728,6 @@ function resolveTypeReference(
   name?: string,
   onlyExported = false,
 ): ScopeTypeNode | undefined {
-  if (
-    node.leadingComments &&
-    node.leadingComments.some(c => c.value.includes('@vue-ignore'))
-  ) {
-    return undefined
-  }
-
   const canCache = !scope?.isGenericScope
   if (canCache && node._resolvedReference) {
     return node._resolvedReference


### PR DESCRIPTION
only for the strict pattern `{[K in keyof T]: T[K]}`

close #13847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved runtime inference for certain TypeScript mapped types in component props, producing more accurate runtime prop types and better support for advanced TS patterns.
* **Tests**
  * Added tests covering mapped types with indexed access in defineProps to ensure correct prop type resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->