### PR TITLE
chore(types): improve type safety in watch functions and instanceWatch

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -270,7 +270,7 @@ export function instanceWatch(
 export function createPathGetter(
   ctx: ComponentPublicInstance,
   path: string,
-): WatchSource | WatchSource[] | WatchEffect | object {
+): () => WatchSource | WatchSource[] | WatchEffect | object {
   const segments = path.split('.')
   return (): WatchSource | WatchSource[] | WatchEffect | object => {
     let cur = ctx

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -21,7 +21,7 @@ import { queuePostRenderEffect } from './renderer'
 import { warn } from './warning'
 import type { ObjectWatchOptionItem } from './componentOptions'
 import { useSSRContext } from './helpers/useSsrContext'
-import type { ComponentPublicInstance } from '@vue/runtime-core'
+import type { ComponentPublicInstance } from './componentPublicInstance'
 
 export type {
   WatchHandle,

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -852,7 +852,7 @@ export function createWatcher(
 ): void {
   let getter = key.includes('.')
     ? createPathGetter(publicThis, key)
-    : () => (publicThis as any)[key]
+    : () => (publicThis)[key as keyof typeof publicThis]
 
   const options: WatchOptions = {}
   if (__COMPAT__) {


### PR DESCRIPTION
removed some any types and used the correct type to ensure type safety

by the way, Is this `WatchSource` not in line with the expected design? The `watch` api is not directly using the `type WatchSource`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tightened internal typings around watcher and path-based APIs for clearer, safer public behavior.
* **Developer Experience**
  * Improved editor autocompletion, type inference, and dev-time diagnostics when creating watches and referencing paths.
* **Chores**
  * Removed loose casts and aligned internal definitions for more consistent development tooling.

Note: No runtime behavior changes; impact is limited to TypeScript/development-time ergonomics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->