### PR TITLE
fix(runtime-vapor): guard VaporSlot when vnode.vs is undefined

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -3659,12 +3659,43 @@ describe('vdomInterop', () => {
       const root = document.createElement('div')
       const app = createApp(App)
       app.use(vaporInteropPlugin)
+      const errorHandler = vi.fn()
+      app.config.errorHandler = errorHandler
 
       expect(() => app.mount(root)).not.toThrow()
 
       tick.value++
       await nextTick()
       expect(root.childNodes.length).toBeGreaterThan(0)
+      expect(errorHandler).not.toHaveBeenCalled()
+      app.unmount()
+    })
+
+    test('mount and update do not throw when vs slot is missing', async () => {
+      const tick = ref(0)
+      const App = defineComponent({
+        setup() {
+          return () => {
+            tick.value
+            const vnode = createVNode(VaporSlot, {})
+            ;(vnode as any).vs = {}
+            return vnode
+          }
+        },
+      })
+
+      const root = document.createElement('div')
+      const app = createApp(App)
+      app.use(vaporInteropPlugin)
+      const errorHandler = vi.fn()
+      app.config.errorHandler = errorHandler
+
+      expect(() => app.mount(root)).not.toThrow()
+
+      tick.value++
+      await nextTick()
+      expect(errorHandler).not.toHaveBeenCalled()
+      app.unmount()
     })
   })
 

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -30,6 +30,7 @@ import {
   vShow,
   withDirectives,
 } from '@vue/runtime-dom'
+import { VaporSlot } from '../../runtime-core/src/vnode'
 import { makeInteropRender } from './_utils'
 import {
   VaporKeepAlive,
@@ -3638,6 +3639,32 @@ describe('vdomInterop', () => {
 
       await nextTick()
       expect(html()).toContain('<span>resolved</span>')
+    })
+  })
+
+  describe('VaporSlot vnode vs metadata', () => {
+    test('mount and update do not throw when vs is missing (nuxt/ui #6395)', async () => {
+      const tick = ref(0)
+      const App = defineComponent({
+        setup() {
+          return () => {
+            tick.value
+            const vnode = createVNode(VaporSlot, {})
+            delete (vnode as any).vs
+            return vnode
+          }
+        },
+      })
+
+      const root = document.createElement('div')
+      const app = createApp(App)
+      app.use(vaporInteropPlugin)
+
+      expect(() => app.mount(root)).not.toThrow()
+
+      tick.value++
+      await nextTick()
+      expect(root.childNodes.length).toBeGreaterThan(0)
     })
   })
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -352,7 +352,8 @@ const vaporInteropImpl: Omit<
       // update
       // slot function changed (e.g. dynamic slots from _createForSlots),
       // need to re-mount the vapor block
-      if (n2.vs!.slot !== n1.vs!.slot) {
+      const needsRemount = !n1.vs || !n2.vs || n2.vs.slot !== n1.vs.slot
+      if (needsRemount) {
         const selfAnchor = n1.anchor as Node
         const parent = selfAnchor.parentNode as ParentNode
         const nextSibling = selfAnchor.nextSibling
@@ -377,10 +378,12 @@ const vaporInteropImpl: Omit<
         insert((n2.el = n2.anchor = newAnchor), parent, insertAnchor)
         insert((n2.vb = slotBlock), parent, newAnchor)
       } else {
+        const vs1 = n1.vs!
+        const vs2 = n2.vs!
         n2.el = n2.anchor = n1.anchor
         n2.vb = n1.vb
-        ;(n2.vs!.ref = n1.vs!.ref)!.value = n2.props
-        n2.vs!.scope = n1.vs!.scope
+        ;(vs2.ref = vs1.ref)!.value = n2.props
+        vs2.scope = vs1.scope
         syncInteropVaporSlotState(n1, n2)
       }
     }
@@ -1607,6 +1610,9 @@ function renderVaporSlot(
     prevSuspense = setParentSuspense(parentSuspense)
   }
   try {
+    if (!vnode.vs || !vnode.vs.slot) {
+      return []
+    }
     const slotState = resolveInteropVaporSlotState(vnode)
     // Most of the interop setup is shared, but slots that start with a local
     // VDOM fallback still need to let an inner SlotFragment own the active

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -352,7 +352,12 @@ const vaporInteropImpl: Omit<
       // update
       // slot function changed (e.g. dynamic slots from _createForSlots),
       // need to re-mount the vapor block
-      const needsRemount = !n1.vs || !n2.vs || n2.vs.slot !== n1.vs.slot
+      const needsRemount =
+        !n1.vs ||
+        !n2.vs ||
+        !n1.vs.slot ||
+        !n2.vs.slot ||
+        n2.vs.slot !== n1.vs.slot
       if (needsRemount) {
         const selfAnchor = n1.anchor as Node
         const parent = selfAnchor.parentNode as ParentNode


### PR DESCRIPTION
Fixes a runtime error when Vapor/VDOM interop leaves `VaporSlot` vnodes without vapor slot metadata (`vnode.vs` / missing slot function), e.g. when using VDOM component libraries (Nuxt UI) from Vapor parents (https://github.com/nuxt/ui/issues/6395).

- Return an empty block from `renderVaporSlot` when `vnode.vs` or `vnode.vs.slot` is missing, before resolving interop slot state
- Remount the slot when either side of an update lacks `vs` or the slot function changes
- Add regression test

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot component handling stability during updates.
  * Fixed potential issues when slot state information is missing.
  * Enhanced slot remounting detection for accurate updates.

* **Tests**
  * Added regression test coverage for slot component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->