### PR TITLE
fix(runtime-vapor): correctly obtain the template child node

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/template.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/template.spec.ts
@@ -1,5 +1,5 @@
 import { template } from '../../src/dom/template'
-import { child, next, nthChild } from '../../src/dom/node'
+import { child, next, nthChild, txt } from '../../src/dom/node'
 
 describe('api: template', () => {
   test('create element', () => {
@@ -39,6 +39,21 @@ describe('api: template', () => {
     expect(b).toBe(root.childNodes[1])
     expect(nthChild(root, 2)).toBe(root.childNodes[2])
     expect(next(b)).toBe(root.childNodes[2])
+  })
+
+  test('retrieve child nodes from the template tag', () => {
+    const t = template('<template><span>')
+    const root = t() as ParentNode
+    const span = child(root)
+    expect(span.nodeName).toBe('SPAN')
+  })
+
+  test('retrieve the text node from the template tag', () => {
+    const t = template('<template> ')
+    const root = t() as ParentNode
+    const text = txt(root)
+    expect(text.nodeType).toBe(3)
+    expect(text.textContent).toBe(' ')
   })
 
   test('attribute quote omission', () => {

--- a/packages/runtime-vapor/src/dom/node.ts
+++ b/packages/runtime-vapor/src/dom/node.ts
@@ -1,6 +1,10 @@
 import type { ChildItem, InsertionParent } from '../insertionState'
 import { isComment, isHydrating, locateEndAnchor } from './hydration'
 
+function unwrapTemplate<T extends Node>(node: T): T {
+  return (node instanceof HTMLTemplateElement ? node.content : node) as T
+}
+
 /*@__NO_SIDE_EFFECTS__*/
 export function createElement(tagName: string): HTMLElement {
   return document.createElement(tagName)
@@ -28,6 +32,7 @@ export function parentNode(node: Node): ParentNode | null {
 
 /*@__NO_SIDE_EFFECTS__*/
 export function txt(node: ParentNode): Node {
+  node = unwrapTemplate(node)
   if (isHydrating) {
     // since SSR doesn't generate blank text nodes,
     // manually insert a text node as the first child
@@ -42,6 +47,7 @@ export function txt(node: ParentNode): Node {
 
 /*@__NO_SIDE_EFFECTS__*/
 export function child(node: InsertionParent, logicalIndex?: number): Node {
+  node = unwrapTemplate(node)
   if (isHydrating) {
     return locateChildByLogicalIndex(node, logicalIndex ?? 0)!
   }


### PR DESCRIPTION
### Problem Description

Interpolation in the template tag will result in an error.

### Vue Version

3.6.0-beta.10

### Link to minimal reproduction

[Playground](https://play.vuejs.org/#eNp9Uc1OwzAMfhWTS0Fau40hDlOZBGgHOAACjpFQ6byS0SZRkpZJVd8dJ9XKmKadEn8/1me7ZbdaJ02NbM5SmxuhHVh0tYYm08osuBQVvQ5aMLiGDtZGVRCRIeKSy1xJ66CyBdx4/jyaXkYXnkjHfTNqkDqsdJk5pD9AehbH8B8CaNvQo+uCYjywEMe96UCfrkSzGEzp2JcHVh9hr2Aj5iylXYsi2VgladzWOzjLVaVFieZZO0HTcDaHwHguK0v18xgwZ2oc7fD8C/PvI/jGbj3G2YtBi6ZBzgbOZaZA19PLtyfc0n8gK7WqS1KfIF/RqrL2GXvZXS1XFHtPF9I+hHMJWbzb5dahtLuhfFCv7IKeMzrh/YnR/+LOkqvg47KjLX40aHxPWuAsuU4m8Se6LJlOWPcLm1y/rg==)