### PR TITLE
perf(runtime-vapor): add class toggle fast path

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -615,12 +615,12 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: element transform > props merging: class 1`] = `
-"import { setClass as _setClass, renderEffect as _renderEffect, template as _template } from 'vue';
-const t0 = _template("<div>", true)
+"import { toggleClass as _toggleClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div class=foo>", true)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => _setClass(n0, ["foo", { bar: _ctx.isBar }]))
+  _renderEffect(() => _toggleClass(n0, "bar", _ctx.isBar))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -416,7 +416,11 @@ const t0 = _template("<div>", true)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => (_toggleClass(n0, "active", _ctx.ok), _toggleClass(n0, "foo", _ctx.bar)))
+  _renderEffect(() => {
+    
+    _toggleClass(n0, "active", _ctx.ok)
+    _toggleClass(n0, "foo", _ctx.bar)
+  })
   return n0
 }"
 `;
@@ -459,7 +463,11 @@ const t0 = _template("<div>", true)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => (_toggleClass(n0, "foo", _ctx.isActive), _toggleClass(n0, "bar", _ctx.isActive)))
+  _renderEffect(() => {
+    
+    _toggleClass(n0, "foo", _ctx.isActive)
+    _toggleClass(n0, "bar", _ctx.isActive)
+  })
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -410,6 +410,17 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler v-bind > multiple simple object class fast path 1`] = `
+"import { toggleClass as _toggleClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => (_toggleClass(n0, "active", _ctx.ok), _toggleClass(n0, "foo", _ctx.bar)))
+  return n0
+}"
+`;
+
 exports[`compiler v-bind > no expression (shorthand) 1`] = `
 "import { setAttr as _setAttr, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", true)
@@ -442,12 +453,78 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler v-bind > object class with multi-token key 1`] = `
+"import { toggleClass as _toggleClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => (_toggleClass(n0, "foo", _ctx.isActive), _toggleClass(n0, "bar", _ctx.isActive)))
+  return n0
+}"
+`;
+
 exports[`compiler v-bind > should error if empty expression 1`] = `
 "import { template as _template } from 'vue';
 const t0 = _template("<div arg>", true, true)
 
 export function render(_ctx) {
   const n0 = t0()
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > simple object class fast path 1`] = `
+"import { toggleClass as _toggleClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _toggleClass(n0, "active", _ctx.isActive))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > static class with overlapping multi-token object class 1`] = `
+"import { setClass as _setClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _setClass(n0, ["foo", { 'foo bar': _ctx.isActive }]))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > static class with overlapping object class 1`] = `
+"import { setClass as _setClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _setClass(n0, ["bar", { bar: _ctx.isBar }]))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > static class with simple object class fast path 1`] = `
+"import { toggleClass as _toggleClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div class=foo>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _toggleClass(n0, "bar", _ctx.isBar))
+  return n0
+}"
+`;
+
+exports[`compiler v-bind > static class with simple object class fast path in reverse order 1`] = `
+"import { toggleClass as _toggleClass, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div class=foo>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _toggleClass(n0, "bar", _ctx.isBar))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -202,7 +202,7 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: v-for > selector pattern 4`] = `
-"import { setClass as _setClass, createFor as _createFor, template as _template } from 'vue';
+"import { toggleClass as _toggleClass, createFor as _createFor, template as _template } from 'vue';
 const t0 = _template("<tr>")
 
 export function render(_ctx) {
@@ -210,7 +210,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
     const n2 = t0()
     _selector0_0(() => {
-      _setClass(n2, { danger: _for_item0.value.id === _ctx.selected })
+      _toggleClass(n2, "danger", _for_item0.value.id === _ctx.selected)
     })
     return n2
   }, (row) => (row.id), undefined, ({ createSelector }) => {

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -62,6 +62,25 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: v-for > multi class toggle with repeated v-for value 1`] = `
+"import { toggleClass as _toggleClass, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n0 = _createFor(() => (_ctx.todos), (_for_item0) => {
+    const n2 = t0()
+    _renderEffect(() => {
+      const _todo = _for_item0.value
+      
+      _toggleClass(n2, "completed", _todo.completed)
+      _toggleClass(n2, "editing", _todo === _ctx.editedTodo)
+    })
+    return n2
+  }, (todo) => (todo.id))
+  return n0
+}"
+`;
+
 exports[`compiler: v-for > multi effect 1`] = `
 "import { setProp as _setProp, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
 const t0 = _template("<div>")

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -952,11 +952,6 @@ describe('compiler: element transform', () => {
               values: [
                 {
                   type: NodeTypes.SIMPLE_EXPRESSION,
-                  content: `foo`,
-                  isStatic: true,
-                },
-                {
-                  type: NodeTypes.SIMPLE_EXPRESSION,
                   content: `{ bar: isBar }`,
                   isStatic: false,
                 },

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -721,6 +721,75 @@ describe('compiler v-bind', () => {
     expect(code).contains('_setClass(n0, _ctx.cls, true))')
   })
 
+  test('simple object class fast path', () => {
+    const { code } = compileWithVBind(`
+      <div :class="{ active: isActive }"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_toggleClass(n0, "active", _ctx.isActive)')
+    expect(code).not.contains('{ active:')
+  })
+
+  test('static class with simple object class fast path', () => {
+    const { code } = compileWithVBind(`
+      <div class="foo" :class="{ bar: isBar }"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('const t0 = _template("<div class=foo>", true)')
+    expect(code).contains('_toggleClass(n0, "bar", _ctx.isBar)')
+    expect(code).not.contains('{ bar:')
+  })
+
+  test('static class with simple object class fast path in reverse order', () => {
+    const { code } = compileWithVBind(`
+      <div :class="{ bar: isBar }" class="foo"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('const t0 = _template("<div class=foo>", true)')
+    expect(code).contains('_toggleClass(n0, "bar", _ctx.isBar)')
+    expect(code).not.contains('{ bar:')
+  })
+
+  test('multiple simple object class fast path', () => {
+    const { code } = compileWithVBind(`
+      <div :class="{ active: ok, foo: bar }"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_toggleClass(n0, "active", _ctx.ok)')
+    expect(code).contains('_toggleClass(n0, "foo", _ctx.bar)')
+    expect(code).not.contains('{ active:')
+  })
+
+  test('static class with overlapping object class', () => {
+    const { code } = compileWithVBind(`
+      <div class="bar" :class="{ bar: isBar }"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_setClass(n0, ["bar", { bar: _ctx.isBar }])')
+    expect(code).not.contains('_toggleClass')
+  })
+
+  test('object class with multi-token key', () => {
+    const { code } = compileWithVBind(`
+      <div :class="{ 'foo bar': isActive }"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains('_toggleClass(n0, "foo", _ctx.isActive)')
+    expect(code).contains('_toggleClass(n0, "bar", _ctx.isActive)')
+    expect(code).not.contains("'foo bar':")
+  })
+
+  test('static class with overlapping multi-token object class', () => {
+    const { code } = compileWithVBind(`
+      <div class="foo" :class="{ 'foo bar': isActive }"/>
+    `)
+    expect(code).matchSnapshot()
+    expect(code).contains(
+      '_setClass(n0, ["foo", { \'foo bar\': _ctx.isActive }])',
+    )
+    expect(code).not.contains('_toggleClass')
+  })
+
   test(':style w/ svg elements', () => {
     const { code } = compileWithVBind(`
       <svg :style="style"/>

--- a/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
@@ -141,6 +141,18 @@ describe('compiler: v-for', () => {
     expect(code).matchSnapshot()
   })
 
+  test('multi class toggle with repeated v-for value', () => {
+    const { code } = compileWithVFor(
+      `<div v-for="todo of todos" :key="todo.id" :class="{ completed: todo.completed, editing: todo === editedTodo }" />`,
+    )
+    expect(code).matchSnapshot()
+    expect(code).contains(`const _todo = _for_item0.value`)
+    expect(code).contains(`_toggleClass(n2, "completed", _todo.completed)`)
+    expect(code).contains(
+      `_toggleClass(n2, "editing", _todo === _ctx.editedTodo)`,
+    )
+  })
+
   test('w/o value', () => {
     const { code } = compileWithVFor(`<div v-for=" of items">item</div>`)
     expect(code).matchSnapshot()

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -74,20 +74,15 @@ export function genSetProp(
       ? genToggleClassValues(values, context)
       : undefined
   if (toggleClassValues) {
-    const calls = toggleClassValues.map(toggleClassValue =>
-      genCall(
+    return toggleClassValues.flatMap(toggleClassValue => [
+      NEWLINE,
+      ...genCall(
         [helper(helpers.toggleClass.name), null],
         `n${oper.element}`,
         JSON.stringify(toggleClassValue.className),
         toggleClassValue.value,
       ),
-    )
-    return [
-      NEWLINE,
-      toggleClassValues.length > 1 && '(',
-      ...calls.flatMap((call, i) => (i > 0 ? [', ', ...call] : call)),
-      toggleClassValues.length > 1 && ')',
-    ]
+    ])
   }
   const propValue = genPropValue(values, context)
   return [

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -1,8 +1,16 @@
 import {
   NewlineType,
   type SimpleExpressionNode,
+  createSimpleExpression,
   isSimpleIdentifier,
 } from '@vue/compiler-dom'
+import type {
+  Expression,
+  Identifier,
+  ObjectProperty,
+  StringLiteral,
+} from '@babel/types'
+import { type ParserOptions, parseExpression } from '@babel/parser'
 import type { CodegenContext } from '../generate'
 import {
   IRDynamicPropsKind,
@@ -42,6 +50,7 @@ const helpers = {
   setText: { name: 'setText' },
   setHtml: { name: 'setHtml' },
   setClass: { name: 'setClass' },
+  toggleClass: { name: 'toggleClass' },
   setStyle: { name: 'setStyle' },
   setValue: { name: 'setValue' },
   setAttr: { name: 'setAttr', needKey: true },
@@ -60,6 +69,26 @@ export function genSetProp(
     tag,
   } = oper
   const resolvedHelper = getRuntimeHelper(tag, key.content, modifier)
+  const toggleClassValues =
+    resolvedHelper.name === 'setClass' && !resolvedHelper.isSVG
+      ? genToggleClassValues(values, context)
+      : undefined
+  if (toggleClassValues) {
+    const calls = toggleClassValues.map(toggleClassValue =>
+      genCall(
+        [helper(helpers.toggleClass.name), null],
+        `n${oper.element}`,
+        JSON.stringify(toggleClassValue.className),
+        toggleClassValue.value,
+      ),
+    )
+    return [
+      NEWLINE,
+      toggleClassValues.length > 1 && '(',
+      ...calls.flatMap((call, i) => (i > 0 ? [', ', ...call] : call)),
+      toggleClassValues.length > 1 && ')',
+    ]
+  }
   const propValue = genPropValue(values, context)
   return [
     NEWLINE,
@@ -167,6 +196,84 @@ export function genPropValue(
     DELIMITERS_ARRAY,
     ...values.map(expr => genExpression(expr, context)),
   )
+}
+
+function genToggleClassValues(
+  values: SimpleExpressionNode[],
+  context: CodegenContext,
+): { className: string; value: CodeFragment[] }[] | undefined {
+  if (values.length !== 1) {
+    return
+  }
+  const simpleObjectClasses = getSimpleObjectClasses(values[0])
+  if (!simpleObjectClasses) {
+    return
+  }
+  return simpleObjectClasses.flatMap(({ classNames, value }) => {
+    const exp = createSimpleExpression(
+      values[0].content.slice(value.start! - 1, value.end! - 1),
+      false,
+      values[0].loc,
+    )
+    exp.ast = parseExpression(`(${exp.content})`, getParserOptions(context))
+    const valueCode = genExpression(exp, context)
+    return classNames.map(className => ({ className, value: valueCode }))
+  })
+}
+
+function getParserOptions(context: CodegenContext): ParserOptions {
+  return {
+    plugins: context.options.expressionPlugins
+      ? [...context.options.expressionPlugins, 'typescript']
+      : ['typescript'],
+  }
+}
+
+function getSimpleObjectClasses(
+  value: SimpleExpressionNode | undefined,
+): { classNames: string[]; value: Expression }[] | undefined {
+  const ast = value && value.ast
+  if (ast == null || ast === false || ast.type !== 'ObjectExpression') {
+    return
+  }
+  if (!ast.properties.length) {
+    return
+  }
+  const classes: { classNames: string[]; value: Expression }[] = []
+  for (const prop of ast.properties) {
+    if (prop.type !== 'ObjectProperty' || prop.computed || prop.shorthand) {
+      return
+    }
+    const classNames = getStaticClassNames(prop)
+    if (
+      !classNames ||
+      prop.value.start == null ||
+      prop.value.end == null ||
+      !isExpression(prop.value)
+    ) {
+      return
+    }
+    classes.push({ classNames, value: prop.value })
+  }
+  return classes
+}
+
+function getStaticClassNames(prop: ObjectProperty): string[] | undefined {
+  const key = prop.key as Identifier | StringLiteral
+  const value =
+    key.type === 'Identifier'
+      ? key.name
+      : key.type === 'StringLiteral'
+        ? key.value
+        : undefined
+  const classNames = value && value.trim().split(/\s+/)
+  if (classNames && classNames[0]) {
+    return classNames
+  }
+}
+
+function isExpression(value: ObjectProperty['value']): value is Expression {
+  return !value.type.endsWith('Pattern')
 }
 
 function getRuntimeHelper(

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -363,6 +363,7 @@ function transformNativeElement(
     let prevWasQuoted = false
     for (const prop of propsResult[1]) {
       const { key, values } = prop
+      const staticClass = getStaticClassForToggleClassFastPath(prop)
       // handling asset imports
       if (
         context.imports.some(imported =>
@@ -391,6 +392,24 @@ function transformNativeElement(
         } else {
           prevWasQuoted = false
         }
+      } else if (staticClass) {
+        if (!prevWasQuoted) template += ` `
+        template += key.content
+        template += (prevWasQuoted = NEEDS_QUOTES_RE.test(staticClass.content))
+          ? `="${staticClass.content.replace(/"/g, '&quot;')}"`
+          : `=${staticClass.content}`
+        context.registerEffect(
+          [staticClass.dynamic],
+          {
+            type: IRNodeTypes.SET_PROP,
+            element: context.reference(),
+            prop: extend({}, prop, {
+              values: [staticClass.dynamic],
+            }),
+            tag,
+          },
+          getEffectIndex,
+        )
       } else {
         dynamicProps.push(key.content)
         context.registerEffect(
@@ -645,6 +664,89 @@ function dedupeProperties(results: DirectiveTransformResult[]): IRProp[] {
     }
   }
   return deduped
+}
+
+function getStaticClassForToggleClassFastPath(
+  prop: IRProp,
+): { content: string; dynamic: SimpleExpressionNode } | undefined {
+  if (
+    !prop.key.isStatic ||
+    prop.key.content !== 'class' ||
+    prop.values.length !== 2
+  ) {
+    return
+  }
+  const staticIndex = prop.values.findIndex(value => value.isStatic)
+  const dynamicIndex = staticIndex === 0 ? 1 : 0
+  if (staticIndex < 0) {
+    return
+  }
+  const staticClass = prop.values[staticIndex]
+  const dynamicClass = prop.values[dynamicIndex]
+  const dynamicClassKeys =
+    dynamicClass && !dynamicClass.isStatic
+      ? getSimpleObjectClassKeys(dynamicClass)
+      : undefined
+  if (
+    !dynamicClass ||
+    dynamicClass.isStatic ||
+    !dynamicClassKeys ||
+    hasOverlappingClass(staticClass.content, dynamicClassKeys)
+  ) {
+    return
+  }
+  return { content: staticClass.content, dynamic: dynamicClass }
+}
+
+function getSimpleObjectClassKeys(
+  value: SimpleExpressionNode,
+): string[] | undefined {
+  const ast = value.ast
+  if (ast == null || ast === false || ast.type !== 'ObjectExpression') {
+    return
+  }
+  if (!ast.properties.length) {
+    return
+  }
+  const keys: string[] = []
+  for (const prop of ast.properties) {
+    const rawKey =
+      prop.type === 'ObjectProperty' && !prop.computed
+        ? prop.key.type === 'Identifier'
+          ? prop.key.name
+          : prop.key.type === 'StringLiteral'
+            ? prop.key.value
+            : undefined
+        : undefined
+    const classNames = rawKey && rawKey.trim().split(/\s+/)
+    if (
+      prop.type !== 'ObjectProperty' ||
+      prop.computed ||
+      prop.shorthand ||
+      !classNames ||
+      !classNames[0] ||
+      prop.value.start == null ||
+      prop.value.end == null ||
+      prop.value.type.endsWith('Pattern')
+    ) {
+      return
+    }
+    keys.push(...classNames)
+  }
+  return keys
+}
+
+function hasOverlappingClass(
+  staticClass: string,
+  dynamicKeys: string[],
+): boolean {
+  const staticClassSet = new Set(staticClass.trim().split(/\s+/))
+  for (const key of dynamicKeys) {
+    if (staticClassSet.has(key)) {
+      return true
+    }
+  }
+  return false
 }
 
 function resolveDirectiveResult(prop: DirectiveTransformResult): IRProp {

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -11,6 +11,7 @@ import {
   setProp,
   setText,
   setValue,
+  toggleClass,
 } from '../../src/dom/prop'
 import { setStyle } from '../../src/dom/prop'
 import { VaporComponentInstance, createComponent } from '../../src/component'
@@ -45,6 +46,23 @@ describe('patchProp', () => {
       expect(el.className).toBe('bar baz')
       setClass(el, { a: true, b: false })
       expect(el.className).toBe('a')
+    })
+  })
+
+  describe('toggleClass', () => {
+    test('should skip unchanged values', () => {
+      const el = document.createElement('div')
+      const toggle = vi.spyOn(el.classList, 'toggle')
+
+      toggleClass(el, 'active', true)
+      toggleClass(el, 'active', true)
+      expect(toggle).toHaveBeenCalledTimes(1)
+      expect(el.classList.contains('active')).toBe(true)
+
+      toggleClass(el, 'active', false)
+      toggleClass(el, 'active', false)
+      expect(toggle).toHaveBeenCalledTimes(2)
+      expect(el.classList.contains('active')).toBe(false)
     })
   })
 

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -50,6 +50,7 @@ type TargetElement = Element & {
   $root?: true
   $html?: string
   $cls?: string
+  $tcls?: Record<string, boolean>
   $sty?: NormalizedStyle | string | undefined
   value?: string
   _value?: any
@@ -204,15 +205,22 @@ export function setClass(
 
 export function toggleClass(el: TargetElement, name: string, value: any): void {
   value = !!value
+  const cache = el.$tcls || (el.$tcls = Object.create(null))
+  if (cache[name] === value) {
+    return
+  }
+
   if (
     (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
     isHydrating &&
     !toggleClassHasMismatch(el, name, value)
   ) {
+    cache[name] = value
     return
   }
 
   el.classList.toggle(name, value)
+  cache[name] = value
 }
 
 function setClassIncremental(el: any, value: any): void {
@@ -565,6 +573,7 @@ export function optimizePropertyLookup(): void {
   proto.$fc = proto.$evtclick = undefined
   proto.$root = false
   proto.$html = proto.$cls = proto.$sty = ''
+  proto.$tcls = undefined
   // Initialize $txt to undefined instead of empty string to ensure setText()
   // properly updates the text node even when the value is empty string.
   // This prevents issues where setText(node, '') would be skipped because

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -202,6 +202,19 @@ export function setClass(
   }
 }
 
+export function toggleClass(el: TargetElement, name: string, value: any): void {
+  value = !!value
+  if (
+    (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
+    isHydrating &&
+    !toggleClassHasMismatch(el, name, value)
+  ) {
+    return
+  }
+
+  el.classList.toggle(name, value)
+}
+
 function setClassIncremental(el: any, value: any): void {
   const cacheKey = `$clsi${isApplyingFallthroughProps ? '$' : ''}`
   const normalizedValue = normalizeClass(value)
@@ -586,6 +599,28 @@ function classHasMismatch(
   }
 
   return false
+}
+
+function toggleClassHasMismatch(
+  el: TargetElement,
+  name: string,
+  value: boolean,
+): boolean {
+  const actual = el.getAttribute('class')
+  const actualClassSet = toClassSet(actual || '')
+  if (actualClassSet.has(name) === value) {
+    return false
+  }
+
+  if (value) {
+    actualClassSet.add(name)
+  } else {
+    actualClassSet.delete(name)
+  }
+  const expected = Array.from(actualClassSet).join(' ')
+  warnPropMismatch(el, 'class', MismatchTypes.CLASS, actual, expected)
+  logMismatchError()
+  return true
 }
 
 function styleHasMismatch(

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -39,6 +39,7 @@ export {
   setHtml,
   setBlockHtml,
   setClass,
+  toggleClass,
   setStyle,
   setAttr,
   setValue,


### PR DESCRIPTION
Compile simple object class bindings to direct classList toggles in Vapor, avoiding the normalizeClass/setClass path for common static-key cases. Static class tokens stay in the template when safe, multi-token keys are split at compile time, and overlapping static/dynamic tokens fall back to setClass to preserve behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimized `:class` directive with object syntax to prevent redundant DOM updates when values remain unchanged.
  * Improved handling of combined static and dynamic class bindings for better performance.

* **Tests**
  * Added comprehensive test coverage for class binding scenarios, including v-for loops and object syntax combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->