### PR TITLE
feat(vapor): bridge VDOM Teleport/Suspense in dynamic component interop

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -205,6 +205,7 @@ export interface VaporInteropInterface {
     container: any,
     anchor: any,
     parentComponent: ComponentInternalInstance | null,
+    parentSuspense: SuspenseBoundary | null,
   ): void
   hydrate(
     vnode: VNode,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -465,6 +465,7 @@ function baseCreateRenderer(
           container,
           anchor,
           parentComponent,
+          parentSuspense,
         )
         break
       default:

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1579,7 +1579,6 @@ describe('vdomInterop', () => {
 
       await new Promise(resolve => setTimeout(resolve, duration + 1))
       await nextTick()
-      await nextTick()
 
       expect(html()).toContain('<div>slot async</div>')
     })
@@ -1623,7 +1622,6 @@ describe('vdomInterop', () => {
       expect(html()).toContain('loading')
 
       await new Promise(resolve => setTimeout(resolve, duration + 1))
-      await nextTick()
       await nextTick()
 
       expect(html()).toContain('<button>vnode async</button>')

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1467,6 +1467,168 @@ describe('vdomInterop', () => {
   })
 
   describe('Suspense', () => {
+    test('renders async vapor child inside VDOM Suspense', async () => {
+      const duration = 5
+
+      const VaporAsyncChild = defineVaporComponent({
+        async setup() {
+          await new Promise(resolve => setTimeout(resolve, duration))
+          return template('<div><button>click</button></div>')()
+        },
+      })
+
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(
+            Suspense as any,
+            null,
+            {
+              default: () => createComponent(VaporAsyncChild, null, null, true),
+              fallback: () => template('loading')(),
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporParent as any)
+        },
+      }).render()
+
+      expect(html()).toContain('loading')
+
+      await new Promise(resolve => setTimeout(resolve, duration + 1))
+      await nextTick()
+
+      expect(html()).toContain('<div><button>click</button></div>')
+    })
+
+    test('renders async VDOM child inside VDOM Suspense', async () => {
+      const duration = 5
+
+      const VDomAsyncChild = defineComponent({
+        async setup() {
+          await new Promise(resolve => setTimeout(resolve, duration))
+          return () => h('div', [h('button', 'click')])
+        },
+      })
+
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(
+            Suspense as any,
+            null,
+            {
+              default: () =>
+                createComponent(VDomAsyncChild as any, null, null, true),
+              fallback: () => template('loading')(),
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporParent as any)
+        },
+      }).render()
+
+      expect(html()).toContain('loading')
+
+      await new Promise(resolve => setTimeout(resolve, duration + 1))
+      await nextTick()
+
+      expect(html()).toContain('<div><button>click</button></div>')
+    })
+
+    test('renders async VDOM child from vapor slot outlet inside VDOM Suspense', async () => {
+      const duration = 5
+
+      const VaporSlotOutlet = defineVaporComponent({
+        setup() {
+          return createSlot('default')
+        },
+      })
+
+      const VDomAsyncChild = defineComponent({
+        async setup() {
+          await new Promise(resolve => setTimeout(resolve, duration))
+          return () => h('div', 'slot async')
+        },
+      })
+
+      const App = defineComponent({
+        setup() {
+          return () =>
+            h(Suspense, null, {
+              default: () =>
+                h(VaporSlotOutlet as any, null, {
+                  default: () => [h(VDomAsyncChild as any)],
+                }),
+              fallback: () => h('div', 'loading'),
+            })
+        },
+      })
+
+      const { html } = define(App).render()
+
+      expect(html()).toContain('loading')
+
+      await new Promise(resolve => setTimeout(resolve, duration + 1))
+      await nextTick()
+      await nextTick()
+
+      expect(html()).toContain('<div>slot async</div>')
+    })
+
+    test('renders async VDOM vnode via createDynamicComponent inside VDOM Suspense', async () => {
+      const duration = 5
+
+      const VDomAsyncChild = defineComponent({
+        async setup() {
+          await new Promise(resolve => setTimeout(resolve, duration))
+          return () => h('button', 'vnode async')
+        },
+      })
+
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(
+            Suspense as any,
+            null,
+            {
+              default: () =>
+                createDynamicComponent(
+                  () => h(VDomAsyncChild as any),
+                  null,
+                  null,
+                  true,
+                ),
+              fallback: () => template('loading')(),
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporParent as any)
+        },
+      }).render()
+
+      expect(html()).toContain('loading')
+
+      await new Promise(resolve => setTimeout(resolve, duration + 1))
+      await nextTick()
+      await nextTick()
+
+      expect(html()).toContain('<button>vnode async</button>')
+    })
+
     test('mounts VDOM Suspense from createDynamicComponent', async () => {
       const VaporChild = defineVaporComponent({
         setup() {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1,6 +1,8 @@
 import {
   KeepAlive,
   type ShallowRef,
+  Suspense,
+  Teleport,
   createApp,
   createVNode,
   defineComponent,
@@ -1427,6 +1429,67 @@ describe('vdomInterop', () => {
       show.value = true
       await nextTick()
       expect(html()).toBe('slot text<!--if-->')
+    })
+  })
+
+  describe('Teleport', () => {
+    test('mounts VDOM Teleport from createDynamicComponent', async () => {
+      const target = document.createElement('div')
+      target.id = 'interop-teleport-target'
+      document.body.appendChild(target)
+
+      try {
+        const VaporChild = defineVaporComponent({
+          setup() {
+            return createDynamicComponent(
+              () => Teleport,
+              { to: () => '#interop-teleport-target' },
+              {
+                default: () => template('<span>teleported</span>')(),
+              },
+              true,
+            )
+          },
+        })
+
+        define({
+          setup() {
+            return () => h(VaporChild as any)
+          },
+        }).render()
+
+        await nextTick()
+        expect(target.innerHTML).toContain('<span>teleported</span>')
+      } finally {
+        target.remove()
+      }
+    })
+  })
+
+  describe('Suspense', () => {
+    test('mounts VDOM Suspense from createDynamicComponent', async () => {
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return createDynamicComponent(
+            () => Suspense,
+            null,
+            {
+              default: () => template('<span>resolved</span>')(),
+              fallback: () => template('<span>fallback</span>')(),
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporChild as any)
+        },
+      }).render()
+
+      await nextTick()
+      expect(html()).toContain('<span>resolved</span>')
     })
   })
 })

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -100,7 +100,10 @@ import {
   deactivate,
   setCurrentKeepAliveCtx,
 } from './components/KeepAlive'
-import { setParentSuspense } from './components/Suspense'
+import {
+  parentSuspense as currentParentSuspense,
+  setParentSuspense,
+} from './components/Suspense'
 
 export const interopKey: unique symbol = Symbol(`interop`)
 
@@ -246,10 +249,21 @@ const vaporInteropImpl: Omit<
   /**
    * vapor slot in vdom
    */
-  slot(n1: VNode, n2: VNode, container, anchor, parentComponent) {
+  slot(
+    n1: VNode,
+    n2: VNode,
+    container,
+    anchor,
+    parentComponent,
+    parentSuspense,
+  ) {
     if (!n1) {
       const prev = currentInstance
+      let prevSuspense: SuspenseBoundary | null = null
       simpleSetCurrentInstance(parentComponent)
+      if (__FEATURE_SUSPENSE__ && parentSuspense) {
+        prevSuspense = setParentSuspense(parentSuspense)
+      }
       // mount
       let selfAnchor: Node | undefined
       const { slot, fallback } = n2.vs!
@@ -265,6 +279,9 @@ const vaporInteropImpl: Omit<
       if (isFragment(slotBlock)) {
         // use fragment's anchor when possible
         selfAnchor = slotBlock.anchor
+      }
+      if (__FEATURE_SUSPENSE__ && parentSuspense) {
+        setParentSuspense(prevSuspense)
       }
       simpleSetCurrentInstance(prev)
       if (!selfAnchor) selfAnchor = createTextNode()
@@ -374,6 +391,11 @@ function mountVNode(
   vnode: VNode,
   parentComponent: VaporComponentInstance | null,
 ): VaporFragment {
+  const suspense =
+    currentParentSuspense ||
+    (parentComponent &&
+      (parentComponent.suspense as SuspenseBoundary | null)) ||
+    null
   const frag = new VaporFragment([])
   frag.vnode = vnode
 
@@ -437,7 +459,7 @@ function mountVNode(
           parentNode,
           anchor,
           parentComponent as any,
-          null, // parentSuspense
+          suspense,
           undefined, // namespace
           vnode.slotScopeIds,
         )
@@ -474,6 +496,11 @@ function createVDOMComponent(
   rawSlots?: LooseRawSlots | null,
   isSingleRoot?: boolean,
 ): VaporFragment {
+  const suspense =
+    currentParentSuspense ||
+    (parentComponent &&
+      (parentComponent.suspense as SuspenseBoundary | null)) ||
+    null
   const useBridge = shouldUseRendererBridge(component)
   const comp = useBridge ? ensureRendererBridge(component) : component
   const frag = new VaporFragment([])
@@ -572,7 +599,7 @@ function createVDOMComponent(
           parentNode,
           anchor,
           parentComponent as any,
-          null,
+          suspense,
           undefined,
           false,
         )
@@ -667,6 +694,9 @@ function renderVDOMSlot(
   parentComponent: VaporComponentInstance,
   fallback?: VaporSlot,
 ): VaporFragment {
+  const suspense =
+    currentParentSuspense ||
+    (parentComponent.suspense as SuspenseBoundary | null)
   const frag = new VaporFragment([])
 
   if (fallback && !frag.fallback) frag.fallback = fallback
@@ -785,7 +815,7 @@ function renderVDOMSlot(
           parentNode!,
           anchor,
           parentComponent as any,
-          null, // parentSuspense
+          suspense,
           undefined, // namespace
           resolved.slotScopeIds, // pass slotScopeIds for :slotted styles
         )

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -2,6 +2,7 @@ import {
   type App,
   type ComponentInternalInstance,
   type ConcreteComponent,
+  type FunctionalComponent,
   type HydrationRenderer,
   type KeepAliveContext,
   MoveType,
@@ -473,9 +474,11 @@ function createVDOMComponent(
   rawSlots?: LooseRawSlots | null,
   isSingleRoot?: boolean,
 ): VaporFragment {
+  const useBridge = shouldUseRendererBridge(component)
+  const comp = useBridge ? ensureRendererBridge(component) : component
   const frag = new VaporFragment([])
   const vnode = (frag.vnode = createVNode(
-    component,
+    comp,
     rawProps && extend({}, new Proxy(rawProps, rawPropsProxyHandlers)),
   ))
 
@@ -485,7 +488,7 @@ function createVDOMComponent(
   }
 
   const wrapper = new VaporComponentInstance(
-    { props: component.props },
+    useBridge ? (comp as any) : { props: component.props },
     rawProps as RawProps,
     rawSlots as RawSlots,
     parentComponent ? parentComponent.appContext : undefined,
@@ -617,6 +620,40 @@ function createVDOMComponent(
   }
 
   return frag
+}
+
+const rendererBridgeCache = new WeakMap<
+  ConcreteComponent,
+  FunctionalComponent
+>()
+
+/**
+ * Teleport/Suspense are renderer primitives (`__isTeleport` / `__isSuspense`),
+ * not regular components with their own render pipeline.
+ *
+ * We wrap them with a tiny functional bridge so they can pass through the
+ * interop component mount path while preserving built-in vnode semantics.
+ */
+function shouldUseRendererBridge(
+  component: ConcreteComponent & {
+    __isTeleport?: boolean
+    __isSuspense?: boolean
+  },
+): boolean {
+  return !!(component.__isTeleport || component.__isSuspense)
+}
+
+function ensureRendererBridge(
+  component: ConcreteComponent,
+): FunctionalComponent {
+  let bridge = rendererBridgeCache.get(component)
+  if (!bridge) {
+    rendererBridgeCache.set(
+      component,
+      (bridge = (props, { slots }) => createVNode(component, props, slots)),
+    )
+  }
+  return bridge
 }
 
 /**


### PR DESCRIPTION
close #14481


split into #14484 and #14485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Suspense boundary context propagation in Vapor interop methods, enabling better async component handling.
  * Added Teleport component support in VDOM interop, allowing dynamic content mounting to separate DOM targets.

* **Tests**
  * Expanded test coverage for Suspense and Teleport components in interop scenarios, including async children, slots, and dynamic component rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->