### PR TITLE
fix(types): set dom stub type to `never` instead of `{}`

### DIFF
--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -38,8 +38,7 @@ import type { VModelDirective } from './directives/vModel'
  *
  * To enable proper types, add `"dom"` to `"lib"` in your `tsconfig.json`.
  */
-type DomStub = {}
-type DomType<T> = typeof globalThis extends { window: unknown } ? T : DomStub
+type DomType<T> = typeof globalThis extends { window: unknown } ? T : never
 
 declare module '@vue/reactivity' {
   export interface RefUnwrapBailTypes {


### PR DESCRIPTION
re-fix #11564

`{}` represents any non-nullable value, which is bad to use here.