### PR TITLE
fix(runtime-dom): preserve textarea resize dimensions

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vShow.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vShow.spec.ts
@@ -177,33 +177,6 @@ describe('runtime-dom: v-show directive', () => {
     expect($div.style.display).toEqual('block')
   })
 
-  test('should preserve display from unchanged object styles while v-show is hidden', async () => {
-    const style = ref({
-      display: 'block',
-    })
-    const display = ref(false)
-    const component = defineComponent({
-      render() {
-        return withVShow(h('div', { style: style.value }), display.value)
-      },
-    })
-    render(h(component), root)
-
-    const $div = root.children[0]
-
-    expect($div.style.display).toEqual('none')
-
-    style.value = {
-      display: 'block',
-    }
-    await nextTick()
-    expect($div.style.display).toEqual('none')
-
-    display.value = true
-    await nextTick()
-    expect($div.style.display).toEqual('block')
-  })
-
   // #2583, #2757
   test('the value of `display` set by v-show should not be overwritten by the style attribute when updated (with Transition)', async () => {
     const style = ref('width: 100px')

--- a/packages/runtime-dom/__tests__/directives/vShow.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vShow.spec.ts
@@ -177,6 +177,33 @@ describe('runtime-dom: v-show directive', () => {
     expect($div.style.display).toEqual('block')
   })
 
+  test('should preserve display from unchanged object styles while v-show is hidden', async () => {
+    const style = ref({
+      display: 'block',
+    })
+    const display = ref(false)
+    const component = defineComponent({
+      render() {
+        return withVShow(h('div', { style: style.value }), display.value)
+      },
+    })
+    render(h(component), root)
+
+    const $div = root.children[0]
+
+    expect($div.style.display).toEqual('none')
+
+    style.value = {
+      display: 'block',
+    }
+    await nextTick()
+    expect($div.style.display).toEqual('none')
+
+    display.value = true
+    await nextTick()
+    expect($div.style.display).toEqual('block')
+  })
+
   // #2583, #2757
   test('the value of `display` set by v-show should not be overwritten by the style attribute when updated (with Transition)', async () => {
     const style = ref('width: 100px')

--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -23,19 +23,6 @@ describe(`runtime-dom: style patching`, () => {
     expect(fn).not.toBeCalled()
   })
 
-  it('should not overwrite external DOM mutations when string style is unchanged', () => {
-    const el = document.createElement('textarea')
-    const value = 'width: 200px; height: 100px;'
-
-    patchProp(el, 'style', {}, value)
-    el.style.width = '320px'
-    el.style.height = '160px'
-
-    patchProp(el, 'style', value, value)
-    expect(el.style.width).toBe('320px')
-    expect(el.style.height).toBe('160px')
-  })
-
   it('plain object', () => {
     const el = document.createElement('div')
     patchProp(el, 'style', {}, { color: 'red' })
@@ -59,40 +46,6 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.width).toBe('320px')
     expect(el.style.height).toBe('160px')
     expect(el.style.display).toBe('none')
-  })
-
-  it('should patch in-place mutations on the same object style', () => {
-    const el = document.createElement('textarea')
-    const value = {
-      width: '200px',
-      height: '100px',
-    }
-
-    patchProp(el, 'style', null, value)
-
-    value.width = '320px'
-    value.height = '160px'
-    patchProp(el, 'style', value, value)
-
-    expect(el.style.width).toBe('320px')
-    expect(el.style.height).toBe('160px')
-  })
-
-  it('should clear removed keys from in-place mutations on the same object style', () => {
-    const el = document.createElement('textarea')
-    const value = {
-      width: '200px',
-      height: '100px',
-    }
-
-    patchProp(el, 'style', null, value)
-
-    // @ts-expect-error
-    delete value.width
-    patchProp(el, 'style', value, value)
-
-    expect(el.style.width).toBe('')
-    expect(el.style.height).toBe('100px')
   })
 
   it('camelCase', () => {
@@ -222,19 +175,6 @@ describe(`runtime-dom: style patching`, () => {
       {},
       { display: ['-webkit-box', '-ms-flexbox', 'flex'] },
     )
-    expect(el.style.display).toBe('flex')
-  })
-
-  it('should reapply unchanged array style values after DOM mutation', () => {
-    const el = document.createElement('textarea')
-    const value = {
-      display: ['-webkit-box', '-ms-flexbox', 'flex'],
-    }
-
-    patchProp(el, 'style', null, value)
-    el.style.display = 'grid'
-
-    patchProp(el, 'style', value, value)
     expect(el.style.display).toBe('flex')
   })
 

--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -23,10 +23,73 @@ describe(`runtime-dom: style patching`, () => {
     expect(fn).not.toBeCalled()
   })
 
+  it('should not overwrite external DOM mutations when string style is unchanged', () => {
+    const el = document.createElement('textarea')
+    const value = 'width: 200px; height: 100px;'
+
+    patchProp(el, 'style', {}, value)
+    el.style.width = '320px'
+    el.style.height = '160px'
+
+    patchProp(el, 'style', value, value)
+    expect(el.style.width).toBe('320px')
+    expect(el.style.height).toBe('160px')
+  })
+
   it('plain object', () => {
     const el = document.createElement('div')
     patchProp(el, 'style', {}, { color: 'red' })
     expect(el.style.cssText.replace(/\s/g, '')).toBe('color:red;')
+  })
+
+  it('should not overwrite external DOM mutations when object style is unchanged', () => {
+    const el = document.createElement('textarea')
+    const value = {
+      width: '200px',
+      height: '100px',
+    }
+
+    patchProp(el, 'style', null, value)
+    el.style.width = '320px'
+    el.style.height = '160px'
+
+    patchProp(el, 'style', value, value)
+    expect(el.style.width).toBe('320px')
+    expect(el.style.height).toBe('160px')
+  })
+
+  it('should patch in-place mutations on the same object style', () => {
+    const el = document.createElement('textarea')
+    const value = {
+      width: '200px',
+      height: '100px',
+    }
+
+    patchProp(el, 'style', null, value)
+
+    value.width = '320px'
+    value.height = '160px'
+    patchProp(el, 'style', value, value)
+
+    expect(el.style.width).toBe('320px')
+    expect(el.style.height).toBe('160px')
+  })
+
+  it('should clear removed keys from in-place mutations on the same object style', () => {
+    const el = document.createElement('textarea')
+    const value = {
+      width: '200px',
+      height: '100px',
+    }
+
+    patchProp(el, 'style', null, value)
+
+    // @ts-expect-error
+    delete value.width
+    patchProp(el, 'style', value, value)
+
+    expect(el.style.width).toBe('')
+    expect(el.style.height).toBe('100px')
   })
 
   it('camelCase', () => {
@@ -157,6 +220,19 @@ describe(`runtime-dom: style patching`, () => {
       { display: ['-webkit-box', '-ms-flexbox', 'flex'] },
     )
     expect(el.style.display).toBe('flex')
+  })
+
+  it('should not overwrite external DOM mutations when array style values are unchanged', () => {
+    const el = document.createElement('textarea')
+    const value = {
+      display: ['-webkit-box', '-ms-flexbox', 'flex'],
+    }
+
+    patchProp(el, 'style', null, value)
+    el.style.display = 'grid'
+
+    patchProp(el, 'style', value, value)
+    expect(el.style.display).toBe('grid')
   })
 
   it('should clear previous css string value', () => {

--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -42,20 +42,23 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.cssText.replace(/\s/g, '')).toBe('color:red;')
   })
 
-  it('should not overwrite external DOM mutations when object style is unchanged', () => {
+  it('should preserve textarea resize dimensions while reapplying unrelated unchanged object styles', () => {
     const el = document.createElement('textarea')
     const value = {
       width: '200px',
       height: '100px',
+      display: 'none',
     }
 
     patchProp(el, 'style', null, value)
     el.style.width = '320px'
     el.style.height = '160px'
+    el.style.display = 'block'
 
     patchProp(el, 'style', value, value)
     expect(el.style.width).toBe('320px')
     expect(el.style.height).toBe('160px')
+    expect(el.style.display).toBe('none')
   })
 
   it('should patch in-place mutations on the same object style', () => {
@@ -222,7 +225,7 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.display).toBe('flex')
   })
 
-  it('should not overwrite external DOM mutations when array style values are unchanged', () => {
+  it('should reapply unchanged array style values after DOM mutation', () => {
     const el = document.createElement('textarea')
     const value = {
       display: ['-webkit-box', '-ms-flexbox', 'flex'],
@@ -232,7 +235,7 @@ describe(`runtime-dom: style patching`, () => {
     el.style.display = 'grid'
 
     patchProp(el, 'style', value, value)
-    expect(el.style.display).toBe('grid')
+    expect(el.style.display).toBe('flex')
   })
 
   it('should clear previous css string value', () => {

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -139,8 +139,9 @@ function autoPrefix(style: CSSStyleDeclaration, rawName: string): string {
 }
 
 /**
- * #14741 Browsers update textarea width/height directly during native resize.
- * Skip rewriting unchanged values so Vue doesn't clobber those dimensions.
+ * Browsers update textarea width/height directly during native resize.
+ * Only special-case this common textarea path for now; other resize scenarios
+ * still follow normal vnode style patching.
  */
 function shouldPreserveTextareaResizeStyle(
   el: Element,

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -7,28 +7,17 @@ import {
 } from '../directives/vShow'
 import { CSS_VAR_TEXT } from '../helpers/useCssVars'
 
-type ObjectStyle = Record<string, string | string[]>
-type Style = string | ObjectStyle | null
+type Style = string | Record<string, string | string[]> | null
 
 const displayRE = /(?:^|;)\s*display\s*:/
-const cacheKey: unique symbol = Symbol('_vsc')
 
-export function patchStyle(
-  el: Element & { [cacheKey]?: ObjectStyle },
-  prev: Style,
-  next: Style,
-): void {
+export function patchStyle(el: Element, prev: Style, next: Style): void {
   const style = (el as HTMLElement).style
   const isCssString = isString(next)
   let hasControlledDisplay = false
   if (next && !isCssString) {
-    const cachedStyle = el[cacheKey]
-    const nextCache: ObjectStyle = {}
     if (prev) {
       if (!isString(prev)) {
-        // Compare removals against the last applied snapshot so prev === next
-        // still clears keys deleted by in-place mutations.
-        if (cachedStyle) prev = cachedStyle
         for (const key in prev) {
           if (next[key] == null) {
             setStyle(style, key, '')
@@ -49,24 +38,21 @@ export function patchStyle(
       }
       const value = next[key]
       if (value != null) {
-        // Nullish values are cleared by the removal pass above, or are a
-        // no-op on the first object patch when nothing has been applied yet.
-        nextCache[key] = isArray(value) ? value.slice() : value
         if (
           !shouldPreserveTextareaResizeStyle(
             el,
             key,
-            cachedStyle && cachedStyle[key],
+            !isString(prev) && prev ? prev[key] : undefined,
             value,
           )
         ) {
           setStyle(style, key, value)
         }
+      } else {
+        setStyle(style, key, '')
       }
     }
-    el[cacheKey] = nextCache
   } else {
-    el[cacheKey] = undefined
     if (isCssString) {
       if (prev !== next) {
         // #9821
@@ -152,28 +138,9 @@ function autoPrefix(style: CSSStyleDeclaration, rawName: string): string {
   return rawName
 }
 
-function styleValueEqual(
-  prev: string | string[] | undefined,
-  next: string | string[],
-): boolean {
-  if (isArray(prev) && isArray(next)) {
-    if (prev.length !== next.length) {
-      return false
-    }
-    for (let i = 0; i < prev.length; i++) {
-      if (prev[i] !== next[i]) {
-        return false
-      }
-    }
-    return true
-  }
-  return prev === next
-}
-
 /**
- * Keep vnode style authoritative except for unchanged textarea width/height.
- * This avoids resize flicker and also preserves manual DOM mutations for those
- * two keys; other unchanged keys still reapply vnode state.
+ * #14741 Browsers update textarea width/height directly during native resize.
+ * Skip rewriting unchanged values so Vue doesn't clobber those dimensions.
  */
 function shouldPreserveTextareaResizeStyle(
   el: Element,
@@ -184,6 +151,7 @@ function shouldPreserveTextareaResizeStyle(
   return (
     el.tagName === 'TEXTAREA' &&
     (key === 'width' || key === 'height') &&
-    styleValueEqual(prev, next)
+    isString(next) &&
+    prev === next
   )
 }

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -7,17 +7,28 @@ import {
 } from '../directives/vShow'
 import { CSS_VAR_TEXT } from '../helpers/useCssVars'
 
-type Style = string | Record<string, string | string[]> | null
+type ObjectStyle = Record<string, string | string[]>
+type Style = string | ObjectStyle | null
 
 const displayRE = /(?:^|;)\s*display\s*:/
+const cacheKey: unique symbol = Symbol('_vsc')
 
-export function patchStyle(el: Element, prev: Style, next: Style): void {
+export function patchStyle(
+  el: Element & { [cacheKey]?: ObjectStyle },
+  prev: Style,
+  next: Style,
+): void {
   const style = (el as HTMLElement).style
   const isCssString = isString(next)
   let hasControlledDisplay = false
   if (next && !isCssString) {
+    const cachedStyle = el[cacheKey]
+    const nextCache: ObjectStyle = {}
     if (prev) {
       if (!isString(prev)) {
+        // Compare removals against the last applied snapshot so prev === next
+        // still clears keys deleted by in-place mutations.
+        if (cachedStyle) prev = cachedStyle
         for (const key in prev) {
           if (next[key] == null) {
             setStyle(style, key, '')
@@ -36,9 +47,23 @@ export function patchStyle(el: Element, prev: Style, next: Style): void {
       if (key === 'display') {
         hasControlledDisplay = true
       }
-      setStyle(style, key, next[key])
+      const value = next[key]
+      if (value != null) {
+        // Nullish values are cleared by the removal pass above, or are a
+        // no-op on the first object patch when nothing has been applied yet.
+        nextCache[key] = isArray(value) ? value.slice() : value
+        if (
+          !cachedStyle ||
+          !styleValueEqual(cachedStyle[key], value) ||
+          (key === 'display' && vShowOriginalDisplay in el)
+        ) {
+          setStyle(style, key, value)
+        }
+      }
     }
+    el[cacheKey] = nextCache
   } else {
+    el[cacheKey] = undefined
     if (isCssString) {
       if (prev !== next) {
         // #9821
@@ -122,4 +147,22 @@ function autoPrefix(style: CSSStyleDeclaration, rawName: string): string {
     }
   }
   return rawName
+}
+
+function styleValueEqual(
+  prev: string | string[] | undefined,
+  next: string | string[],
+): boolean {
+  if (isArray(prev) && isArray(next)) {
+    if (prev.length !== next.length) {
+      return false
+    }
+    for (let i = 0; i < prev.length; i++) {
+      if (prev[i] !== next[i]) {
+        return false
+      }
+    }
+    return true
+  }
+  return prev === next
 }

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -53,9 +53,12 @@ export function patchStyle(
         // no-op on the first object patch when nothing has been applied yet.
         nextCache[key] = isArray(value) ? value.slice() : value
         if (
-          !cachedStyle ||
-          !styleValueEqual(cachedStyle[key], value) ||
-          (key === 'display' && vShowOriginalDisplay in el)
+          !shouldPreserveTextareaResizeStyle(
+            el,
+            key,
+            cachedStyle && cachedStyle[key],
+            value,
+          )
         ) {
           setStyle(style, key, value)
         }
@@ -165,4 +168,22 @@ function styleValueEqual(
     return true
   }
   return prev === next
+}
+
+/**
+ * Keep vnode style authoritative except for unchanged textarea width/height.
+ * This avoids resize flicker and also preserves manual DOM mutations for those
+ * two keys; other unchanged keys still reapply vnode state.
+ */
+function shouldPreserveTextareaResizeStyle(
+  el: Element,
+  key: string,
+  prev: string | string[] | undefined,
+  next: string | string[],
+): boolean {
+  return (
+    el.tagName === 'TEXTAREA' &&
+    (key === 'width' || key === 'height') &&
+    styleValueEqual(prev, next)
+  )
 }


### PR DESCRIPTION
close #14741 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve manually-set textarea width and height when reapplying styles to avoid unexpected resizing.
  * Ensure null/empty style values explicitly clear the corresponding properties.

* **Tests**
  * Added test coverage validating textarea style patching and preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->