### PR TITLE
test(vapor): use browser mode instead of pupeteer to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dts-build/packages
 *.tsbuildinfo
 *.tgz
 packages-private/benchmark/reference
+**/__tests__/**/__screenshots__/**/*

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/node": "^22.17.2",
     "@types/semver": "^7.7.0",
     "@types/serve-handler": "^6.1.4",
+    "@vitest/ui": "^4.0.0-beta.12",
     "@vitest/browser": "^4.0.0-beta.12",
     "@vitest/coverage-v8": "^4.0.0-beta.12",
     "@vitest/eslint-plugin": "^1.3.12",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "vitest",
     "test-unit": "vitest --project unit --project unit-jsdom",
     "test-e2e": "node scripts/build.js vue -f global -d && vitest --project e2e",
-    "test-e2e-vapor": "pnpm run prepare-e2e-vapor && vitest --project e2e-vapor",
+    "test-e2e-vapor": "vitest --project e2e-vapor",
     "prepare-e2e-vapor": "node scripts/build.js -f cjs+esm-bundler+esm-bundler-runtime && pnpm run -C packages-private/vapor-e2e-test build",
     "test-dts": "run-s build-dts test-dts-only",
     "test-dts-only": "tsc -p packages-private/dts-built-test/tsconfig.json && tsc -p ./packages-private/dts-test/tsconfig.test.json",
@@ -74,9 +74,9 @@
     "@types/node": "^22.17.2",
     "@types/semver": "^7.7.0",
     "@types/serve-handler": "^6.1.4",
-    "@vitest/ui": "^3.0.2",
-    "@vitest/coverage-v8": "^3.2.4",
-    "@vitest/eslint-plugin": "^1.3.4",
+    "@vitest/browser": "^4.0.0-beta.12",
+    "@vitest/coverage-v8": "^4.0.0-beta.12",
+    "@vitest/eslint-plugin": "^1.3.12",
     "@vue/consolidate": "1.0.0",
     "conventional-changelog-cli": "^5.0.0",
     "enquirer": "^2.4.1",
@@ -93,6 +93,7 @@
     "marked": "13.0.3",
     "npm-run-all2": "^7.0.2",
     "picocolors": "^1.1.1",
+    "playwright": "^1.55.1",
     "prettier": "^3.5.3",
     "pretty-bytes": "^6.1.1",
     "pug": "^3.0.3",
@@ -111,6 +112,6 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.32.1",
     "vite": "catalog:",
-    "vitest": "^3.2.4"
+    "vitest": "^4.0.0-beta.12"
   }
 }

--- a/packages-private/vapor-e2e-test/__tests__/e2eUtils.ts
+++ b/packages-private/vapor-e2e-test/__tests__/e2eUtils.ts
@@ -1,0 +1,9 @@
+import { type Locator, page, userEvent } from '@vitest/browser/context'
+
+export const css = (css: string) => page.getByCSS(css)
+export const E2E_TIMEOUT: number = 30 * 1000
+
+export async function enterValue(locator: Locator, text: string) {
+  await locator.fill(text)
+  await userEvent.type(locator, '{enter}')
+}

--- a/packages-private/vapor-e2e-test/__tests__/setupBrowser.ts
+++ b/packages-private/vapor-e2e-test/__tests__/setupBrowser.ts
@@ -1,0 +1,17 @@
+import { locators } from '@vitest/browser/context'
+
+locators.extend({
+  getByCSS(css: string) {
+    return `css=${css}`
+  },
+})
+
+const div = document.createElement('div')
+div.id = 'app'
+document.body.appendChild(div)
+
+declare module '@vitest/browser/context' {
+  interface LocatorSelectors {
+    getByCSS(css: string): Locator
+  }
+}

--- a/packages-private/vapor-e2e-test/__tests__/todomvc.spec.ts
+++ b/packages-private/vapor-e2e-test/__tests__/todomvc.spec.ts
@@ -1,195 +1,182 @@
-import path from 'node:path'
-import {
-  E2E_TIMEOUT,
-  setupPuppeteer,
-} from '../../../packages/vue/__tests__/e2e/e2eUtils'
-import connect from 'connect'
-import sirv from 'sirv'
+import { userEvent } from '@vitest/browser/context'
+import { createVaporApp } from 'vue'
+import App from '../todomvc/App.vue'
+import 'todomvc-app-css/index.css'
+import { E2E_TIMEOUT, css, enterValue } from './e2eUtils'
+
+beforeAll(() => {
+  // MVC relies on local storage, but it persists between reruns in watch mode
+  localStorage.clear()
+})
 
 describe('e2e: todomvc', () => {
-  const {
-    page,
-    click,
-    isVisible,
-    count,
-    text,
-    value,
-    isChecked,
-    isFocused,
-    classList,
-    enterValue,
-    clearValue,
-    timeout,
-  } = setupPuppeteer()
+  test('vapor', { timeout: E2E_TIMEOUT }, async () => {
+    createVaporApp(App).mount('#app')
 
-  let server: any
-  const port = '8194'
-  beforeAll(() => {
-    server = connect()
-      .use(sirv(path.resolve(import.meta.dirname, '../dist')))
-      .listen(port)
-    process.on('SIGTERM', () => server && server.close())
+    expect(css('.main')).not.toBeVisible()
+    expect(css('.footer')).not.toBeVisible()
+    expect(css('.filters .selected')).toHaveLength(1)
+    expect(css('.filters .selected')).toHaveTextContent('All')
+    expect(css('.todo')).toHaveLength(0)
+
+    await enterValue(css('.new-todo'), 'test')
+    expect(css('.todo')).toHaveLength(1)
+    expect(css('.todo .edit')).not.toBeVisible()
+    expect(css('.todo label')).toHaveTextContent('test')
+    expect(css('.todo-count strong')).toHaveTextContent('1')
+    expect(css('.todo .toggle')).not.toBeChecked()
+    expect(css('.main')).toBeVisible()
+    expect(css('.footer')).toBeVisible()
+    expect(css('.clear-completed')).not.toBeVisible()
+    expect(css('.new-todo')).toHaveValue('')
+
+    await enterValue(css('.new-todo'), 'test2')
+    expect(css('.todo')).toHaveLength(2)
+    expect(css('.todo:nth-child(2) label')).toHaveTextContent('test2')
+    expect(css('.todo-count strong')).toHaveTextContent('2')
+
+    // toggle
+    await css('.todo .toggle').first().click()
+    expect(css('.todo.completed')).toHaveLength(1)
+    expect(css('.todo:nth-child(1)')).toHaveClass('completed')
+    expect(css('.todo-count strong')).toHaveTextContent('1')
+    expect(css('.clear-completed')).toBeVisible()
+
+    await enterValue(css('.new-todo'), 'test3')
+    expect(css('.todo')).toHaveLength(3)
+    expect(css('.todo:nth-child(3) label')).toHaveTextContent('test3')
+    expect(css('.todo-count strong')).toHaveTextContent('2')
+
+    await enterValue(css('.new-todo'), 'test4')
+    await enterValue(css('.new-todo'), 'test5')
+    expect(css('.todo')).toHaveLength(5)
+    expect(css('.todo-count strong')).toHaveTextContent('4')
+
+    // toggle more
+    await css('.todo:nth-child(4) .toggle').click()
+    await css('.todo:nth-child(5) .toggle').click()
+    expect(css('.todo.completed')).toHaveLength(3)
+    expect(css('.todo-count strong')).toHaveTextContent('2')
+
+    // remove
+    await removeItemAt(1)
+    expect(css('.todo')).toHaveLength(4)
+    expect(css('.todo.completed')).toHaveLength(2)
+    expect(css('.todo-count strong')).toHaveTextContent('2')
+    await removeItemAt(2)
+    expect(css('.todo')).toHaveLength(3)
+    expect(css('.todo.completed')).toHaveLength(2)
+    expect(css('.todo-count strong')).toHaveTextContent('1')
+
+    // remove all
+    await css('.clear-completed').click()
+    expect(css('.todo')).toHaveLength(1)
+    expect(css('.todo label')).toHaveTextContent('test2')
+    expect(css('.todo.completed')).toHaveLength(0)
+    expect(css('.todo-count strong')).toHaveTextContent('1')
+    expect(css('.clear-completed')).not.toBeVisible()
+
+    // prepare to test filters
+    await enterValue(css('.new-todo'), 'test')
+    await enterValue(css('.new-todo'), 'test')
+    await css('.todo:nth-child(2) .toggle').click()
+    await css('.todo:nth-child(3) .toggle').click()
+
+    // active filter
+    await css('.filters li:nth-child(2) a').click()
+
+    await expect.element(css('.todo')).toHaveLength(1)
+    expect(css('.todo.completed')).toHaveLength(0)
+    // add item with filter active
+    await enterValue(css('.new-todo'), 'test')
+    expect(css('.todo')).toHaveLength(2)
+
+    // completed filter
+    await css('.filters li:nth-child(3) a').click()
+
+    await expect.element(css('.todo')).toHaveLength(2)
+    expect(css('.todo.completed')).toHaveLength(2)
+
+    // filter on page load
+    location.hash = '#active'
+
+    await expect.element(css('.todo.completed')).toHaveLength(0)
+    await expect.element(css('.todo')).toHaveLength(2)
+    expect(css('.todo-count strong')).toHaveTextContent('2')
+
+    // completed on page load
+    location.hash = '#completed'
+
+    // expect.element().toHaveLength(0) will also pass here
+    // because it's 0 at the start! make sure we wait the hash change
+    await expect.element(css('.todo.completed')).not.toHaveLength(0)
+    await expect.element(css('.todo')).toHaveLength(2)
+
+    expect(css('.todo.completed')).toHaveLength(2)
+    expect(css('.todo-count strong')).toHaveTextContent('2')
+
+    // toggling with filter active
+    await css('.todo .toggle').first().click()
+    await expect.element(css('.todo')).toHaveLength(1)
+
+    await css('.filters li:nth-child(2) a').click()
+    await expect.element(css('.todo')).toHaveLength(3)
+
+    await css('.todo .toggle').first().click()
+    await expect.element(css('.todo')).toHaveLength(2)
+
+    // editing triggered by blur
+    await css('.filters li:nth-child(1) a').click()
+    await css('.todo:nth-child(1) label').dblClick()
+
+    await expect.element(css('.todo.editing')).toHaveLength(1)
+    await expect.element(css('.todo:nth-child(1) .edit')).toHaveFocus()
+
+    await css('.todo:nth-child(1) .edit').clear()
+    await userEvent.type(css('.todo:nth-child(1) .edit'), 'edited!')
+    await css('.new-todo').click() // blur
+
+    expect(css('.todo.editing')).toHaveLength(0)
+    expect(css('.todo:nth-child(1) label')).toHaveTextContent('edited!')
+
+    // editing triggered by enter
+    await css('.todo label').first().dblClick()
+    await enterValue(css('.todo:nth-child(1) .edit'), 'edited again!')
+    await expect.element(css('.todo.editing')).toHaveLength(0)
+    await expect
+      .element(css('.todo:nth-child(1) label'))
+      .toHaveTextContent('edited again!')
+
+    // cancel
+    await css('.todo label').first().dblClick()
+    await css('.todo:nth-child(1) .edit').clear()
+    await userEvent.type(css('.todo:nth-child(1) .edit'), 'edited!{escape}')
+
+    await expect.element(css('.todo.editing')).toHaveLength(0)
+    await expect
+      .element(css('.todo:nth-child(1) label'))
+      .toHaveTextContent('edited again!')
+
+    // empty value should remove
+    await css('.todo label').first().dblClick()
+    await enterValue(css('.todo:nth-child(1) .edit'), ' ')
+    await expect.element(css('.todo')).toHaveLength(3)
+
+    // toggle all
+    await css('.toggle-all+label').click()
+    expect(css('.todo.completed')).toHaveLength(3)
+    await css('.toggle-all+label').click()
+    expect(css('.todo:not(.completed)')).toHaveLength(3)
   })
-
-  afterAll(() => {
-    server.close()
-  })
-
-  async function removeItemAt(n: number) {
-    const item = (await page().$('.todo:nth-child(' + n + ')'))!
-    const itemBBox = (await item.boundingBox())!
-    await page().mouse.move(itemBBox.x + 10, itemBBox.y + 10)
-    await click('.todo:nth-child(' + n + ') .destroy')
-  }
-
-  test(
-    'vapor',
-    async () => {
-      const baseUrl = `http://localhost:${port}/todomvc/`
-      await page().goto(baseUrl)
-
-      expect(await isVisible('.main')).toBe(false)
-      expect(await isVisible('.footer')).toBe(false)
-      expect(await count('.filters .selected')).toBe(1)
-      expect(await text('.filters .selected')).toBe('All')
-      expect(await count('.todo')).toBe(0)
-
-      await enterValue('.new-todo', 'test')
-      expect(await count('.todo')).toBe(1)
-      expect(await isVisible('.todo .edit')).toBe(false)
-      expect(await text('.todo label')).toBe('test')
-      expect(await text('.todo-count strong')).toBe('1')
-      expect(await isChecked('.todo .toggle')).toBe(false)
-      expect(await isVisible('.main')).toBe(true)
-      expect(await isVisible('.footer')).toBe(true)
-      expect(await isVisible('.clear-completed')).toBe(false)
-      expect(await value('.new-todo')).toBe('')
-
-      await enterValue('.new-todo', 'test2')
-      expect(await count('.todo')).toBe(2)
-      expect(await text('.todo:nth-child(2) label')).toBe('test2')
-      expect(await text('.todo-count strong')).toBe('2')
-
-      // toggle
-      await click('.todo .toggle')
-      expect(await count('.todo.completed')).toBe(1)
-      expect(await classList('.todo:nth-child(1)')).toContain('completed')
-      expect(await text('.todo-count strong')).toBe('1')
-      expect(await isVisible('.clear-completed')).toBe(true)
-
-      await enterValue('.new-todo', 'test3')
-      expect(await count('.todo')).toBe(3)
-      expect(await text('.todo:nth-child(3) label')).toBe('test3')
-      expect(await text('.todo-count strong')).toBe('2')
-
-      await enterValue('.new-todo', 'test4')
-      await enterValue('.new-todo', 'test5')
-      expect(await count('.todo')).toBe(5)
-      expect(await text('.todo-count strong')).toBe('4')
-
-      // toggle more
-      await click('.todo:nth-child(4) .toggle')
-      await click('.todo:nth-child(5) .toggle')
-      expect(await count('.todo.completed')).toBe(3)
-      expect(await text('.todo-count strong')).toBe('2')
-
-      // remove
-      await removeItemAt(1)
-      expect(await count('.todo')).toBe(4)
-      expect(await count('.todo.completed')).toBe(2)
-      expect(await text('.todo-count strong')).toBe('2')
-      await removeItemAt(2)
-      expect(await count('.todo')).toBe(3)
-      expect(await count('.todo.completed')).toBe(2)
-      expect(await text('.todo-count strong')).toBe('1')
-
-      // remove all
-      await click('.clear-completed')
-      expect(await count('.todo')).toBe(1)
-      expect(await text('.todo label')).toBe('test2')
-      expect(await count('.todo.completed')).toBe(0)
-      expect(await text('.todo-count strong')).toBe('1')
-      expect(await isVisible('.clear-completed')).toBe(false)
-
-      // prepare to test filters
-      await enterValue('.new-todo', 'test')
-      await enterValue('.new-todo', 'test')
-      await click('.todo:nth-child(2) .toggle')
-      await click('.todo:nth-child(3) .toggle')
-
-      // active filter
-      await click('.filters li:nth-child(2) a')
-      await timeout(1)
-      expect(await count('.todo')).toBe(1)
-      expect(await count('.todo.completed')).toBe(0)
-      // add item with filter active
-      await enterValue('.new-todo', 'test')
-      expect(await count('.todo')).toBe(2)
-
-      // completed filter
-      await click('.filters li:nth-child(3) a')
-      await timeout(1)
-      expect(await count('.todo')).toBe(2)
-      expect(await count('.todo.completed')).toBe(2)
-
-      // filter on page load
-      await page().goto(`${baseUrl}#active`)
-      expect(await count('.todo')).toBe(2)
-      expect(await count('.todo.completed')).toBe(0)
-      expect(await text('.todo-count strong')).toBe('2')
-
-      // completed on page load
-      await page().goto(`${baseUrl}#completed`)
-      expect(await count('.todo')).toBe(2)
-      expect(await count('.todo.completed')).toBe(2)
-      expect(await text('.todo-count strong')).toBe('2')
-
-      // toggling with filter active
-      await click('.todo .toggle')
-      expect(await count('.todo')).toBe(1)
-      await click('.filters li:nth-child(2) a')
-      await timeout(1)
-      expect(await count('.todo')).toBe(3)
-      await click('.todo .toggle')
-      expect(await count('.todo')).toBe(2)
-
-      // editing triggered by blur
-      await click('.filters li:nth-child(1) a')
-      await timeout(1)
-      await click('.todo:nth-child(1) label', { clickCount: 2 })
-      expect(await count('.todo.editing')).toBe(1)
-      expect(await isFocused('.todo:nth-child(1) .edit')).toBe(true)
-      await clearValue('.todo:nth-child(1) .edit')
-      await page().type('.todo:nth-child(1) .edit', 'edited!')
-      await click('.new-todo') // blur
-      expect(await count('.todo.editing')).toBe(0)
-      expect(await text('.todo:nth-child(1) label')).toBe('edited!')
-
-      // editing triggered by enter
-      await click('.todo label', { clickCount: 2 })
-      await enterValue('.todo:nth-child(1) .edit', 'edited again!')
-      expect(await count('.todo.editing')).toBe(0)
-      expect(await text('.todo:nth-child(1) label')).toBe('edited again!')
-
-      // cancel
-      await click('.todo label', { clickCount: 2 })
-      await clearValue('.todo:nth-child(1) .edit')
-      await page().type('.todo:nth-child(1) .edit', 'edited!')
-      await page().keyboard.press('Escape')
-      expect(await count('.todo.editing')).toBe(0)
-      expect(await text('.todo:nth-child(1) label')).toBe('edited again!')
-
-      // empty value should remove
-      await click('.todo label', { clickCount: 2 })
-      await enterValue('.todo:nth-child(1) .edit', ' ')
-      expect(await count('.todo')).toBe(3)
-
-      // toggle all
-      await click('.toggle-all+label')
-      expect(await count('.todo.completed')).toBe(3)
-      await click('.toggle-all+label')
-      expect(await count('.todo:not(.completed)')).toBe(3)
-    },
-    E2E_TIMEOUT,
-  )
 })
+
+// no timeout is needed because expect.element awaits
+// const timeout = async (ms: number) => {
+//   await new Promise(resolve => setTimeout(resolve, ms))
+// }
+
+async function removeItemAt(n: number) {
+  const item = css(`.todo:nth-child(${n})`)
+  await item.hover()
+  await css(`.todo:nth-child(${n}) .destroy`).click()
+}

--- a/packages-private/vapor-e2e-test/__tests__/vdomInterop.spec.ts
+++ b/packages-private/vapor-e2e-test/__tests__/vdomInterop.spec.ts
@@ -1,84 +1,62 @@
-import path from 'node:path'
-import {
-  E2E_TIMEOUT,
-  setupPuppeteer,
-} from '../../../packages/vue/__tests__/e2e/e2eUtils'
-import connect from 'connect'
-import sirv from 'sirv'
+import { createApp, vaporInteropPlugin } from 'vue'
+import App from '../interop/App.vue'
+import { E2E_TIMEOUT, css } from './e2eUtils'
 
 describe('vdom / vapor interop', () => {
-  const { page, click, text, enterValue } = setupPuppeteer()
+  test('should work', { timeout: E2E_TIMEOUT }, async () => {
+    createApp(App).use(vaporInteropPlugin).mount('#app')
 
-  let server: any
-  const port = '8193'
-  beforeAll(() => {
-    server = connect()
-      .use(sirv(path.resolve(import.meta.dirname, '../dist')))
-      .listen(port)
-    process.on('SIGTERM', () => server && server.close())
+    await expect
+      .element(css('.vapor > h2'))
+      .toHaveTextContent('Vapor component in VDOM')
+
+    expect(css('.vapor-prop')).toHaveTextContent('hello')
+
+    const l = css('.vdom-slot-in-vapor-default')
+    expect(l).toHaveTextContent('slot prop: slot prop')
+    expect(l).toHaveTextContent('component prop: hello')
+
+    await css('.change-vdom-slot-in-vapor-prop').click()
+    expect(css('.vdom-slot-in-vapor-default')).toHaveTextContent(
+      'slot prop: changed',
+    )
+
+    expect(css('.vdom-slot-in-vapor-test')).toHaveTextContent('A test slot')
+
+    await css('.toggle-vdom-slot-in-vapor').click()
+    expect(css('.vdom-slot-in-vapor-test')).toHaveTextContent(
+      'fallback content',
+    )
+
+    await css('.toggle-vdom-slot-in-vapor').click()
+    expect(css('.vdom-slot-in-vapor-test')).toHaveTextContent('A test slot')
+
+    expect(css('.vdom > h2')).toHaveTextContent('VDOM component in Vapor')
+
+    expect(css('.vdom-prop')).toHaveTextContent('hello')
+
+    const tt = css('.vapor-slot-in-vdom-default')
+    expect(tt).toHaveTextContent('slot prop: slot prop')
+    expect(tt).toHaveTextContent('component prop: hello')
+
+    await css('.change-vapor-slot-in-vdom-prop').click()
+    expect(css('.vapor-slot-in-vdom-default')).toHaveTextContent(
+      'slot prop: changed',
+    )
+
+    expect(css('.vapor-slot-in-vdom-test')).toHaveTextContent('fallback')
+
+    await css('.toggle-vapor-slot-in-vdom-default').click()
+    expect(css('.vapor-slot-in-vdom-default')).toHaveTextContent(
+      'default slot fallback',
+    )
+
+    await css('.toggle-vapor-slot-in-vdom-default').click()
+
+    await css('input').fill('bye')
+    expect(css('.vapor-prop')).toHaveTextContent('bye')
+    expect(css('.vdom-slot-in-vapor-default')).toHaveTextContent('bye')
+    expect(css('.vdom-prop')).toHaveTextContent('bye')
+    expect(css('.vapor-slot-in-vdom-default')).toHaveTextContent('bye')
   })
-
-  afterAll(() => {
-    server.close()
-  })
-
-  test(
-    'should work',
-    async () => {
-      const baseUrl = `http://localhost:${port}/interop/`
-      await page().goto(baseUrl)
-
-      expect(await text('.vapor > h2')).toContain('Vapor component in VDOM')
-
-      expect(await text('.vapor-prop')).toContain('hello')
-
-      const t = await text('.vdom-slot-in-vapor-default')
-      expect(t).toContain('slot prop: slot prop')
-      expect(t).toContain('component prop: hello')
-
-      await click('.change-vdom-slot-in-vapor-prop')
-      expect(await text('.vdom-slot-in-vapor-default')).toContain(
-        'slot prop: changed',
-      )
-
-      expect(await text('.vdom-slot-in-vapor-test')).toContain('A test slot')
-
-      await click('.toggle-vdom-slot-in-vapor')
-      expect(await text('.vdom-slot-in-vapor-test')).toContain(
-        'fallback content',
-      )
-
-      await click('.toggle-vdom-slot-in-vapor')
-      expect(await text('.vdom-slot-in-vapor-test')).toContain('A test slot')
-
-      expect(await text('.vdom > h2')).toContain('VDOM component in Vapor')
-
-      expect(await text('.vdom-prop')).toContain('hello')
-
-      const tt = await text('.vapor-slot-in-vdom-default')
-      expect(tt).toContain('slot prop: slot prop')
-      expect(tt).toContain('component prop: hello')
-
-      await click('.change-vapor-slot-in-vdom-prop')
-      expect(await text('.vapor-slot-in-vdom-default')).toContain(
-        'slot prop: changed',
-      )
-
-      expect(await text('.vapor-slot-in-vdom-test')).toContain('fallback')
-
-      await click('.toggle-vapor-slot-in-vdom-default')
-      expect(await text('.vapor-slot-in-vdom-default')).toContain(
-        'default slot fallback',
-      )
-
-      await click('.toggle-vapor-slot-in-vdom-default')
-
-      await enterValue('input', 'bye')
-      expect(await text('.vapor-prop')).toContain('bye')
-      expect(await text('.vdom-slot-in-vapor-default')).toContain('bye')
-      expect(await text('.vdom-prop')).toContain('bye')
-      expect(await text('.vapor-slot-in-vdom-default')).toContain('bye')
-    },
-    E2E_TIMEOUT,
-  )
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@vitest/eslint-plugin':
         specifier: ^1.3.12
         version: 1.3.13(eslint@9.33.0)(typescript@5.6.3)(vitest@4.0.0-beta.13)
+      '@vitest/ui':
+        specifier: ^4.0.0-beta.12
+        version: 4.0.0-beta.13(vitest@4.0.0-beta.13)
       '@vue/consolidate':
         specifier: 1.0.0
         version: 1.0.0
@@ -184,7 +187,7 @@ importers:
         version: 6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)
       vitest:
         specifier: ^4.0.0-beta.12
-        version: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+        version: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(@vitest/ui@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
 
   packages-private/benchmark:
     dependencies:
@@ -1662,6 +1665,11 @@ packages:
   '@vitest/spy@4.0.0-beta.13':
     resolution: {integrity: sha512-wjIjMhR385hfExvh6IpEvCaYCvnRb/7Uu9SXXFPbnalGIuG8CGiMsId02nNI3Q3WvqSon5IYqgXU3zkrzKtQ4A==}
 
+  '@vitest/ui@4.0.0-beta.13':
+    resolution: {integrity: sha512-g8tkmHDDKQ+OisOyyPeHD1ecuDiFTRs9RytPS3hr4lMyIL/wul7dbkQvwE2W18PjKBnv23XyomkyFaB6c8dkIA==}
+    peerDependencies:
+      vitest: 4.0.0-beta.13
+
   '@vitest/utils@4.0.0-beta.13':
     resolution: {integrity: sha512-vR+JiskbK9zYbnSn2OLZvAUOItAZSDaXSfi3lJwax21ue162ODNSM5GHk/GtnBtoHQoe0IWMpAMwRaJm8Isftg==}
 
@@ -2399,6 +2407,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4804,7 +4815,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(@vitest/ui@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.55.1
@@ -4827,7 +4838,7 @@ snapshots:
       magicast: 0.3.5
       std-env: 3.9.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(@vitest/ui@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
     optionalDependencies:
       '@vitest/browser': 4.0.0-beta.13(playwright@1.55.1)(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))(vitest@4.0.0-beta.13)
     transitivePeerDependencies:
@@ -4840,7 +4851,7 @@ snapshots:
       eslint: 9.33.0
     optionalDependencies:
       typescript: 5.6.3
-      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(@vitest/ui@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4876,6 +4887,17 @@ snapshots:
       pathe: 2.0.3
 
   '@vitest/spy@4.0.0-beta.13': {}
+
+  '@vitest/ui@4.0.0-beta.13(vitest@4.0.0-beta.13)':
+    dependencies:
+      '@vitest/utils': 4.0.0-beta.13
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(@vitest/ui@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
 
   '@vitest/utils@4.0.0-beta.13':
     dependencies:
@@ -5683,6 +5705,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -7146,7 +7170,7 @@ snapshots:
       sass: 1.90.0
       yaml: 2.8.1
 
-  vitest@4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1):
+  vitest@4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(@vitest/ui@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.0-beta.13
       '@vitest/mocker': 4.0.0-beta.13(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))
@@ -7172,6 +7196,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.17.2
       '@vitest/browser': 4.0.0-beta.13(playwright@1.55.1)(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))(vitest@4.0.0-beta.13)
+      '@vitest/ui': 4.0.0-beta.13(vitest@4.0.0-beta.13)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,15 +68,15 @@ importers:
       '@types/serve-handler':
         specifier: ^6.1.4
         version: 6.1.4
+      '@vitest/browser':
+        specifier: ^4.0.0-beta.12
+        version: 4.0.0-beta.13(playwright@1.55.1)(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))(vitest@4.0.0-beta.13)
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: ^4.0.0-beta.12
+        version: 4.0.0-beta.13(@vitest/browser@4.0.0-beta.13)(vitest@4.0.0-beta.13)
       '@vitest/eslint-plugin':
-        specifier: ^1.3.4
-        version: 1.3.4(eslint@9.33.0)(typescript@5.6.3)(vitest@3.2.4)
-      '@vitest/ui':
-        specifier: ^3.0.2
-        version: 3.2.4(vitest@3.2.4)
+        specifier: ^1.3.12
+        version: 1.3.13(eslint@9.33.0)(typescript@5.6.3)(vitest@4.0.0-beta.13)
       '@vue/consolidate':
         specifier: 1.0.0
         version: 1.0.0
@@ -125,6 +125,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      playwright:
+        specifier: ^1.55.1
+        version: 1.55.1
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -180,8 +183,8 @@ importers:
         specifier: 'catalog:'
         version: 6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.17.2)(@vitest/ui@3.2.4)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+        specifier: ^4.0.0-beta.12
+        version: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
 
   packages-private/benchmark:
     dependencies:
@@ -547,10 +550,6 @@ importers:
 
 packages:
 
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
-
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
@@ -573,6 +572,10 @@ packages:
     resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
@@ -999,13 +1002,6 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
-
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1063,42 +1059,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1121,10 +1111,6 @@ packages:
   '@parcel/watcher@2.5.1':
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1234,67 +1220,56 @@ packages:
     resolution: {integrity: sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.1':
     resolution: {integrity: sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.1':
     resolution: {integrity: sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.50.1':
     resolution: {integrity: sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.50.1':
     resolution: {integrity: sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.1':
     resolution: {integrity: sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.1':
     resolution: {integrity: sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.1':
     resolution: {integrity: sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.1':
     resolution: {integrity: sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.1':
     resolution: {integrity: sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.50.1':
     resolution: {integrity: sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.1':
     resolution: {integrity: sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==}
@@ -1339,28 +1314,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.3':
     resolution: {integrity: sha512-bc+CXYlFc1t8pv9yZJGus372ldzOVscBl7encUBlU1m/Sig0+NDJLz6cXXRcFyl6ABNOApWeR4Yl7iUWx6C8og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.3':
     resolution: {integrity: sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.3':
     resolution: {integrity: sha512-ieyjisLB+ldexiE/yD8uomaZuZIbTc8tjquYln9Quh5ykOBY7LpJJYBWvWtm1g3pHv6AXlBI8Jay7Fffb6aLfA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.3':
     resolution: {integrity: sha512-elTQpnaX5vESSbhCEgcwXjpMsnUbqqHfEpB7ewpkAsLzKEXZaK67ihSRYAuAx6ewRQTo7DS5iTT6X5aQD3MzMw==}
@@ -1395,11 +1366,24 @@ packages:
   '@swc/types@0.1.24':
     resolution: {integrity: sha512-tjTMh3V4vAORHtdTprLlfoMptu1WfTZG9Rsca6yOKyNYsRr+MUXutKmliB17orgSZk5DpnDxs8GUdd/qwYxOng==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1468,6 +1452,10 @@ packages:
     resolution: {integrity: sha512-y9ObStCcdCiZKzwqsE8CcpyuVMwRouJbbSrNuThDpv16dFAj429IkM6LNb1dZ2m7hK5fHyzNcErZf7CEeKXR4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.44.1':
+    resolution: {integrity: sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.40.0':
     resolution: {integrity: sha512-jtMytmUaG9d/9kqSl/W3E3xaWESo4hFDxAIHGVW/WKKtQhesnRIJSAJO6XckluuJ6KDB5woD1EiqknriCtAmcw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1485,6 +1473,10 @@ packages:
     resolution: {integrity: sha512-ETdbFlgbAmXHyFPwqUIYrfc12ArvpBhEVgGAxVYSwli26dn8Ko+lIo4Su9vI9ykTZdJn+vJprs/0eZU0YMAEQg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.44.1':
+    resolution: {integrity: sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.40.0':
     resolution: {integrity: sha512-k1z9+GJReVVOkc1WfVKs1vBrR5MIKKbdAjDTPvIK3L8De6KbFfPFt6BKpdkdk7rZS2GtC/m6yI5MYX+UsuvVYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1500,6 +1492,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.40.0':
     resolution: {integrity: sha512-8CZ47QwalyRjsypfwnbI3hKy5gJDPmrkLjkgMxhi0+DZZ2QNx2naS6/hWoVYUHU7LU2zleF68V9miaVZvhFfTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.44.1':
+    resolution: {integrity: sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -1541,49 +1537,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1612,17 +1600,32 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/browser@4.0.0-beta.13':
+    resolution: {integrity: sha512-Vn9XmqM24644xLbNnWIGdb3wTfHnCF5gu3wLo+8488bCfhkYAWmfX6wCIsSa3FtNnW1VmrD36FOTsTlMNl/XeA==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      playwright: '*'
+      safaridriver: '*'
+      vitest: 4.0.0-beta.13
+      webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+
+  '@vitest/coverage-v8@4.0.0-beta.13':
+    resolution: {integrity: sha512-eqvLu4tQcuM+Y77E/dOSF21UrMSgnJYcV2G9yQwwFTL+p9qpbBozDlE+MC31NsrBW5WejkgHPBJR+NchTgayXQ==}
+    peerDependencies:
+      '@vitest/browser': 4.0.0-beta.13
+      vitest: 4.0.0-beta.13
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/eslint-plugin@1.3.4':
-    resolution: {integrity: sha512-EOg8d0jn3BAiKnR55WkFxmxfWA3nmzrbIIuOXyTe6A72duryNgyU+bdBEauA97Aab3ho9kLmAwgPX63Ckj4QEg==}
+  '@vitest/eslint-plugin@1.3.13':
+    resolution: {integrity: sha512-QfzXd1+lCY3dIqPHOZlagA2bJYoWC5yAU3adv8Gks0rHAL6FpyXKYBiyMCuU6mRrbKUMphGqwDQobinOvYgJig==}
     peerDependencies:
       eslint: '>= 8.57.0'
       typescript: '>= 5.0.0'
@@ -1633,39 +1636,34 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.0.0-beta.13':
+    resolution: {integrity: sha512-IedkvNE1MdIy3chCbXLqHqhaFGyOaF27p7UuRiMg6UAAcj0ls2vLFaig/GYZkuCmkAHyIbSzwwyGGpBqEEMuMQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.0.0-beta.13':
+    resolution: {integrity: sha512-aE0e4ClvYDrhK8vZFrDFt3M+9rFev6oJrEI5UpA92zytf/+FmjBAoPCZrJCFRNCtyyadwVMYMjvDcM9dd/eLvg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.0.0-beta.13':
+    resolution: {integrity: sha512-s/CRImJgxB8TsaEmFJn/coheUfs6ln5rZw0d7YK1Fw3Tebck4HDBZT1LoBF3cXVEc4h9WS4n1CjuxtQo6qNnRQ==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.0.0-beta.13':
+    resolution: {integrity: sha512-nntrDl4/G3YWTUy/4Nm6lcWjZhPLzLYaNlctTP2WxPFvqIxkeKt4QmCUsTbiI0ltkdJ3PNhKRKDnXZEY6NPr+Q==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.0.0-beta.13':
+    resolution: {integrity: sha512-4eIcUWQMr2UzA011iS/q+pfbtIiCAhFxlqoZkt3DEn/6rE2IIQV7w1wU9Jl8rzzGp2e42yTDoM7W+92imGnAeA==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.0.0-beta.13':
+    resolution: {integrity: sha512-wjIjMhR385hfExvh6IpEvCaYCvnRb/7Uu9SXXFPbnalGIuG8CGiMsId02nNI3Q3WvqSon5IYqgXU3zkrzKtQ4A==}
 
-  '@vitest/ui@3.2.4':
-    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
-    peerDependencies:
-      vitest: 3.2.4
-
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.0.0-beta.13':
+    resolution: {integrity: sha512-vR+JiskbK9zYbnSn2OLZvAUOItAZSDaXSfi3lJwax21ue162ODNSM5GHk/GtnBtoHQoe0IWMpAMwRaJm8Isftg==}
 
   '@vue/compiler-core@3.6.0-alpha.2':
     resolution: {integrity: sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==}
@@ -1778,6 +1776,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -1791,6 +1793,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
@@ -1800,16 +1805,12 @@ packages:
   assert-never@1.4.0:
     resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
 
-  assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
-
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@0.3.4:
-    resolution: {integrity: sha512-cxrAnZNLBnQwBPByK4CeDaw5sWZtMilJE/Q3iDA0aamgaIVNDF9T6K2/8DfYDZEejZ2jNnDrG9m8MY72HFd0KA==}
+  ast-v8-to-istanbul@0.3.5:
+    resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -1900,8 +1901,8 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
 
-  chai@5.3.1:
-    resolution: {integrity: sha512-48af6xm9gQK8rhIcOxWwdGzIervm8BVTin+yRp9HEvU20BtVZ2lBywlIJBzwaDtvo0FvjeL7QdCADoUoqIbV3A==}
+  chai@6.0.1:
+    resolution: {integrity: sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==}
     engines: {node: '>=18'}
 
   chalk-template@0.4.0:
@@ -1922,10 +1923,6 @@ packages:
 
   character-parser@2.2.0:
     resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
-
-  check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2122,12 +2119,17 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2156,6 +2158,10 @@ packages:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
@@ -2166,6 +2172,9 @@ packages:
 
   doctypes@1.1.0:
     resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -2391,9 +2400,6 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -2431,6 +2437,11 @@ packages:
   fs-extra@11.3.1:
     resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2491,10 +2502,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
@@ -2722,9 +2729,6 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
@@ -2826,9 +2830,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  loupe@3.2.0:
-    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
-
   lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
@@ -2844,8 +2845,15 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
@@ -3087,10 +3095,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
@@ -3103,10 +3107,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -3129,6 +3129,24 @@ packages:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  pixelmatch@7.1.0:
+    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
+    hasBin: true
+
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss-modules-extract-imports@3.1.0:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
@@ -3182,6 +3200,10 @@ packages:
   pretty-bytes@6.1.1:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -3262,6 +3284,9 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   read-package-json-fast@4.0.0:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
@@ -3427,6 +3452,10 @@ packages:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -3526,9 +3555,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@3.0.0:
-    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3554,10 +3580,6 @@ packages:
     resolution: {integrity: sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==}
     engines: {node: '>=14.18'}
 
-  test-exclude@7.0.1:
-    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
-    engines: {node: '>=18'}
-
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
@@ -3571,16 +3593,16 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
+  tinypool@2.0.0:
+    resolution: {integrity: sha512-/RX9RzeH2xU5ADE7n2Ykvmi9ED3FBGPAjw9u3zucrNNaEBIO0HPSYgL0NT7+3p147ojeSdaVu08F6hjpv31HJg==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
-  tinyspy@4.0.3:
-    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -3707,11 +3729,6 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-plugin-inspect@0.8.9:
     resolution: {integrity: sha512-22/8qn+LYonzibb1VeFZmISdVao5kC22jmEKm24vfFE8siEn47EpVcCLYMv6iKOYMJfjSvSJfueOwcFCkUnV3A==}
     engines: {node: '>=14'}
@@ -3793,16 +3810,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.0.0-beta.13:
+    resolution: {integrity: sha512-Y37TT2UTQHfv4UfzlqgYd+98sUqSWrSrCiaM1WDZASQCNKam1eBJ74hfdgnCHu9hG+eyGduHC/xloQayQibrig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@vitest/browser': 4.0.0-beta.13
+      '@vitest/ui': 4.0.0-beta.13
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3961,11 +3978,6 @@ packages:
 
 snapshots:
 
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
-
   '@antfu/utils@0.7.10': {}
 
   '@asamuzakjp/css-color@3.2.0':
@@ -3989,6 +4001,8 @@ snapshots:
   '@babel/parser@7.28.3':
     dependencies:
       '@babel/types': 7.28.2
+
+  '@babel/runtime@7.28.4': {}
 
   '@babel/types@7.28.2':
     dependencies:
@@ -4262,13 +4276,6 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@istanbuljs/schema@0.1.3': {}
-
-  '@jridgewell/gen-mapping@0.3.13':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.30
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -4358,9 +4365,6 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.1
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
-    optional: true
-
-  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
@@ -4550,12 +4554,29 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -4639,6 +4660,11 @@ snapshots:
       '@typescript-eslint/types': 8.40.0
       '@typescript-eslint/visitor-keys': 8.40.0
 
+  '@typescript-eslint/scope-manager@8.44.1':
+    dependencies:
+      '@typescript-eslint/types': 8.44.1
+      '@typescript-eslint/visitor-keys': 8.44.1
+
   '@typescript-eslint/tsconfig-utils@8.40.0(typescript@5.6.3)':
     dependencies:
       typescript: 5.6.3
@@ -4656,6 +4682,8 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.40.0': {}
+
+  '@typescript-eslint/types@8.44.1': {}
 
   '@typescript-eslint/typescript-estree@8.40.0(typescript@5.6.3)':
     dependencies:
@@ -4687,6 +4715,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.40.0':
     dependencies:
       '@typescript-eslint/types': 8.40.0
+      eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.44.1':
+    dependencies:
+      '@typescript-eslint/types': 8.44.1
       eslint-visitor-keys: 4.2.1
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -4760,87 +4793,94 @@ snapshots:
       vite: 6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)
       vue: link:packages/vue
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+  '@vitest/browser@4.0.0-beta.13(playwright@1.55.1)(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))(vitest@4.0.0-beta.13)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/mocker': 4.0.0-beta.13(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))
+      '@vitest/utils': 4.0.0-beta.13
+      magic-string: 0.30.19
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+      ws: 8.18.3
+    optionalDependencies:
+      playwright: 1.55.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/coverage-v8@4.0.0-beta.13(@vitest/browser@4.0.0-beta.13)(vitest@4.0.0-beta.13)':
+    dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.4
-      debug: 4.4.1
+      '@vitest/utils': 4.0.0-beta.13
+      ast-v8-to-istanbul: 0.3.5
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.17
       magicast: 0.3.5
       std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.17.2)(@vitest/ui@3.2.4)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+      tinyrainbow: 3.0.3
+      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+    optionalDependencies:
+      '@vitest/browser': 4.0.0-beta.13(playwright@1.55.1)(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))(vitest@4.0.0-beta.13)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.3.4(eslint@9.33.0)(typescript@5.6.3)(vitest@3.2.4)':
+  '@vitest/eslint-plugin@1.3.13(eslint@9.33.0)(typescript@5.6.3)(vitest@4.0.0-beta.13)':
     dependencies:
+      '@typescript-eslint/scope-manager': 8.44.1
       '@typescript-eslint/utils': 8.40.0(eslint@9.33.0)(typescript@5.6.3)
       eslint: 9.33.0
     optionalDependencies:
       typescript: 5.6.3
-      vitest: 3.2.4(@types/node@22.17.2)(@vitest/ui@3.2.4)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
+      vitest: 4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.0.0-beta.13':
     dependencies:
       '@types/chai': 5.2.2
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.1
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.0.0-beta.13
+      '@vitest/utils': 4.0.0-beta.13
+      chai: 6.0.1
+      tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.0-beta.13(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.0.0-beta.13
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.19
     optionalDependencies:
       vite: 6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.0.0-beta.13':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.0.3
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.0.0-beta.13':
     dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.0.0
-
-  '@vitest/snapshot@3.2.4':
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.17
+      '@vitest/utils': 4.0.0-beta.13
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
+  '@vitest/snapshot@4.0.0-beta.13':
     dependencies:
-      tinyspy: 4.0.3
-
-  '@vitest/ui@3.2.4(vitest@3.2.4)':
-    dependencies:
-      '@vitest/utils': 3.2.4
-      fflate: 0.8.2
-      flatted: 3.3.3
+      '@vitest/pretty-format': 4.0.0-beta.13
+      magic-string: 0.30.19
       pathe: 2.0.3
-      sirv: 3.0.1
-      tinyglobby: 0.2.14
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.17.2)(@vitest/ui@3.2.4)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1)
 
-  '@vitest/utils@3.2.4':
+  '@vitest/spy@4.0.0-beta.13': {}
+
+  '@vitest/utils@4.0.0-beta.13':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.0
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.0.0-beta.13
+      tinyrainbow: 3.0.3
 
   '@vue/compiler-core@3.6.0-alpha.2':
     dependencies:
@@ -4864,7 +4904,7 @@ snapshots:
       '@vue/compiler-vapor': 3.6.0-alpha.2
       '@vue/shared': 3.6.0-alpha.2
       estree-walker: 2.0.2
-      magic-string: 0.30.17
+      magic-string: 0.30.19
       postcss: 8.5.6
       source-map-js: 1.2.1
 
@@ -4985,6 +5025,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   arch@2.2.0: {}
@@ -4993,19 +5035,21 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   array-ify@1.0.0: {}
 
   asap@2.0.6: {}
 
   assert-never@1.4.0: {}
 
-  assertion-error@2.0.1: {}
-
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@0.3.4:
+  ast-v8-to-istanbul@0.3.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       estree-walker: 3.0.3
@@ -5094,13 +5138,7 @@ snapshots:
 
   camelcase@7.0.1: {}
 
-  chai@5.3.1:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.2
-      loupe: 3.2.0
-      pathval: 2.0.1
+  chai@6.0.1: {}
 
   chalk-template@0.4.0:
     dependencies:
@@ -5118,8 +5156,6 @@ snapshots:
   character-parser@2.2.0:
     dependencies:
       is-regex: 1.2.1
-
-  check-error@2.1.1: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -5327,9 +5363,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.6.0: {}
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
-  deep-eql@5.0.2: {}
+  decimal.js@10.6.0: {}
 
   deep-extend@0.6.0: {}
 
@@ -5352,12 +5390,16 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  dequal@2.0.3: {}
+
   detect-libc@1.0.3:
     optional: true
 
   devtools-protocol@0.0.1475386: {}
 
   doctypes@1.1.0: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dot-prop@5.3.0:
     dependencies:
@@ -5642,8 +5684,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fflate@0.8.2: {}
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -5690,6 +5730,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -5763,15 +5806,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@11.0.3:
     dependencies:
@@ -5955,7 +5989,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -5964,12 +5998,6 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.1.1:
     dependencies:
@@ -6103,8 +6131,6 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
-  loupe@3.2.0: {}
-
   lru-cache@10.1.0: {}
 
   lru-cache@10.4.3: {}
@@ -6113,7 +6139,13 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -6333,11 +6365,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-
   path-scurry@2.0.0:
     dependencies:
       lru-cache: 11.1.0
@@ -6348,8 +6375,6 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
@@ -6362,6 +6387,20 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  pixelmatch@7.1.0:
+    dependencies:
+      pngjs: 7.0.0
+
+  playwright-core@1.55.1: {}
+
+  playwright@1.55.1:
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
@@ -6414,6 +6453,12 @@ snapshots:
   prettier@3.6.2: {}
 
   pretty-bytes@6.1.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   process-nextick-args@2.0.1: {}
 
@@ -6551,6 +6596,8 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-is@17.0.2: {}
 
   read-package-json-fast@4.0.0:
     dependencies:
@@ -6755,6 +6802,12 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -6853,10 +6906,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@3.0.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6887,12 +6936,6 @@ snapshots:
     dependencies:
       temp-dir: 3.0.0
 
-  test-exclude@7.0.1:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.4.5
-      minimatch: 9.0.5
-
   text-decoder@1.2.3:
     dependencies:
       b4a: 1.6.7
@@ -6906,11 +6949,14 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
 
-  tinyrainbow@2.0.0: {}
+  tinypool@2.0.0: {}
 
-  tinyspy@4.0.3: {}
+  tinyrainbow@3.0.3: {}
 
   tldts-core@6.1.86: {}
 
@@ -7060,27 +7106,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-plugin-inspect@0.8.9(rollup@4.50.1)(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)):
     dependencies:
       '@antfu/utils': 0.7.10
@@ -7121,34 +7146,32 @@ snapshots:
       sass: 1.90.0
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/node@22.17.2)(@vitest/ui@3.2.4)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1):
+  vitest@4.0.0-beta.13(@types/node@22.17.2)(@vitest/browser@4.0.0-beta.13)(jsdom@26.1.0)(sass@1.90.0)(yaml@2.8.1):
     dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.1
-      debug: 4.4.1
+      '@vitest/expect': 4.0.0-beta.13
+      '@vitest/mocker': 4.0.0-beta.13(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.0-beta.13
+      '@vitest/runner': 4.0.0-beta.13
+      '@vitest/snapshot': 4.0.0-beta.13
+      '@vitest/spy': 4.0.0-beta.13
+      '@vitest/utils': 4.0.0-beta.13
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
       expect-type: 1.2.2
-      magic-string: 0.30.17
+      magic-string: 0.30.19
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyglobby: 0.2.15
+      tinypool: 2.0.0
+      tinyrainbow: 3.0.3
       vite: 6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.2
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      '@vitest/browser': 4.0.0-beta.13(playwright@1.55.1)(vite@6.3.5(@types/node@22.17.2)(sass@1.90.0)(yaml@2.8.1))(vitest@4.0.0-beta.13)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { configDefaults, defineConfig } from 'vitest/config'
 import { entries } from './scripts/aliases.js'
+import { playwright } from '@vitest/browser/providers/playwright'
 
 export default defineConfig({
   define: {
@@ -52,7 +53,7 @@ export default defineConfig({
         'packages/runtime-dom/src/components/Transition*',
       ],
     },
-    workspace: [
+    projects: [
       {
         extends: true,
         test: {
@@ -89,17 +90,33 @@ export default defineConfig({
         },
       },
       {
-        extends: true,
+        extends: './packages-private/vapor-e2e-test/vite.config.ts',
+        root: './packages-private/vapor-e2e-test',
         test: {
+          globals: true,
+          isolate: true,
           name: 'e2e-vapor',
-          poolOptions: {
-            threads: {
-              singleThread: !!process.env.CI,
-            },
+          setupFiles: ['./__tests__/setupBrowser.ts'],
+          browser: {
+            enabled: true,
+            provider: playwright({
+              launchOptions: {
+                args: process.env.CI
+                  ? ['--no-sandbox', '--disable-setuid-sandbox']
+                  : [],
+              },
+            }),
+            headless: true,
+            instances: [{ browser: 'chromium' }],
           },
-          include: ['packages-private/vapor-e2e-test/__tests__/*.spec.ts'],
+          include: ['./__tests__/*.spec.ts'],
         },
       },
     ],
+    onConsoleLog(log) {
+      if (log.startsWith('You are running a development build of Vue.')) {
+        return false
+      }
+    },
   },
 })


### PR DESCRIPTION
This PR rewrites the tests for Vue Vapor mode to use Vitest Browser Mode. The logic of the test stayed the same, although it maybe also good to rewrite some of it or split it into separate tests.

Happy to get any feedback.

If there is desire, I can also update older e2e tests.


