### PR TITLE
chore(compiler): Update Babel 8

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -592,7 +592,7 @@ describe('compiler: expression transform', () => {
           [
             'pipelineOperator',
             {
-              proposal: 'minimal',
+              proposal: 'fsharp',
             },
           ],
         ],

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -1358,20 +1358,6 @@ _sfc_.setup = __setup__
 "
 `;
 
-exports[`SFC genDefaultAs > parser plugins > import attributes (user override for deprecated syntax) 1`] = `
-"import { foo } from './foo.js' assert { type: 'foobar' }
-        
-export default {
-  setup(__props, { expose: __expose }) {
-  __expose();
-
-        
-return { get foo() { return foo } }
-}
-
-}"
-`;
-
 exports[`SFC genDefaultAs > parser plugins > import attributes 1`] = `
 "import { foo } from './foo.js' with { type: 'foobar' }
         

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1510,22 +1510,6 @@ describe('SFC genDefaultAs', () => {
         </script>`),
       ).toThrow()
     })
-
-    test('import attributes (user override for deprecated syntax)', () => {
-      const { content } = compile(
-        `
-        <script setup>
-        import { foo } from './foo.js' assert { type: 'foobar' }
-        </script>
-      `,
-        {
-          babelParserPlugins: [
-            ['importAttributes', { deprecatedAssertSyntax: true }],
-          ],
-        },
-      )
-      assertCode(content)
-    })
   })
 })
 

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1653,7 +1653,7 @@ function resolve(
       s.expression.type === 'CallExpression' &&
       (s.expression.callee as Identifier).name === 'defineProps'
     ) {
-      target = s.expression.typeParameters!.params[0]
+      target = s.expression.typeArguments!.params[0]
     }
   }
   const raw = resolveTypeElements(ctx, target)

--- a/packages/compiler-sfc/__tests__/utils.ts
+++ b/packages/compiler-sfc/__tests__/utils.ts
@@ -29,10 +29,7 @@ export function assertCode(code: string): void {
   try {
     babelParse(code, {
       sourceType: 'module',
-      plugins: [
-        'typescript',
-        ['importAttributes', { deprecatedAssertSyntax: true }],
-      ],
+      plugins: ['typescript'],
     })
   } catch (e: any) {
     console.log(code)

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1161,7 +1161,7 @@ function walkDeclaration(
       }
     }
   } else if (node.type === 'TSEnumDeclaration') {
-    isAllLiteral = node.members.every(
+    isAllLiteral = node.body.members.every(
       member => !member.initializer || isStaticNode(member.initializer),
     )
     bindings[node.id!.name] = isAllLiteral

--- a/packages/compiler-sfc/src/script/context.ts
+++ b/packages/compiler-sfc/src/script/context.ts
@@ -1,6 +1,6 @@
 import type { CallExpression, Node, ObjectPattern, Program } from '@babel/types'
 import type { SFCDescriptor } from '../parse'
-import { generateCodeFrame, isArray } from '@vue/shared'
+import { generateCodeFrame } from '@vue/shared'
 import { type ParserPlugin, parse as babelParse } from '@babel/parser'
 import type { ImportBinding, SFCScriptCompileOptions } from '../compileScript'
 import type { PropsDestructureBindings } from './defineProps'
@@ -170,17 +170,6 @@ export function resolveParserPlugins(
   dts = false,
 ): ParserPlugin[] {
   const plugins: ParserPlugin[] = []
-  if (
-    !userPlugins ||
-    !userPlugins.some(
-      p =>
-        p === 'importAssertions' ||
-        p === 'importAttributes' ||
-        (isArray(p) && p[0] === 'importAttributes'),
-    )
-  ) {
-    plugins.push('importAttributes')
-  }
   if (lang === 'jsx' || lang === 'tsx' || lang === 'mtsx') {
     plugins.push('jsx')
   } else if (userPlugins) {
@@ -189,7 +178,7 @@ export function resolveParserPlugins(
     userPlugins = userPlugins.filter(p => p !== 'jsx')
   }
   if (lang === 'ts' || lang === 'mts' || lang === 'tsx' || lang === 'mtsx') {
-    plugins.push(['typescript', { dts }], 'explicitResourceManagement')
+    plugins.push(['typescript', { dts }])
     if (!userPlugins || !userPlugins.includes('decorators')) {
       plugins.push('decorators-legacy')
     }

--- a/packages/compiler-sfc/src/script/defineEmits.ts
+++ b/packages/compiler-sfc/src/script/defineEmits.ts
@@ -29,7 +29,7 @@ export function processDefineEmits(
   }
   ctx.hasDefineEmitCall = true
   ctx.emitsRuntimeDecl = node.arguments[0]
-  if (node.typeParameters) {
+  if (node.typeArguments) {
     if (ctx.emitsRuntimeDecl) {
       ctx.error(
         `${DEFINE_EMITS}() cannot accept both type and non-type arguments ` +
@@ -37,7 +37,7 @@ export function processDefineEmits(
         node,
       )
     }
-    ctx.emitsTypeDecl = node.typeParameters.params[0]
+    ctx.emitsTypeDecl = node.typeArguments.params[0]
   }
 
   ctx.emitDecl = declId
@@ -75,7 +75,7 @@ export function extractRuntimeEmits(ctx: TypeResolveContext): Set<string> {
   const node = ctx.emitsTypeDecl!
 
   if (node.type === 'TSFunctionType') {
-    extractEventNames(ctx, node.parameters[0], emits)
+    extractEventNames(ctx, node.params[0], emits)
     return emits
   }
 
@@ -95,7 +95,7 @@ export function extractRuntimeEmits(ctx: TypeResolveContext): Set<string> {
       )
     }
     for (const call of calls) {
-      extractEventNames(ctx, call.parameters[0], emits)
+      extractEventNames(ctx, call.params[0], emits)
     }
   }
 

--- a/packages/compiler-sfc/src/script/defineModel.ts
+++ b/packages/compiler-sfc/src/script/defineModel.ts
@@ -24,8 +24,9 @@ export function processDefineModel(
 
   ctx.hasDefineModelCall = true
 
-  const type =
-    (node.typeParameters && node.typeParameters.params[0]) || undefined
+  const type = (node.typeArguments && node.typeArguments.params[0]) as
+    | TSType
+    | undefined
   let modelName: string
   let options: Node | undefined
   const arg0 = node.arguments[0] && unwrapTSNode(node.arguments[0])

--- a/packages/compiler-sfc/src/script/defineOptions.ts
+++ b/packages/compiler-sfc/src/script/defineOptions.ts
@@ -19,7 +19,7 @@ export function processDefineOptions(
   if (ctx.hasDefineOptionsCall) {
     ctx.error(`duplicate ${DEFINE_OPTIONS}() call`, node)
   }
-  if (node.typeParameters) {
+  if (node.typeArguments) {
     ctx.error(`${DEFINE_OPTIONS}() cannot accept type arguments`, node)
   }
   if (!node.arguments[0]) return true

--- a/packages/compiler-sfc/src/script/defineProps.ts
+++ b/packages/compiler-sfc/src/script/defineProps.ts
@@ -70,7 +70,7 @@ export function processDefineProps(
   }
 
   // call has type parameters - infer runtime types from it
-  if (node.typeParameters) {
+  if (node.typeArguments) {
     if (ctx.propsRuntimeDecl) {
       ctx.error(
         `${DEFINE_PROPS}() cannot accept both type and non-type arguments ` +
@@ -78,7 +78,7 @@ export function processDefineProps(
         node,
       )
     }
-    ctx.propsTypeDecl = node.typeParameters.params[0]
+    ctx.propsTypeDecl = node.typeArguments.params[0]
   }
 
   // handle props destructure

--- a/packages/compiler-sfc/src/script/utils.ts
+++ b/packages/compiler-sfc/src/script/utils.ts
@@ -1,12 +1,13 @@
 import type {
   CallExpression,
-  Expression,
   Identifier,
   ImportDefaultSpecifier,
   ImportNamespaceSpecifier,
   ImportSpecifier,
   Node,
   StringLiteral,
+  TSEntityName,
+  TSQualifiedName,
 } from '@babel/types'
 import path from 'path'
 
@@ -69,14 +70,16 @@ export function getImportedName(
   return 'default'
 }
 
-export function getId(node: Identifier | StringLiteral): string
-export function getId(node: Expression): string | null
-export function getId(node: Expression) {
+export function getId(node: Identifier | StringLiteral | TSEntityName): string
+export function getId(node: Node): string | null
+export function getId(node: Node) {
   return node.type === 'Identifier'
     ? node.name
     : node.type === 'StringLiteral'
       ? node.value
-      : null
+      : node.type === 'TSQualifiedName'
+        ? getId(node.left as TSQualifiedName)
+        : null
 }
 
 const identity = (str: string) => str

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@babel/parser':
-      specifier: ^7.28.4
-      version: 7.28.4
+      specifier: ^8.0.0-beta.2
+      version: 8.0.0-beta.2
     '@babel/types':
-      specifier: ^7.28.4
-      version: 7.28.4
+      specifier: ^8.0.0-beta.2
+      version: 8.0.0-beta.2
     '@vitejs/plugin-vue':
       specifier: ^6.0.1
       version: 6.0.1
@@ -34,10 +34,10 @@ importers:
     devDependencies:
       '@babel/parser':
         specifier: 'catalog:'
-        version: 7.28.4
+        version: 8.0.0-beta.2
       '@babel/types':
         specifier: 'catalog:'
-        version: 7.28.4
+        version: 8.0.0-beta.2
       '@rollup/plugin-alias':
         specifier: ^5.1.1
         version: 5.1.1(rollup@4.52.2)
@@ -248,7 +248,7 @@ importers:
     dependencies:
       '@babel/parser':
         specifier: 'catalog:'
-        version: 7.28.4
+        version: 8.0.0-beta.2
       '@vue/shared':
         specifier: workspace:*
         version: link:../shared
@@ -264,7 +264,7 @@ importers:
     devDependencies:
       '@babel/types':
         specifier: 'catalog:'
-        version: 7.28.4
+        version: 8.0.0-beta.2
 
   packages/compiler-dom:
     dependencies:
@@ -279,7 +279,7 @@ importers:
     dependencies:
       '@babel/parser':
         specifier: 'catalog:'
-        version: 7.28.4
+        version: 8.0.0-beta.2
       '@vue/compiler-core':
         specifier: workspace:*
         version: link:../compiler-core
@@ -307,7 +307,7 @@ importers:
     devDependencies:
       '@babel/types':
         specifier: 'catalog:'
-        version: 7.28.4
+        version: 8.0.0-beta.2
       '@vue/consolidate':
         specifier: ^1.0.0
         version: 1.0.0
@@ -427,7 +427,7 @@ importers:
     dependencies:
       '@babel/parser':
         specifier: 'catalog:'
-        version: 7.28.4
+        version: 8.0.0-beta.2
       estree-walker:
         specifier: 'catalog:'
         version: 2.0.2
@@ -461,18 +461,35 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0-beta.2':
+    resolution: {integrity: sha512-AmrScvsE0jJzEGEmhM+KNg9IYZFmmvDmfN903qDnMR3fWKZ5UGLACAyb0dcaYFDatW/Ru21w8SzOZy8qP6Ix+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.0-beta.2':
+    resolution: {integrity: sha512-n5STLJIc4loOeI2G+mMZwYIiztQWZdy+3du0cspVWoUjZ4AgkCIld4XcY0jJPgLImStacvJKCO6qCf0UBMpETw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/parser@7.28.4':
     resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@8.0.0-beta.2':
+    resolution: {integrity: sha512-91A5GVa6ROgyF1uzDvGJlscf9tktIrXS4ohp8cnW22gwX1ERMw9m9KzdtoFgfdzt9rmSXKYtjwHhh5samc4Pdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0-beta.2':
+    resolution: {integrity: sha512-dnlxcfISuGiHBhyq+Jmbp14lis59INgqHX/i95bfZLqIvBztd5F1jMZ0ozq36z3eWs3hXUG3AgS867wkaeRKfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -3692,16 +3709,29 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@8.0.0-beta.2': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-identifier@8.0.0-beta.2': {}
 
   '@babel/parser@7.28.4':
     dependencies:
       '@babel/types': 7.28.4
 
+  '@babel/parser@8.0.0-beta.2':
+    dependencies:
+      '@babel/types': 8.0.0-beta.2
+
   '@babel/types@7.28.4':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@8.0.0-beta.2':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-beta.2
+      '@babel/helper-validator-identifier': 8.0.0-beta.2
 
   '@bcoe/v8-coverage@1.0.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,8 @@ packages:
   - 'packages-private/*'
 
 catalog:
-  '@babel/parser': ^7.28.4
-  '@babel/types': ^7.28.4
+  '@babel/parser': ^8.0.0-beta.2
+  '@babel/types': ^8.0.0-beta.2
   'estree-walker': ^2.0.2
   'magic-string': ^0.30.19
   'source-map-js': ^1.2.1

--- a/scripts/inline-enums.js
+++ b/scripts/inline-enums.js
@@ -90,8 +90,8 @@ export function scanEnums() {
         /** @type {Array<EnumMember>} */
         const members = []
 
-        for (let i = 0; i < decl.members.length; i++) {
-          const e = decl.members[i]
+        for (let i = 0; i < decl.body.members.length; i++) {
+          const e = decl.body.members[i]
           const key = e.id.type === 'Identifier' ? e.id.name : e.id.value
           const fullKey = /** @type {const} */ (`${id}.${key}`)
           const saveValue = (/** @type {string | number} */ value) => {


### PR DESCRIPTION
This PR updates Babel 7 to Babel 8.
This appears to be a breaking change, so it may not be merged yet. This PR is only for future use.

Ref: https://github.com/babel/babel/issues/17530
