### PR TITLE
fix(teleport): don't move teleport children if not mounted

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -2570,6 +2570,44 @@ describe('Suspense', () => {
     expect(serializeInner(target)).toBe(``)
   })
 
+  // #14701
+  test('should not crash when moving disabled teleport with component children inside suspense', async () => {
+    const target = nodeOps.createElement('div')
+
+    const Comp = {
+      render() {
+        return h('div', 'comp')
+      },
+    }
+
+    const Async = defineAsyncComponent({
+      render() {
+        // Multi-root fragment: element + disabled teleport with component child
+        return [
+          h('div', 'content'),
+          h(Teleport, { to: target, disabled: true }, h(Comp)),
+        ]
+      },
+    })
+
+    const root = nodeOps.createElement('div')
+    render(
+      h(Suspense, null, {
+        default: h(Async),
+        fallback: h('div', 'fallback'),
+      }),
+      root,
+    )
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+
+    await Promise.all(deps)
+    await nextTick()
+    await nextTick()
+    expect(serializeInner(root)).toBe(
+      `<div>content</div><!--teleport start--><div>comp</div><!--teleport end-->`,
+    )
+  })
+
   //#11617
   test('update async component before resolve then update again', async () => {
     const arr: boolean[] = []

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -94,7 +94,7 @@ export const TeleportImpl = {
       mc: mountChildren,
       pc: patchChildren,
       pbc: patchBlockChildren,
-      o: { insert, querySelector, createText, createComment },
+      o: { insert, querySelector, createText, createComment, parentNode },
     } = internals
 
     const disabled = isTeleportDisabled(n2.props)
@@ -162,7 +162,11 @@ export const TeleportImpl = {
         if (pendingMounts.get(vnode) !== mountJob) return
         pendingMounts.delete(vnode)
         if (isTeleportDisabled(vnode.props)) {
-          mount(vnode, container, vnode.anchor!)
+          // Use the current parent of the placeholder instead of the
+          // captured `container`, which may be stale if Suspense has moved
+          // the branch to a different container during resolve.
+          const mountContainer = parentNode(vnode.el!) || container
+          mount(vnode, mountContainer, vnode.anchor!)
           updateCssVars(vnode, true)
         }
         mountToTarget(vnode)

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -393,7 +393,8 @@ function moveTeleport(
   // if this is a re-order and teleport is enabled (content is in target)
   // do not move children. So the opposite is: only move children if this
   // is not a reorder, or the teleport is disabled
-  if (!isReorder || isTeleportDisabled(props)) {
+  // #14701 don't move children if in pending mount
+  if (!pendingMounts.has(vnode) && (!isReorder || isTeleportDisabled(props))) {
     // Teleport has either Array children or no children.
     if (shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
       for (let i = 0; i < (children as VNode[]).length; i++) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2047,12 +2047,7 @@ function baseCreateRenderer(
   ) => {
     const { el, type, transition, children, shapeFlag } = vnode
     if (shapeFlag & ShapeFlags.COMPONENT) {
-      // vnode.component may be null if the component is inside a Teleport
-      // whose mount was deferred by Suspense (pendingMounts). Skip the move
-      // — the deferred mount job will handle placement after effects flush.
-      if (vnode.component) {
-        move(vnode.component.subTree, container, anchor, moveType)
-      }
+      move(vnode.component!.subTree, container, anchor, moveType)
       return
     }
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2047,7 +2047,12 @@ function baseCreateRenderer(
   ) => {
     const { el, type, transition, children, shapeFlag } = vnode
     if (shapeFlag & ShapeFlags.COMPONENT) {
-      move(vnode.component!.subTree, container, anchor, moveType)
+      // vnode.component may be null if the component is inside a Teleport
+      // whose mount was deferred by Suspense (pendingMounts). Skip the move
+      // — the deferred mount job will handle placement after effects flush.
+      if (vnode.component) {
+        move(vnode.component.subTree, container, anchor, moveType)
+      }
       return
     }
 


### PR DESCRIPTION
close #14701

## Problem

When a disabled `<Teleport>` inside `<Suspense>` has its mount deferred via `pendingMounts` (introduced in #14642), component children have `vnode.component === null` because `mountChildren` was never called. During `Suspense.resolve()`, `move(pendingBranch)` walks the vnode tree and crashes on `vnode.component.subTree` for these unmounted components.

**Reproduction:** https://play.vuejs.org/#eNp9UstuwjAQ/JWVewAklKhqTyggtYhDq75UOPoSkgUMiW3ZDlCh/HvXDgFatdw8O7Pr2ceBPWgdbStkA5bYzAjtwKKr9IhLUWplHLyqvCoQFkaV0IniBvqUDpdJ3OSQmoDDUhepQ49cMq2sRmkbRPhYJ25xq4abRVoU8zTbjF5Umgu5jKIoiX8Wiy+qXXCsz5zNlFyIZbS2SlIXBy4BOMtUqUWB5l07oaTlbACB8Rx9p3bPIeZMhf02nq0w2/wRX9u9j3H2YdCi2SJnJ86lZomuoSfTN9zT+0SWoeWr5CdaVVTeYyN7rGROti90we1T2AXNZmYne0eDaJvyRr2yDnrOaC/jK62f7d5F9yGPy5qmeN7q/4dwgBXUxzto1s8lzd468D/CkAQGZY5mAN0eDEew6nZyse30/CdcprtUOLi9fjSkH42VpA5p5x6E6AwLDBacGnI2V/kXZ5ALm84LzNt78htXkhJhICzJvCmSNfeWxG2NXwdUfwNztgbg

Trigger conditions (all required):
1. `<Suspense>` wrapping an async component (`await` in setup)
2. Multi-root template (Fragment)
3. `<Teleport disabled>` as a root sibling
4. Component child (not element) inside the Teleport

- 3.5.31: no error
- 3.5.32: crash

## Fix

Add a null check for `vnode.component` in the `move` function before accessing `.subTree`. Components with null instances are skipped — the deferred mount job handles their placement after Suspense flushes its effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
* Added test coverage for Suspense with disabled Teleports containing nested async components, validating fallback display and post-resolution rendering.

## Bug Fixes
* Fixed mounting of disabled Teleports within Suspense boundaries during async component resolution.
* Improved teleport movement logic to account for pending mount operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->