### PR TITLE
fix(runtime-vapor): hydrate transition-group tag v-for anchors

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -45,6 +45,16 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: element transform > component > component vue vnode hooks 1`] = `
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback } from 'vue';
+
+export function render(_ctx, $props, $emit, $attrs, $slots) {
+  const _component_Foo = _resolveComponent("Foo")
+  const n0 = _createComponentWithFallback(_component_Foo, { onVnodeMounted: () => _ctx.handleMounted }, null, true)
+  return n0
+}"
+`;
+
 exports[`compiler: element transform > component > do not resolve component from non-script-setup bindings 1`] = `
 "import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback } from 'vue';
 

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -409,6 +409,32 @@ describe('compiler: element transform', () => {
       })
     })
 
+    test('component vue vnode hooks', () => {
+      const { code, ir } = compileWithElementTransform(
+        `<Foo @vue:mounted="handleMounted" />`,
+        {
+          bindingMetadata: {
+            handleMounted: BindingTypes.SETUP_CONST,
+          },
+        },
+      )
+      expect(code).toMatchSnapshot()
+      expect(code).contains(`onVnodeMounted`)
+      expect(ir.block.dynamic.children[0].operation).toMatchObject({
+        type: IRNodeTypes.CREATE_COMPONENT_NODE,
+        tag: 'Foo',
+        props: [
+          [
+            {
+              key: { content: 'vnode-mounted' },
+              handler: true,
+              values: [{ content: 'handleMounted' }],
+            },
+          ],
+        ],
+      })
+    })
+
     test('v-on expression is a function call', () => {
       const { code, ir } = compileWithElementTransform(
         `<Foo v-on:bar="handleBar($event)" />`,

--- a/packages/compiler-vapor/src/transforms/vOn.ts
+++ b/packages/compiler-vapor/src/transforms/vOn.ts
@@ -34,6 +34,12 @@ export const transformVOn: DirectiveTransform = (dir, node, context) => {
   }
   arg = resolveExpression(arg!)
 
+  if (arg.isStatic && arg.content.startsWith('vue:')) {
+    arg = extend({}, arg, {
+      content: `vnode-${arg.content.slice(4)}`,
+    })
+  }
+
   const { keyModifiers, nonKeyModifiers, eventOptionModifiers } =
     resolveModifiers(
       arg.isStatic ? `on${arg.content}` : arg,

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -194,6 +194,38 @@ describe('VaporKeepAlive', () => {
     expect(root.innerHTML).toBe(`<div>changed</div><!--dynamic-component-->`)
   })
 
+  test('should not use wrapper key as child cache key', async () => {
+    const viewRef = ref('one')
+    let cache!: Map<any, any>
+
+    const { mount } = define({
+      setup() {
+        const n0 = createComponent(VaporKeepAlive, null, {
+          default: () => createDynamicComponent(() => views[viewRef.value]),
+        })
+        setBlockKey(n0, 'wrapper')
+        cache = (n0 as any).__v_cache
+        return n0
+      },
+    }).create()
+
+    mount(root)
+    await nextTick()
+    expect(cache.has(one)).toBe(true)
+    expect(cache.has('wrapper')).toBe(false)
+    expect(oneHooks.beforeMount).toHaveBeenCalledTimes(1)
+
+    viewRef.value = 'two'
+    await nextTick()
+    expect(cache.has(one)).toBe(true)
+    expect(cache.has(two)).toBe(true)
+    expect(cache.has('wrapper')).toBe(false)
+
+    viewRef.value = 'one'
+    await nextTick()
+    expect(oneHooks.beforeMount).toHaveBeenCalledTimes(1)
+  })
+
   test('should cache same component across branches', async () => {
     const toggle = ref(true)
     const instanceA = ref<any>(null)

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -2,7 +2,6 @@ import {
   VaporTeleport,
   child,
   createComponent,
-  createFor,
   createPlainElement,
   createVaporSSRApp,
   defineVaporAsyncComponent,
@@ -12,7 +11,6 @@ import {
   setStyle,
   setText,
   template,
-  txt,
   useVaporCssVars,
 } from '../src'
 import {
@@ -4059,45 +4057,107 @@ describe('Vapor Mode hydration', () => {
       ).not.toHaveBeenWarned()
     })
 
-    test('v-for should use transition-group container marker after cursor leaves container', async () => {
-      const host = document.createElement('div')
-      host.innerHTML = `<ul><li>1</li><li>2</li></ul><span>after</span>`
-      const ul = host.querySelector('ul')!
-      ;(ul as any).$tgt = 1
-      const items = ref([1, 2])
-      const itemTemplate = template(`<li> `)
-      const Child = defineVaporComponent({
-        setup() {
-          return createFor(
-            () => items.value,
-            item => {
-              const li = itemTemplate() as HTMLElement
-              const text = txt(li) as Text
-              renderEffect(() => setText(text, String(item.value)))
-              return li
-            },
-            item => item,
-          )
-        },
+    test('with tag should remove stale SSR v-for children when client list is shorter', async () => {
+      const ssrData = ref({
+        items: [1, 2, 3],
       })
-
-      setIsHydratingEnabled(true)
-      try {
-        hydrateNode(ul.firstChild!, () => {
-          createComponent(Child, null, null, false, false, undefined, true)
-        })
-      } finally {
-        setIsHydratingEnabled(false)
-      }
-      await nextTick()
-      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
-        `"<li>1</li><li>2</li><!--for-->"`,
+      const data = ref({
+        items: [1],
+      })
+      const code = `
+        <TransitionGroup :css="false" tag="ul">
+          <li v-for="item in data.items" :key="item">{{ item }}</li>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, ssrData, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
       )
+      const { container } = await mountWithHydration(html, code, data)
+      const ul = container.querySelector('ul')!
 
-      items.value.splice(1, 0, 3)
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><!--for-->"`,
+      )
+      expect(`Hydration children mismatch`).toHaveBeenWarned()
+
+      data.value.items.push(4)
       await nextTick()
       expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
-        `"<li>1</li><li>3</li><li>2</li><!--for-->"`,
+        `"<li>1</li><li>4</li><!--for-->"`,
+      )
+    })
+
+    test('with tag should preserve trailing sibling when removing stale SSR v-for children', async () => {
+      const ssrData = ref({
+        items: [1, 2, 3],
+        tail: 'tail',
+      })
+      const data = ref({
+        items: [1],
+        tail: 'tail',
+      })
+      const code = `
+        <TransitionGroup :css="false" tag="ul">
+          <li v-for="item in data.items" :key="item" class="item">{{ item }}</li>
+          <li key="tail" class="tail">{{ data.tail }}</li>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, ssrData, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const { container } = await mountWithHydration(html, code, data)
+      const ul = container.querySelector('ul')!
+
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li class="item">1</li><!--for--><li class="item">tail</li>"`,
+      )
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(`Hydration children mismatch`).toHaveBeenWarned()
+
+      data.value.items.push(4)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li class="item">1</li><li class="item">4</li><!--for--><li class="item">tail updated</li>"`,
+      )
+    })
+
+    test('with tag should keep v-for anchor before replaced trailing sibling', async () => {
+      const ssrData = ref({
+        items: [1, 2, 3],
+        tail: 'tail',
+      })
+      const data = ref({
+        items: [1],
+        tail: 'tail',
+      })
+      const code = `
+        <TransitionGroup :css="false" tag="div">
+          <span v-for="item in data.items" :key="item">{{ item }}</span>
+          <p key="tail">{{ data.tail }}</p>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, ssrData, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const { container } = await mountWithHydration(html, code, data)
+      const div = container.querySelector('div')!
+
+      expect(formatHtml(div.innerHTML)).toMatchInlineSnapshot(
+        `"<span>1</span><!--for--><p>tail</p>"`,
+      )
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(`Hydration children mismatch`).toHaveBeenWarned()
+
+      data.value.items.push(4)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(formatHtml(div.innerHTML)).toMatchInlineSnapshot(
+        `"<span>1</span><span>4</span><!--for--><p>tail updated</p>"`,
       )
     })
 

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -1021,6 +1021,72 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test('v-if KeepAlive with dynamic component should preserve cached branches', async () => {
+      const data = ref({
+        current: 'CompA',
+        useKeepAlive: true,
+      })
+      const { container } = await testHydration(
+        `<script setup>
+          import { KeepAlive, computed } from 'vue'
+          const data = _data
+          const components = _components
+          const current = computed(() => components[data.value.current])
+        </script>
+        <template>
+          <KeepAlive v-if="data.useKeepAlive">
+            <component :is="current" />
+          </KeepAlive>
+          <component v-else :is="current" />
+        </template>`,
+        {
+          CompA: `<script setup>
+            import { ref } from 'vue'
+            const count = ref(0)
+          </script>
+          <template>
+            <button @click="count++">A {{ count }}</button>
+          </template>`,
+          CompB: `<script setup>
+            import { ref } from 'vue'
+            const msg = ref('')
+          </script>
+          <template>
+            <input v-model="msg">
+            <p>B {{ msg }}</p>
+          </template>`,
+        },
+        data,
+      )
+
+      const getButton = () =>
+        container.querySelector('button') as HTMLButtonElement
+      const getInput = () =>
+        container.querySelector('input') as HTMLInputElement
+      const getText = () => container.querySelector('p')!.textContent
+
+      expect(getButton().textContent).toBe('A 0')
+      triggerEvent('click', getButton())
+      await nextTick()
+      expect(getButton().textContent).toBe('A 1')
+
+      data.value.current = 'CompB'
+      await nextTick()
+      getInput().value = 'hello'
+      triggerEvent('input', getInput())
+      await nextTick()
+      expect(getText()).toBe('B hello')
+
+      data.value.current = 'CompA'
+      await nextTick()
+      expect(getButton().textContent).toBe('A 1')
+
+      data.value.current = 'CompB'
+      await nextTick()
+      expect(getInput().value).toBe('hello')
+      expect(getText()).toBe('B hello')
+    })
+
     test('consecutive dynamic components with insertion anchor', async () => {
       const { container, data } = await testHydration(
         `<template>

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -2,6 +2,7 @@ import {
   VaporTeleport,
   child,
   createComponent,
+  createFor,
   createPlainElement,
   createVaporSSRApp,
   defineVaporAsyncComponent,
@@ -11,6 +12,7 @@ import {
   setStyle,
   setText,
   template,
+  txt,
   useVaporCssVars,
 } from '../src'
 import {
@@ -3955,6 +3957,82 @@ describe('Vapor Mode hydration', () => {
       expect(
         `Hydration completed but contains mismatches.`,
       ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should keep nested v-for anchor inside container', async () => {
+      const data = reactive({
+        items: [1, 2, 3, 4, 5],
+      })
+      const { container } = await testWithVDOMApp(
+        `<template><components.Child /></template>`,
+        {
+          Child: {
+            code: `
+              <template>
+                <div class="demo">
+                  <TransitionGroup name="list" tag="ul" style="margin-top:20px;">
+                    <li v-for="item in data.items" :key="item">{{ item }}</li>
+                  </TransitionGroup>
+                </div>
+              </template>
+            `,
+            vapor: true,
+          },
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+
+      data.items.splice(2, 0, 6)
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><li>2</li><li class="list-enter-from list-enter-active">6</li><li>3</li><li>4</li><li>5</li><!--for-->"`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('v-for should use transition-group container marker after cursor leaves container', async () => {
+      const host = document.createElement('div')
+      host.innerHTML = `<ul><li>1</li><li>2</li></ul><span>after</span>`
+      const ul = host.querySelector('ul')!
+      ;(ul as any).$tgt = 1
+      const items = ref([1, 2])
+      const itemTemplate = template(`<li> `)
+      const Child = defineVaporComponent({
+        setup() {
+          return createFor(
+            () => items.value,
+            item => {
+              const li = itemTemplate() as HTMLElement
+              const text = txt(li) as Text
+              renderEffect(() => setText(text, String(item.value)))
+              return li
+            },
+            item => item,
+          )
+        },
+      })
+
+      setIsHydratingEnabled(true)
+      try {
+        hydrateNode(ul.firstChild!, () => {
+          createComponent(Child, null, null, false, false, undefined, true)
+        })
+      } finally {
+        setIsHydratingEnabled(false)
+      }
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><li>2</li><!--for-->"`,
+      )
+
+      items.value.splice(1, 0, 3)
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><li>3</li><li>2</li><!--for-->"`,
+      )
     })
 
     test('with tag should place v-for anchor before trailing sibling without SSR close marker', async () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5592,6 +5592,67 @@ describe('Vapor Mode hydration', () => {
       `)
     })
 
+    test('trigger @vue:mounted for VDOM async component mounted after hydration', async () => {
+      const data = ref({
+        started: false,
+        loaded: false,
+      })
+      const ResolvedComp = defineComponent({
+        setup() {
+          return () =>
+            h('div', { id: 'docsearch' }, [
+              h('button', { type: 'button' }, 'loaded'),
+            ])
+        },
+      })
+      const appCode = `
+        <components.AsyncComp v-if="data.started" @vue:mounted="data.loaded = true" />
+        <div v-if="!data.loaded" id="docsearch">placeholder</div>
+      `
+      const SSRApp = compileVaporComponent(
+        appCode,
+        data,
+        { AsyncComp: ResolvedComp },
+        true,
+      )
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+
+      let clientResolve: any
+      const AsyncComp = defineAsyncComponent(
+        () =>
+          new Promise(r => {
+            clientResolve = r
+          }),
+      )
+
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const app = createVaporSSRApp(App)
+      app.use(runtimeVapor.vaporInteropPlugin)
+      app.mount(container)
+
+      expect(container.querySelectorAll('#docsearch')).toHaveLength(1)
+
+      data.value.started = true
+      await nextTick()
+      clientResolve(ResolvedComp)
+      await new Promise(r => setTimeout(r))
+      await nextTick()
+
+      expect(data.value.loaded).toBe(true)
+      expect(container.querySelectorAll('#docsearch')).toHaveLength(1)
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+        "
+        <!--[--><div id="docsearch"><button type="button">loaded</button></div><!----><!--if--><!--]-->
+        "
+      `)
+    })
+
     describe('suspense', () => {
       describe('VDOM suspense', () => {
         test('hydrate VDOM Suspense vapor async setup updates empty v-for before trailing sibling', async () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -3892,6 +3892,256 @@ describe('Vapor Mode hydration', () => {
         `"<button style="" class="v-enter-from v-enter-active">1</button>"`,
       )
     })
+
+    test('transition should hydrate empty v-if placeholder without fragment markers', async () => {
+      const data = ref(false)
+      const { container } = await testHydration(
+        `<template>
+          <Transition :css="false">
+            <div v-if="data">foo</div>
+          </Transition>
+        </template>`,
+        undefined,
+        data,
+      )
+
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`"<!---->"`)
+      expect(`mismatch`).not.toHaveBeenWarned()
+
+      data.value = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<div>foo</div><!---->"`,
+      )
+
+      data.value = false
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`"<!---->"`)
+    })
+  })
+
+  describe('transition-group', () => {
+    test('with tag should hydrate existing container for flattened v-for children', async () => {
+      const data = ref({
+        items: [1],
+      })
+      const code = `
+        <TransitionGroup name="list" tag="ul" style="margin-top:20px;">
+          <li v-for="item in data.items" :key="item">
+            {{ item }}
+          </li>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, data, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+
+      const { container } = await mountWithHydration(html, code, data)
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<ul name="list" style="margin-top:20px;"><li>1</li><!--for--></ul><!--transition-group-->"`,
+      )
+      data.value.items.push(2)
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<ul name="list" style="margin-top:20px;"><li>1</li><li class="list-enter-from list-enter-active">2</li><!--for--></ul><!--transition-group-->"`,
+      )
+
+      data.value.items.shift()
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<ul name="list" style="margin-top:20px;"><li class="list-leave-from list-leave-active">1</li><li class="list-enter-from list-enter-active">2</li><!--for--></ul><!--transition-group-->"`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should place v-for anchor before trailing sibling without SSR close marker', async () => {
+      const data = ref({
+        items: [1, 2],
+        tail: 'tail',
+      })
+      const code = `
+        <TransitionGroup :css="false" tag="ul">
+          <li v-for="item in data.items" :key="item">{{ item }}</li>
+          <li key="tail">{{ data.tail }}</li>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, data, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const { container } = await mountWithHydration(html, code, data)
+      const ul = container.querySelector('ul')!
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><li>2</li><li>3</li><!--for--><li>tail updated</li>"`,
+      )
+
+      data.value.items.shift()
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>2</li><li>3</li><!--for--><li>tail updated</li>"`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should hydrate empty claimed container for flattened v-for children', async () => {
+      const data = ref({
+        items: [] as number[],
+      })
+      const code = `
+        <TransitionGroup :css="false" tag="ul">
+          <li v-for="item in data.items" :key="item">{{ item }}</li>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, data, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const { container } = await mountWithHydration(html, code, data)
+      const ul = container.querySelector('ul')!
+
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(`"<!--for-->"`)
+
+      data.value.items.push(1, 2)
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><li>2</li><!--for-->"`,
+      )
+
+      data.value.items.shift()
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>2</li><!--for-->"`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should place empty v-for anchor before trailing sibling', async () => {
+      const data = ref({
+        items: [] as number[],
+        tail: 'tail',
+      })
+      const code = `
+        <TransitionGroup :css="false" tag="ul">
+          <li v-for="item in data.items" :key="item">{{ item }}</li>
+          <li key="tail">{{ data.tail }}</li>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, data, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const { container } = await mountWithHydration(html, code, data)
+      const ul = container.querySelector('ul')!
+
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<!--for--><li>tail</li>"`,
+      )
+
+      data.value.items.push(1)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><!--for--><li>tail updated</li>"`,
+      )
+
+      data.value.items.shift()
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<!--for--><li>tail updated</li>"`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should keep empty v-for anchor inside container when wrapped by parent fragment boundary', async () => {
+      const data = ref({
+        items: [] as number[],
+        after: 'after',
+      })
+      const code = `
+        <div>
+          <template v-if="true">
+            <TransitionGroup :css="false" tag="ul">
+              <li v-for="item in data.items" :key="item">{{ item }}</li>
+            </TransitionGroup>
+            <span>{{ data.after }}</span>
+          </template>
+        </div>
+      `
+      const SSRComp = compileVaporComponent(code, data, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const { container } = await mountWithHydration(html, code, data)
+      const ul = container.querySelector('ul')!
+
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(`"<!--for-->"`)
+      expect(formatHtml(container.innerHTML)).toContain('<span>after</span>')
+
+      data.value.items.push(1)
+      data.value.after = 'after updated'
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><!--for-->"`,
+      )
+      expect(formatHtml(container.innerHTML)).toContain(
+        '<span>after updated</span>',
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should prefer local anchor over slot fallback boundary', async () => {
+      const data = reactive({
+        items: [] as number[],
+        tail: 'tail',
+        after: 'after',
+      })
+      const { container } = await testHydration(
+        `<template><components.Child /></template>`,
+        {
+          Child: `<template>
+            <slot>
+              <TransitionGroup :css="false" tag="ul">
+                <li v-for="item in data.items" :key="item">{{ item }}</li>
+                <li key="tail">{{ data.tail }}</li>
+              </TransitionGroup>
+              <i>{{ data.after }}</i>
+            </slot>
+          </template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<!--for--><li>tail</li>"`,
+      )
+      expect(formatHtml(container.innerHTML)).toContain('<i>after</i>')
+
+      data.items.push(1)
+      data.after = 'after updated'
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>1</li><!--for--><li>tail</li>"`,
+      )
+      expect(formatHtml(container.innerHTML)).toContain('<i>after updated</i>')
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
   })
 
   describe('teleport', () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -7107,6 +7107,26 @@ describe('mismatch handling', () => {
       await nextTick()
       expect(container.innerHTML).toBe(`<div>claimed</div><span>updated</span>`)
     })
+
+    test('stripped static template can be cloned after hydration', () => {
+      const container = document.createElement('div')
+      container.innerHTML = `<div>claimed</div>`
+      const t1 = template('', true, true)
+      let hydrated: HTMLElement
+
+      hydrateNode(container.firstChild!, () => {
+        hydrated = t1() as HTMLElement
+        expect(hydrated).toBe(container.firstChild)
+        expect((hydrated as any).$root).toBe(true)
+      })
+
+      hydrated!.textContent = 'mutated'
+
+      const cloned = t1() as HTMLElement
+      expect(cloned).not.toBe(hydrated!)
+      expect((cloned as any).$root).toBe(true)
+      expect(cloned.outerHTML).toBe(`<div>claimed</div>`)
+    })
   })
 })
 

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -151,13 +151,38 @@ export const createFor = (
               if (nextNode) setCurrentHydrationNode(nextNode)
             }
 
-            // Slot fallback can fall through an empty/invalid `v-for`. In that
-            // case SSR only rendered the parent slot range, so this `v-for` has no
-            // own `<!--]-->` to reuse. If `hydrationStart` is not the parent slot
-            // end anchor, use `hydrationStart.nextSibling` as the insertion point
-            // so the runtime `<!--for-->` lands immediately after that local SSR
-            // range. Otherwise insert it before the parent slot end anchor.
-            if (slotFallbackRange && !isValidBlock(newBlocks)) {
+            // transition-group + v-for, without <!--]--> marker
+            const container =
+              // empty list: hydrationStart is container
+              hydrationStart.nodeType === 1 && !!(hydrationStart as any).$tgt
+                ? (hydrationStart as ParentNode)
+                : // non-empty list: parent node is container
+                  currentHydrationNode!.parentNode &&
+                    !!(currentHydrationNode!.parentNode as any).$tgt
+                  ? (currentHydrationNode!.parentNode as ParentNode)
+                  : null
+            if (container) {
+              const anchorNode = newLength ? nextNode : currentHydrationNode
+              const anchor =
+                anchorNode &&
+                anchorNode !== container &&
+                anchorNode.parentNode === container
+                  ? anchorNode
+                  : null
+              parentAnchor = markHydrationAnchor(
+                __DEV__ ? createComment('for') : createTextNode(),
+              )
+              pendingHydrationAnchor = true
+              queuePostFlushCb(() =>
+                container.insertBefore(parentAnchor, anchor),
+              )
+            } else if (slotFallbackRange && !isValidBlock(newBlocks)) {
+              // Slot fallback can fall through an empty/invalid `v-for`. In that
+              // case SSR only rendered the parent slot range, so this `v-for` has no
+              // own `<!--]-->` to reuse. If `hydrationStart` is not the parent slot
+              // end anchor, use `hydrationStart.nextSibling` as the insertion point
+              // so the runtime `<!--for-->` lands immediately after that local SSR
+              // range. Otherwise insert it before the parent slot end anchor.
               const anchor =
                 // The invalid list still consumed local SSR item ranges.
                 currentHydrationNode !== hydrationStart

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -156,10 +156,10 @@ export const createFor = (
               // empty list: hydrationStart is container
               hydrationStart.nodeType === 1 && !!(hydrationStart as any).$tgt
                 ? (hydrationStart as ParentNode)
-                : // non-empty list: parent node is container
-                  currentHydrationNode!.parentNode &&
-                    !!(currentHydrationNode!.parentNode as any).$tgt
-                  ? (currentHydrationNode!.parentNode as ParentNode)
+                : // non-empty list: hydrationStart parent is container
+                  hydrationStart.parentNode &&
+                    !!(hydrationStart.parentNode as any).$tgt
+                  ? (hydrationStart.parentNode as ParentNode)
                   : null
             if (container) {
               const anchorNode = newLength ? nextNode : currentHydrationNode

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -60,6 +60,19 @@ type ResolvedSource = {
   keys?: string[]
 }
 
+type ForHydrationAnchorResolver = (
+  hydrationStart: Node,
+  anchorNode: Node | null | undefined,
+) => Node | undefined
+
+let resolveForHydrationAnchor: ForHydrationAnchorResolver | undefined
+
+export function setForHydrationAnchorResolver(
+  resolver: ForHydrationAnchorResolver,
+): void {
+  resolveForHydrationAnchor = resolver
+}
+
 export const createFor = (
   src: () => Source,
   renderItem: (
@@ -151,31 +164,16 @@ export const createFor = (
               if (nextNode) setCurrentHydrationNode(nextNode)
             }
 
-            // transition-group + v-for, without <!--]--> marker
-            const container =
-              // empty list: hydrationStart is container
-              hydrationStart.nodeType === 1 && !!(hydrationStart as any).$tgt
-                ? (hydrationStart as ParentNode)
-                : // non-empty list: hydrationStart parent is container
-                  hydrationStart.parentNode &&
-                    !!(hydrationStart.parentNode as any).$tgt
-                  ? (hydrationStart.parentNode as ParentNode)
-                  : null
-            if (container) {
-              const anchorNode = newLength ? nextNode : currentHydrationNode
-              const anchor =
-                anchorNode &&
-                anchorNode !== container &&
-                anchorNode.parentNode === container
-                  ? anchorNode
-                  : null
-              parentAnchor = markHydrationAnchor(
-                __DEV__ ? createComment('for') : createTextNode(),
+            // special handling transition-group + v-for, without <!--]--> marker
+            const resolvedAnchor =
+              resolveForHydrationAnchor &&
+              resolveForHydrationAnchor(
+                hydrationStart,
+                newLength ? nextNode : currentHydrationNode,
               )
+            if (resolvedAnchor) {
+              parentAnchor = resolvedAnchor
               pendingHydrationAnchor = true
-              queuePostFlushCb(() =>
-                container.insertBefore(parentAnchor, anchor),
-              )
             } else if (slotFallbackRange && !isValidBlock(newBlocks)) {
               // Slot fallback can fall through an empty/invalid `v-for`. In that
               // case SSR only rendered the parent slot range, so this `v-for` has no

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -44,6 +44,13 @@ import {
   defineVaporComponent,
 } from '../apiDefineComponent'
 import { isInteropEnabled } from '../vdomInteropState'
+import {
+  adoptTemplate,
+  currentHydrationNode,
+  isHydrating,
+  locateNextNode,
+  setCurrentHydrationNode,
+} from '../dom/hydration'
 
 const positionMap = new WeakMap<TransitionBlock, DOMRect>()
 const newPositionMap = new WeakMap<TransitionBlock, DOMRect>()
@@ -154,17 +161,36 @@ const VaporTransitionGroupImpl = defineVaporComponent({
       // if the tag and slot are the same as previous render, no need to update.
       if (isMounted && tag === currentTag && slot === currentSlot) return
 
-      const container = tag ? createElement(tag) : undefined
+      const container = tag
+        ? isHydrating
+          ? (adoptTemplate(currentHydrationNode!, `<${tag}/>`) as HTMLElement)
+          : createElement(tag)
+        : undefined
+      let nextNode: Node | null = null
+      if (isHydrating && container) {
+        // `transition-group + v-for` SSR output does not include `<!--]-->`.
+        // Mark the container so `v-for` hydration can create its own anchor.
+        ;(container as any).$tgt = 1
+        nextNode = locateNextNode(container)
+        setCurrentHydrationNode(container.firstChild || container)
+      }
       let block: Block = slottedBlock
-      frag.update(() => {
-        block = (slot && slot()) || []
-        applyGroupTransitionHooks(block, propsProxy, state, instance)
-        if (container) {
-          insert(block, container)
-          return container
+      try {
+        frag.update(() => {
+          block = (slot && slot()) || []
+          applyGroupTransitionHooks(block, propsProxy, state, instance)
+          if (container) {
+            if (!isHydrating) insert(block, container)
+            return container
+          }
+          return block
+        })
+      } finally {
+        if (isHydrating && container) {
+          delete (container as any).$tgt
+          setCurrentHydrationNode(nextNode)
         }
-        return block
-      })
+      }
       slottedBlock = block
 
       currentTag = tag

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -36,8 +36,8 @@ import {
   type VaporComponentOptions,
   isVaporComponent,
 } from '../component'
-import { isForBlock } from '../apiCreateFor'
-import { createElement } from '../dom/node'
+import { isForBlock, setForHydrationAnchorResolver } from '../apiCreateFor'
+import { createComment, createElement, createTextNode } from '../dom/node'
 import { DynamicFragment, type VaporFragment, isFragment } from '../fragment'
 import {
   type DefineVaporComponent,
@@ -46,14 +46,46 @@ import {
 import { isInteropEnabled } from '../vdomInteropState'
 import {
   adoptTemplate,
+  cleanupHydrationTail,
   currentHydrationNode,
   isHydrating,
   locateNextNode,
+  markHydrationAnchor,
   setCurrentHydrationNode,
 } from '../dom/hydration'
 
 const positionMap = new WeakMap<TransitionBlock, DOMRect>()
 const newPositionMap = new WeakMap<TransitionBlock, DOMRect>()
+
+let isForHydrationAnchorResolverRegistered = false
+let currentForHydrationContainer: ParentNode | undefined
+
+function ensureForHydrationAnchorResolver(): void {
+  if (isForHydrationAnchorResolverRegistered) return
+  isForHydrationAnchorResolverRegistered = true
+  setForHydrationAnchorResolver((hydrationStart, anchorNode) => {
+    const container = currentForHydrationContainer
+    if (!container) return
+    if (
+      hydrationStart !== container &&
+      hydrationStart.parentNode !== container
+    ) {
+      return
+    }
+
+    const anchor =
+      anchorNode &&
+      anchorNode !== container &&
+      anchorNode.parentNode === container
+        ? anchorNode
+        : null
+    const parentAnchor = markHydrationAnchor(
+      __DEV__ ? createComment('for') : createTextNode(),
+    )
+    container.insertBefore(parentAnchor, anchor)
+    return parentAnchor
+  })
+}
 
 const decorate = <T extends VaporComponentOptions>(t: T): T => {
   delete (t.props! as any).mode
@@ -167,27 +199,47 @@ const VaporTransitionGroupImpl = defineVaporComponent({
           : createElement(tag)
         : undefined
       let nextNode: Node | null = null
+      let prevForHydrationContainer: ParentNode | undefined
       if (isHydrating && container) {
         // `transition-group + v-for` SSR output does not include `<!--]-->`.
-        // Mark the container so `v-for` hydration can create its own anchor.
-        ;(container as any).$tgt = 1
+        // Expose the container so `v-for` hydration can create its own anchor.
+        ensureForHydrationAnchorResolver()
+        prevForHydrationContainer = currentForHydrationContainer
+        currentForHydrationContainer = container
         nextNode = locateNextNode(container)
         setCurrentHydrationNode(container.firstChild || container)
       }
       let block: Block = slottedBlock
+      let transitionBlocks: ResolvedTransitionBlock[] = []
       try {
         frag.update(() => {
           block = (slot && slot()) || []
-          applyGroupTransitionHooks(block, propsProxy, state, instance)
+          transitionBlocks = applyGroupTransitionHooks(
+            block,
+            propsProxy,
+            state,
+            instance,
+          )
           if (container) {
             if (!isHydrating) insert(block, container)
             return container
           }
           return block
         })
+        if (
+          isHydrating &&
+          container &&
+          currentHydrationNode &&
+          currentHydrationNode.parentNode === container &&
+          !transitionBlocks.some(child => child === currentHydrationNode)
+        ) {
+          // Remove extra SSR nodes left after hydrating the current children,
+          // but keep a node that was claimed as a transition child.
+          cleanupHydrationTail(currentHydrationNode, container)
+        }
       } finally {
         if (isHydrating && container) {
-          delete (container as any).$tgt
+          currentForHydrationContainer = prevForHydrationContainer
           setCurrentHydrationNode(nextNode)
         }
       }
@@ -212,7 +264,7 @@ function applyGroupTransitionHooks(
   props: TransitionProps,
   state: TransitionState,
   instance: VaporComponentInstance,
-): void {
+): ResolvedTransitionBlock[] {
   const fragments: VaporFragment[] = []
   const children = getTransitionBlocks(block, frag => fragments.push(frag))
   for (let i = 0; i < children.length; i++) {
@@ -235,6 +287,7 @@ function applyGroupTransitionHooks(
     hooks.applyGroup = applyGroupTransitionHooks
     frag.$transition = hooks
   })
+  return children
 }
 
 function inheritKey(children: TransitionBlock[], key: any): void {

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -62,6 +62,8 @@ function performHydration<T>(
     ;(Node.prototype as any).$idx = undefined
     ;(Node.prototype as any).$llc = undefined
     ;(Node.prototype as any).$vha = undefined
+    // transition-group tag
+    ;(Node.prototype as any).$tgt = undefined
 
     isOptimized = true
   }

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -62,8 +62,6 @@ function performHydration<T>(
     ;(Node.prototype as any).$idx = undefined
     ;(Node.prototype as any).$llc = undefined
     ;(Node.prototype as any).$vha = undefined
-    // transition-group tag
-    ;(Node.prototype as any).$tgt = undefined
 
     isOptimized = true
   }
@@ -370,12 +368,22 @@ function removeHydrationNode(node: Node, close: Node | null = null): void {
   remove(node, parent)
 }
 
-export function cleanupHydrationTail(node: Node): void {
-  const container = node.parentElement
-  if (container) {
-    warnHydrationChildrenMismatch(container)
+export function cleanupHydrationTail(node: Node, container?: ParentNode): void {
+  const mismatchContainer = container || node.parentElement
+  if (mismatchContainer instanceof Element) {
+    warnHydrationChildrenMismatch(mismatchContainer)
   }
-  removeHydrationNode(node)
+  if (!container) {
+    removeHydrationNode(node)
+    return
+  }
+
+  let current: Node | null = node
+  while (current && current.parentNode === container) {
+    const next = locateNextNode(current)
+    removeHydrationNode(current)
+    current = next
+  }
 }
 
 export function markHydrationAnchor<T extends Node>(node: T): T {

--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -27,6 +27,7 @@ export function template(
       // never mutates their DOM afterwards.
       if (isStatic) {
         adopted = resolveHydrationTarget(currentHydrationNode!)
+        node = adopted.cloneNode(true)
         advanceHydrationNode(adopted)
       } else {
         // do not cache the adopted node in node because it contains child nodes
@@ -37,20 +38,24 @@ export function template(
       return adopted
     }
 
+    if (node) {
+      const ret = node.cloneNode(true)
+      if (root) (ret as any).$root = true
+      return ret
+    }
+
     // fast path for text nodes
     if (html[0] !== '<') {
       return createTextNode(html)
     }
-    if (!node) {
-      t = t || document.createElement('template')
-      if (ns) {
-        const tag = ns === Namespaces.SVG ? 'svg' : 'math'
-        t.innerHTML = `<${tag}>${html}</${tag}>`
-        node = _child(_child(t.content) as ParentNode)
-      } else {
-        t.innerHTML = html
-        node = _child(t.content)
-      }
+    t = t || document.createElement('template')
+    if (ns) {
+      const tag = ns === Namespaces.SVG ? 'svg' : 'math'
+      t.innerHTML = `<${tag}>${html}</${tag}>`
+      node = _child(_child(t.content) as ParentNode)
+    } else {
+      t.innerHTML = html
+      node = _child(t.content)
     }
     const ret = node.cloneNode(true)
     if (root) (ret as any).$root = true

--- a/packages/runtime-vapor/src/helpers/setKey.ts
+++ b/packages/runtime-vapor/src/helpers/setKey.ts
@@ -1,4 +1,5 @@
 import { isArray } from '@vue/shared'
+import { isKeepAlive } from '@vue/runtime-dom'
 import type { Block } from '../block'
 import { isVaporComponent } from '../component'
 
@@ -12,7 +13,10 @@ export function setBlockKey(
     block.$key = key
   } else if (isVaporComponent(block)) {
     block.$key = key
-    if (block.block) setBlockKey(block.block, key)
+    // KeepAlive resolves cache keys from its child block. An outer wrapper key
+    // (for example from v-if) must not override the child's own component type
+    // or explicit key, otherwise cached branches will not be found again.
+    if (!isKeepAlive(block) && block.block) setBlockKey(block.block, key)
   } else if (isArray(block)) {
     if (block.length === 1) {
       setBlockKey(block[0], key)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for vnode hook directives in Vue Vapor (e.g., `@vue:mounted`).

* **Bug Fixes & Improvements**
  * Enhanced hydration accuracy and state preservation for server-side rendered components.
  * Improved KeepAlive cache isolation in wrapped components.
  * Better TransitionGroup support during server-side rendering.
  * Refined list rendering hydration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->