### PR TITLE
Enable preview theme in Repl component

### DIFF
--- a/packages-private/sfc-playground/src/App.vue
+++ b/packages-private/sfc-playground/src/App.vue
@@ -161,6 +161,7 @@ const previewOptions = computed(() => ({
   <Repl
     ref="replRef"
     :theme="theme"
+    :previewTheme="true"
     :editor="Monaco"
     @keydown.ctrl.s.prevent
     @keydown.meta.s.prevent


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="709" height="290" alt="image" src="https://github.com/user-attachments/assets/df5d0c84-f5c8-4640-b2f0-472ffa993855" /> | <img width="705" height="272" alt="image" src="https://github.com/user-attachments/assets/a534e9c3-5d04-43b3-9fb2-98a3528e830b" /> | 


Related PR: https://github.com/vuejs/repl/pull/366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled theming for the preview pane in the SFC Playground, aligning it with the selected app theme (e.g., light/dark) for a consistent experience.

* **UI Improvements**
  * Improved visual consistency between the editor and the preview, enhancing readability and reducing visual mismatches across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->