### PR TITLE
fix(custom-element): properly mount multiple Teleports in custom element component w/ shadowRoot false

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -1273,5 +1273,5 @@ export interface ComponentCustomElementInterface {
   /**
    * @internal attached by the nested Teleport when shadowRoot is false.
    */
-  _teleportTargets?: RendererElement[]
+  _teleportTargets?: Set<RendererElement>
 }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -1273,5 +1273,5 @@ export interface ComponentCustomElementInterface {
   /**
    * @internal attached by the nested Teleport when shadowRoot is false.
    */
-  _teleportTarget?: RendererElement
+  _teleportTargets?: RendererElement[]
 }

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -119,14 +119,6 @@ export const TeleportImpl = {
         // Teleport *always* has Array children. This is enforced in both the
         // compiler and vnode children normalization.
         if (shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
-          if (parentComponent && parentComponent.isCE) {
-            const _teleportTargets = parentComponent.ce!._teleportTargets
-            if (!_teleportTargets) {
-              parentComponent.ce!._teleportTargets = [container]
-            } else {
-              _teleportTargets.push(container)
-            }
-          }
           mountChildren(
             children as VNodeArrayChildren,
             container,
@@ -150,6 +142,15 @@ export const TeleportImpl = {
           } else if (namespace !== 'mathml' && isTargetMathML(target)) {
             namespace = 'mathml'
           }
+
+          // track CE teleport targets
+          if (parentComponent && parentComponent.isCE) {
+            ;(
+              parentComponent.ce!._teleportTargets ||
+              (parentComponent.ce!._teleportTargets = [])
+            ).push(target)
+          }
+
           if (!disabled) {
             mount(target, targetAnchor)
             updateCssVars(n2, false)

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -120,7 +120,12 @@ export const TeleportImpl = {
         // compiler and vnode children normalization.
         if (shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
           if (parentComponent && parentComponent.isCE) {
-            parentComponent.ce!._teleportTarget = container
+            const _teleportTargets = parentComponent.ce!._teleportTargets
+            if (!_teleportTargets) {
+              parentComponent.ce!._teleportTargets = [container]
+            } else {
+              _teleportTargets.push(container)
+            }
           }
           mountChildren(
             children as VNodeArrayChildren,

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -147,8 +147,8 @@ export const TeleportImpl = {
           if (parentComponent && parentComponent.isCE) {
             ;(
               parentComponent.ce!._teleportTargets ||
-              (parentComponent.ce!._teleportTargets = [])
-            ).push(target)
+              (parentComponent.ce!._teleportTargets = new Set())
+            ).add(target)
           }
 
           if (!disabled) {

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -1319,6 +1319,45 @@ describe('defineCustomElement', () => {
       app.unmount()
     })
 
+    test('render two Teleports w/ shadowRoot false (with disabled)', async () => {
+      const target1 = document.createElement('div')
+      const target2 = document.createElement('span')
+      const Child = defineCustomElement(
+        {
+          render() {
+            return [
+              // with disabled: true
+              h(Teleport, { to: target1, disabled: true }, [
+                renderSlot(this.$slots, 'header'),
+              ]),
+              h(Teleport, { to: target2 }, [renderSlot(this.$slots, 'body')]),
+            ]
+          },
+        },
+        { shadowRoot: false },
+      )
+      customElements.define('my-el-two-teleport-child-0', Child)
+
+      const App = {
+        render() {
+          return h('my-el-two-teleport-child-0', null, {
+            default: () => [
+              h('div', { slot: 'header' }, 'header'),
+              h('span', { slot: 'body' }, 'body'),
+            ],
+          })
+        },
+      }
+      const app = createApp(App)
+      app.mount(container)
+      await nextTick()
+      expect(target1.outerHTML).toBe(`<div></div>`)
+      expect(target2.outerHTML).toBe(
+        `<span><span slot="body">body</span></span>`,
+      )
+      app.unmount()
+    })
+
     test('toggle nested custom element with shadowRoot: false', async () => {
       customElements.define(
         'my-el-child-shadow-false',

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -1281,6 +1281,44 @@ describe('defineCustomElement', () => {
       app.unmount()
     })
 
+    test('render nested tow Teleports w/ shadowRoot false', async () => {
+      const target1 = document.createElement('div')
+      const target2 = document.createElement('span')
+      const Child = defineCustomElement(
+        {
+          render() {
+            return [
+              h(Teleport, { to: target1 }, [renderSlot(this.$slots, 'header')]),
+              h(Teleport, { to: target2 }, [renderSlot(this.$slots, 'body')]),
+            ]
+          },
+        },
+        { shadowRoot: false },
+      )
+      customElements.define('my-el-tow-teleport-child', Child)
+
+      const App = {
+        render() {
+          return h('my-el-tow-teleport-child', null, {
+            default: () => [
+              h('div', { slot: 'header' }, 'header'),
+              h('span', { slot: 'body' }, 'body'),
+            ],
+          })
+        },
+      }
+      const app = createApp(App)
+      app.mount(container)
+      await nextTick()
+      expect(target1.outerHTML).toBe(
+        `<div><div slot="header">header</div></div>`,
+      )
+      expect(target2.outerHTML).toBe(
+        `<span><span slot="body">body</span></span>`,
+      )
+      app.unmount()
+    })
+
     test('toggle nested custom element with shadowRoot: false', async () => {
       customElements.define(
         'my-el-child-shadow-false',

--- a/packages/runtime-dom/__tests__/customElement.spec.ts
+++ b/packages/runtime-dom/__tests__/customElement.spec.ts
@@ -1281,7 +1281,7 @@ describe('defineCustomElement', () => {
       app.unmount()
     })
 
-    test('render nested tow Teleports w/ shadowRoot false', async () => {
+    test('render two Teleports w/ shadowRoot false', async () => {
       const target1 = document.createElement('div')
       const target2 = document.createElement('span')
       const Child = defineCustomElement(
@@ -1295,11 +1295,11 @@ describe('defineCustomElement', () => {
         },
         { shadowRoot: false },
       )
-      customElements.define('my-el-tow-teleport-child', Child)
+      customElements.define('my-el-two-teleport-child', Child)
 
       const App = {
         render() {
-          return h('my-el-tow-teleport-child', null, {
+          return h('my-el-two-teleport-child', null, {
             default: () => [
               h('div', { slot: 'header' }, 'header'),
               h('span', { slot: 'body' }, 'body'),

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -635,7 +635,7 @@ export class VueElement
    * Only called when shadowRoot is false
    */
   private _renderSlots() {
-    const outlets = [...getSlots(this._teleportTargets), ...getSlots([this])]
+    const outlets = this._getSlots()
     const scopeId = this._instance!.type.__scopeId
     for (let i = 0; i < outlets.length; i++) {
       const o = outlets[i] as HTMLSlotElement
@@ -663,6 +663,19 @@ export class VueElement
     }
   }
 
+  /**
+   * @internal
+   */
+  private _getSlots(): HTMLSlotElement[] {
+    const roots: HTMLElement[] = [this]
+    if (this._teleportTargets) {
+      roots.push(...this._teleportTargets)
+    }
+    return roots.reduce<HTMLSlotElement[]>((res, i) => {
+      res.push(...Array.from(i.querySelectorAll('slot')))
+      return res
+    }, [])
+  }
   /**
    * @internal
    */
@@ -715,12 +728,4 @@ export function useHost(caller?: string): VueElement | null {
 export function useShadowRoot(): ShadowRoot | null {
   const el = __DEV__ ? useHost('useShadowRoot') : useHost()
   return el && el.shadowRoot
-}
-
-function getSlots(roots: HTMLElement[] | undefined): HTMLSlotElement[] {
-  if (!roots) return []
-  return roots.reduce<HTMLSlotElement[]>((res, i) => {
-    res.push(...Array.from(i.querySelectorAll('slot')))
-    return res
-  }, [])
 }

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -224,7 +224,7 @@ export class VueElement
   /**
    * @internal
    */
-  _teleportTargets?: Set<HTMLElement>
+  _teleportTargets?: Set<Element>
 
   private _connected = false
   private _resolved = false
@@ -338,6 +338,10 @@ export class VueElement
         this._app && this._app.unmount()
         if (this._instance) this._instance.ce = undefined
         this._app = this._instance = null
+        if (this._teleportTargets) {
+          this._teleportTargets.clear()
+          this._teleportTargets = undefined
+        }
       }
     })
   }
@@ -667,7 +671,7 @@ export class VueElement
    * @internal
    */
   private _getSlots(): HTMLSlotElement[] {
-    const roots: HTMLElement[] = [this]
+    const roots: Element[] = [this]
     if (this._teleportTargets) {
       roots.push(...this._teleportTargets)
     }

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -224,7 +224,7 @@ export class VueElement
   /**
    * @internal
    */
-  _teleportTarget?: HTMLElement
+  _teleportTargets?: HTMLElement[]
 
   private _connected = false
   private _resolved = false
@@ -635,7 +635,7 @@ export class VueElement
    * Only called when shadowRoot is false
    */
   private _renderSlots() {
-    const outlets = (this._teleportTarget || this).querySelectorAll('slot')
+    const outlets = [...getSlots(this._teleportTargets), ...getSlots([this])]
     const scopeId = this._instance!.type.__scopeId
     for (let i = 0; i < outlets.length; i++) {
       const o = outlets[i] as HTMLSlotElement
@@ -715,4 +715,12 @@ export function useHost(caller?: string): VueElement | null {
 export function useShadowRoot(): ShadowRoot | null {
   const el = __DEV__ ? useHost('useShadowRoot') : useHost()
   return el && el.shadowRoot
+}
+
+function getSlots(roots: HTMLElement[] | undefined): HTMLSlotElement[] {
+  if (!roots) return []
+  return roots.reduce<HTMLSlotElement[]>((res, i) => {
+    res.push(...Array.from(i.querySelectorAll('slot')))
+    return res
+  }, [])
 }

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -224,7 +224,7 @@ export class VueElement
   /**
    * @internal
    */
-  _teleportTargets?: HTMLElement[]
+  _teleportTargets?: Set<HTMLElement>
 
   private _connected = false
   private _resolved = false


### PR DESCRIPTION
close #13899


Additionally, when two Teleports are used inside `ce-component`, only one of them renders correctly.

```vue
<template>
  <div class="widget">
    <Teleport to="#portal">
      <div class="widget__header">
        header start
        <slot name="headerContent" />
        header end
      </div>
    </Teleport>

    <Teleport to="#portal1">
      <div class="widget__body">
        body start
        <slot name="bodyContent" />
        body end
      </div>
    </Teleport>
  </div>
</template>
```

[issue playground](https://play.vuejs.org/#eNqNU9tuGjEQ/RXXfSCVgFXVPlESKSFIbR+aikaqKlmKtusBnHrtlT0LVIh/79jL3gQlebN9zpk5nsue3xbFeFMCn/Cpz5wqkHnAsrgRRuWFdcj2TMJSGZiVHm0+15CDQXZgS2dzNiDp4FPD/ankCvAIjZPqGsIHjjBJwjJrNkBMZdCyLIZkcIxJmEdXZmidMPFyDFgnvT5n5ariDMmoX6fSbhfW4oQtU+2BHd7ViR2slEcIkbtqP65CXg22Mcwog8GwnzaEmCZVcagsdEHIC50i0I2xqVQbpuS14KEEqRb8ZprQ21nwfR9tcsbrke61RRKsIZXgZtYgeSDZ5/nt/XzRivvs31b+bbl3D/e/OmmSbp5p0rHPhxw9lXqpVuNnbw2NwT5IBM9sXigN7qFARa0QfMIiErBUa7v9Gt+oXzCs37M1ZH/OvD/7XXgT/LsDD24DgjcYpo6sVfD8xzfY0bkBcytLTewL4AK81WXwWNHuSiPJdocX3X6JA6rM6tHPd1QlX38qGA3MQ+QLTsM6u/D11u6H8ceoE+ZAVWxH/WSTXpqdTKfeUwurJlH3jt19pL2IW4WW0LfNdFXwWfHTUzU1HRbx3oxGcUyYLdErCayJPBp1eJWUefoidtRRadIcTmeSJadyMLIx2J3VpE4ay/D/D4YNufjDMOm9/4WHi657u9HzHKWvcdxC/fU5/AMoLrt1)

[this pr playground](https://deploy-preview-13900--vue-sfc-playground.netlify.app/#eNqNU9tuGjEQ/RXXfSCVgFXVPlESKSFIbR+aikaqKlmKtusBnHrtlT0LVIh/79jL3gQlebN9zpk5nsue3xbFeFMCn/Cpz5wqkHnAsrgRRuWFdcj2TMJSGZiVHm0+15CDQXZgS2dzNiDp4FPD/ankCvAIjZPqGsIHjjBJwjJrNkBMZdCyLIZkcIxJmEdXZmidMPFyDFgnvT5n5ariDMmoX6fSbhfW4oQtU+2BHd7ViR2slEcIkbtqP65CXg22Mcwog8GwnzaEmCZVcagsdEHIC50i0I2xqVQbpuS14KEEqRb8ZprQ21nwfR9tcsbrke61RRKsIZXgZtYgeSDZ5/nt/XzRivvs31b+bbl3D/e/OmmSbp5p0rHPhxw9lXqpVuNnbw2NwT5IBM9sXigN7qFARa0QfMIiErBUa7v9Gt+oXzCs37M1ZH/OvD/7XXgT/LsDD24DgjcYpo6sVfD8xzfY0bkBcytLTewL4AK81WXwWNHuSiPJdocX3X6JA6rM6tHPd1QlX38qGA3MQ+QLTsM6u/D11u6H8ceoE+ZAVWxH/WSTXpqdTKfeUwurJlH3jt19pL2IW4WW0LfNdFXwWfHTUzU1HRbx3oxGcUyYLdErCayJPBp1eJWUefoidtRRadIcTmeSJadyMLIx2J3VpE4ay/D/D4YNufjDMOm9/4WHi657u9HzHKWvcdxC/fU5/AMoLrt1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom elements can teleport content to multiple targets (not just one).
  - Slot projection now aggregates slots from all teleport targets and the host element when not using Shadow DOM, improving multi-outlet content distribution.

- **Tests**
  - Added tests verifying rendering of multiple Teleport instances into separate targets, including a disabled-target variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->