### PR TITLE
fix(compiler-core): handle unnamed function expressions with semicolons in v-on handlers

### DIFF
--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -202,14 +202,17 @@ export const isFnExpressionNode: (
   ? (NOOP as any)
   : (exp, context) => {
       try {
+        const plugins = context.expressionPlugins
+          ? [...context.expressionPlugins, 'typescript']
+          : ['typescript']
         let ret: Node =
           exp.ast ||
           parseExpression(getExpSource(exp), {
-            plugins: context.expressionPlugins
-              ? [...context.expressionPlugins, 'typescript']
-              : ['typescript'],
+            plugins,
           })
         // parser may parse the exp as statements when it contains semicolons
+        // e.g. `function () { ';' }` is parsed as FunctionDeclaration (error)
+        // because function declarations require a name
         if (ret.type === 'Program') {
           ret = ret.body[0]
           if (ret.type === 'ExpressionStatement') {
@@ -217,10 +220,28 @@ export const isFnExpressionNode: (
           }
         }
         ret = unwrapTSNode(ret) as Expression
-        return (
-          ret.type === 'FunctionExpression' ||
-          ret.type === 'ArrowFunctionExpression'
-        )
+        if (ret.type === 'FunctionExpression' || ret.type === 'ArrowFunctionExpression') {
+          return true
+        }
+        // If we got a FunctionDeclaration without a name (e.g. `function () { ';' }`),
+        // try wrapping in parens to force it to be parsed as an expression
+        if (ret.type === 'FunctionDeclaration' && !ret.id) {
+          ret = parseExpression(`(${getExpSource(exp)})`, {
+            plugins,
+          })
+          if (ret.type === 'Program') {
+            ret = ret.body[0]
+            if (ret.type === 'ExpressionStatement') {
+              ret = ret.expression
+            }
+          }
+          ret = unwrapTSNode(ret) as Expression
+          return (
+            ret.type === 'FunctionExpression' ||
+            ret.type === 'ArrowFunctionExpression'
+          )
+        }
+        return false
       } catch (e) {
         return false
       }


### PR DESCRIPTION
## Summary

When a v-on handler contains a function expression with semicolons (e.g. `@input="function () { ';' }"`), the Babel parser incorrectly identifies it as a `FunctionDeclaration` (which requires a name) rather than a `FunctionExpression`.

This happens because Babel's `parseExpression` treats `function () { ';' }` as a statement (FunctionDeclaration without a name), which is invalid JavaScript. When this heuristic incorrectly classifies the handler as an inline statement, the generated code causes a parsing error.

## Fix

Added a fallback in `isFnExpressionNode`: if the initial parse result is an unnamed `FunctionDeclaration`, we wrap it in parentheses and try parsing again as an expression. This correctly identifies `function () { ';' }` as a `FunctionExpression`.

## Test case

```vue
<template>
  <input @input="function () { ';' }" />
</template>
```

Previously caused: `(2:18) Error parsing JavaScript expression: Unexpected token (1:10)`

Now works correctly without parsing errors.

## Related

Fixes #14287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler's ability to accurately detect and handle complex function expressions, enhancing compatibility with various function declaration patterns and strengthening TypeScript support during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->