### PR TITLE
fix(compiler-sfc): custom lang import usage detection for non-inline templates

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/importUsageCheck.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/importUsageCheck.spec.ts.snap
@@ -49,6 +49,21 @@ return { fooBar, get FooBaz() { return FooBaz }, get FooQux() { return FooQux },
 })"
 `;
 
+exports[`custom template lang 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { Thing1, Thing2, Thing3, Thing4, Thing5, Thing6 } from "./types.ts"
+    
+export default /*@__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+      
+return { get Thing2() { return Thing2 }, get Thing3() { return Thing3 }, get Thing4() { return Thing4 }, get Thing5() { return Thing5 }, get Thing6() { return Thing6 } }
+}
+
+})"
+`;
+
 exports[`directive 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 import { vMyDir } from './x'

--- a/packages/compiler-sfc/__tests__/compileScript/importUsageCheck.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/importUsageCheck.spec.ts
@@ -265,3 +265,31 @@ test('shorthand binding w/ kebab-case', () => {
   )
   expect(content).toMatch('return { get fooBar() { return fooBar }')
 })
+
+test('custom template lang', () => {
+  const { content } = compile(
+    `
+    <script setup lang="ts">
+      import { Thing1, Thing2, Thing3, Thing4, Thing5, Thing6 } from "./types.ts"
+    </script>
+    <template lang="pug">
+      h1 Thing1
+        div {{ Thing2 }}
+      
+        Thing3 World
+
+        div(v-bind:abc='Thing4')
+
+        div(v-text='Thing5')
+
+        div(ref='Thing6')
+    </template>
+    `,
+    { templateOptions: { preprocessLang: 'pug' } },
+  )
+  // Thing1 is just a string in the template so should not be included
+  expect(content).toMatch(
+    'return { get Thing2() { return Thing2 }, get Thing3() { return Thing3 }, get Thing4() { return Thing4 }, get Thing5() { return Thing5 }, get Thing6() { return Thing6 } }',
+  )
+  assertCode(content)
+})

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_FILENAME,
   type SFCDescriptor,
   type SFCScriptBlock,
+  type SFCTemplateBlock,
 } from './parse'
 import type { ParserPlugin } from '@babel/parser'
 import { generateCodeFrame } from '@vue/shared'
@@ -36,6 +37,7 @@ import {
 import { CSS_VARS_HELPER, genCssVarsCode } from './style/cssVars'
 import {
   type SFCTemplateCompileOptions,
+  type SFCTemplateCompileResults,
   compileTemplate,
 } from './compileTemplate'
 import { warnOnce } from './warn'
@@ -245,6 +247,8 @@ export function compileScript(
     ctx.s.move(start, end, 0)
   }
 
+  let customTemplateLangCompiledSFC: SFCTemplateCompileResults | undefined
+
   function registerUserImport(
     source: string,
     local: string,
@@ -260,10 +264,22 @@ export function compileScript(
       needTemplateUsageCheck &&
       ctx.isTS &&
       sfc.template &&
-      !sfc.template.src &&
-      !sfc.template.lang
+      !sfc.template.src
     ) {
-      isUsedInTemplate = isImportUsed(local, sfc)
+      if (!sfc.template.lang) {
+        isUsedInTemplate = isImportUsed(
+          local,
+          sfc.template.content,
+          sfc.template.ast!,
+        )
+      } else {
+        customTemplateLangCompiledSFC ||= compileSFCTemplate(sfc.template)
+        isUsedInTemplate = isImportUsed(
+          local,
+          sfc.template.content,
+          customTemplateLangCompiledSFC.ast!,
+        )
+      }
     }
 
     ctx.userImports[local] = {
@@ -290,6 +306,28 @@ export function compileScript(
           id,
         )
       }
+    })
+  }
+
+  function compileSFCTemplate(
+    sfcTemplate: SFCTemplateBlock,
+  ): SFCTemplateCompileResults {
+    return compileTemplate({
+      filename,
+      ast: sfcTemplate.ast,
+      source: sfcTemplate.content,
+      inMap: sfcTemplate.map,
+      ...options.templateOptions,
+      id: scopeId,
+      scoped: sfc.styles.some(s => s.scoped),
+      isProd: options.isProd,
+      ssrCssVars: sfc.cssVars,
+      compilerOptions: {
+        ...(options.templateOptions && options.templateOptions.compilerOptions),
+        inline: true,
+        isTS: ctx.isTS,
+        bindingMetadata: ctx.bindingMetadata,
+      },
     })
   }
 
@@ -880,24 +918,9 @@ export function compileScript(
       }
       // inline render function mode - we are going to compile the template and
       // inline it right here
-      const { code, ast, preamble, tips, errors, map } = compileTemplate({
-        filename,
-        ast: sfc.template.ast,
-        source: sfc.template.content,
-        inMap: sfc.template.map,
-        ...options.templateOptions,
-        id: scopeId,
-        scoped: sfc.styles.some(s => s.scoped),
-        isProd: options.isProd,
-        ssrCssVars: sfc.cssVars,
-        compilerOptions: {
-          ...(options.templateOptions &&
-            options.templateOptions.compilerOptions),
-          inline: true,
-          isTS: ctx.isTS,
-          bindingMetadata: ctx.bindingMetadata,
-        },
-      })
+      const { code, ast, preamble, tips, errors, map } = compileSFCTemplate(
+        sfc.template,
+      )
       templateMap = map
       if (tips.length) {
         tips.forEach(warnOnce)

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -448,7 +448,10 @@ export function hmrShouldReload(
   for (const key in prevImports) {
     // if an import was previous unused, but now is used, we need to force
     // reload so that the script now includes that import.
-    if (!prevImports[key].isUsedInTemplate && isImportUsed(key, next)) {
+    if (
+      !prevImports[key].isUsedInTemplate &&
+      isImportUsed(key, next.template!.content!, next.template!.ast!)
+    ) {
       return true
     }
   }


### PR DESCRIPTION
close #12542

Improve detection of imported binding usage in template for non-inline SFC compilation mode when using custom template languages.

**Sample code**

App.vue
```vue
<script setup lang="ts">
import { MyType, myVal } from './decls'

defineProps<MyType>()
</script>

<template lang="pug">
  div Hello
    div {{ myVal }}
</template>
```

decls.ts
```ts
export interface MyType {
  abc: number;
}

export const myVal = 123
```

In dev/non-inline mode before this change:
<img width="1654" height="56" alt="Screenshot From 2025-09-07 22-56-37" src="https://github.com/user-attachments/assets/79761963-24e2-42d5-867b-3216fbfd3172" />

After change; builds/runs as expected:
<img width="160" height="156" alt="Screenshot From 2025-09-07 22-57-49" src="https://github.com/user-attachments/assets/fe599b21-9b55-4c44-9b09-e2f9f90be99a" />

*no change in behavior in prod/inline mode, sample code works before and after change*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proper support for custom template languages (e.g., Pug) in <script setup lang="ts"> import usage detection and template inlining.
* **Bug Fixes**
  * More accurate detection of template-used imports, including handling of identifiers without the _ctx. prefix.
  * Improved HMR reload decisions by analyzing the actual template content/AST.
* **Performance**
  * Caching of compiled custom-language templates to reduce redundant compilations.
* **Tests**
  * Added coverage for custom template language usage with TypeScript to ensure correct exposure of bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->