### PR TITLE
fix(compiler-vapor): escape html for safer template output 

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/transformText.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformText.spec.ts
@@ -48,4 +48,10 @@ describe('compiler: text transform', () => {
     expect(ir.block.operation).toMatchObject([])
     expect(ir.block.effect.length).toBe(1)
   })
+
+  it('escapes raw static text when generating the template string', () => {
+    const { ir } = compileWithTextTransform('<code>&lt;script&gt;</code>')
+    expect(ir.template).toContain('<code>&lt;script&gt;</code>')
+    expect(ir.template).not.toContain('<code><script></code>')
+  })
 })

--- a/packages/compiler-vapor/src/transforms/transformComment.ts
+++ b/packages/compiler-vapor/src/transforms/transformComment.ts
@@ -6,6 +6,7 @@ import {
 } from '@vue/compiler-dom'
 import type { NodeTransform, TransformContext } from '../transform'
 import { DynamicFlag } from '../ir'
+import { escapeHtml } from '@vue/shared'
 
 export const transformComment: NodeTransform = (node, context) => {
   if (node.type !== NodeTypes.COMMENT) return
@@ -14,7 +15,7 @@ export const transformComment: NodeTransform = (node, context) => {
     context.comment.push(node)
     context.dynamic.flags |= DynamicFlag.NON_TEMPLATE
   } else {
-    context.template += `<!--${node.content}-->`
+    context.template += `<!--${escapeHtml(node.content)}-->`
   }
 }
 

--- a/packages/compiler-vapor/src/transforms/transformText.ts
+++ b/packages/compiler-vapor/src/transforms/transformText.ts
@@ -16,6 +16,7 @@ import {
   isConstantExpression,
   isStaticExpression,
 } from '../utils'
+import { escapeHtml } from '@vue/shared'
 
 type TextLike = TextNode | InterpolationNode
 const seen = new WeakMap<
@@ -82,7 +83,7 @@ export const transformText: NodeTransform = (node, context) => {
   } else if (node.type === NodeTypes.INTERPOLATION) {
     processInterpolation(context as TransformContext<InterpolationNode>)
   } else if (node.type === NodeTypes.TEXT) {
-    context.template += node.content
+    context.template += escapeHtml(node.content)
   }
 }
 
@@ -143,7 +144,7 @@ function processTextContainer(
   const literals = values.map(getLiteralExpressionValue)
 
   if (literals.every(l => l != null)) {
-    context.childrenTemplate = literals.map(l => String(l))
+    context.childrenTemplate = literals.map(l => escapeHtml(String(l)))
   } else {
     context.childrenTemplate = [' ']
     context.registerOperation({


### PR DESCRIPTION
see [Playground](https://play.vuejs.org/#eNp9UMFKAzEQ/ZUlh55qKlY8tGFBpQc9qKjHgITsuE3NJiGZrAtl/90kS2sPpbeZ997MvHl7cu8c7SOQFWFBeuWwCoDRVb1w1tfcsMUEpzI1CJ3TAiF1VcUa1ddM2gbqmcb1pJu1uGaLArJFFuQVJ2NkTjBIa75VS3fBmnR4n5dxIm3nlAb/6lBZEzhZVYXJnNDa/j4XDH2E+QGXW5A/Z/BdGDLGyZuHAL4HTo4cCt8CTvTm4wWGVB/JzjZRJ/UF8h2C1TF7nGQP0TTJ9omuuH3qUoCoTPsZNgOCCYenstGsHIuek5T+44XX/+0u6W2Z42ZMKX714PPOFOCS3tHrK6HdVtAbMv4BMW+aBQ==)


https://github.com/vuejs/core/blob/5edb7ba546f5ad911c98575cca54d721fdebcac2/packages/compiler-dom/src/transforms/stringifyStatic.ts#L299-L315