### PR TITLE
fix(server-renderer): propagate sync errors from `ssrRenderSuspense`

### DIFF
--- a/packages/server-renderer/__tests__/ssrSuspense.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSuspense.spec.ts
@@ -1,5 +1,7 @@
-import { Suspense, createApp, h } from 'vue'
+import { Suspense, createApp, defineComponent, h } from 'vue'
 import { renderToString } from '../src/renderToString'
+import { ssrRenderComponent } from '../src/helpers/ssrRenderComponent'
+import { ssrRenderSuspense } from '../src/helpers/ssrRenderSuspense'
 
 describe('SSR Suspense', () => {
   const ResolvingAsync = {
@@ -101,6 +103,28 @@ describe('SSR Suspense', () => {
 
     expect(Comp.errorCaptured).toHaveBeenCalledTimes(1)
     expect('missing template').toHaveBeenWarned()
+  })
+
+  // nuxt/nuxt#28162
+  test('propagates sync errors from compiled ssrRenderSuspense default slot', async () => {
+    const Throwing = defineComponent({
+      ssrRender(_ctx: any, _push: any) {
+        throw new TypeError('bang')
+      },
+    })
+
+    const Root = defineComponent({
+      ssrRender(_ctx: any, _push: any, _parent: any) {
+        ssrRenderSuspense(_push, {
+          default: () => {
+            _push(ssrRenderComponent(Throwing, null, null, _parent))
+          },
+          _: 1,
+        } as any)
+      },
+    })
+
+    await expect(renderToString(createApp(Root))).rejects.toThrow('bang')
   })
 
   test('passing suspense in failing suspense', async () => {

--- a/packages/server-renderer/src/helpers/ssrRenderSuspense.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSuspense.ts
@@ -1,9 +1,12 @@
 import type { PushFn } from '../render'
 
-export async function ssrRenderSuspense(
+// Must remain synchronous: compiled output is `ssrRenderSuspense(_push, ...)`,
+// not `_push(ssrRenderSuspense(...))`, so any returned Promise (and its
+// rejection) would be silently discarded.
+export function ssrRenderSuspense(
   push: PushFn,
   { default: renderContent }: Record<string, (() => void) | undefined>,
-): Promise<void> {
+): void {
   if (renderContent) {
     renderContent()
   } else {


### PR DESCRIPTION
resolves nuxt/nuxt#28162

we want errors when rendering to throw - but at the moment a sync throw inside the default slot gets converted by the async-function machinery into a rejected `Promise<void>` that is then thrown away...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error propagation in server-side rendering with Suspense to ensure synchronous errors are correctly handled and reported during rendering.

* **Tests**
  * Added test case to verify synchronous error handling in Suspense rendering scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14804)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->