### PR TITLE
fix(reactivity): respect readonly during ref unwrapping

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -522,6 +522,16 @@ describe('reactivity/readonly', () => {
     expect(obj.r).toBe(ro)
     expect(r.value).toBe(ro)
   })
+
+  test('should keep nested ref readonly', () => {
+    const items = ref(['one', 'two', 'three'])
+    const obj = {
+      o: readonly({
+        items,
+      }),
+    }
+    expect(isReadonly(obj.o.items)).toBe(true)
+  })
 })
 
 test('should be able to trigger with triggerRef', () => {

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -119,7 +119,8 @@ class BaseReactiveHandler implements ProxyHandler<Target> {
 
     if (isRef(res)) {
       // ref unwrapping - skip unwrap for Array + integer key.
-      return targetIsArray && isIntegerKey(key) ? res : res.value
+      const value = targetIsArray && isIntegerKey(key) ? res : res.value
+      return isReadonly && isObject(value) ? readonly(value) : value
     }
 
     if (isObject(res)) {


### PR DESCRIPTION
close #13903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nested objects obtained via refs inside readonly structures are now correctly treated as read-only, preventing unintended mutations while preserving prior array-index behavior for refs.
* **Tests**
  * Added a test verifying that refs nested within readonly containers are recognized as readonly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->