### PR TITLE
fix(types): allow narrower HTMLElement types in function refs

### DIFF
--- a/packages-private/dts-test/tsx.test-d.tsx
+++ b/packages-private/dts-test/tsx.test-d.tsx
@@ -77,6 +77,7 @@ expectType<JSX.Element>(<div style={false} />)
 // allow key/ref on arbitrary element
 expectType<JSX.Element>(<div key="foo" />)
 expectType<JSX.Element>(<div ref="bar" />)
+expectType<JSX.Element>(<form ref={(el: HTMLFormElement | null) => {}} />)
 
 expectType<JSX.Element>(
   <input

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -86,10 +86,16 @@ export type VNodeTypes =
 export type VNodeRef =
   | string
   | Ref
-  | ((
-      ref: Element | ComponentPublicInstance | null,
-      refs: Record<string, any>,
-    ) => void)
+  | {
+      /**
+       * Make function refs bivariant so callbacks can accept
+       * narrower element types (e.g. HTMLFormElement).
+       */
+      bivarianceHack(
+        ref: Element | ComponentPublicInstance | null,
+        refs: Record<string, any>,
+      ): void
+    }['bivarianceHack']
 
 export type VNodeNormalizedRefAtom = {
   /**


### PR DESCRIPTION
### Problem

Fixes #13969.

`VNodeRef` function refs are currently typed with a callback parameter of:

`Element | ComponentPublicInstance | null`

Under TypeScript function parameter variance, this rejects callbacks that use a narrower DOM type, e.g.:

```tsx
<form ref={(el: HTMLFormElement | null) => {}} />
This is unintuitive for function refs on concrete elements and causes unnecessary type errors.

Solution
Adjust VNodeRef callback typing in runtime-core to use the standard bivariant callback pattern (bivarianceHack), so narrower element parameter types are accepted where appropriate.

This is a type-only change and does not affect runtime behavior.

Tests
Added a dts regression case:

tsx.test-d.tsx
verifies <form ref={(el: HTMLFormElement | null) => {}} /> type-checks
Validation run locally:

pnpm build-dts
pnpm test-dts-only
Both passed.

Scope / Risk
Minimal, focused change (2 files)
Type-level only
No runtime logic changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test assertion verifying form element ref callback support.

* **Refactor**
  * Improved TypeScript type handling for ref callbacks to support narrower element types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->