### PR TITLE
fix(compiler-sfc): preserve hash hrefs on `<image>` elements

### DIFF
--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -150,7 +150,6 @@ describe('compiler sfc: transform asset url', () => {
     expect(code).toContain(`import _imports_0 from './foo%.png'`)
   })
 
-  // #14753
   test('should not transform hash fragments on <image>', () => {
     // `<image href="#...">` is an in-document fragment reference to another
     // SVG element (like `<use>`), not a Node.js subpath import specifier.

--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -150,6 +150,30 @@ describe('compiler sfc: transform asset url', () => {
     expect(code).toContain(`import _imports_0 from './foo%.png'`)
   })
 
+  // #14753
+  test('should not transform hash fragments on <image>', () => {
+    // `<image href="#...">` is an in-document fragment reference to another
+    // SVG element (like `<use>`), not a Node.js subpath import specifier.
+    const { code } = compileWithAssetUrls(
+      `<svg><image href="#" /><image href="#myClip" /></svg>`,
+      { includeAbsolute: true },
+    )
+    expect(code).toContain(`href: "#"`)
+    expect(code).toContain(`href: "#myClip"`)
+    expect(code).not.toContain(`from '#'`)
+    expect(code).not.toContain(`from '#myClip'`)
+  })
+
+  test('should not transform bare `#` value into an import', () => {
+    // A bare `#` is never a valid module specifier and should always be left
+    // untouched, even on tags that otherwise support subpath imports.
+    const { code } = compileWithAssetUrls(`<img src="#" />`, {
+      includeAbsolute: true,
+    })
+    expect(code).toContain(`src: "#"`)
+    expect(code).not.toContain(`from '#'`)
+  })
+
   test('should allow for full base URLs, with paths', () => {
     const { code } = compileWithAssetUrls(`<img src="./logo.png" />`, {
       base: 'http://localhost:3000/src/',

--- a/packages/compiler-sfc/src/template/transformAssetUrl.ts
+++ b/packages/compiler-sfc/src/template/transformAssetUrl.ts
@@ -35,13 +35,14 @@ export interface AssetURLOptions {
   tags?: AssetURLTagConfig
 }
 
-// Built-in attrs that always represent resource URLs. `use` is intentionally
-// omitted because its hash-only values may still be fragment references.
+// Built-in attrs that always represent resource URLs. `use` and `image` are
+// intentionally omitted because their hash-only values are fragment references
+// to in-document elements (e.g. `<image href="#myClip" />`), not module
+// specifiers.
 const resourceUrlTagConfig: AssetURLTagConfig = {
   video: ['src', 'poster'],
   source: ['src'],
   img: ['src'],
-  image: ['xlink:href', 'href'],
 }
 
 export const defaultAssetUrlOptions: Required<AssetURLOptions> = {
@@ -49,6 +50,7 @@ export const defaultAssetUrlOptions: Required<AssetURLOptions> = {
   includeAbsolute: false,
   tags: {
     ...resourceUrlTagConfig,
+    image: ['xlink:href', 'href'],
     use: ['xlink:href', 'href'],
   },
 }
@@ -125,6 +127,8 @@ export const transformAssetUrl: NodeTransform = (
       if (
         isExternalUrl(urlValue) ||
         isDataUrl(urlValue) ||
+        // a bare `#` is never a valid import specifier
+        urlValue === '#' ||
         (isHashOnlyValue && !canTransformHashImport(node.tag, attr.name)) ||
         (!options.includeAbsolute && !isRelativeUrl(urlValue))
       ) {


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/34858

this addresses a regression from #13045 which introduced handling for node import conditions in image hrefs.

it's common to have `<image>` elements in svgs with fragment references, just as it is to have `<use>` (referenced in the above PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve fragment-only URLs (e.g., "#" or "#id") in image and SVG references so they aren't turned into module imports.

* **Tests**
  * Added tests to verify fragment-only URLs remain unchanged during asset URL transformation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->