### PR TITLE
chore: add `minimumReleaseAge` settings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
   labels: ['dependencies'],
   ignorePaths: ['**/__tests__/**'],
   rangeStrategy: 'bump',
+  minimumReleaseAge: '24 hours',
   packageRules: [
     {
       matchDepTypes: ['peerDependencies'],

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,3 +28,5 @@ peerDependencyRules:
     '@typescript-eslint/parser>eslint': '^9.0.0'
     '@typescript-eslint/type-utils>eslint': '^9.0.0'
     '@typescript-eslint/utils>eslint': '^9.0.0'
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
Relevant docs:

- https://pnpm.io/settings#minimumreleaseage
- https://docs.renovatebot.com/key-concepts/minimum-release-age/

These settings delay dependency updates by 1 day. This helps to avoid supply chain attacks, as compromised packages are typically removed from the npm registry within a few hours.

`minimumReleaseAge: 1440` is the default for pnpm 11. We're currently using pnpm 10, so this aligns us with the newer version. Renovate also needs to take this into account when suggesting updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to enforce a 24-hour minimum release age requirement before dependency updates are applied to the project. New dependency updates will now wait 24 hours after release before being considered.
  * Updated workspace configuration with matching minimum release age settings for consistent dependency management policies across all project workspaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14814)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->