### PR TITLE
fix(compiler-sfc): preserve selectors after global pseudo

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -240,6 +240,16 @@ color: red
       ".foo .bar { color: red;
       }"
     `)
+    expect(compileScoped(`:global(body) h1 { color: red; }`))
+      .toMatchInlineSnapshot(`
+      "body h1[data-v-test] { color: red;
+      }"
+    `)
+    expect(compileScoped(`:global(html.dark) .foo { color: red; }`))
+      .toMatchInlineSnapshot(`
+      "html.dark .foo[data-v-test] { color: red;
+      }"
+    `)
   })
 
   test(':is() and :where() with multiple selectors', () => {

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -103,6 +103,9 @@ function rewriteSelector(
   let shouldInject = !deep
   let hasNestedDeep = false
   let splitForNestedDeep = false
+  if (rewriteGlobalSelector(selector)) {
+    return
+  }
   // find the last child node to insert attribute selector
   selector.each(n => {
     // DEPRECATED ">>>" and "/deep/" combinator
@@ -338,6 +341,34 @@ function rewriteSelector(
       }),
     )
   }
+}
+
+function rewriteGlobalSelector(selector: selectorParser.Selector): boolean {
+  const globalIndex = selector.nodes.findIndex(
+    node =>
+      node.type === 'pseudo' &&
+      (node.value === ':global' || node.value === '::v-global'),
+  )
+  if (globalIndex === -1) {
+    return false
+  }
+
+  const global = selector.at(globalIndex) as selectorParser.Pseudo
+  const hasTrailingNodes = globalIndex < selector.length - 1
+  for (const node of selector.nodes.slice(0, globalIndex)) {
+    selector.removeChild(node)
+  }
+  let last: selectorParser.Selector['nodes'][0] = global
+  global.nodes[0].each(node => {
+    selector.insertAfter(last, node)
+    last = node
+  })
+  selector.removeChild(global)
+  if (selector.first) {
+    selector.first.spaces.before = ''
+  }
+
+  return !hasTrailingNodes
 }
 
 function isSpaceCombinator(node: selectorParser.Node) {


### PR DESCRIPTION
fix #12404

👨: Hey, real human speaking here. Not sure what's your AI code policy, but I encountered this issue while trying to implement a css-vars based theme/switcher in a [sli.dev](https://sli.dev/) project, and dedicated a couple of tokens to an agent to try and fix it.

🤖: When a scoped selector started with :global(...) and then continued with a descendant or combinator selector, the scoped CSS transform replaced the entire selector with the :global() inner selector. That dropped the trailing local selector and compiled :global(body) h1 to body.

This updates the :global()/::v-global rewrite to replace only the pseudo node, preserve trailing selector nodes for normal scoped processing, and keep standalone global selectors unscoped.

Added regression coverage for both :global(body) h1 and :global(html.dark) .foo.

Validation:
- pnpm vitest packages/compiler-sfc/__tests__/compileStyle.spec.ts --run
- pnpm check