### PR TITLE
fix(compiler-sfc): infer Vue ref wrapper types when source is unresolvable

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -803,6 +803,61 @@ describe('resolveType', () => {
         foo: ['Boolean', 'Symbol', 'Number'],
       })
     })
+
+    // #14729 — original user repro shape
+    test('MaybeRef wrapped array type in interface inheritance chain', () => {
+      expect(
+        resolve(`
+        import type { MaybeRef } from 'unresolvable-pkg-xyz'
+        type OptionItem = { label: string; value: string | number }
+        type FormItemOptions<T = any, C = any> =
+          | MaybeRef<OptionItem[]>
+          | Promise<OptionItem[]>
+          | ((row: T, context: C) => OptionItem[] | Promise<OptionItem[]>)
+        interface ISelectable<T = any, C = any> {
+          options?: FormItemOptions<T, C>
+        }
+        interface XSelectProps<T = any, C = any> extends ISelectable<T, C> {
+          modelValue?: unknown
+        }
+        defineProps<XSelectProps>()
+      `).props,
+      ).toMatchObject({
+        // 'Array' must be present so that array values pass runtime type check
+        options: expect.arrayContaining(['Array', 'Promise', 'Function']),
+      })
+    })
+
+    // #14729
+    test('Vue ref wrapper types in union are inferred when source is unresolvable', () => {
+      expect(
+        resolve(`
+        import type {
+          MaybeRef,
+          Ref,
+          ShallowRef,
+          ComputedRef,
+          WritableComputedRef,
+          MaybeRefOrGetter,
+        } from 'unresolvable-pkg-xyz'
+        defineProps<{
+          a?: MaybeRef<string[]> | Promise<string[]> | (() => string[])
+          b?: Ref<number>
+          c?: ShallowRef<number>
+          d?: ComputedRef<number>
+          e?: WritableComputedRef<number>
+          f?: MaybeRefOrGetter<boolean>
+        }>()
+      `).props,
+      ).toStrictEqual({
+        a: ['Object', 'Array', 'Promise', 'Function'],
+        b: ['Object'],
+        c: ['Object'],
+        d: ['Object'],
+        e: ['Object'],
+        f: ['Object', 'Function', 'Boolean'],
+      })
+    })
   })
 
   describe('generics', () => {

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1656,7 +1656,13 @@ export function inferRuntimeType(
         }
 
       case 'TSTypeReference': {
-        const resolved = resolveTypeReference(ctx, node, scope)
+        // #14729 — if resolution fails (e.g. an unresolvable import), still
+        // fall through to the built-in name handling below so that well-known
+        // types like Ref/MaybeRef/Promise can be inferred from the name alone.
+        let resolved: ScopeTypeNode | undefined
+        try {
+          resolved = resolveTypeReference(ctx, node, scope)
+        } catch {}
         if (resolved) {
           if (resolved.type === 'TSTypeAliasDeclaration') {
             // #13240
@@ -1787,6 +1793,34 @@ export function inferRuntimeType(
                 return ['Map']
               case 'ReadonlySet':
                 return ['Set']
+
+              // Vue ref wrapper types — handled here so that runtime type
+              // inference still works when `vue` types cannot be resolved
+              // (e.g. consumed as built artifacts in another package). #14729
+              case 'Ref':
+              case 'ShallowRef':
+              case 'ComputedRef':
+              case 'WritableComputedRef':
+                return ['Object']
+              case 'MaybeRef':
+              case 'MaybeRefOrGetter': {
+                const types = new Set<string>(['Object'])
+                if (node.typeName.name === 'MaybeRefOrGetter') {
+                  types.add('Function')
+                }
+                if (node.typeParameters && node.typeParameters.params[0]) {
+                  for (const t of inferRuntimeType(
+                    ctx,
+                    node.typeParameters.params[0],
+                    scope,
+                    false,
+                    typeParameters,
+                  )) {
+                    types.add(t)
+                  }
+                }
+                return Array.from(types)
+              }
 
               case 'NonNullable':
                 if (node.typeParameters && node.typeParameters.params[0]) {


### PR DESCRIPTION
Close #14729

## Summary

- When `MaybeRef<T[]>` (or any other Vue ref-wrapper type) appears in a `defineProps` union and the `vue` import cannot be resolved by the SFC compiler — for example when the type lives in a separately-built package consumed by another app — `resolveTypeReference` throws inside `inferRuntimeType`. The throw is caught at the function's top-level `try/catch` and the entire branch collapses to `UNKNOWN_TYPE`. After the `UNKNOWN_TYPE` filtering in `defineProps.ts`, valid runtime types (e.g. `Array`) are silently dropped from the generated runtime props, producing `Invalid prop: type check failed` warnings at runtime even though the value is valid per the source TS type.
- The fix has two parts:
  1. Catch the resolution failure locally inside the `TSTypeReference` case so the existing built-in name handling still gets a chance to run.
  2. Add fallbacks in that built-in switch for the well-known Vue wrapper types — `Ref`, `ShallowRef`, `ComputedRef`, `WritableComputedRef` (each → `Object`), `MaybeRef<T>` (→ `Object | inferRuntimeType(T)`) and `MaybeRefOrGetter<T>` (→ `Object | Function | inferRuntimeType(T)`). This mirrors the existing handling for `Promise`, `Date`, `Map`, etc.

## Test plan

- [x] Added `MaybeRef wrapped array type in interface inheritance chain` mirroring the issue's exact code shape — confirms `Array` is now present for the `options` prop.
- [x] Added `Vue ref wrapper types in union are inferred when source is unresolvable` covering all six wrapper types.
- [x] Full `packages/compiler-sfc` test suite passes (455 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced type inference to gracefully handle unresolvable type references while maintaining support for Vue ref wrapper types.

* **Tests**
  * Added comprehensive test cases for complex type reference and Vue ref wrapper type resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->