### PR TITLE
refactor(runtime-core): check feature flag when forwarding `data` properties

### DIFF
--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -448,7 +448,11 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
       } else if (hasSetupBinding(setupState, key)) {
         accessCache![key] = AccessTypes.SETUP
         return setupState[key]
-      } else if (data !== EMPTY_OBJ && hasOwn(data, key)) {
+      } else if (
+        __FEATURE_OPTIONS_API__ &&
+        data !== EMPTY_OBJ &&
+        hasOwn(data, key)
+      ) {
         accessCache![key] = AccessTypes.DATA
         return data[key]
       } else if (
@@ -545,7 +549,11 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     ) {
       warn(`Cannot mutate <script setup> binding "${key}" from Options API.`)
       return false
-    } else if (data !== EMPTY_OBJ && hasOwn(data, key)) {
+    } else if (
+      __FEATURE_OPTIONS_API__ &&
+      data !== EMPTY_OBJ &&
+      hasOwn(data, key)
+    ) {
       data[key] = value
       return true
     } else if (hasOwn(instance.props, key)) {
@@ -582,7 +590,10 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     let normalizedProps, cssModules
     return !!(
       accessCache![key] ||
-      (data !== EMPTY_OBJ && key[0] !== '$' && hasOwn(data, key)) ||
+      (__FEATURE_OPTIONS_API__ &&
+        data !== EMPTY_OBJ &&
+        key[0] !== '$' &&
+        hasOwn(data, key)) ||
       hasSetupBinding(setupState, key) ||
       ((normalizedProps = propsOptions[0]) && hasOwn(normalizedProps, key)) ||
       hasOwn(ctx, key) ||


### PR DESCRIPTION
This is a minor refactoring that adds `__FEATURE_OPTIONS_API__` to places where `PublicInstanceProxyHandlers` uses `data`. For builds using `__VUE_OPTIONS_API__: false` this should allow the code to be removed from production builds.

Usages of `data` inside dev-only code haven't been changed and shouldn't be impacted.

This is a small part of a larger refactoring I'm attempting, which also includes #13507 and #13514. That should eventually allow the `switch`/`case` logic to be replaced. For now, the usage of `data` inside the `switch` is retained as there isn't a convenient way to remove it.