### PR TITLE
chore(compiler-core): fix duplicated "to" in codegen.ts comment

### DIFF
--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -67,7 +67,7 @@ import type { ImportItem } from './transform'
  *
  * Since TS 5.3, dts generation starts to strangely include broken triple slash
  * references for source-map-js, so we are inlining all source map related types
- * here to to workaround that.
+ * here to workaround that.
  */
 export interface CodegenSourceMapGenerator {
   setSourceContent(sourceFile: string, sourceContent: string): void


### PR DESCRIPTION
One-line typo fix in `packages/compiler-core/src/codegen.ts`: "here to to workaround that." → "here to workaround that.". No code/behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code comment cleanup to improve clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14818)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->