### PR TITLE
fix(shared): class presence overrides

### DIFF
--- a/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
@@ -144,6 +144,12 @@ describe('ssr: renderClass', () => {
     expect(ssrRenderClass(`"><script`)).toBe(`&quot;&gt;&lt;script`)
   })
 
+  test('overrides + duplicates', () => {
+    expect(
+      ssrRenderClass(['foo foo', { foo: true }, 'bar', { bar: false }]),
+    ).toBe('foo foo foo')
+  })
+
   test('className', () => {
     expect(
       ssrRenderAttrs({

--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -76,6 +76,43 @@ describe('normalizeClass', () => {
     ).toEqual('foo bar baz qux quux')
   })
 
+  test('handles overrides correctly', () => {
+    expect(
+      normalizeClass([
+        { foo: true },
+
+        'bar',
+        { bar: false, foo: undefined },
+
+        ' baz ',
+        { baz: false },
+
+        { qux: false },
+        ' qux \n  baz  ',
+
+        { quux: true },
+        [' quux quux2 ', [{ ' quux  quux3 ': false }]],
+
+        'quux3',
+      ]),
+    ).toEqual('qux baz quux2 quux3')
+  })
+
+  test('handles duplicates correctly', () => {
+    expect(
+      normalizeClass([
+        'foo  foo  baz  baz  baz',
+        { foo: true },
+
+        'bar bar ',
+        { bar: false },
+
+        { baz: false },
+        'baz baz',
+      ]),
+    ).toEqual('foo foo foo baz baz')
+  })
+
   // #6777
   test('parse multi-line inline style', () => {
     expect(


### PR DESCRIPTION
fix #13025 for `class`

Match behavior of style overriding present in `normalizeStyle` for `normalizeClass`.

Example: `<div class="foo" :class="{ foo: false }"></div>` -> `<div class=""></div>`

I have assumed that the discrepancy between `class` and `style` is a bug hence listing this as a fix.