### PR TITLE
fix(compiler-sfc): resolve numeric literals and template literals without expressions as static property key

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -20,6 +20,7 @@ describe('resolveType', () => {
       foo: number // property
       bar(): void // method
       'baz': string // string literal key
+      [\`qux\`]: boolean // template literal key
       (e: 'foo'): void // call signature
       (e: 'bar'): void
     }>()`)
@@ -27,6 +28,7 @@ describe('resolveType', () => {
       foo: ['Number'],
       bar: ['Function'],
       baz: ['String'],
+      qux: ['Boolean'],
     })
     expect(calls?.length).toBe(2)
   })
@@ -195,7 +197,7 @@ describe('resolveType', () => {
     type T = 'foo' | 'bar'
     type S = 'x' | 'y'
     defineProps<{
-      [\`_\${T}_\${S}_\`]: string
+      [K in \`_\${T}_\${S}_\`]: string
     }>()
     `).props,
     ).toStrictEqual({

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -21,6 +21,7 @@ describe('resolveType', () => {
       bar(): void // method
       'baz': string // string literal key
       [\`qux\`]: boolean // template literal key
+      123: symbol // numeric literal key
       (e: 'foo'): void // call signature
       (e: 'bar'): void
     }>()`)
@@ -29,6 +30,7 @@ describe('resolveType', () => {
       bar: ['Function'],
       baz: ['String'],
       qux: ['Boolean'],
+      123: ['Symbol'],
     })
     expect(calls?.length).toBe(2)
   })

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -337,7 +337,7 @@ function typeElementsToMap(
       }
       ;(e as MaybeWithScope)._ownerScope = scope
       const name = getId(e.key)
-      if (name !== null) {
+      if (name !== null && (!e.computed || e.key.type === 'TemplateLiteral')) {
         res.props[name] = e as ResolvedElements['props'][string]
       } else {
         ctx.error(

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -337,12 +337,8 @@ function typeElementsToMap(
       }
       ;(e as MaybeWithScope)._ownerScope = scope
       const name = getId(e.key)
-      if (name && !e.computed) {
+      if (name !== null) {
         res.props[name] = e as ResolvedElements['props'][string]
-      } else if (e.key.type === 'TemplateLiteral') {
-        for (const key of resolveTemplateKeys(ctx, e.key, scope)) {
-          res.props[key] = e as ResolvedElements['props'][string]
-        }
       } else {
         ctx.error(
           `Unsupported computed key in type referenced by a macro`,

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -29,6 +29,7 @@ import {
   createGetCanonicalFileName,
   getId,
   getImportedName,
+  getStringLiteralKey,
   joinPaths,
   normalizePath,
 } from './utils'
@@ -336,8 +337,8 @@ function typeElementsToMap(
         Object.assign(scope.types, typeParameters)
       }
       ;(e as MaybeWithScope)._ownerScope = scope
-      const name = getId(e.key)
-      if (name !== null && (!e.computed || e.key.type === 'TemplateLiteral')) {
+      const name = getStringLiteralKey(e)
+      if (name !== null) {
         res.props[name] = e as ResolvedElements['props'][string]
       } else {
         ctx.error(
@@ -2025,8 +2026,7 @@ function findStaticPropertyType(node: TSTypeLiteral, key: string) {
   const prop = node.members.find(
     m =>
       m.type === 'TSPropertySignature' &&
-      !m.computed &&
-      getId(m.key) === key &&
+      getStringLiteralKey(m) === key &&
       m.typeAnnotation,
   )
   return prop && prop.typeAnnotation!.typeAnnotation

--- a/packages/compiler-sfc/src/script/utils.ts
+++ b/packages/compiler-sfc/src/script/utils.ts
@@ -76,7 +76,9 @@ export function getId(node: Expression) {
     ? node.name
     : node.type === 'StringLiteral'
       ? node.value
-      : null
+      : node.type === 'TemplateLiteral' && !node.expressions.length
+        ? node.quasis.map(q => q.value.cooked).join('')
+        : null
 }
 
 const identity = (str: string) => str

--- a/packages/compiler-sfc/src/script/utils.ts
+++ b/packages/compiler-sfc/src/script/utils.ts
@@ -7,6 +7,8 @@ import type {
   ImportSpecifier,
   Node,
   StringLiteral,
+  TSMethodSignature,
+  TSPropertySignature,
 } from '@babel/types'
 import path from 'path'
 
@@ -76,9 +78,23 @@ export function getId(node: Expression) {
     ? node.name
     : node.type === 'StringLiteral'
       ? node.value
-      : node.type === 'TemplateLiteral' && !node.expressions.length
-        ? node.quasis.map(q => q.value.cooked).join('')
-        : null
+      : null
+}
+
+export function getStringLiteralKey(
+  node: TSPropertySignature | TSMethodSignature,
+): string | null {
+  return node.computed
+    ? node.key.type === 'TemplateLiteral' && !node.key.expressions.length
+      ? node.key.quasis.map(q => q.value.cooked).join('')
+      : null
+    : node.key.type === 'Identifier'
+      ? node.key.name
+      : node.key.type === 'StringLiteral'
+        ? node.key.value
+        : node.key.type === 'NumericLiteral'
+          ? String(node.key.value)
+          : null
 }
 
 const identity = (str: string) => str


### PR DESCRIPTION
fix https://github.com/vuejs/core/pull/13937#issuecomment-3342427976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for template-literal-style and numeric-style prop keys in type-based prop declarations (e.g., `_foo_x_`, `123`).

* **Improvements**
  * Broader, more consistent handling of computed and template-literal property names for more accurate type inference.
  * Improved mapping of template-derived prop name patterns via enhanced iteration/mapping logic.

* **Bug Fixes**
  * Adjusted runtime expectations to align with expanded key types (boolean/symbol identification).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->