### PR TITLE
fix(teleport): preserve nested teleported children across HMR reloads

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -272,6 +272,108 @@ describe('renderer: VaporTeleport', () => {
       expect(target.innerHTML).toBe('<div>teleported</div>')
     })
 
+    test('child reload in nested teleport branch keeps content after parent reload', async () => {
+      const target = document.createElement('div')
+      const root = document.createElement('div')
+      const childId = 'test4-child-reload-nested-teleport'
+      const parentId = 'test4-parent-in-teleport-branch'
+
+      const { component: Child } = define({
+        __hmrId: childId,
+        setup() {
+          const msg = ref('teleported')
+          return { msg }
+        },
+        render(ctx) {
+          const n0 = template(`<div> </div>`)()
+          const x0 = child(n0 as any)
+          renderEffect(() => setText(x0 as any, ctx.msg))
+          return [n0]
+        },
+      })
+      createRecord(childId, Child as any)
+
+      const { mount, component: Parent } = define({
+        __hmrId: parentId,
+        components: { Child },
+        setup() {
+          const show = ref(true)
+          return { show, target }
+        },
+        render(ctx) {
+          return createComp(
+            VaporTeleport,
+            { to: () => target },
+            {
+              default: () =>
+                createIf(
+                  () => ctx.show,
+                  () =>
+                    createIf(
+                      () => true,
+                      () => createComp(Child),
+                      () => template('<span>fallback</span>')(),
+                    ),
+                ),
+            },
+          )
+        },
+      }).create()
+      createRecord(parentId, Parent as any)
+
+      mount(root)
+      expect(target.innerHTML).toContain('teleported')
+
+      reload(childId, {
+        __hmrId: childId,
+        __vapor: true,
+        setup() {
+          const msg = ref('teleported 2')
+          return { msg }
+        },
+        render(ctx: any) {
+          const n0 = template(`<div> </div>`)()
+          const x0 = child(n0 as any)
+          renderEffect(() => setText(x0 as any, ctx.msg))
+          return [n0]
+        },
+      })
+      await nextTick()
+      expect(target.textContent).toBe('teleported 2')
+
+      reload(
+        parentId,
+        define({
+          __hmrId: parentId,
+          components: { Child },
+          setup() {
+            const show = ref(true)
+            return { show, target }
+          },
+          render(ctx) {
+            return createComp(
+              VaporTeleport,
+              { to: () => target },
+              {
+                default: () =>
+                  createIf(
+                    () => ctx.show,
+                    () =>
+                      createIf(
+                        () => true,
+                        () => createComp(Child),
+                        () => template('<span>fallback</span>')(),
+                      ),
+                  ),
+              },
+            )
+          },
+        }),
+      )
+      await nextTick()
+      expect(target.innerHTML).toContain('teleported 2')
+    })
+
     test('reload child + reload parent', async () => {
       const target = document.createElement('div')
       const root = document.createElement('div')

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -160,13 +160,25 @@ export class TeleportFragment extends VaporFragment {
     }
 
     if (__DEV__) {
-      if (isVaporComponent(block)) {
-        block.parentTeleport = this
-      } else if (isArray(block)) {
-        block.forEach(
-          node => isVaporComponent(node) && (node.parentTeleport = this),
-        )
+      this.bindParentTeleport(block)
+    }
+  }
+
+  private bindParentTeleport(block: Block): void {
+    if (isVaporComponent(block)) {
+      block.parentTeleport = this
+      return
+    }
+
+    if (isArray(block)) {
+      for (const node of block) {
+        this.bindParentTeleport(node)
       }
+      return
+    }
+
+    if (isFragment(block)) {
+      this.bindParentTeleport(block.nodes)
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for nested teleport content preservation across reloads.

* **Refactor**
  * Improved internal code organization for hierarchical block structure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->