### PR TITLE
fix(compiler-sfc): add support for `@vue-ignore` in runtime type resolution

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -149,6 +149,17 @@ describe('resolveType', () => {
     })
   })
 
+  test('TSPropertySignature with ignore', () => {
+    expect(
+      resolve(`
+      type Foo = string
+      defineProps<{ foo: /* @vue-ignore */ Foo }>()
+    `).props,
+    ).toStrictEqual({
+      foo: ['Unknown'],
+    })
+  })
+
   // #7553
   test('union type', () => {
     expect(

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1515,6 +1515,13 @@ export function inferRuntimeType(
   isKeyOf = false,
   typeParameters?: Record<string, Node>,
 ): string[] {
+  if (
+    node.leadingComments &&
+    node.leadingComments.some(c => c.value.includes('@vue-ignore'))
+  ) {
+    return [UNKNOWN_TYPE]
+  }
+
   try {
     switch (node.type) {
       case 'TSStringKeyword':


### PR DESCRIPTION
[Playground](https://play.vuejs.org/#eNp9Uc1O4zAQfpWRhTa7CJrD7qkKXX7EAZCggt4wEiWZBINjW/aktAp5dyZOWyqBuI2/n/E3M604cW60aFCMRRZyrxyBnpvqSAoKUkBAatxEGlo5hKlHIlWustkEjqCF+ytQBl5xZUuYPYxhdn/1AB38grZbO+5UgSxNyLoE3iHxqnqmWD1ZIlvHUmNJydpwolVlsJjqeY41GmLz417bt+kOpdxrI98T3eOuYy1NAs390B9Nsem522w7Qkz2/uU/HlWaAktlcOqtC1krDYDb0P/HkO4f87oO2WY97qdbpzTd5PcfabJ0WGPslBHWbCbkF0BWqEUsuAzaEqQDnA54lu6oxQEfILemVNXoJVjD94lRpMht7ZRGf+NIWcNHGkNkem6utX27jBj5Bg82eP6M+es3+EtY9pgUvJeAfoFSbDleZYU00Od317jkekvWtmg0q38gbzFY3fQZB9lpYwqOvaOLaS9qZz0pU83C+ZLQhM1QfdBe2UW9FLz1sx9G/4z7d/Qv+vgiovsA0DL26Q==)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support ignoring runtime type inference for props annotated with @vue-ignore, ensuring those props resolve to an unknown type at runtime.

- Bug Fixes
  - Align behavior across inference paths so @vue-ignore consistently prevents runtime type inference, avoiding unintended prop type resolutions.

- Tests
  - Added coverage to verify that properties marked with @vue-ignore are treated as unknown during prop resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->