### PR TITLE
fix(ssr): ensure duplicate component VNodes render after hydration

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -2109,6 +2109,41 @@ describe('SSR hydration', () => {
     expect(root.innerHTML).toBe('<div>bar</div>')
   })
 
+  // #14635
+  test('duplicate component VNode rendered after hydration in SSR mode', async () => {
+    const MyLink = defineComponent({
+      setup() {
+        return () => h('a', { href: '#' }, 'link')
+      },
+    })
+
+    const DuplicateTest = defineComponent({
+      setup() {
+        return () => {
+          const link = h(MyLink)
+          return h('p', ['Click this ', link, ' and that ', link, '.'])
+        }
+      },
+    })
+
+    const show = ref(false)
+    const App = defineComponent({
+      setup() {
+        return () => [show.value ? h(DuplicateTest) : null]
+      },
+    })
+
+    const container = document.createElement('div')
+    container.innerHTML = await renderToString(h(App))
+    createSSRApp(App).mount(container)
+    // toggle to show DuplicateTest (mounted fresh, not hydrated)
+    show.value = true
+    await nextTick()
+    expect(container.innerHTML).toContain(
+      '<p>Click this <a href="#">link</a> and that <a href="#">link</a>.</p>',
+    )
+  })
+
   describe('mismatch handling', () => {
     test('text node', () => {
       const { container } = mountWithHydration(`foo`, () => 'bar')

--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -203,12 +203,18 @@ describe('vnode', () => {
     const vnode = createVNode('div')
     expect(normalizeVNode(vnode)).toBe(vnode)
 
-    // mounted VNode -> cloned VNode
+    // mounted VNode -> cloned VNode with el/anchor reset
     const mounted = createVNode('div')
     mounted.el = {}
     const normalized = normalizeVNode(mounted)
     expect(normalized).not.toBe(mounted)
-    expect(normalized).toEqual(mounted)
+    // el and anchor are reset so the clone is treated as fresh during mount
+    expect(normalized.el).toBe(null)
+    expect(normalized.anchor).toBe(null)
+    // everything else should match the original
+    expect({ ...normalized, el: mounted.el, anchor: mounted.anchor }).toEqual(
+      mounted,
+    )
 
     // primitive types
     expect(normalizeVNode('foo')).toMatchObject({ type: Text, children: `foo` })

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -809,10 +809,19 @@ export function normalizeVNode(child: VNodeChild): VNode {
 
 // optimized normalization for template-compiled render fns
 export function cloneIfMounted(child: VNode): VNode {
-  return (child.el === null && child.patchFlag !== PatchFlags.CACHED) ||
+  if (
+    (child.el === null && child.patchFlag !== PatchFlags.CACHED) ||
     child.memo
-    ? child
-    : cloneVNode(child)
+  ) {
+    return child
+  }
+  const cloned = cloneVNode(child)
+  // reset el so that the cloned vnode is treated as fresh during mount
+  // this is important in SSR mode where a non-null el causes the renderer
+  // to enter the hydration path instead of the normal mount path (#14635)
+  cloned.el = null
+  cloned.anchor = null
+  return cloned
 }
 
 export function normalizeChildren(vnode: VNode, children: unknown): void {


### PR DESCRIPTION
fix https://github.com/vuejs/core/issues/14635

This should fix a problem where the renderer incorrectly enters the hydration path for a cloned **component** VNode during client-side rendering.

https://github.com/vuejs/core/blob/81615d398a89beeccfe56a4a96fd2fba0c6fb37b/packages/runtime-core/src/renderer.ts#L1341-L1344


I'm not familiar with the Vue codebase _that_ much, so please let me know if there is something I might have overlooked. It's a little intimidating for me to touch the renderer 🙈😅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed SSR hydration handling when the same component renders multiple times after initial hydration

* **Tests**
  * Added regression test for duplicate component rendering in SSR hydration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->