### PR TITLE
refactor(runtime-vapor): hoist createSelector out of createFor

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -211,12 +211,12 @@ export function render(_ctx) {
 `;
 
 exports[`compile > execution order > does not flush later v-for effects before child component 1`] = `
-"import { resolveComponent as _resolveComponent, child as _child, next as _next, txt as _txt, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, createSelector as _createSelector, child as _child, next as _next, txt as _txt, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
 const t0 = _template("<div><span> </span><!><span> ")
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const _component_Child = _resolveComponent("Child")
-  let _selector0_0
+  const _selector0 = _createSelector(() => _ctx.selected)
   const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
     const n6 = t0()
     const n2 = _child(n6)
@@ -227,13 +227,12 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
     const n3 = _createComponentWithFallback(_component_Child)
     const x4 = _txt(n4)
     _renderEffect(() => _setText(x4, _toDisplayString(_ctx.useId())))
-    _selector0_0(() => {
+    _selector0(_for_item0.value.id, () => {
       _setText(x2, _toDisplayString(_ctx.selected === _for_item0.value.id ? 'danger' : ''))
     })
     return n6
-  }, (row) => (row.id), undefined, ({ createSelector }) => {
-    _selector0_0 = createSelector(() => _ctx.selected)
-  })
+  }, (row) => (row.id))
+  n0.onReset(_selector0.reset)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -96,6 +96,29 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: v-for > multiple selector patterns on one v-for 1`] = `
+"import { createSelector as _createSelector, setClassName as _setClassName, setProp as _setProp, createFor as _createFor, template as _template } from 'vue';
+const t0 = _template("<tr>")
+
+export function render(_ctx) {
+  const _selector0_0 = _createSelector(() => _ctx.selected)
+  const _selector0_1 = _createSelector(() => _ctx.active)
+  const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
+    const n2 = t0()
+    _selector0_0(_for_item0.value.id, () => {
+      _setClassName(n2, (_ctx.selected === _for_item0.value.id ? 1 : 0), "a")
+    })
+    _selector0_1(_for_item0.value.id, () => {
+      _setProp(n2, "title", _ctx.active === _for_item0.value.id ? 'b' : '')
+    })
+    return n2
+  }, (row) => (row.id))
+  n0.onReset(_selector0_0.reset)
+  n0.onReset(_selector0_1.reset)
+  return n0
+}"
+`;
+
 exports[`compiler: v-for > nested v-for 1`] = `
 "import { setInsertionState as _setInsertionState, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
 const t0 = _template("<span> ")
@@ -163,40 +186,38 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: v-for > selector pattern 1`] = `
-"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, createFor as _createFor, template as _template } from 'vue';
+"import { createSelector as _createSelector, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, createFor as _createFor, template as _template } from 'vue';
 const t0 = _template("<tr> ")
 
 export function render(_ctx) {
-  let _selector0_0
+  const _selector0 = _createSelector(() => _ctx.selected)
   const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
     const n2 = t0()
     const x2 = _txt(n2)
-    _selector0_0(() => {
+    _selector0(_for_item0.value.id, () => {
       _setText(x2, _toDisplayString(_ctx.selected === _for_item0.value.id ? 'danger' : ''))
     })
     return n2
-  }, (row) => (row.id), undefined, ({ createSelector }) => {
-    _selector0_0 = createSelector(() => _ctx.selected)
-  })
+  }, (row) => (row.id))
+  n0.onReset(_selector0.reset)
   return n0
 }"
 `;
 
 exports[`compiler: v-for > selector pattern 2`] = `
-"import { setClassName as _setClassName, createFor as _createFor, template as _template } from 'vue';
+"import { createSelector as _createSelector, setClassName as _setClassName, createFor as _createFor, template as _template } from 'vue';
 const t0 = _template("<tr>")
 
 export function render(_ctx) {
-  let _selector0_0
+  const _selector0 = _createSelector(() => _ctx.selected)
   const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
     const n2 = t0()
-    _selector0_0(() => {
+    _selector0(_for_item0.value.id, () => {
       _setClassName(n2, (_ctx.selected === _for_item0.value.id ? 1 : 0), "danger")
     })
     return n2
-  }, (row) => (row.id), undefined, ({ createSelector }) => {
-    _selector0_0 = createSelector(() => _ctx.selected)
-  })
+  }, (row) => (row.id))
+  n0.onReset(_selector0.reset)
   return n0
 }"
 `;
@@ -219,20 +240,19 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: v-for > selector pattern 4`] = `
-"import { setClassName as _setClassName, createFor as _createFor, template as _template } from 'vue';
+"import { createSelector as _createSelector, setClassName as _setClassName, createFor as _createFor, template as _template } from 'vue';
 const t0 = _template("<tr>")
 
 export function render(_ctx) {
-  let _selector0_0
+  const _selector0 = _createSelector(() => _ctx.selected)
   const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
     const n2 = t0()
-    _selector0_0(() => {
+    _selector0(_for_item0.value.id, () => {
       _setClassName(n2, (_for_item0.value.id === _ctx.selected ? 1 : 0), "danger")
     })
     return n2
-  }, (row) => (row.id), undefined, ({ createSelector }) => {
-    _selector0_0 = createSelector(() => _ctx.selected)
-  })
+  }, (row) => (row.id))
+  n0.onReset(_selector0.reset)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
@@ -134,6 +134,30 @@ describe('compiler: v-for', () => {
     ).matchSnapshot()
   })
 
+  test('multiple selector patterns on one v-for', () => {
+    const { code } = compileWithVFor(
+      `
+          <tr
+            v-for="row of rows"
+            :key="row.id"
+            :class="selected === row.id ? 'a' : ''"
+            :title="active === row.id ? 'b' : ''"
+          ></tr>
+      `,
+    )
+    expect(code).matchSnapshot()
+    // both selectors created at outer scope with sub-indexed names
+    expect(code).contains(
+      `const _selector0_0 = _createSelector(() => _ctx.selected)`,
+    )
+    expect(code).contains(
+      `const _selector0_1 = _createSelector(() => _ctx.active)`,
+    )
+    // both wired to the same fragment's onReset
+    expect(code).contains(`n0.onReset(_selector0_0.reset)`)
+    expect(code).contains(`n0.onReset(_selector0_1.reset)`)
+  })
+
   test('multi effect', () => {
     const { code } = compileWithVFor(
       `<div v-for="(item, index) of items" :item="item" :index="index" />`,

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -81,26 +81,19 @@ export function genFor(
     idMap,
   )
   const selectorDeclarations: CodeFragment[] = []
-  const selectorSetup: CodeFragment[] = []
+  const selectorName = (i: number) =>
+    selectorPatterns.length > 1 ? `_selector${id}_${i}` : `_selector${id}`
 
   for (let i = 0; i < selectorPatterns.length; i++) {
     const { selector } = selectorPatterns[i]
-    const selectorName = `_selector${id}_${i}`
-    selectorDeclarations.push(`let ${selectorName}`, NEWLINE)
-    if (i === 0) {
-      selectorSetup.push(`({ createSelector }) => {`, INDENT_START)
-    }
-    selectorSetup.push(
-      NEWLINE,
-      `${selectorName} = `,
-      ...genCall(`createSelector`, [
+    selectorDeclarations.push(
+      `const ${selectorName(i)} = `,
+      ...genCall(helper('createSelector'), [
         `() => `,
         ...genExpression(selector, context),
       ]),
+      NEWLINE,
     )
-    if (i === selectorPatterns.length - 1) {
-      selectorSetup.push(INDENT_END, NEWLINE, '}')
-    }
   }
 
   const blockFn = context.withId(() => {
@@ -115,7 +108,9 @@ export function genFor(
             const { effect } = selectorPatterns[i]
             patternFrag.push(
               NEWLINE,
-              `_selector${id}_${i}(() => {`,
+              `${selectorName(i)}(`,
+              ...genExpression(keyProp!, context),
+              `, () => {`,
               INDENT_START,
             )
             for (const oper of effect.operations) {
@@ -152,6 +147,11 @@ export function genFor(
     flags |= VaporVForFlags.ONCE
   }
 
+  const onResetCalls: CodeFragment[] = []
+  for (let i = 0; i < selectorPatterns.length; i++) {
+    onResetCalls.push(NEWLINE, `n${id}.onReset(${selectorName(i)}.reset)`)
+  }
+
   return [
     NEWLINE,
     ...selectorDeclarations,
@@ -162,9 +162,9 @@ export function genFor(
       blockFn,
       genCallback(keyProp),
       flags ? String(flags) : undefined,
-      selectorSetup.length ? selectorSetup : undefined,
       // todo: hydrationNode
     ),
+    ...onResetCalls,
   ]
 
   function genCallback(expr: SimpleExpressionNode | undefined) {

--- a/packages/runtime-vapor/__tests__/apiCreateSelector.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateSelector.spec.ts
@@ -1,6 +1,6 @@
 import { ref } from '@vue/reactivity'
 import { makeRender } from './_utils'
-import { createFor } from '../src'
+import { createFor, createSelector } from '../src'
 import { nextTick } from '@vue/runtime-dom'
 
 const define = makeRender()
@@ -14,12 +14,12 @@ describe('api: createSelector', () => {
     const index = ref(0)
 
     const { host } = define(() => {
-      let selector: (cb: () => void) => void
+      const selector = createSelector(() => index.value)
       return createFor(
         () => list.value,
         item => {
           const span = document.createElement('li')
-          selector(() => {
+          selector(item.value.id, () => {
             calledTimes += 1
             const { id } = item.value
             span.textContent = `${id}.${id === index.value ? 't' : 'f'}`
@@ -27,10 +27,6 @@ describe('api: createSelector', () => {
           return span
         },
         item => item.id,
-        undefined,
-        ({ createSelector }) => {
-          selector = createSelector(() => index.value)
-        },
       )
     }).render()
 
@@ -52,13 +48,6 @@ describe('api: createSelector', () => {
       '<li>0.f</li><li>1.f</li><li>2.t</li><!--for-->',
     )
     expect(calledTimes).toBe((expectedCalledTimes += 2))
-
-    // list.value[2].id = 3
-    // await nextTick()
-    // expect(host.innerHTML).toBe(
-    //   '<li>0.f</li><li>1.f</li><li>3.f</li><!--for-->',
-    // )
-    // expect(calledTimes).toBe((expectedCalledTimes += 1))
   })
 
   test('selector runs after list updates when value changes first', async () => {
@@ -66,12 +55,12 @@ describe('api: createSelector', () => {
     const index = ref(-1)
 
     const { host } = define(() => {
-      let selector: (cb: () => void) => void
+      const selector = createSelector(() => index.value)
       return createFor(
         () => items.value,
         item => {
           const div = document.createElement('div')
-          selector(() => {
+          selector(item.value, () => {
             div.className = index.value === item.value ? 'active' : ''
           })
           const btn = document.createElement('button')
@@ -80,10 +69,6 @@ describe('api: createSelector', () => {
           return div
         },
         item => item,
-        undefined,
-        ({ createSelector }) => {
-          selector = createSelector(() => index.value)
-        },
       )
     }).render()
 
@@ -101,5 +86,94 @@ describe('api: createSelector', () => {
     expect(host.innerHTML).toBe(
       '<div class=""><button>0</button></div><!--for-->',
     )
+  })
+
+  test('multiple selectors on one v-for, each tracking its own source', async () => {
+    const list = ref([{ id: 0 }, { id: 1 }, { id: 2 }])
+    const selA = ref(0)
+    const selB = ref(2)
+
+    const { host } = define(() => {
+      const sA = createSelector(() => selA.value)
+      const sB = createSelector(() => selB.value)
+      return createFor(
+        () => list.value,
+        item => {
+          const span = document.createElement('span')
+          let a = ''
+          let b = ''
+          const update = () => (span.textContent = `${item.value.id}:${a},${b}`)
+          sA(item.value.id, () => {
+            a = item.value.id === selA.value ? 'A' : ''
+            update()
+          })
+          sB(item.value.id, () => {
+            b = item.value.id === selB.value ? 'B' : ''
+            update()
+          })
+          return span
+        },
+        item => item.id,
+      )
+    }).render()
+
+    expect(host.innerHTML).toBe(
+      '<span>0:A,</span><span>1:,</span><span>2:,B</span><!--for-->',
+    )
+
+    selA.value = 1
+    selB.value = 0
+    await nextTick()
+    expect(host.innerHTML).toBe(
+      '<span>0:,B</span><span>1:A,</span><span>2:,</span><!--for-->',
+    )
+  })
+
+  test('fast-reset path: clearing list bulk-resets selector state', async () => {
+    const list = ref([{ id: 0 }, { id: 1 }, { id: 2 }])
+    const sel = ref(0)
+    let resetCalls = 0
+
+    const { host } = define(() => {
+      const s = createSelector(() => sel.value)
+      // wrap reset to count invocations
+      const realReset = s.reset
+      s.reset = () => {
+        resetCalls++
+        realReset()
+      }
+      const frag = createFor(
+        () => list.value,
+        item => {
+          const span = document.createElement('span')
+          s(item.value.id, () => {
+            span.textContent =
+              item.value.id === sel.value
+                ? `${item.value.id}*`
+                : `${item.value.id}`
+          })
+          return span
+        },
+        item => item.id,
+      )
+      frag.onReset(s.reset)
+      return frag
+    }).render()
+
+    expect(host.innerHTML).toBe(
+      '<span>0*</span><span>1</span><span>2</span><!--for-->',
+    )
+    expect(resetCalls).toBe(0)
+
+    list.value = []
+    await nextTick()
+    expect(host.innerHTML).toBe('<!--for-->')
+    expect(resetCalls).toBe(1)
+
+    // After bulk reset, refilling and changing source should still work
+    list.value = [{ id: 5 }, { id: 6 }]
+    sel.value = 6
+    await nextTick()
+    expect(host.innerHTML).toBe('<span>5</span><span>6*</span><!--for-->')
   })
 })

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -4,6 +4,7 @@ import {
   isReactive,
   isReadonly,
   isShallow,
+  onScopeDispose,
   setActiveSub,
   shallowReadArray,
   shallowRef,
@@ -83,9 +84,6 @@ export const createFor = (
   ) => Block,
   getKey?: (item: any, key: any, index?: number) => any,
   flags = 0,
-  setup?: (_: {
-    createSelector: (source: () => any) => (cb: () => void) => void
-  }) => void,
 ): ForFragment => {
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor
@@ -101,8 +99,6 @@ export const createFor = (
   let oldBlocks: ForBlock[] = []
   let newBlocks: ForBlock[]
   let parent: ParentNode | undefined | null
-  // createSelector only
-  let currentKey: any
   let parentAnchor: Node
   let pendingHydrationAnchor = false
   if (!isHydrating) {
@@ -113,10 +109,6 @@ export const createFor = (
   const instance = currentInstance!
   const canUseFastRemove = !!(flags & VaporVForFlags.FAST_REMOVE)
   const isComponent = !!(flags & VaporVForFlags.IS_COMPONENT)
-  const selectors: {
-    deregister: (key: any) => void
-    cleanup: () => void
-  }[] = []
 
   const slotOwner = currentSlotOwner
 
@@ -149,13 +141,17 @@ export const createFor = (
           mount(source, i)
         }
       } else if (!newLength) {
-        // fast path for clearing all
-        for (const selector of selectors) {
-          selector.cleanup()
+        // fast path for clearing all.
+        // Fire reset listeners BEFORE per-item unmount so attached selectors
+        // bump their generation counter; the subsequent block.scope.stop()
+        // calls then short-circuit their onScopeDispose deregisters instead
+        // of doing N individual Map.delete() ops.
+        if (frag.resetListeners) {
+          for (const fn of frag.resetListeners) fn()
         }
         const doRemove = !canUseFastRemove
         for (let i = 0; i < oldLength; i++) {
-          unmount(oldBlocks[i], doRemove, false)
+          unmount(oldBlocks[i], doRemove)
         }
         if (canUseFastRemove) {
           parent!.textContent = ''
@@ -278,21 +274,20 @@ export const createFor = (
 
         const useFastRemove = mountCounter === newLength
 
+        // Same ordering note as the !newLength path: reset before unmount so
+        // the generation bump turns per-item deregisters into no-ops.
+        if (useFastRemove && frag.resetListeners) {
+          for (const fn of frag.resetListeners) fn()
+        }
         for (const leftoverIndex of oldKeyIndexMap.values()) {
           unmount(
             oldBlocks[leftoverIndex],
             !(useFastRemove && canUseFastRemove),
-            !useFastRemove,
           )
         }
-        if (useFastRemove) {
-          for (const selector of selectors) {
-            selector.cleanup()
-          }
-          if (canUseFastRemove) {
-            parent!.textContent = ''
-            parent!.appendChild(parentAnchor)
-          }
+        if (useFastRemove && canUseFastRemove) {
+          parent!.textContent = ''
+          parent!.appendChild(parentAnchor)
         }
 
         if (opers.length === mountCounter) {
@@ -382,7 +377,6 @@ export const createFor = (
     const keyRef = needKey ? shallowRef(key) : undefined
     const indexRef = needIndex ? shallowRef(index) : undefined
 
-    currentKey = key2
     let nodes: Block
     let scope: EffectScope | undefined
     if (isComponent) {
@@ -523,22 +517,13 @@ export const createFor = (
     }
   }
 
-  const unmount = (block: ForBlock, doRemove = true, doDeregister = true) => {
+  const unmount = (block: ForBlock, doRemove = true) => {
     if (!isComponent) {
       block.scope!.stop()
     }
     if (doRemove) {
       remove(block.nodes, parent!)
     }
-    if (doDeregister) {
-      for (const selector of selectors) {
-        selector.deregister(block.key)
-      }
-    }
-  }
-
-  if (setup) {
-    setup({ createSelector })
   }
 
   if (flags & VaporVForFlags.ONCE) {
@@ -565,61 +550,90 @@ export const createFor = (
   }
 
   return frag
+}
 
-  function createSelector(source: () => any): (cb: () => void) => void {
-    let operMap = new Map<any, (() => void)[]>()
-    let activeKey = source()
-    let activeOpers: (() => void)[] | undefined
+export interface ForSelector {
+  (key: any, oper: () => void): void
+  /**
+   * Bulk-reset the selector's internal state. Hook into a v-for's fast-reset
+   * paths via `forFragment.onReset(selector.reset)` so the lazy per-item
+   * `onScopeDispose` teardowns short-circuit instead of doing N individual
+   * Map.delete() calls.
+   */
+  reset(): void
+}
 
-    watch(source, newValue => {
+/**
+ * Builds a key-indexed selector that activates only the opers registered with
+ * the key matching the current source value. Compared to letting each item
+ * subscribe directly, this keeps re-renders on source change O(2) instead of
+ * O(N) (only previous and new active item re-run).
+ *
+ * Selector cleanup follows the current scope. Per-item teardown is auto-wired
+ * via `onScopeDispose` so callers (typically v-for item scopes) don't need
+ * explicit deregistration. For bulk-reset hot paths, attach the selector to
+ * the v-for via `frag.onReset(selector.reset)` to skip the per-item Map ops.
+ */
+export function createSelector(source: () => any): ForSelector {
+  const operMap = new Map<any, (() => void)[]>()
+  let activeKey = source()
+  let activeOpers: (() => void)[] | undefined
+  // bumped by reset(); register captures the current value and uses it as
+  // a stale-check so post-reset deregisters become no-ops
+  let generation = 0
+
+  watch(source, newValue => {
+    if (activeOpers !== undefined) {
+      for (const oper of activeOpers) {
+        oper()
+      }
+    }
+
+    // watch may trigger before list patched
+    // defer to post-flush so operMap is up to date
+    queuePostFlushCb(() => {
+      activeKey = newValue
+      activeOpers = operMap.get(newValue)
       if (activeOpers !== undefined) {
         for (const oper of activeOpers) {
           oper()
         }
       }
-
-      // watch may trigger before list patched
-      // defer to post-flush so operMap is up to date
-      queuePostFlushCb(() => {
-        activeKey = newValue
-        activeOpers = operMap.get(newValue)
-        if (activeOpers !== undefined) {
-          for (const oper of activeOpers) {
-            oper()
-          }
-        }
-      })
     })
+  })
 
-    selectors.push({ deregister, cleanup })
-    return register
-
-    function cleanup() {
-      operMap = new Map()
-      activeOpers = undefined
-    }
-
-    function register(oper: () => void) {
-      oper()
-      let opers = operMap.get(currentKey)
-      if (opers !== undefined) {
-        opers.push(oper)
-      } else {
-        opers = [oper]
-        operMap.set(currentKey, opers)
-        if (currentKey === activeKey) {
-          activeOpers = opers
-        }
-      }
-    }
-
-    function deregister(key: any) {
-      operMap.delete(key)
+  const register: ForSelector = (key, oper) => {
+    oper()
+    let opers = operMap.get(key)
+    if (opers !== undefined) {
+      opers.push(oper)
+    } else {
+      opers = [oper]
+      operMap.set(key, opers)
       if (key === activeKey) {
-        activeOpers = undefined
+        activeOpers = opers
       }
     }
+    const myGen = generation
+    onScopeDispose(() => {
+      if (myGen !== generation) return // bulk-cleared, skip
+      const list = operMap.get(key)
+      if (list === undefined) return
+      if (list.length === 1) {
+        operMap.delete(key)
+        if (key === activeKey) activeOpers = undefined
+      } else {
+        const idx = list.indexOf(oper)
+        if (idx !== -1) list.splice(idx, 1)
+      }
+    }, true)
   }
+  register.reset = () => {
+    operMap.clear()
+    activeOpers = undefined
+    generation++
+  }
+  return register
 }
 
 function moveLink(block: ForBlock, newPrev?: ForBlock, newNext?: ForBlock) {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -129,9 +129,19 @@ export class VaporFragment<
 }
 
 export class ForFragment extends VaporFragment<Block[]> {
+  // Listeners fired when the v-for resets its items in one shot
+  // (whole-list clear or full remount). Selectors hook in here via
+  // `frag.onReset(selector.reset)` so they can drop their internal state in
+  // O(1) instead of N per-item Map.delete calls.
+  resetListeners?: (() => void)[]
+
   constructor(nodes: Block[]) {
     super(nodes)
     trackSlotBoundaryDirtying(this)
+  }
+
+  onReset(fn: () => void): void {
+    ;(this.resetListeners ||= []).push(fn)
   }
 }
 

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -60,6 +60,7 @@ export { createKeyedFragment } from './apiCreateFragment'
 export {
   createFor,
   createForSlots,
+  createSelector,
   getRestElement,
   getDefaultValue,
 } from './apiCreateFor'


### PR DESCRIPTION
## Summary

Decouple `createSelector` from `createFor`. The two used to communicate
through closure-captured state (`currentKey`, `selectors[]`) and a setup
callback parameter; this PR makes the API explicit.

- `createSelector` is exported standalone. It takes the source getter and
  returns a `(key, oper) => void` registrar with a `.reset()` method.
- The compiler emits the selector as an outer-scope `const` and passes
  the `:key` expression at each call site, so `createFor` no longer
  needs to expose `currentKey` to a hidden inner factory.
- Per-item deregister is auto-wired via `onScopeDispose`, so `createFor`
  no longer maintains a `selectors[]` array or a `doDeregister` flag on
  `unmount`.
- Fast-reset paths (whole-list clear, full remount) fire an `onReset`
  event on the `ForFragment`. Selectors hook in via
  `frag.onReset(selector.reset)`. A generation counter on the selector
  makes post-reset per-item deregisters O(1) no-ops, keeping fast-reset
  performance equivalent to the previous bulk `cleanup()` path.

This is offered as an alternative direction to #14811. The two PRs are
not in conflict — the scope-detach work from #14811 is orthogonal and
can be layered on top of this refactor.

## Generated code (before vs after)

Before (on `minor`):

```js
let _selector0_0
const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
  _selector0_0(() => { /* ... */ })
  return n2
}, (row) => (row.id), undefined, ({ createSelector }) => {
  _selector0_0 = createSelector(() => _ctx.selected)
})
```

After:

```js
const _selector0 = _createSelector(() => _ctx.selected)
const n0 = _createFor(() => (_ctx.rows), (_for_item0) => {
  _selector0(_for_item0.value.id, () => { /* ... */ })
  return n2
}, (row) => (row.id))
n0.onReset(_selector0.reset)
```

- no outer `let`
- no setup callback parameter on `createFor`
- single-selector v-fors compile to `_selector${id}` (no double-zero); the
  `_${i}` suffix only appears when one v-for has multiple selectors

## Test plan

- [x] `apiCreateSelector.spec.ts` — existing tests adapted to the new
      `(key, oper)` signature, plus two new cases:
  - multiple selectors on one v-for, each with its own source
  - fast-reset path counts a single `.reset()` invocation when the list
    is cleared
- [x] `vFor.spec.ts` — selector pattern snapshots updated; new test for
      multi-selector on one v-for asserts both `_createSelector` calls
      and both `onReset` wirings are emitted
- [x] `compile.spec.ts` — snapshot updated for the new code shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new selector API for improved reactive tracking in list items with enhanced reset behavior.

* **Refactor**
  * Optimized selector initialization and lifecycle management in list rendering for better performance during list updates and clearing operations.

* **Tests**
  * Added test coverage for multiple selectors on single list, selector reset mechanics, and inline selector creation patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14812)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->