### PR TITLE
fix(transition-group): run `forceReflow` on the correct document (fix #13849)

### DIFF
--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -260,11 +260,11 @@ export function resolveTransitionProps(
       // the css will not get the final state (#10677)
       if (!el._enterCancelled) {
         // force reflow so *-leave-from classes immediately take effect (#2593)
-        forceReflow()
+        forceReflow(el)
         addTransitionClass(el, leaveActiveClass)
       } else {
         addTransitionClass(el, leaveActiveClass)
-        forceReflow()
+        forceReflow(el)
       }
       nextFrame(() => {
         if (!el._isLeaving) {
@@ -476,6 +476,7 @@ function toMs(s: string): number {
 }
 
 // synchronously force layout to put elements into a certain state
-export function forceReflow(): number {
-  return document.body.offsetHeight
+export function forceReflow(el?: Node): number {
+  const targetDocument = el ? el.ownerDocument! : document
+  return targetDocument.body.offsetHeight
 }

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -92,7 +92,7 @@ const TransitionGroupImpl: ComponentOptions = /*@__PURE__*/ decorate({
       const movedChildren = prevChildren.filter(applyTranslation)
 
       // force reflow to put everything in position
-      forceReflow()
+      forceReflow(instance.vnode.el as Node)
 
       movedChildren.forEach(c => {
         const el = c.el as ElementWithTransition


### PR DESCRIPTION
Previously, `forceReflow()` would always use `document`. When a component with a `TransitionGroup` was moved to another document, move transitions broke because of this.
This is fixed by accessing the current instance's `ownerDocument` and using that for the reflow.

This is my first time contributing to vue, and I'm not entirely sure if this fix is the right way to go (especially when it comes to perf and possibly unintended side effects).

Fixes #13849 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transition reliability so animations trigger correctly in iframes, popouts, and embedded contexts.
  * Fixed intermittent enter/leave transition failures and visual jitter by ensuring reflows target the correct element/document.
  * More consistent animation behavior across multi-document or cross-window environments.

* **Chores**
  * No public API changes affecting end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->