### PR TITLE
fix(compiler-vapor): preserve useId evaluation order before dynamic boundaries

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -149,7 +149,7 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 `;
 
 exports[`compile > directives > v-pre > should not affect siblings after it 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, child as _child, setProp as _setProp, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, setProp as _setProp, renderEffect as _renderEffect, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, child as _child, toDisplayString as _toDisplayString, setText as _setText, template as _template } from 'vue';
 const t0 = _template("<div :id=foo><Comp></Comp>{{ bar }}", false, true)
 const t1 = _template("<div> ")
 
@@ -158,12 +158,10 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
   const n3 = t1()
   const n2 = _child(n3, 1)
+  _renderEffect(() => _setProp(n3, "id", _ctx.foo))
   _setInsertionState(n3, 0, 0, true)
   const n1 = _createComponentWithFallback(_component_Comp)
-  _renderEffect(() => {
-    _setProp(n3, "id", _ctx.foo)
-    _setText(n2, _toDisplayString(_ctx.bar))
-  })
+  _renderEffect(() => _setText(n2, _toDisplayString(_ctx.bar)))
   return [n0, n3]
 }"
 `;
@@ -209,6 +207,62 @@ export function render(_ctx) {
     _setText(x0, _toDisplayString(_ctx.bar))
   })
   return n0
+}"
+`;
+
+exports[`compile > execution order > does not flush later v-for effects before child component 1`] = `
+"import { resolveComponent as _resolveComponent, child as _child, next as _next, txt as _txt, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
+const t0 = _template("<div><span> </span><!><span> ")
+
+export function render(_ctx, $props, $emit, $attrs, $slots) {
+  const _component_Child = _resolveComponent("Child")
+  let _selector0_0
+  const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
+    const n6 = t0()
+    const n2 = _child(n6)
+    const n5 = _next(n2, 1)
+    const n4 = _next(n5, 2)
+    const x2 = _txt(n2)
+    _setInsertionState(n6, n5, 1, true)
+    const n3 = _createComponentWithFallback(_component_Child)
+    const x4 = _txt(n4)
+    _renderEffect(() => _setText(x4, _toDisplayString(_ctx.useId())))
+    _selector0_0(() => {
+      _setText(x2, _toDisplayString(_ctx.selected === _for_item0.value.id ? 'danger' : ''))
+    })
+    return n6
+  }, (row) => (row.id), undefined, ({ createSelector }) => {
+    _selector0_0 = createSelector(() => _ctx.selected)
+  })
+  return n0
+}"
+`;
+
+exports[`compile > execution order > flushes parent props before creating child component 1`] = `
+"import { resolveComponent as _resolveComponent, setProp as _setProp, renderEffect as _renderEffect, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, template as _template } from 'vue';
+const t0 = _template("<div>", true)
+
+export function render(_ctx, $props, $emit, $attrs, $slots) {
+  const _component_Child = _resolveComponent("Child")
+  const n1 = t0()
+  _renderEffect(() => _setProp(n1, "id", _ctx.useId()))
+  _setInsertionState(n1, null, 0, true)
+  const n0 = _createComponentWithFallback(_component_Child)
+  return n1
+}"
+`;
+
+exports[`compile > execution order > flushes previous effects before creating child component 1`] = `
+"import { resolveComponent as _resolveComponent, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createComponentWithFallback as _createComponentWithFallback, template as _template } from 'vue';
+const t0 = _template("<div> ")
+
+export function render(_ctx, $props, $emit, $attrs, $slots) {
+  const _component_Child = _resolveComponent("Child")
+  const n0 = t0()
+  const x0 = _txt(n0)
+  _renderEffect(() => _setText(x0, "parent: " + _toDisplayString(_ctx.useId())))
+  const n1 = _createComponentWithFallback(_component_Child)
+  return [n0, n1]
 }"
 `;
 

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -245,6 +245,54 @@ describe('compile', () => {
       )
     })
 
+    test('flushes previous effects before creating child component', () => {
+      const code = compile(`<div>parent: {{ useId() }}</div><Child />`, {
+        bindingMetadata: {
+          useId: BindingTypes.SETUP_CONST,
+        },
+      })
+      expect(code).matchSnapshot()
+      expect(code).contains(
+        `_renderEffect(() => _setText(x0, "parent: " + _toDisplayString(_ctx.useId())))
+  const n1 = _createComponentWithFallback(_component_Child)`,
+      )
+    })
+
+    test('flushes parent props before creating child component', () => {
+      const code = compile(`<div :id="useId()"><Child /></div>`, {
+        bindingMetadata: {
+          useId: BindingTypes.SETUP_CONST,
+        },
+      })
+      expect(code).contains(
+        `_renderEffect(() => _setProp(n1, "id", _ctx.useId()))
+  _setInsertionState(n1, null, 0, true)
+  const n0 = _createComponentWithFallback(_component_Child)`,
+      )
+      expect(code).matchSnapshot()
+    })
+
+    test('does not flush later v-for effects before child component', () => {
+      const code = compile(
+        `<div v-for="row of rows" :key="row.id">
+          <span>{{ selected === row.id ? 'danger' : '' }}</span>
+          <Child />
+          <span>{{ useId() }}</span>
+        </div>`,
+        {
+          bindingMetadata: {
+            useId: BindingTypes.SETUP_CONST,
+          },
+        },
+      )
+      expect(code).matchSnapshot()
+      expect(code).contains(
+        `const n3 = _createComponentWithFallback(_component_Child)
+    const x4 = _txt(n4)
+    _renderEffect(() => _setText(x4, _toDisplayString(_ctx.useId())))`,
+      )
+    })
+
     describe('setInsertionState', () => {
       test('next, child and nthChild should be above the setInsertionState', () => {
         const code = compile(`

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -1,4 +1,5 @@
-import type { BlockIRNode, CoreHelper } from '../ir'
+import type { BlockIRNode, CoreHelper, IRDynamicInfo } from '../ir'
+import { isBlockOperation } from '../ir'
 import {
   type CodeFragment,
   DELIMITERS_ARRAY,
@@ -10,7 +11,11 @@ import {
   genMulti,
 } from './utils'
 import type { CodegenContext } from '../generate'
-import { genEffects, genOperations } from './operation'
+import {
+  genEffects,
+  genOperationWithInsertionState,
+  genOperations,
+} from './operation'
 import { genChildren, genSelf } from './template'
 import { toValidAssetId } from '@vue/compiler-dom'
 
@@ -61,17 +66,70 @@ export function genBlockContent(
     genResolveAssets('directive', 'resolveDirective')
   }
 
-  for (const child of dynamic.children) {
-    push(...genSelf(child, context))
+  let operationIndex = 0
+  let effectIndex = 0
+  const flushPendingOperations = (
+    operationEnd: number,
+    effectEnd: number,
+    push: (...items: CodeFragment[]) => number,
+  ) => {
+    while (operationIndex < operationEnd) {
+      push(
+        ...genOperationWithInsertionState(operation[operationIndex], context),
+      )
+      operationIndex++
+    }
+
+    if (effectIndex < effectEnd) {
+      push(...genEffects(effect.slice(effectIndex, effectEnd), context))
+      effectIndex = effectEnd
+    }
   }
-  for (const child of dynamic.children) {
-    if (!child.hasDynamicChild) {
-      push(...genChildren(child, context, push, `n${child.id!}`))
+  const flushBeforeDynamic = (
+    dynamic: IRDynamicInfo,
+    push: (...items: CodeFragment[]) => number,
+  ) => {
+    const operation = dynamic.operation
+    if (
+      operation &&
+      isBlockOperation(operation) &&
+      operation.operationIndex !== undefined &&
+      operation.effectIndex !== undefined
+    ) {
+      flushPendingOperations(
+        operation.operationIndex,
+        operation.effectIndex,
+        push,
+      )
     }
   }
 
-  push(...genOperations(operation, context))
-  push(...genEffects(effect, context, genEffectsExtraFrag))
+  for (const child of dynamic.children) {
+    flushBeforeDynamic(child, push)
+    push(...genSelf(child, context, flushBeforeDynamic))
+  }
+  for (const child of dynamic.children) {
+    if (!child.hasDynamicChild) {
+      push(
+        ...genChildren(
+          child,
+          context,
+          push,
+          `n${child.id!}`,
+          flushBeforeDynamic,
+        ),
+      )
+    }
+  }
+
+  if (operationIndex < operation.length) {
+    push(...genOperations(operation.slice(operationIndex), context))
+  }
+  if (effectIndex < effect.length) {
+    push(...genEffects(effect.slice(effectIndex), context, genEffectsExtraFrag))
+  } else if (genEffectsExtraFrag) {
+    push(...genEffects([], context, genEffectsExtraFrag))
+  }
 
   push(NEWLINE, `return `)
 

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -6,7 +6,13 @@ import {
 import { genBlockContent } from './block'
 import { genExpression } from './expression'
 import type { CodegenContext } from '../generate'
-import type { BlockIRNode, ForIRNode, IREffect } from '../ir'
+import {
+  type BlockIRNode,
+  type ForIRNode,
+  type IRDynamicInfo,
+  type IREffect,
+  isBlockOperation,
+} from '../ir'
 import {
   type CodeFragment,
   INDENT_END,
@@ -333,17 +339,20 @@ function matchPatterns(
   const keyOnlyBindingPatterns: NonNullable<
     ReturnType<typeof matchKeyOnlyBindingPattern>
   >[] = []
+  const removedEffectIndexes: number[] = []
 
-  render.effect = render.effect.filter(effect => {
+  render.effect = render.effect.filter((effect, index) => {
     if (keyProp !== undefined) {
       const selector = matchSelectorPattern(effect, keyProp.content, idMap)
       if (selector) {
         selectorPatterns.push(selector)
+        removedEffectIndexes.push(index)
         return false
       }
       const keyOnly = matchKeyOnlyBindingPattern(effect, keyProp.content)
       if (keyOnly) {
         keyOnlyBindingPatterns.push(keyOnly)
+        removedEffectIndexes.push(index)
         return false
       }
     }
@@ -351,9 +360,39 @@ function matchPatterns(
     return true
   })
 
+  if (removedEffectIndexes.length) {
+    shiftEffectBoundaries(render.dynamic, removedEffectIndexes)
+  }
+
   return {
     keyOnlyBindingPatterns,
     selectorPatterns,
+  }
+}
+
+function shiftEffectBoundaries(
+  dynamic: IRDynamicInfo,
+  removedEffectIndexes: number[],
+): void {
+  const operation = dynamic.operation
+  if (
+    operation &&
+    isBlockOperation(operation) &&
+    operation.effectIndex !== undefined
+  ) {
+    let offset = 0
+    for (const removedIndex of removedEffectIndexes) {
+      if (removedIndex < operation.effectIndex) {
+        offset++
+      } else {
+        break
+      }
+    }
+    operation.effectIndex -= offset
+  }
+
+  for (const child of dynamic.children) {
+    shiftEffectBoundaries(child, removedEffectIndexes)
   }
 }
 

--- a/packages/compiler-vapor/src/generators/template.ts
+++ b/packages/compiler-vapor/src/generators/template.ts
@@ -43,9 +43,15 @@ export function genTemplates(
   return result.join('')
 }
 
+type FlushBeforeDynamic = (
+  dynamic: IRDynamicInfo,
+  push: (...items: CodeFragment[]) => number,
+) => void
+
 export function genSelf(
   dynamic: IRDynamicInfo,
   context: CodegenContext,
+  flushBeforeDynamic?: FlushBeforeDynamic,
 ): CodeFragment[] {
   const [frag, push] = buildCodeFragment()
   const { id, template, operation, hasDynamicChild } = dynamic
@@ -60,7 +66,7 @@ export function genSelf(
   }
 
   if (hasDynamicChild) {
-    push(...genChildren(dynamic, context, push, `n${id}`))
+    push(...genChildren(dynamic, context, push, `n${id}`, flushBeforeDynamic))
   }
 
   return frag
@@ -71,6 +77,7 @@ export function genChildren(
   context: CodegenContext,
   pushBlock: (...items: CodeFragment[]) => number,
   from: string = `n${dynamic.id}`,
+  flushBeforeDynamic?: FlushBeforeDynamic,
 ): CodeFragment[] {
   const { helper } = context
   const [frag, push] = buildCodeFragment()
@@ -85,7 +92,8 @@ export function genChildren(
     }
 
     if (child.flags & DynamicFlag.INSERT && child.template != null) {
-      push(...genSelf(child, context))
+      flushBeforeDynamic && flushBeforeDynamic(child, push)
+      push(...genSelf(child, context, flushBeforeDynamic))
       continue
     }
 
@@ -97,7 +105,8 @@ export function genChildren(
         : undefined
 
     if (id === undefined && !child.hasDynamicChild) {
-      push(...genSelf(child, context))
+      flushBeforeDynamic && flushBeforeDynamic(child, push)
+      push(...genSelf(child, context, flushBeforeDynamic))
       continue
     }
 
@@ -150,7 +159,8 @@ export function genChildren(
     }
 
     if (id === child.anchor && !child.hasDynamicChild) {
-      push(...genSelf(child, context))
+      flushBeforeDynamic && flushBeforeDynamic(child, push)
+      push(...genSelf(child, context, flushBeforeDynamic))
     }
 
     if (id !== undefined) {
@@ -158,7 +168,9 @@ export function genChildren(
     }
 
     prev = [variable, elementIndex]
-    push(...genChildren(child, context, pushBlock, variable))
+    push(
+      ...genChildren(child, context, pushBlock, variable, flushBeforeDynamic),
+    )
   }
 
   return frag

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -42,6 +42,11 @@ export interface BaseIRNode {
   type: IRNodeTypes
 }
 
+export interface EffectBoundary {
+  operationIndex?: number
+  effectIndex?: number
+}
+
 export type CoreHelper = keyof typeof import('packages/runtime-dom/src')
 
 export type VaporHelper = keyof typeof import('packages/runtime-vapor/src')
@@ -82,7 +87,7 @@ export class TemplateRegistry {
   }
 }
 
-export interface IfIRNode extends BaseIRNode {
+export interface IfIRNode extends BaseIRNode, EffectBoundary {
   type: IRNodeTypes.IF
   id: number
   blockShape: number
@@ -105,7 +110,7 @@ export interface IRFor {
   index?: SimpleExpressionNode
 }
 
-export interface ForIRNode extends BaseIRNode, IRFor {
+export interface ForIRNode extends BaseIRNode, IRFor, EffectBoundary {
   type: IRNodeTypes.FOR
   id: number
   keyProp?: SimpleExpressionNode
@@ -120,7 +125,7 @@ export interface ForIRNode extends BaseIRNode, IRFor {
   last?: boolean
 }
 
-export interface KeyIRNode extends BaseIRNode {
+export interface KeyIRNode extends BaseIRNode, EffectBoundary {
   type: IRNodeTypes.KEY
   id: number
   value: SimpleExpressionNode
@@ -224,7 +229,7 @@ export interface DirectiveIRNode extends BaseIRNode {
   modelType?: 'text' | 'dynamic' | 'radio' | 'checkbox' | 'select'
 }
 
-export interface CreateComponentIRNode extends BaseIRNode {
+export interface CreateComponentIRNode extends BaseIRNode, EffectBoundary {
   type: IRNodeTypes.CREATE_COMPONENT_NODE
   id: number
   tag: string
@@ -242,7 +247,7 @@ export interface CreateComponentIRNode extends BaseIRNode {
   last?: boolean
 }
 
-export interface SlotOutletIRNode extends BaseIRNode {
+export interface SlotOutletIRNode extends BaseIRNode, EffectBoundary {
   type: IRNodeTypes.SLOT_OUTLET_NODE
   id: number
   name: SimpleExpressionNode

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -34,6 +34,7 @@ import {
   type SetEventIRNode,
   TemplateRegistry,
   type VaporDirectiveNode,
+  isBlockOperation,
 } from './ir'
 import { isConstantExpression, isStaticExpression } from './utils'
 import { newBlock, newDynamic } from './transforms/utils'
@@ -270,7 +271,7 @@ export class TransformContext<T extends AllNode = AllNode> {
   registerEffect(
     expressions: SimpleExpressionNode[],
     operation: OperationNode | OperationNode[],
-    getIndex = (): number => this.block.effect.length,
+    getIndex?: () => number,
   ): void {
     const operations = [operation].flat()
     expressions = expressions.filter(exp => !isConstantExpression(exp))
@@ -284,14 +285,25 @@ export class TransformContext<T extends AllNode = AllNode> {
       return this.registerOperation(...operations)
     }
 
-    this.block.effect.splice(getIndex(), 0, {
+    const index = getIndex ? getIndex() : this.block.effect.length
+    this.block.effect.splice(index, 0, {
       expressions,
       operations,
     })
+    if (getIndex) {
+      this.shiftEffectBoundaries(index)
+    }
   }
 
   registerOperation(...node: OperationNode[]): void {
     this.block.operation.push(...node)
+  }
+
+  effectBoundary(): { operationIndex: number; effectIndex: number } {
+    return {
+      operationIndex: this.operationIndex,
+      effectIndex: this.effectIndex,
+    }
   }
 
   create<T extends TemplateChildNode>(
@@ -349,6 +361,25 @@ export class TransformContext<T extends AllNode = AllNode> {
       isOnRightmostPath,
       hasInlineAncestorNeedingClose,
     } satisfies Partial<TransformContext<T>>)
+  }
+
+  private shiftEffectBoundaries(
+    index: number,
+    dynamic: IRDynamicInfo = this.dynamic,
+  ): void {
+    const operation = dynamic.operation
+    if (
+      operation &&
+      isBlockOperation(operation) &&
+      operation.effectIndex !== undefined &&
+      operation.effectIndex >= index
+    ) {
+      operation.effectIndex++
+    }
+
+    for (const child of dynamic.children) {
+      this.shiftEffectBoundaries(index, child)
+    }
   }
 
   private isEffectivelyLastChild(index: number): boolean {

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -270,6 +270,7 @@ function transformComponentElement(
   context.dynamic.operation = {
     type: IRNodeTypes.CREATE_COMPONENT_NODE,
     id,
+    ...context.effectBoundary(),
     tag,
     props: propsResult[0] ? propsResult[1] : [propsResult[1]],
     asset,

--- a/packages/compiler-vapor/src/transforms/transformKey.ts
+++ b/packages/compiler-vapor/src/transforms/transformKey.ts
@@ -32,6 +32,7 @@ export const transformKey: NodeTransform = (node, context) => {
     context.dynamic.operation = {
       type: IRNodeTypes.KEY,
       id,
+      ...context.effectBoundary(),
       value,
       block,
     }

--- a/packages/compiler-vapor/src/transforms/transformSlotOutlet.ts
+++ b/packages/compiler-vapor/src/transforms/transformSlotOutlet.ts
@@ -103,6 +103,7 @@ export const transformSlotOutlet: NodeTransform = (node, context) => {
     context.dynamic.operation = {
       type: IRNodeTypes.SLOT_OUTLET_NODE,
       id,
+      ...context.effectBoundary(),
       name: slotName,
       props: irProps,
       fallback,

--- a/packages/compiler-vapor/src/transforms/vFor.ts
+++ b/packages/compiler-vapor/src/transforms/vFor.ts
@@ -74,6 +74,7 @@ export function processFor(
     context.dynamic.operation = {
       type: IRNodeTypes.FOR,
       id,
+      ...context.effectBoundary(),
       source: source as SimpleExpressionNode,
       value: value as SimpleExpressionNode | undefined,
       key: key as SimpleExpressionNode | undefined,

--- a/packages/compiler-vapor/src/transforms/vIf.ts
+++ b/packages/compiler-vapor/src/transforms/vIf.ts
@@ -53,6 +53,7 @@ export function processIf(
       context.dynamic.operation = {
         type: IRNodeTypes.IF,
         id,
+        ...context.effectBoundary(),
         blockShape: encodeIfBlockShape(branch, forceMultiRoot),
         condition: dir.exp!,
         positive: branch,

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -11328,6 +11328,35 @@ describe('VDOM interop', () => {
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()
   })
 
+  test('hydrate useId in parent template before child setup', async () => {
+    const { container } = await testWithVaporApp(
+      `<script setup>
+        import { useId } from 'vue'
+        const components = _components
+      </script>
+      <template>
+        <div>parent: {{ useId() }}</div>
+        <components.Child />
+      </template>`,
+      {
+        Child: `<script setup>
+          import { useId } from 'vue'
+          const id = useId()
+        </script>
+        <template>
+          <div>child: {{ id }}</div>
+        </template>`,
+      },
+    )
+
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "
+      <!--[--><div>parent: v-0</div><div>child: v-1</div><!--]-->
+      "
+    `)
+    expect(`Hydration text mismatch`).not.toHaveBeenWarned()
+  })
+
   test('hydrate forwarded empty named VDOM slot with trailing sibling nodes', async () => {
     const { container } = await testWithVaporApp(
       `<script setup>


### PR DESCRIPTION
close #14781 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved effect execution order to ensure parent effects and props flush before child components are created
  * Fixed v-for effect handling to prevent unnecessary flushing before child component creation

* **Tests**
  * Added comprehensive tests validating effect execution order in component and v-for scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->