### PR TITLE
fix(compiler-core): correctly identify unnamed function expressions in v-on handlers with semicolons

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -369,6 +369,22 @@ describe('compiler: transform v-on', () => {
     })
   })
 
+  test('should treat function expression with semicolons as a single expression', () => {
+    // regression test for https://github.com/vuejs/core/issues/14287
+    const { node } = parseWithVOn(`<div @click="function () { ';' }"/>`)
+    expect((node.codegenNode as VNodeCall).props).toMatchObject({
+      properties: [
+        {
+          key: { content: `onClick` },
+          value: {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `function () { ';' }`,
+          },
+        },
+      ],
+    })
+  })
+
   test('should NOT wrap as function if expression is complex member expression', () => {
     const { node } = parseWithVOn(`<div @click="a['b' + c]"/>`)
     expect((node.codegenNode as VNodeCall).props).toMatchObject({

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -217,6 +217,18 @@ export const isFnExpressionNode: (
           }
         }
         ret = unwrapTSNode(ret) as Expression
+        // An unnamed function declaration (e.g. `function () { ';' }`) is
+        // actually a valid function expression. Babel's parseExpression may
+        // parse it as a FunctionDeclaration when the source contains a
+        // semicolon, so re-parse wrapped in parens to disambiguate.
+        if (ret.type === 'FunctionDeclaration' && (ret as any).id === null) {
+          ret = parseExpression(`(${getExpSource(exp)})`, {
+            plugins: context.expressionPlugins
+              ? [...context.expressionPlugins, 'typescript']
+              : ['typescript'],
+          })
+          ret = unwrapTSNode(ret) as Expression
+        }
         return (
           ret.type === 'FunctionExpression' ||
           ret.type === 'ArrowFunctionExpression'


### PR DESCRIPTION
## Summary

Fixes #14287

When a `v-on` handler contains an unnamed function expression with a semicolon inside (e.g. `@click="function () { ';' }"`), the Vue compiler incorrectly throws a parsing error:

```
(2:18) Error parsing JavaScript expression: Unexpected token (1:10)
```

### Root Cause

`isFnExpressionNode` in `utils.ts` uses Babel's `parseExpression` to determine whether an event handler is a function expression. However, when the source contains a semicolon, Babel parses `function () { ';' }` as a **`FunctionDeclaration`** (a statement) rather than a **`FunctionExpression`** — because Babel's parser is ambiguous between the two when fed raw source without parentheses.

Since `isFnExpression` returns `false` for this input, the handler is classified as an `isInlineStatement = true`, which then causes the `hasMultipleStatements` check to fire (because of the `;`), producing the erroneous parse error.

### Fix

In `isFnExpressionNode`, after unwrapping the parsed node: if we get back a `FunctionDeclaration` with **no `id`** (i.e. anonymous), we know it must actually be a function expression written without parentheses. We wrap it in parentheses and re-parse, which correctly yields a `FunctionExpression`.

```ts
// Before (buggy):
// function () { ';' }  →  FunctionDeclaration (id: null) → not detected as fn expression

// After (fixed):
// function () { ';' }  → FunctionDeclaration (id: null)
//   → re-parse as `(function () { ';' })`  → FunctionExpression ✓
```

This is the minimal, targeted fix: we only re-parse when we detect an unnamed `FunctionDeclaration`, which is the exact ambiguity case.

### Before / After

```vue
<!-- Before: throws "(2:18) Error parsing JavaScript expression: Unexpected token (1:10)" -->
<!-- After: compiles correctly, identical behavior to arrow functions -->
<template>
  <input @input="function () { ';' }" />
</template>
```

### Test

Added a regression test to `vOn.spec.ts` verifying that an unnamed function expression with a semicolon in the body is treated as a single expression (not multiple statements), and the handler is passed through unchanged.

### Related

- Closes #14287
- - Related open PR: #14312 (different approach using a new `isValidExpression` utility)
- - Closed PR: #14783 (similar approach, closed as duplicate of #14312)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for inline event handler parsing to verify that function expressions containing semicolons are correctly handled as single expressions, preventing unwanted splitting or rewriting.

* **Bug Fixes**
  * Improved function expression detection for inline event handlers to correctly handle edge cases where expressions are initially misidentified during parsing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14806)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->