### PR TITLE
fix(compiler-core): handle semicolons in v-on expressions

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -369,6 +369,21 @@ describe('compiler: transform v-on', () => {
     })
   })
 
+  test('should treat semicolons inside function expressions as expression', () => {
+    const { node } = parseWithVOn(`<div @click="function () { ';' }"/>`)
+    expect((node.codegenNode as VNodeCall).props).toMatchObject({
+      properties: [
+        {
+          key: { content: `onClick` },
+          value: {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `function () { ';' }`,
+          },
+        },
+      ],
+    })
+  })
+
   test('should NOT wrap as function if expression is complex member expression', () => {
     const { node } = parseWithVOn(`<div @click="a['b' + c]"/>`)
     expect((node.codegenNode as VNodeCall).props).toMatchObject({

--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -13,7 +13,12 @@ import { camelize, toHandlerKey } from '@vue/shared'
 import { ErrorCodes, createCompilerError } from '../errors'
 import { processExpression } from './transformExpression'
 import { validateBrowserExpression } from '../validateExpression'
-import { hasScopeRef, isFnExpression, isMemberExpression } from '../utils'
+import {
+  hasScopeRef,
+  isFnExpression,
+  isMemberExpression,
+  isValidExpression,
+} from '../utils'
 import { TO_HANDLER_KEY } from '../runtimeHelpers'
 
 export interface VOnDirectiveNode extends DirectiveNode {
@@ -83,7 +88,8 @@ export const transformOn: DirectiveTransform = (
   if (exp) {
     const isMemberExp = isMemberExpression(exp, context)
     const isInlineStatement = !(isMemberExp || isFnExpression(exp, context))
-    const hasMultipleStatements = exp.content.includes(`;`)
+    const hasMultipleStatements =
+      exp.content.includes(`;`) && !isValidExpression(exp, context)
 
     // process the expression since it's been skipped
     if (!__BROWSER__ && context.prefixIdentifiers) {

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -231,6 +231,42 @@ export const isFnExpression: (
   context: TransformContext,
 ) => boolean = __BROWSER__ ? isFnExpressionBrowser : isFnExpressionNode
 
+export const isValidExpressionBrowser: (
+  exp: ExpressionNode,
+) => boolean = exp => {
+  try {
+    // Use parens to normalize object expressions and arrow functions.
+    new Function(`return (${getExpSource(exp)})`)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+export const isValidExpressionNode: (
+  exp: ExpressionNode,
+  context: TransformContext,
+) => boolean = __BROWSER__
+  ? (NOOP as any)
+  : (exp, context) => {
+      try {
+        parseExpression(`(${getExpSource(exp)})`, {
+          sourceType: 'module',
+          plugins: context.expressionPlugins
+            ? [...context.expressionPlugins, 'typescript']
+            : ['typescript'],
+        })
+        return true
+      } catch (e) {
+        return false
+      }
+    }
+
+export const isValidExpression: (
+  exp: ExpressionNode,
+  context: TransformContext,
+) => boolean = __BROWSER__ ? isValidExpressionBrowser : isValidExpressionNode
+
 export function advancePositionWithClone(
   pos: Position,
   source: string,

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -231,6 +231,10 @@ export const isFnExpression: (
   context: TransformContext,
 ) => boolean = __BROWSER__ ? isFnExpressionBrowser : isFnExpressionNode
 
+/**
+ * Check whether an expression can be parsed in the browser build, so
+ * semicolons inside valid expressions aren't treated as statements.
+ */
 export const isValidExpressionBrowser: (
   exp: ExpressionNode,
 ) => boolean = exp => {
@@ -243,6 +247,9 @@ export const isValidExpressionBrowser: (
   }
 }
 
+/**
+ * Check whether an expression can be parsed in the Node build.
+ */
 export const isValidExpressionNode: (
   exp: ExpressionNode,
   context: TransformContext,
@@ -262,6 +269,9 @@ export const isValidExpressionNode: (
       }
     }
 
+/**
+ * Check whether an expression parses as an expression in the current build.
+ */
 export const isValidExpression: (
   exp: ExpressionNode,
   context: TransformContext,


### PR DESCRIPTION
close https://github.com/vuejs/core/issues/14287

Summary:
- Treat semicolons in v-on handlers as multi-statement only when expression parsing fails
- Add regression coverage for function expressions containing semicolons

Motivation:
- Function expressions with semicolons are valid expressions but were parsed as statements, causing compiler errors

Validation:
- pnpm exec vitest --project unit packages/compiler-core/__tests__/transforms/vOn.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of inline event-handler expressions so semicolons inside function expressions are correctly treated as part of the expression, preventing misclassification of handler code.

* **Tests**
  * Added a test covering inline function expressions containing semicolons to ensure correct parsing and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->