### PR TITLE
docs(runtime-core): clarify watchEffect dependency tracking

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -53,6 +53,9 @@ export interface WatchOptions<Immediate = boolean> extends WatchEffectOptions {
 }
 
 // Simple effect.
+// watchEffect tracks dependencies during each synchronous run, so conditional
+// branches can update the active dependency list between re-runs. For async
+// effects, only accesses before the first await are tracked.
 export function watchEffect(
   effect: WatchEffect,
   options?: WatchEffectOptions,


### PR DESCRIPTION
Issue link
https://github.com/vuejs/core/issues/13688
Description
This PR clarifies watchEffect dependency collection behavior in source comments used for API understanding.

Why
watchEffect behavior with conditional access and async effects is often misunderstood.

Changes
Added concise clarifications that:
Dependencies are collected per synchronous run.
Conditional branches can change tracked dependencies between runs.
For async effects, only access before first await is tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for dependency tracking behavior in reactive watchers, clarifying how synchronous and asynchronous effects handle dependency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->