### PR TITLE
fix(scheduler): improve error recovery

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -708,6 +708,25 @@ describe('scheduler', () => {
     expect(job2).toHaveBeenCalledTimes(1)
   })
 
+  test('post job error should not leave newly queued main jobs pending', async () => {
+    const calls: string[] = []
+
+    const job2: SchedulerJob = () => {
+      calls.push('job2')
+    }
+
+    const job1: SchedulerJob = () => {
+      queueJob(job2, 2)
+      throw new Error('test')
+    }
+
+    queuePostFlushCb(job1, 1)
+
+    await expect(nextTick()).rejects.toThrow('test')
+    await nextTick()
+    expect(calls).toEqual(['job2'])
+  })
+
   test('should prevent self-triggering jobs by default', async () => {
     let count = 0
     const job = () => {

--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -613,6 +613,58 @@ describe('scheduler', () => {
     expect(job2).toHaveBeenCalledTimes(1)
   })
 
+  test('post jobs can be re-queued after an error', async () => {
+    const err = new Error('test')
+    let shouldThrow = true
+
+    const job1: SchedulerJob = vi.fn(() => {
+      if (shouldThrow) {
+        shouldThrow = false
+        throw err
+      }
+    })
+    const job2: SchedulerJob = vi.fn()
+
+    queuePostFlushCb(job1, 1)
+    queuePostFlushCb(job2, 2)
+
+    try {
+      await nextTick()
+    } catch (e: any) {
+      expect(e).toBe(err)
+    }
+
+    expect(job1).toHaveBeenCalledTimes(1)
+    expect(job2).toHaveBeenCalledTimes(0)
+
+    queuePostFlushCb(job1, 1)
+    queuePostFlushCb(job2, 2)
+
+    await nextTick()
+
+    expect(job1).toHaveBeenCalledTimes(2)
+    expect(job2).toHaveBeenCalledTimes(1)
+  })
+
+  test(`jobs won't be left on queue after an post job error`, async () => {
+    const job1: SchedulerJob = vi.fn(() => {
+      queueJob(job2, 2)
+      queuePostFlushCb(job3, 1)
+      throw new Error('test')
+    })
+    const job2: SchedulerJob = vi.fn()
+    const job3: SchedulerJob = vi.fn()
+
+    queuePostFlushCb(job1, 1)
+
+    try {
+      await nextTick()
+    } catch {}
+
+    expect(job2.flags! & SchedulerJobFlags.QUEUED).toBeFalsy()
+    expect(job3.flags! & SchedulerJobFlags.QUEUED).toBeFalsy()
+  })
+
   test('should prevent self-triggering jobs by default', async () => {
     let count = 0
     const job = () => {
@@ -704,6 +756,31 @@ describe('scheduler', () => {
     job2.flags = SchedulerJobFlags.ALLOW_RECURSE
 
     queueJob(job2, 2)
+
+    await nextTick()
+
+    expect(job2).toHaveBeenCalledTimes(2)
+  })
+
+  test(`recursive post jobs can't be re-queued by other jobs`, async () => {
+    let recurse = true
+
+    const job1: SchedulerJob = () => {
+      if (recurse) {
+        // job2 is already queued, so this shouldn't do anything
+        queuePostFlushCb(job2, 2)
+        recurse = false
+      }
+    }
+    const job2: SchedulerJob = vi.fn(() => {
+      if (recurse) {
+        queuePostFlushCb(job1, 1)
+        queuePostFlushCb(job2, 2)
+      }
+    })
+    job2.flags = SchedulerJobFlags.ALLOW_RECURSE
+
+    queuePostFlushCb(job2, 2)
 
     await nextTick()
 

--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -1,6 +1,7 @@
 import {
   type SchedulerJob,
   SchedulerJobFlags,
+  flushOnAppMount,
   flushPostFlushCbs,
   flushPreFlushCbs,
   nextTick,
@@ -575,6 +576,67 @@ describe('scheduler', () => {
 
     // this one should no longer error
     await nextTick()
+  })
+
+  test('flushOnAppMount error recovery', () => {
+    const err = new Error('test')
+    let shouldThrow = true
+
+    const job1: SchedulerJob = vi.fn(() => {
+      if (shouldThrow) {
+        shouldThrow = false
+        throw err
+      }
+    })
+
+    queuePostFlushCb(job1)
+
+    try {
+      flushOnAppMount()
+    } catch (e: any) {
+      expect(e).toBe(err)
+    }
+
+    expect(job1).toHaveBeenCalledTimes(1)
+
+    queuePostFlushCb(job1)
+
+    flushOnAppMount()
+
+    expect(job1).toHaveBeenCalledTimes(2)
+  })
+
+  test('pre jobs can be re-queued after an error', () => {
+    const err = new Error('test')
+    let shouldThrow = true
+
+    const job1: SchedulerJob = vi.fn(() => {
+      if (shouldThrow) {
+        shouldThrow = false
+        throw err
+      }
+    })
+    const job2: SchedulerJob = vi.fn()
+
+    queueJob(job1, undefined, true)
+    queueJob(job2, undefined, true)
+
+    try {
+      flushPreFlushCbs()
+    } catch (e: any) {
+      expect(e).toBe(err)
+    }
+
+    expect(job1).toHaveBeenCalledTimes(1)
+    expect(job2).toHaveBeenCalledTimes(0)
+
+    queueJob(job1, undefined, true)
+    queueJob(job2, undefined, true)
+
+    flushPreFlushCbs()
+
+    expect(job1).toHaveBeenCalledTimes(2)
+    expect(job2).toHaveBeenCalledTimes(1)
   })
 
   test('jobs can be re-queued after an error', async () => {

--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -646,7 +646,7 @@ describe('scheduler', () => {
     expect(job2).toHaveBeenCalledTimes(1)
   })
 
-  test(`jobs won't be left on queue after an post job error`, async () => {
+  test(`jobs won't be left on queue after a post job error`, async () => {
     const job1: SchedulerJob = vi.fn(() => {
       queueJob(job2, 2)
       queuePostFlushCb(job3, 1)

--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -708,25 +708,6 @@ describe('scheduler', () => {
     expect(job2).toHaveBeenCalledTimes(1)
   })
 
-  test(`jobs won't be left on queue after a post job error`, async () => {
-    const job1: SchedulerJob = vi.fn(() => {
-      queueJob(job2, 2)
-      queuePostFlushCb(job3, 1)
-      throw new Error('test')
-    })
-    const job2: SchedulerJob = vi.fn()
-    const job3: SchedulerJob = vi.fn()
-
-    queuePostFlushCb(job1, 1)
-
-    try {
-      await nextTick()
-    } catch {}
-
-    expect(job2.flags! & SchedulerJobFlags.QUEUED).toBeFalsy()
-    expect(job3.flags! & SchedulerJobFlags.QUEUED).toBeFalsy()
-  })
-
   test('should prevent self-triggering jobs by default', async () => {
     let count = 0
     const job = () => {

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -209,9 +209,12 @@ export function flushPreFlushCbs(
     if (cb.flags! & SchedulerJobFlags.ALLOW_RECURSE) {
       cb.flags! &= ~SchedulerJobFlags.QUEUED
     }
-    cb()
-    if (!(cb.flags! & SchedulerJobFlags.ALLOW_RECURSE)) {
-      cb.flags! &= ~SchedulerJobFlags.QUEUED
+    try {
+      cb()
+    } finally {
+      if (!(cb.flags! & SchedulerJobFlags.ALLOW_RECURSE)) {
+        cb.flags! &= ~SchedulerJobFlags.QUEUED
+      }
     }
   }
 }
@@ -272,9 +275,12 @@ let isFlushing = false
 export function flushOnAppMount(instance?: GenericComponentInstance): void {
   if (!isFlushing) {
     isFlushing = true
-    flushPreFlushCbs(instance)
-    flushPostFlushCbs()
-    isFlushing = false
+    try {
+      flushPreFlushCbs(instance)
+      flushPostFlushCbs()
+    } finally {
+      isFlushing = false
+    }
   }
 }
 

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -160,6 +160,11 @@ const doFlushJobs = () => {
     flushJobs()
   } catch (e) {
     currentFlushPromise = null
+    // If a nested pre/post flush throws after queueing more work, defer the
+    // leftovers to a fresh microtask
+    if (jobsLength || postJobs.length) {
+      queueFlush()
+    }
     throw e
   }
 }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -155,9 +155,18 @@ function queueJobWorker(
   return false
 }
 
+const doFlushJobs = () => {
+  try {
+    flushJobs()
+  } catch (e) {
+    currentFlushPromise = null
+    throw e
+  }
+}
+
 function queueFlush() {
   if (!currentFlushPromise) {
-    currentFlushPromise = resolvedPromise.then(flushJobs)
+    currentFlushPromise = resolvedPromise.then(doFlushJobs)
   }
 }
 
@@ -327,15 +336,13 @@ function flushJobs(seen?: CountMap) {
     jobsLength = 0
     jobs.length = 0
 
-    try {
-      flushPostFlushCbs(seen)
-    } finally {
-      // If new jobs have been added to either queue, keep flushing
-      if (jobsLength || postJobs.length) {
-        flushJobs(seen)
-      } else {
-        currentFlushPromise = null
-      }
+    flushPostFlushCbs(seen)
+
+    // If new jobs have been added to either queue, keep flushing
+    if (jobsLength || postJobs.length) {
+      flushJobs(seen)
+    } else {
+      currentFlushPromise = null
     }
   }
 }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -332,10 +332,11 @@ function flushJobs(seen?: CountMap) {
 
     flushPostFlushCbs(seen)
 
-    currentFlushPromise = null
     // If new jobs have been added to either queue, keep flushing
     if (jobsLength || postJobs.length) {
       flushJobs(seen)
+    } else {
+      currentFlushPromise = null
     }
   }
 }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -155,18 +155,9 @@ function queueJobWorker(
   return false
 }
 
-const doFlushJobs = () => {
-  try {
-    flushJobs()
-  } catch (e) {
-    currentFlushPromise = null
-    throw e
-  }
-}
-
 function queueFlush() {
   if (!currentFlushPromise) {
-    currentFlushPromise = resolvedPromise.then(doFlushJobs)
+    currentFlushPromise = resolvedPromise.then(flushJobs)
   }
 }
 
@@ -330,13 +321,15 @@ function flushJobs(seen?: CountMap) {
     jobsLength = 0
     jobs.length = 0
 
-    flushPostFlushCbs(seen)
-
-    // If new jobs have been added to either queue, keep flushing
-    if (jobsLength || postJobs.length) {
-      flushJobs(seen)
-    } else {
-      currentFlushPromise = null
+    try {
+      flushPostFlushCbs(seen)
+    } finally {
+      // If new jobs have been added to either queue, keep flushing
+      if (jobsLength || postJobs.length) {
+        flushJobs(seen)
+      } else {
+        currentFlushPromise = null
+      }
     }
   }
 }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -243,25 +243,34 @@ export function flushPostFlushCbs(seen?: CountMap): void {
       seen = seen || new Map()
     }
 
-    while (postFlushIndex < activePostJobs.length) {
-      const cb = activePostJobs[postFlushIndex++]
-      if (__DEV__ && checkRecursiveUpdates(seen!, cb)) {
-        continue
-      }
-      if (cb.flags! & SchedulerJobFlags.ALLOW_RECURSE) {
-        cb.flags! &= ~SchedulerJobFlags.QUEUED
-      }
-      if (!(cb.flags! & SchedulerJobFlags.DISPOSED)) {
-        try {
-          cb()
-        } finally {
+    try {
+      while (postFlushIndex < activePostJobs.length) {
+        const cb = activePostJobs[postFlushIndex++]
+        if (__DEV__ && checkRecursiveUpdates(seen!, cb)) {
+          continue
+        }
+        if (cb.flags! & SchedulerJobFlags.ALLOW_RECURSE) {
           cb.flags! &= ~SchedulerJobFlags.QUEUED
         }
+        if (!(cb.flags! & SchedulerJobFlags.DISPOSED)) {
+          try {
+            cb()
+          } finally {
+            if (!(cb.flags! & SchedulerJobFlags.ALLOW_RECURSE)) {
+              cb.flags! &= ~SchedulerJobFlags.QUEUED
+            }
+          }
+        }
       }
-    }
+    } finally {
+      // If there was an error we still need to clear the QUEUED flags
+      while (postFlushIndex < activePostJobs.length) {
+        activePostJobs[postFlushIndex++].flags! &= ~SchedulerJobFlags.QUEUED
+      }
 
-    activePostJobs = null
-    postFlushIndex = 0
+      activePostJobs = null
+      postFlushIndex = 0
+    }
   }
 }
 


### PR DESCRIPTION
This PR improves the error recovery on jobs flush, and with two other changes:
1. recursive post jobs can't be re-queued by other jobs.
2. reset `currentFlushPromise` only when no jobs are left to flush, to avoid unnecessary microtask.

There are two possible issues:
1. jobs may left on queue when `flushPreFlushCbs` or `flushPostFlushCbs` errors.
2. `flushPreFlushCbs` does not check the DISPOSED flag, not sure if it's intentional.

This PR is based on `minor`, let me know if I should change to `main`.