### PR TITLE
fix(compiler-ssr): expand v-model `option` selected inclusion logic

### DIFF
--- a/packages/compiler-ssr/__tests__/ssrVModel.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVModel.spec.ts
@@ -292,6 +292,117 @@ describe('ssr: v-model', () => {
         _push(\`<!--]--></optgroup></select></div>\`)
       }"
     `)
+
+    expect(
+      compileWithWrapper(
+        `<select v-model="model"><option>foo</option></select>`,
+      ).code,
+    ).toMatchInlineSnapshot(`
+      "const { ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrLooseEqual: _ssrLooseEqual, ssrRenderAttrs: _ssrRenderAttrs } = require("vue/server-renderer")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs) {
+        _push(\`<div\${
+          _ssrRenderAttrs(_attrs)
+        }><select><option\${
+          (_ssrIncludeBooleanAttr(_ssrLooseEqual(_ctx.model, \`\${"foo"}\`))) ? " selected" : ""
+        }>foo</option></select></div>\`)
+      }"
+    `)
+
+    expect(
+      compileWithWrapper(
+        `<select v-model="model"><option>{{ myValue }}</option></select>`,
+      ).code,
+    ).toMatchInlineSnapshot(`
+      "const { ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrLooseEqual: _ssrLooseEqual, ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require("vue/server-renderer")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs) {
+        _push(\`<div\${
+          _ssrRenderAttrs(_attrs)
+        }><select><option\${
+          (_ssrIncludeBooleanAttr(_ssrLooseEqual(_ctx.model, \`\${_ctx.myValue}\`))) ? " selected" : ""
+        }>\${
+          _ssrInterpolate(_ctx.myValue)
+        }</option></select></div>\`)
+      }"
+    `)
+
+    expect(
+      compileWithWrapper(
+        `<select v-model="model">
+          <option>
+            A
+            B
+            <!--comment-->
+            <!--comment-->
+            C
+            {{ myValue1 }}
+            D
+            <!--comment-->
+            {{ myValue2 }}
+            <!--comment-->E
+            <!--comment-->
+          </option>
+        </select>`,
+      ).code,
+    ).toMatchInlineSnapshot(`
+      "const { ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrLooseEqual: _ssrLooseEqual, ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require("vue/server-renderer")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs) {
+        _push(\`<div\${
+          _ssrRenderAttrs(_attrs)
+        }><select><option\${
+          (_ssrIncludeBooleanAttr(_ssrLooseEqual(_ctx.model, \`\${
+            "A B C "
+          }\${
+            _ctx.myValue1
+          }\${
+            " D "
+          }\${
+            _ctx.myValue2
+          }\${
+            " E"
+          }\`))) ? " selected" : ""
+        }> A B <!--comment--><!--comment--> C \${
+          _ssrInterpolate(_ctx.myValue1)
+        } D <!--comment--> \${
+          _ssrInterpolate(_ctx.myValue2)
+        } <!--comment-->E <!--comment--></option></select></div>\`)
+      }"
+    `)
+
+    expect(
+      compileWithWrapper(
+        `<select v-model="model"><option v-text="'foo'"></option></select>`,
+      ).code,
+    ).toMatchInlineSnapshot(`
+      "const { ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrLooseEqual: _ssrLooseEqual, ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require("vue/server-renderer")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs) {
+        _push(\`<div\${
+          _ssrRenderAttrs(_attrs)
+        }><select><option\${
+          (_ssrIncludeBooleanAttr(_ssrLooseEqual(_ctx.model, 'foo'))) ? " selected" : ""
+        }>\${
+          _ssrInterpolate('foo')
+        }</option></select></div>\`)
+      }"
+    `)
+
+    expect(
+      compileWithWrapper(`<select v-model="model"><option></option></select>`)
+        .code,
+    ).toMatchInlineSnapshot(`
+      "const { ssrIncludeBooleanAttr: _ssrIncludeBooleanAttr, ssrLooseEqual: _ssrLooseEqual, ssrRenderAttrs: _ssrRenderAttrs } = require("vue/server-renderer")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs) {
+        _push(\`<div\${
+          _ssrRenderAttrs(_attrs)
+        }><select><option\${
+          (_ssrIncludeBooleanAttr(_ssrLooseEqual(_ctx.model, ""))) ? " selected" : ""
+        }></option></select></div>\`)
+      }"
+    `)
   })
 
   test('<input type="radio">', () => {

--- a/packages/compiler-ssr/src/transforms/ssrVModel.ts
+++ b/packages/compiler-ssr/src/transforms/ssrVModel.ts
@@ -6,12 +6,16 @@ import {
   NodeTypes,
   type PlainElementNode,
   type TemplateChildNode,
+  type TemplateLiteral,
+  type TextNode,
   createCallExpression,
   createConditionalExpression,
   createDOMCompilerError,
   createInterpolation,
   createObjectProperty,
   createSimpleExpression,
+  createTemplateLiteral,
+  findDir,
   findProp,
   hasDynamicKeyVBind,
   transformModel,
@@ -54,21 +58,26 @@ export const ssrTransformModel: DirectiveTransform = (dir, node, context) => {
   function processOption(plainNode: PlainElementNode) {
     if (plainNode.tag === 'option') {
       if (plainNode.props.findIndex(p => p.name === 'selected') === -1) {
-        const value = findValueBinding(plainNode)
+        const value = findOptionValue(plainNode)
         plainNode.ssrCodegenNode!.elements.push(
           createConditionalExpression(
             createCallExpression(context.helper(SSR_INCLUDE_BOOLEAN_ATTR), [
-              createConditionalExpression(
-                createCallExpression(`Array.isArray`, [model]),
-                createCallExpression(context.helper(SSR_LOOSE_CONTAIN), [
-                  model,
-                  value,
-                ]),
-                createCallExpression(context.helper(SSR_LOOSE_EQUAL), [
-                  model,
-                  value,
-                ]),
-              ),
+              value.maybeArray
+                ? createConditionalExpression(
+                    createCallExpression(`Array.isArray`, [model]),
+                    createCallExpression(context.helper(SSR_LOOSE_CONTAIN), [
+                      model,
+                      value.node,
+                    ]),
+                    createCallExpression(context.helper(SSR_LOOSE_EQUAL), [
+                      model,
+                      value.node,
+                    ]),
+                  )
+                : createCallExpression(context.helper(SSR_LOOSE_EQUAL), [
+                    model,
+                    value.node,
+                  ]),
             ]),
             createSimpleExpression(' selected', true),
             createSimpleExpression('', true),
@@ -190,6 +199,64 @@ export const ssrTransformModel: DirectiveTransform = (dir, node, context) => {
   }
 }
 
+interface OptionValue {
+  node: ExpressionNode | TemplateLiteral
+  maybeArray: boolean
+}
+
+function findOptionValue(node: PlainElementNode): OptionValue {
+  const valueBinding = findProp(node, 'value')
+  if (valueBinding) {
+    return {
+      node:
+        valueBinding.type === NodeTypes.DIRECTIVE
+          ? valueBinding.exp!
+          : createSimpleExpression(valueBinding.value!.content, true),
+      maybeArray: true,
+    }
+  }
+
+  const textDir = findDir(node, 'text')
+  if (textDir) {
+    return { node: textDir.exp!, maybeArray: false }
+  }
+
+  if (
+    node.children.every(
+      x =>
+        x.type === NodeTypes.TEXT ||
+        x.type === NodeTypes.COMMENT ||
+        x.type === NodeTypes.INTERPOLATION,
+    )
+  ) {
+    const relevantNodes = collapseTextBetweenComments(node.children).filter(
+      x => x.type !== NodeTypes.COMMENT,
+    )
+    if (relevantNodes.length) {
+      const textContentValue = createTemplateLiteral(
+        relevantNodes.map((x, i) => {
+          if (x.type === NodeTypes.TEXT) {
+            let content = x.content
+            if (i === 0) {
+              content = content.trimStart()
+            } else if (i === relevantNodes.length - 1) {
+              content = content.trimEnd()
+            }
+            return createSimpleExpression(content, true)
+          } else {
+            return x.content
+          }
+        }),
+      )
+      if (textContentValue) {
+        return { node: textContentValue, maybeArray: false }
+      }
+    }
+  }
+
+  return { node: createSimpleExpression(``, true), maybeArray: false }
+}
+
 function findValueBinding(node: PlainElementNode): ExpressionNode {
   const valueBinding = findProp(node, 'value')
   return valueBinding
@@ -197,4 +264,42 @@ function findValueBinding(node: PlainElementNode): ExpressionNode {
       ? valueBinding.exp!
       : createSimpleExpression(valueBinding.value!.content, true)
     : createSimpleExpression(`null`, false)
+}
+
+function collapseTextBetweenComments<T extends TemplateChildNode>(
+  children: T[],
+) {
+  const result: (T | TextNode)[] = []
+  let prevTextNode: TextNode | undefined
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i]
+    if (child.type === NodeTypes.TEXT) {
+      if (prevTextNode) {
+        const prevContent = prevTextNode.content
+        let thisContent = child.content
+        if (prevContent.endsWith(' ') && thisContent.startsWith(' ')) {
+          thisContent = thisContent.slice(1)
+        }
+        const combined: TextNode = {
+          ...prevTextNode,
+          content: prevContent + thisContent,
+        }
+        prevTextNode = combined
+      } else {
+        prevTextNode = child
+      }
+    } else if (child.type === NodeTypes.COMMENT) {
+      continue
+    } else {
+      if (prevTextNode) {
+        result.push(prevTextNode)
+        prevTextNode = undefined
+      }
+      result.push(child)
+    }
+  }
+  if (prevTextNode) {
+    result.push(prevTextNode)
+  }
+  return result
 }


### PR DESCRIPTION
close #13436

Expand cases under which the `selected` attribute is added onto an `option` tag in SSR:
* Consider text nodes/interpolations as direct children of the `option`
* Consider `v-text`

An additional side effect of this PR is to fix the current behavior showcased by this playground example, which I believe to be a bug: [link](https://play.vuejs.org/#__SSR__eNp9UsFO4zAQ/ZWRL9mVuokEu5coIO1WHHYPgGjRXiyBm0xag2NH9qQUVf13xg6FVqrwyZ73/Mbvebbid9/n6wFFKapQe90TBKShB6Ps8kIKClJcSqu73nmCLXhsYQetdx1kfC2TVtqigKnR9TPQCkGK2ewObu7nt/dzKYDUogRco3+FoO3SILietLOwUgEeAxqsCZtHUE2DDZADTfCiaZW0FmjcSylt7Wwg2MBFbP8ts4Mx2ffU9xiJANcT8v9dJODksI8OYB2N7U4oZCd1uVYVYzqcBR8Iu94oQj4BVKM6rH90rkHDoW1SZsCrGt1ets5Vxfv+GFkof4RwoyTHh6o46CMm/Bf8rFYv86fgLH/YNvKlqF3Xa4P+Jonwf5WQkIgpwwn+SzXyA0729XqF9fOJeiCva7rmHKeRkQitMhzinvEU2F3Jm1vP2fo1SvGBkfJLpBG+ml3jhvcfIIczGGZ/Ad5hcGaILkban8E2bOyAl/z8TcPI0zQPVxtCG/a2o5XI3CW+FDyg0y/C+Xzuef4z3ZN2xzk/8LhGTY74PP+Vn52J3RtXCAse)


**Example**

```js
const app = createSSRApp({
  setup() {
    const r = ref('asdf')
    const val = 'asdf'
    return { r, val }
  },
  template: `
    <select v-model="r">
      <option>{{ val }}</option>
      <option>fdsa</option>
    </select>
  `
})

// SSR output: <select><option selected>asdf</option><option>fdsa</option></select>
```