### PR TITLE
fix(compiler-ssr): textarea with v-text directive SSR

### DIFF
--- a/packages/server-renderer/__tests__/ssrDirectives.spec.ts
+++ b/packages/server-renderer/__tests__/ssrDirectives.spec.ts
@@ -172,12 +172,45 @@ describe('ssr: directives', () => {
       ).toBe(`<input type="checkbox" value="foo">`)
     })
 
+    test('element with v-html', async () => {
+      expect(
+        await renderToString(
+          createApp({
+            data: () => ({ foo: 'hello' }),
+            template: `<span v-html="foo"/>`,
+          }),
+        ),
+      ).toBe(`<span>hello</span>`)
+    })
+
     test('textarea', async () => {
       expect(
         await renderToString(
           createApp({
             data: () => ({ foo: 'hello' }),
             template: `<textarea v-model="foo"/>`,
+          }),
+        ),
+      ).toBe(`<textarea>hello</textarea>`)
+    })
+
+    test('textarea with v-text', async () => {
+      expect(
+        await renderToString(
+          createApp({
+            data: () => ({ foo: 'hello' }),
+            template: `<textarea v-text="foo"/>`,
+          }),
+        ),
+      ).toBe(`<textarea>hello</textarea>`)
+    })
+
+    test('textarea with v-html', async () => {
+      expect(
+        await renderToString(
+          createApp({
+            data: () => ({ foo: 'hello' }),
+            template: `<textarea v-html="foo"/>`,
           }),
         ),
       ).toBe(`<textarea>hello</textarea>`)


### PR DESCRIPTION
Fix SSR on `textarea` elements with a `v-text` directive value

Related to https://github.com/vuejs/core/pull/12311 but slightly different as this bug would be triggered for `textarea` even without custom user directives.