### PR TITLE
fix(compiler-sfc): resolve type re-exports inside declare global

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1533,6 +1533,30 @@ describe('resolveType', () => {
       })
     })
 
+    test('global types with re-exports preserve source-module scope', () => {
+      const files = {
+        '/types.ts': `export type Name = string`,
+        '/foo.ts': `
+          import type { Name } from './types'
+          export interface Foo { name: Name }
+        `,
+        '/global.d.ts': `
+          declare global {
+            export type { Foo } from './foo'
+          }
+          export {}
+        `,
+      }
+
+      expect(
+        resolve(`defineProps<Foo>()`, files, {
+          globalTypeFiles: ['/global.d.ts'],
+        }).props,
+      ).toStrictEqual({
+        name: ['String'],
+      })
+    })
+
     test('global types with ambient references', () => {
       const files = {
         // with references

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1497,6 +1497,42 @@ describe('resolveType', () => {
       })
     })
 
+    test('global types with re-exports', () => {
+      const files = {
+        '/foo.ts': `export interface Foo { foo: number }`,
+        '/bar.ts': `export interface Bar { bar: boolean }`,
+        '/baz.ts': `export interface Baz { baz: string }`,
+        '/global.d.ts': `
+          declare global {
+            export type { Foo } from './foo'
+            export { Bar } from './bar'
+            export * from './baz'
+          }
+          export {}
+        `,
+      }
+
+      const globalTypeFiles = { globalTypeFiles: ['/global.d.ts'] }
+
+      expect(
+        resolve(`defineProps<Foo>()`, files, globalTypeFiles).props,
+      ).toStrictEqual({
+        foo: ['Number'],
+      })
+
+      expect(
+        resolve(`defineProps<Bar>()`, files, globalTypeFiles).props,
+      ).toStrictEqual({
+        bar: ['Boolean'],
+      })
+
+      expect(
+        resolve(`defineProps<Baz>()`, files, globalTypeFiles).props,
+      ).toStrictEqual({
+        baz: ['String'],
+      })
+    })
+
     test('global types with ambient references', () => {
       const files = {
         // with references

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1557,6 +1557,31 @@ describe('resolveType', () => {
       })
     })
 
+    test('global types with re-exports track source deps after cache reuse', () => {
+      const files = {
+        '/foo.ts': `export interface Foo { foo: number }`,
+        '/global.d.ts': `
+          declare global {
+            export type { Foo } from './foo'
+          }
+          export {}
+        `,
+      }
+      const globalTypeFiles = { globalTypeFiles: ['/global.d.ts'] }
+
+      resolve(`defineProps<Foo>()`, files, globalTypeFiles)
+
+      const { deps } = resolve(
+        `defineProps<Foo>()`,
+        files,
+        globalTypeFiles,
+        '/Other.vue',
+        false,
+      )
+
+      expect(deps && [...deps]).toStrictEqual(['/global.d.ts', '/foo.ts'])
+    })
+
     test('global types with ambient references', () => {
       const files = {
         // with references

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1514,23 +1514,32 @@ describe('resolveType', () => {
 
       const globalTypeFiles = { globalTypeFiles: ['/global.d.ts'] }
 
-      expect(
-        resolve(`defineProps<Foo>()`, files, globalTypeFiles).props,
-      ).toStrictEqual({
+      const fooRes = resolve(`defineProps<Foo>()`, files, globalTypeFiles)
+      expect(fooRes.props).toStrictEqual({
         foo: ['Number'],
       })
+      expect(fooRes.deps && [...fooRes.deps]).toStrictEqual([
+        '/global.d.ts',
+        '/foo.ts',
+      ])
 
-      expect(
-        resolve(`defineProps<Bar>()`, files, globalTypeFiles).props,
-      ).toStrictEqual({
+      const barRes = resolve(`defineProps<Bar>()`, files, globalTypeFiles)
+      expect(barRes.props).toStrictEqual({
         bar: ['Boolean'],
       })
+      expect(barRes.deps && [...barRes.deps]).toStrictEqual([
+        '/global.d.ts',
+        '/bar.ts',
+      ])
 
-      expect(
-        resolve(`defineProps<Baz>()`, files, globalTypeFiles).props,
-      ).toStrictEqual({
+      const bazRes = resolve(`defineProps<Baz>()`, files, globalTypeFiles)
+      expect(bazRes.props).toStrictEqual({
         baz: ['String'],
       })
+      expect(bazRes.deps && [...bazRes.deps]).toStrictEqual([
+        '/global.d.ts',
+        '/baz.ts',
+      ])
     })
 
     test('global types with re-exports preserve source-module scope', () => {

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1566,6 +1566,33 @@ describe('resolveType', () => {
       })
     })
 
+    test('global types with re-exports from package directory', () => {
+      const files = {
+        '/node_modules/pkg/package.json': `{ "types": "dist/index.d.ts" }`,
+        '/node_modules/pkg/dist/index.d.ts': `
+          export interface PackageType { value: string }
+        `,
+        '/global.d.ts': `
+          declare global {
+            export type { PackageType } from './node_modules/pkg'
+          }
+          export {}
+        `,
+      }
+
+      const { props, deps } = resolve(`defineProps<PackageType>()`, files, {
+        globalTypeFiles: ['/global.d.ts'],
+      })
+
+      expect(props).toStrictEqual({
+        value: ['String'],
+      })
+      expect(deps && [...deps]).toStrictEqual([
+        '/global.d.ts',
+        '/node_modules/pkg/dist/index.d.ts',
+      ])
+    })
+
     test('global types with re-exports track source deps after cache reuse', () => {
       const files = {
         '/foo.ts': `export interface Foo { foo: number }`,

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1595,7 +1595,13 @@ describe('resolveType', () => {
 
     test('global types with re-exports track source deps after cache reuse', () => {
       const files = {
-        '/foo.ts': `export interface Foo { foo: number }`,
+        '/base.ts': `export interface Base { age: number }`,
+        '/types.ts': `export type Name = string`,
+        '/foo.ts': `
+          import type { Base } from './base'
+          import type { Name } from './types'
+          export interface Foo extends Base { name: Name }
+        `,
         '/global.d.ts': `
           declare global {
             export type { Foo } from './foo'
@@ -1604,8 +1610,14 @@ describe('resolveType', () => {
         `,
       }
       const globalTypeFiles = { globalTypeFiles: ['/global.d.ts'] }
+      const expectedDeps = ['/global.d.ts', '/foo.ts', '/base.ts', '/types.ts']
 
-      resolve(`defineProps<Foo>()`, files, globalTypeFiles)
+      const { deps: coldDeps } = resolve(
+        `defineProps<Foo>()`,
+        files,
+        globalTypeFiles,
+      )
+      expect(coldDeps && [...coldDeps]).toStrictEqual(expectedDeps)
 
       const { deps } = resolve(
         `defineProps<Foo>()`,
@@ -1615,7 +1627,7 @@ describe('resolveType', () => {
         false,
       )
 
-      expect(deps && [...deps]).toStrictEqual(['/global.d.ts', '/foo.ts'])
+      expect(deps && [...deps]).toStrictEqual(expectedDeps)
     })
 
     test('global types with ambient references', () => {

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1337,9 +1337,43 @@ function recordTypes(
         }
       } else if (stmt.type === 'TSModuleDeclaration' && stmt.global) {
         for (const s of (stmt.body as TSModuleBlock).body) {
-          if (s.type === 'ExportNamedDeclaration' && s.declaration) {
-            // Handle export declarations inside declare global
-            recordType(s.declaration, types, declares)
+          if (s.type === 'ExportNamedDeclaration') {
+            if (s.declaration) {
+              // Handle export declarations inside declare global
+              recordType(s.declaration, types, declares)
+            } else if (s.source) {
+              // Handle re-exports inside declare global, e.g.
+              // `export type { Foo } from './foo'`. Global lookup only checks
+              // `types`/`declares`, so resolve the source eagerly.
+              const sourceScope = importSourceToScope(
+                ctx,
+                s.source,
+                scope,
+                s.source.value,
+              )
+              for (const spec of s.specifiers) {
+                if (spec.type === 'ExportSpecifier') {
+                  const exported = getId(spec.exported)
+                  const local = spec.local.name
+                  if (sourceScope.exportedTypes[local]) {
+                    types[exported] = sourceScope.exportedTypes[local]
+                  }
+                  if (sourceScope.exportedDeclares[local]) {
+                    declares[exported] = sourceScope.exportedDeclares[local]
+                  }
+                }
+              }
+            }
+          } else if (s.type === 'ExportAllDeclaration' && s.source) {
+            // Handle `export * from './foo'` inside declare global
+            const sourceScope = importSourceToScope(
+              ctx,
+              s.source,
+              scope,
+              s.source.value,
+            )
+            Object.assign(types, sourceScope.exportedTypes)
+            Object.assign(declares, sourceScope.exportedDeclares)
           } else {
             recordType(s, types, declares)
           }

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1440,11 +1440,11 @@ function recordTypes(
   }
   for (const key of Object.keys(types)) {
     const node = types[key]
-    node._ownerScope = scope
-    if (node._ns) node._ns._ownerScope = scope
+    if (!node._ownerScope) node._ownerScope = scope
+    if (node._ns && !node._ns._ownerScope) node._ns._ownerScope = scope
   }
   for (const key of Object.keys(declares)) {
-    declares[key]._ownerScope = scope
+    if (!declares[key]._ownerScope) declares[key]._ownerScope = scope
   }
 }
 

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -973,6 +973,14 @@ function importSourceToScope(
       }
       resolved = resolveWithTS(scope.filename, source, ts, fs)
     }
+    if (!resolved && source[0] === '.' && __CJS__) {
+      if (!ts) {
+        if (loadTS) ts = loadTS()
+      }
+      if (ts) {
+        resolved = resolveWithTS(scope.filename, source, ts, fs)
+      }
+    }
     if (resolved) {
       resolved = scope.resolvedImportSources[source] = normalizePath(resolved)
     }

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -143,6 +143,24 @@ interface ResolvedElements {
   calls?: (TSCallSignatureDeclaration | TSFunctionType)[]
 }
 
+function recordScopeDep(
+  ctx: TypeResolveContext,
+  scope: TypeScope | undefined,
+): void {
+  if (scope && scope.filename !== ctx.filename) {
+    ;(ctx.deps || (ctx.deps = new Set())).add(scope.filename)
+  }
+}
+
+function recordResolvedElementDeps(
+  ctx: TypeResolveContext,
+  { props }: ResolvedElements,
+): void {
+  for (const key in props) {
+    recordScopeDep(ctx, props[key]._ownerScope)
+  }
+}
+
 /**
  * Resolve arbitrary type node to a list of type elements that can be then
  * mapped to runtime props or emits.
@@ -155,6 +173,7 @@ export function resolveTypeElements(
 ): ResolvedElements {
   const canCache = !typeParameters
   if (canCache && node._resolvedElements) {
+    recordResolvedElementDeps(ctx, node._resolvedElements)
     return node._resolvedElements
   }
   const resolved = innerResolveTypeElements(
@@ -738,6 +757,7 @@ function resolveTypeReference(
 ): ScopeTypeNode | undefined {
   const canCache = !scope?.isGenericScope
   if (canCache && node._resolvedReference) {
+    recordScopeDep(ctx, node._resolvedReference._ownerScope)
     return node._resolvedReference
   }
   const resolved = innerResolveTypeReference(

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -922,6 +922,7 @@ function importSourceToScope(
   node: Node,
   scope: TypeScope,
   source: string,
+  trackDep = true,
 ): TypeScope {
   let fs: FS | undefined
   try {
@@ -978,7 +979,9 @@ function importSourceToScope(
   }
   if (resolved) {
     // (hmr) register dependency file on ctx
-    ;(ctx.deps || (ctx.deps = new Set())).add(resolved)
+    if (trackDep) {
+      ;(ctx.deps || (ctx.deps = new Set())).add(resolved)
+    }
     return fileToScope(ctx, resolved)
   } else {
     return ctx.error(
@@ -1354,6 +1357,7 @@ function recordTypes(
                 s.source,
                 scope,
                 s.source.value,
+                false,
               )
               for (const spec of s.specifiers) {
                 if (spec.type === 'ExportSpecifier') {
@@ -1375,6 +1379,7 @@ function recordTypes(
               s.source,
               scope,
               s.source.value,
+              false,
             )
             Object.assign(types, sourceScope.exportedTypes)
             Object.assign(declares, sourceScope.exportedDeclares)

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -779,7 +779,11 @@ function innerResolveTypeReference(
             const src = node.type === 'TSTypeQuery' ? s.declares : s.types
             if (src[name]) {
               ;(ctx.deps || (ctx.deps = new Set())).add(s.filename)
-              return src[name]
+              const resolved = src[name]
+              if (resolved._ownerScope && resolved._ownerScope !== s) {
+                ctx.deps.add(resolved._ownerScope.filename)
+              }
+              return resolved
             }
           }
         }


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/30213

this was an omission in my earlier pr https://github.com/vuejs/core/pull/13789

this now handles both named exports and star exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of re‑exported global types so runtime type inference uses the original source scope and correctly records source-file dependencies, including across cache reuse.

* **Tests**
  * Added tests validating re‑exported global types, preservation of source‑module scope, dependency tracking (including after cache reuse), and resolution of re‑exports from package directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->