### PR TITLE
refactor(runtime-vapor): simplify slot fallback and slot binding cache

### DIFF
--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -37,7 +37,7 @@ import {
 import { makeRender } from './_utils'
 import type { DynamicSlot } from '../src/componentSlots'
 import { setElementText, setText } from '../src/dom/prop'
-import { type Block, isValidBlock } from '../src/block'
+import { type Block, type BlockFn, isValidBlock } from '../src/block'
 import {
   hydrateNode,
   setCurrentHydrationNode,
@@ -47,12 +47,15 @@ import {
   DynamicFragment,
   ForFragment,
   type SlotBoundaryContext,
-  SlotFallbackController,
+  type SlotFallbackOutlet,
   SlotFragment,
   VaporFragment,
   getCurrentSlotBoundary,
   getCurrentSlotEndAnchor,
   isHydratingSlotFallbackActive,
+  markSlotFallbackDirty,
+  recheckSlotFallback,
+  syncActiveSlotFallback,
   trackSlotBoundaryDirtying,
   withHydratingSlotBoundary,
   withHydratingSlotFallbackActive,
@@ -81,6 +84,36 @@ function renderWithSlots(slots: any): any {
 
   render()
   return instance
+}
+
+function createTestSlotFallbackOutlet(options: {
+  fallback?: BlockFn
+  content?: Block
+  parentNode?: ParentNode | null
+  anchor?: Node | null
+  isContentValid?: () => boolean
+  isDisposed?: () => boolean
+}): SlotFallbackOutlet {
+  let outlet!: SlotFallbackOutlet
+  const boundary: SlotBoundaryContext = {
+    parent: null,
+    getLocalFallback: () => options.fallback,
+    markDirty: () => markSlotFallbackDirty(outlet),
+  }
+  outlet = {
+    boundary,
+    activeFallback: null,
+    pendingRecheck: false,
+    isRenderingFallback: false,
+    getContent: () => options.content || [],
+    getParentNode: () => options.parentNode || null,
+    getAnchor: () => options.anchor || null,
+    runWithRenderCtx: fn => fn(),
+    isDisposed: options.isDisposed,
+    isContentValid: options.isContentValid,
+    notifyFallbackValidityChange: vi.fn(),
+  }
+  return outlet
 }
 
 describe('component: slots', () => {
@@ -393,23 +426,16 @@ describe('component: slots', () => {
       expect(container.innerHTML).toBe('fallback<!--slot-->')
     })
 
-    test('slot fallback controller ignores dirty notifications after dispose', () => {
+    test('slot fallback outlet ignores dirty notifications after dispose', () => {
       let disposed = false
-      const controller = new SlotFallbackController({
-        getParentBoundary: () => null,
-        getLocalFallback: () => undefined,
-        getContent: () => [],
-        getParentNode: () => null,
-        getAnchor: () => null,
-        runWithRenderCtx: fn => fn(),
+      const outlet = createTestSlotFallbackOutlet({
         isDisposed: () => disposed,
-        onValidityChange: vi.fn(),
       })
 
       disposed = true
-      controller.boundary.markDirty()
+      outlet.boundary.markDirty()
 
-      expect(controller.takePendingRecheck()).toBe(false)
+      expect(outlet.pendingRecheck).toBe(false)
     })
 
     test('withHydratingSlotBoundary isolates fallback-active state between boundaries without local markers', () => {
@@ -478,30 +504,24 @@ describe('component: slots', () => {
       expect(`Hydration children mismatch`).not.toHaveBeenWarned()
     })
 
-    test('slot fallback controller stops fallback scope when fallback body throws', async () => {
+    test('slot fallback outlet stops fallback scope when fallback body throws', async () => {
       const source = ref(0)
       const effectRuns = vi.fn()
       const cleanup = vi.fn()
       const err = new Error('fallback boom')
 
-      const controller = new SlotFallbackController({
-        getParentBoundary: () => null,
-        getLocalFallback: () => () => {
+      const outlet = createTestSlotFallbackOutlet({
+        fallback: () => {
           onScopeDispose(cleanup)
           renderEffect(() => {
             effectRuns(source.value)
           })
           throw err
         },
-        getContent: () => [],
-        getParentNode: () => null,
-        getAnchor: () => null,
-        runWithRenderCtx: fn => fn(),
-        onValidityChange: vi.fn(),
       })
 
-      expect(() => controller.recheck()).toThrow(err)
-      expect(controller.getActiveFallback()).toBe(null)
+      expect(() => recheckSlotFallback(outlet)).toThrow(err)
+      expect(outlet.activeFallback).toBe(null)
       expect(cleanup).toHaveBeenCalledTimes(1)
       expect(effectRuns).toHaveBeenCalledTimes(1)
 
@@ -511,31 +531,25 @@ describe('component: slots', () => {
       expect(effectRuns).toHaveBeenCalledTimes(1)
     })
 
-    test('slot fallback controller does not accumulate order-sync hooks', async () => {
+    test('slot fallback outlet does not accumulate order-sync hooks', async () => {
       const fallback = new VaporFragment([
         document.createTextNode('a'),
         document.createTextNode('b'),
       ])
-      const controller = new SlotFallbackController({
-        getParentBoundary: () => null,
-        getLocalFallback: () => () => fallback,
-        getContent: () => [],
-        getParentNode: () => null,
-        getAnchor: () => null,
-        runWithRenderCtx: fn => fn(),
-        onValidityChange: vi.fn(),
+      const outlet = createTestSlotFallbackOutlet({
+        fallback: () => fallback,
       })
 
-      controller.recheck()
+      recheckSlotFallback(outlet)
       expect(fallback.onUpdated).toHaveLength(1)
 
-      controller.syncActiveFallback()
+      syncActiveSlotFallback(outlet)
       await nextTick()
 
       expect(fallback.onUpdated).toHaveLength(1)
     })
 
-    test('slot fallback controller re-syncs the whole carrier block order', async () => {
+    test('slot fallback outlet re-syncs the whole carrier block order', async () => {
       const container = document.createElement('div')
       const carrierA = document.createTextNode('x')
       const carrierB = document.createTextNode('y')
@@ -545,29 +559,26 @@ describe('component: slots', () => {
         document.createTextNode('a'),
         document.createTextNode('b'),
       ])
-      const controller = new SlotFallbackController({
-        getParentBoundary: () => null,
-        getLocalFallback: () => () => fallback,
-        getContent: () => [carrierA, carrierB],
-        getParentNode: () => container,
-        getAnchor: () => slotAnchor,
-        runWithRenderCtx: fn => fn(),
+      const outlet = createTestSlotFallbackOutlet({
+        fallback: () => fallback,
+        content: [carrierA, carrierB],
+        parentNode: container,
+        anchor: slotAnchor,
         isContentValid: () => false,
-        onValidityChange: vi.fn(),
       })
 
       container.append(carrierA, marker, carrierB, slotAnchor)
-      controller.recheck()
+      recheckSlotFallback(outlet)
 
       expect(container.innerHTML).toBe('abx!y<!--slot-->')
 
-      controller.syncActiveFallback()
+      syncActiveSlotFallback(outlet)
       await nextTick()
 
       expect(container.innerHTML).toBe('abxy!<!--slot-->')
     })
 
-    test('slot fallback controller re-syncs carrier order when fallback ends with a fragment anchor', async () => {
+    test('slot fallback outlet re-syncs carrier order when fallback ends with a fragment anchor', async () => {
       const container = document.createElement('div')
       const carrierA = document.createTextNode('x')
       const carrierB = document.createTextNode('y')
@@ -579,43 +590,34 @@ describe('component: slots', () => {
         document.createTextNode('a'),
         trailingFragment,
       ])
-      const controller = new SlotFallbackController({
-        getParentBoundary: () => null,
-        getLocalFallback: () => () => fallback,
-        getContent: () => [carrierA, carrierB],
-        getParentNode: () => container,
-        getAnchor: () => slotAnchor,
-        runWithRenderCtx: fn => fn(),
+      const outlet = createTestSlotFallbackOutlet({
+        fallback: () => fallback,
+        content: [carrierA, carrierB],
+        parentNode: container,
+        anchor: slotAnchor,
         isContentValid: () => false,
-        onValidityChange: vi.fn(),
       })
 
       container.append(carrierA, marker, carrierB, slotAnchor)
-      controller.recheck()
+      recheckSlotFallback(outlet)
 
       expect(container.innerHTML).toBe('ab<!--if-->x!y<!--slot-->')
 
-      controller.syncActiveFallback()
+      syncActiveSlotFallback(outlet)
       await nextTick()
 
       expect(container.innerHTML).toBe('ab<!--if-->xy!<!--slot-->')
     })
 
-    test('slot fallback controller defaults to idle when isBusy is omitted', () => {
+    test('slot fallback outlet defaults to idle when isBusy is omitted', () => {
       const fallback = document.createTextNode('fallback')
-      const controller = new SlotFallbackController({
-        getParentBoundary: () => null,
-        getLocalFallback: () => () => fallback,
-        getContent: () => [],
-        getParentNode: () => null,
-        getAnchor: () => null,
-        runWithRenderCtx: fn => fn(),
-        onValidityChange: vi.fn(),
+      const outlet = createTestSlotFallbackOutlet({
+        fallback: () => fallback,
       })
 
-      controller.boundary.markDirty()
+      outlet.boundary.markDirty()
 
-      expect(controller.getActiveFallback()).toBe(fallback)
+      expect(outlet.activeFallback).toBe(fallback)
     })
 
     test('vdom slot dirties parent boundary once when content stays valid', async () => {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -60,7 +60,6 @@ import {
   withHydratingSlotBoundary,
   withHydratingSlotFallbackActive,
   withOwnedSlotBoundary,
-  withSlotFallbackBoundary,
 } from '../src/fragment'
 
 const define = makeRender<any>()
@@ -97,7 +96,8 @@ function createTestSlotFallbackOutlet(options: {
   let outlet!: SlotFallbackOutlet
   const boundary: SlotBoundaryContext = {
     parent: null,
-    getLocalFallback: () => options.fallback,
+    getFallback: () => options.fallback,
+    run: fn => fn(),
     markDirty: () => markSlotFallbackDirty(outlet),
   }
   outlet = {
@@ -108,7 +108,6 @@ function createTestSlotFallbackOutlet(options: {
     getContent: () => options.content || [],
     getParentNode: () => options.parentNode || null,
     getAnchor: () => options.anchor || null,
-    runWithRenderCtx: fn => fn(),
     isDisposed: options.isDisposed,
     isContentValid: options.isContentValid,
     notifyFallbackValidityChange: vi.fn(),
@@ -246,7 +245,8 @@ describe('component: slots', () => {
       const frag = new SlotFragment()
       frag.parentSlotBoundary = {
         parent: null,
-        getLocalFallback: () => inheritedFallback,
+        getFallback: () => inheritedFallback,
+        run: fn => fn(),
         markDirty: vi.fn(),
       }
 
@@ -261,7 +261,8 @@ describe('component: slots', () => {
     test('slot fragment local fallback renders nested slots against the parent boundary', () => {
       const parentBoundary = {
         parent: null,
-        getLocalFallback: () => () => document.createTextNode('outer fallback'),
+        getFallback: () => () => document.createTextNode('outer fallback'),
+        run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
       const frag = new SlotFragment()
@@ -280,48 +281,12 @@ describe('component: slots', () => {
       expect(fallbackBoundary.parent).toBe(parentBoundary)
     })
 
-    test('withSlotFallbackBoundary reuses the same redirected boundary', () => {
-      const parentBoundaryA = {
-        parent: null,
-        getLocalFallback: () => undefined,
-        markDirty: vi.fn(),
-      }
-      const parentBoundaryB = {
-        parent: null,
-        getLocalFallback: () => undefined,
-        markDirty: vi.fn(),
-      }
-      let activeParent = parentBoundaryA
-      const boundary: SlotBoundaryContext = {
-        get parent() {
-          return activeParent
-        },
-        getLocalFallback: () => () => document.createTextNode('fallback'),
-        markDirty: vi.fn(),
-      }
-      let firstBoundary!: SlotBoundaryContext | null
-      let secondBoundary!: SlotBoundaryContext | null
-
-      withSlotFallbackBoundary(boundary, () => {
-        firstBoundary = getCurrentSlotBoundary()
-      })
-
-      activeParent = parentBoundaryB
-
-      withSlotFallbackBoundary(boundary, () => {
-        secondBoundary = getCurrentSlotBoundary()
-      })
-
-      expect(firstBoundary).toBe(secondBoundary)
-      expect(firstBoundary!.parent).toBe(parentBoundaryB)
-      expect(firstBoundary!.getLocalFallback()).toBeUndefined()
-    })
-
     test('slot fragment local fallback keeps itself as owner for nested fragments', () => {
       const container = document.createElement('div')
       const parentBoundary = {
         parent: null,
-        getLocalFallback: () => () => document.createTextNode('outer fallback'),
+        getFallback: () => () => document.createTextNode('outer fallback'),
+        run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
       const frag = new SlotFragment()
@@ -355,8 +320,8 @@ describe('component: slots', () => {
       const frag = new SlotFragment()
       const parentBoundary = {
         parent: null,
-        getLocalFallback: () => () =>
-          document.createTextNode(ancestorText.value),
+        getFallback: () => () => document.createTextNode(ancestorText.value),
+        run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
       frag.parentSlotBoundary = parentBoundary
@@ -399,6 +364,80 @@ describe('component: slots', () => {
       insert(frag, container)
 
       expect(container.innerHTML).toBe('fallback<!--for--><!--slot-->')
+    })
+
+    test('slot fallback falls through while preserving local carrier', () => {
+      const container = document.createElement('div')
+      const anchor = document.createComment('slot')
+      const localCarrier = new DynamicFragment('if', false, false)
+      let outlet!: SlotFallbackOutlet
+      const parentBoundary: SlotBoundaryContext = {
+        parent: null,
+        getFallback: () => () => document.createTextNode('outlet fallback'),
+        run: fn => fn(),
+        markDirty: vi.fn(),
+      }
+      const boundary: SlotBoundaryContext = {
+        parent: parentBoundary,
+        getFallback: () => () => localCarrier,
+        run: fn => fn(),
+        markDirty: () => markSlotFallbackDirty(outlet),
+      }
+      outlet = {
+        boundary,
+        activeFallback: null,
+        pendingRecheck: false,
+        isRenderingFallback: false,
+        getContent: () => [],
+        getParentNode: () => container,
+        getAnchor: () => anchor,
+        isContentValid: () => false,
+        notifyFallbackValidityChange: vi.fn(),
+      }
+
+      container.append(anchor)
+      recheckSlotFallback(outlet)
+
+      expect(container.innerHTML).toBe('outlet fallback<!--if--><!--slot-->')
+    })
+
+    test('slot fallback falls through when local fallback is removed', () => {
+      const container = document.createElement('div')
+      const anchor = document.createComment('slot')
+      let localFallback: BlockFn | undefined = () =>
+        document.createTextNode('local fallback')
+      let outlet!: SlotFallbackOutlet
+      const parentBoundary: SlotBoundaryContext = {
+        parent: null,
+        getFallback: () => () => document.createTextNode('outlet fallback'),
+        run: fn => fn(),
+        markDirty: vi.fn(),
+      }
+      const boundary: SlotBoundaryContext = {
+        parent: parentBoundary,
+        getFallback: () => localFallback,
+        run: fn => fn(),
+        markDirty: () => markSlotFallbackDirty(outlet),
+      }
+      outlet = {
+        boundary,
+        activeFallback: null,
+        pendingRecheck: false,
+        isRenderingFallback: false,
+        getContent: () => [],
+        getParentNode: () => container,
+        getAnchor: () => anchor,
+        isContentValid: () => false,
+        notifyFallbackValidityChange: vi.fn(),
+      }
+
+      container.append(anchor)
+      recheckSlotFallback(outlet)
+      expect(container.innerHTML).toBe('local fallback<!--slot-->')
+
+      localFallback = undefined
+      recheckSlotFallback(outlet, true)
+      expect(container.innerHTML).toBe('outlet fallback<!--slot-->')
     })
 
     test('slot fragment delays fallback activation until pending child validity resolves', () => {
@@ -624,7 +663,8 @@ describe('component: slots', () => {
       const text = ref('A')
       const boundary = {
         parent: null,
-        getLocalFallback: () => undefined,
+        getFallback: () => undefined,
+        run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
       const instance = renderWithSlots({})
@@ -653,7 +693,8 @@ describe('component: slots', () => {
       const show = ref(true)
       const boundary = {
         parent: null,
-        getLocalFallback: () => undefined,
+        getFallback: () => undefined,
+        run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
       const instance = renderWithSlots({})
@@ -678,6 +719,85 @@ describe('component: slots', () => {
 
       expect(host.innerHTML).toBe('fallback')
       expect(boundary.markDirty).toHaveBeenCalledTimes(1)
+    })
+
+    test('vdom slot dirties parent boundary once when valid content becomes empty', async () => {
+      const show = ref(true)
+      const boundary = {
+        parent: null,
+        getFallback: () => undefined,
+        run: (fn: () => any) => fn(),
+        markDirty: vi.fn(),
+      }
+      const instance = renderWithSlots({})
+      const app = createApp({ render: () => null })
+      app.use(vaporInteropPlugin)
+      const vapor = (app._context as any).vapor
+      const slotsRef = shallowRef({
+        default: () => (show.value ? [h('div', 'content')] : []),
+      })
+      const frag = withOwnedSlotBoundary(boundary, () =>
+        vapor.vdomSlot(slotsRef, 'default', {}, instance),
+      )
+      const host = document.createElement('div')
+
+      insert(frag, host)
+      boundary.markDirty.mockClear()
+
+      show.value = false
+      await nextTick()
+
+      expect(host.innerHTML).toBe('')
+      expect(boundary.markDirty).toHaveBeenCalledTimes(1)
+    })
+
+    test('vdom slot dirties parent boundary when nested fallback validity flips', async () => {
+      const showInnerFallback = ref(true)
+      const boundary = {
+        parent: null,
+        getFallback: () => undefined,
+        run: (fn: () => any) => fn(),
+        markDirty: vi.fn(),
+      }
+      const instance = renderWithSlots({})
+      const app = createApp({ render: () => null })
+      app.use(vaporInteropPlugin)
+      const vapor = (app._context as any).vapor
+      const slotsRef = shallowRef({
+        default: () => [],
+      })
+      const renderInnerFallback = () => {
+        const child = new SlotFragment()
+        renderEffect(() => {
+          child.updateSlot(
+            showInnerFallback.value
+              ? () => template('inner fallback')()
+              : undefined,
+          )
+        })
+        return child
+      }
+      const frag = withOwnedSlotBoundary(boundary, () =>
+        vapor.vdomSlot(slotsRef, 'default', {}, instance, renderInnerFallback),
+      )
+      const host = document.createElement('div')
+
+      insert(frag, host)
+      boundary.markDirty.mockClear()
+
+      expect(host.innerHTML).toBe('inner fallback<!--slot-->')
+
+      showInnerFallback.value = false
+      await nextTick()
+
+      expect(host.innerHTML).toBe('<!--slot-->')
+      expect(boundary.markDirty).toHaveBeenCalledTimes(1)
+
+      showInnerFallback.value = true
+      await nextTick()
+
+      expect(host.innerHTML).toBe('inner fallback<!--slot-->')
+      expect(boundary.markDirty).toHaveBeenCalledTimes(2)
     })
 
     test('vdom slot still renders vapor fallback when slot content resolves empty', () => {
@@ -747,6 +867,22 @@ describe('component: slots', () => {
       src.value = 'footer'
       await nextTick()
       expect(host.innerHTML).toBe('<div><h1>footer</h1><!--slot--></div>')
+    })
+
+    test('plain slot without fallback does not enter fallback boundary', () => {
+      let observedBoundary: SlotBoundaryContext | null | undefined
+      const Comp = defineVaporComponent(() => createSlot('default'))
+
+      define(() =>
+        createComponent(Comp, null, {
+          default: () => {
+            observedBoundary = getCurrentSlotBoundary()
+            return template('content')()
+          },
+        }),
+      ).render()
+
+      expect(observedBoundary).toBe(null)
     })
 
     test('slot props should be isolated per fragment in v-for', async () => {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -477,6 +477,31 @@ describe('component: slots', () => {
       expect(outlet.pendingRecheck).toBe(false)
     })
 
+    test('removed slot fragment ignores queued fallback dirty notifications', () => {
+      const container = document.createElement('div')
+      const fallbackRuns = vi.fn()
+      const cleanup = vi.fn()
+      const frag = new SlotFragment()
+      frag.updateSlot(undefined, () => {
+        fallbackRuns()
+        onScopeDispose(cleanup)
+        return document.createTextNode('fallback')
+      })
+      insert(frag, container)
+      expect(container.innerHTML).toBe('fallback<!--slot-->')
+      expect(fallbackRuns).toHaveBeenCalledTimes(1)
+
+      remove(frag, container)
+      expect(container.innerHTML).toBe('')
+      expect(cleanup).toHaveBeenCalledTimes(1)
+
+      frag.boundary.markDirty()
+
+      expect(fallbackRuns).toHaveBeenCalledTimes(1)
+      expect(frag.fallbackBlock).toBe(null)
+      expect(cleanup).toHaveBeenCalledTimes(1)
+    })
+
     test('withHydratingSlotBoundary isolates fallback-active state between boundaries without local markers', () => {
       const start = document.createComment('[')
       const end = document.createComment(']')

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -10398,6 +10398,106 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate interop vapor slot falls through when vdom local fallback invalidates', async () => {
+    const data = reactive({
+      mode: 'local',
+      local: 'local fallback',
+      outlet: 'outlet fallback',
+    })
+    const { container } = await testWithVDOMApp(
+      `<script setup>
+        const components = _components
+      </script>
+      <template>
+        <components.VaporBridge />
+      </template>`,
+      {
+        VaporBridge: {
+          code: `<script setup>
+            const components = _components
+          </script>
+          <template>
+            <components.VdomInnerSlot>
+              <template #bar><slot name="bar" /></template>
+            </components.VdomInnerSlot>
+          </template>`,
+          vapor: true,
+        },
+        VdomInnerSlot: {
+          code: `<script setup>
+            const data = _data
+            const components = _components
+          </script>
+          <template>
+            <components.VdomOuterSlot>
+              <template #foo>
+                <slot name="bar">
+                  <div v-if="data.mode === 'local'">{{ data.local }}</div>
+                </slot>
+              </template>
+            </components.VdomOuterSlot>
+          </template>`,
+          vapor: false,
+        },
+        VdomOuterSlot: {
+          code: `<script setup>const data = _data</script>
+          <template><slot name="foo"><section>{{ data.outlet }}</section></slot></template>`,
+          vapor: false,
+        },
+      },
+      data,
+    )
+
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[-->
+      <!--[--><div>local fallback</div><!--]-->
+      <!--]-->
+      "
+    `,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+
+    data.mode = 'empty'
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[-->
+      <!--[--><section>outlet fallback</section><!--v-if--><!--v-if--><!--]-->
+      <!--]-->
+      "
+    `,
+    )
+
+    data.outlet = 'updated outlet fallback'
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[-->
+      <!--[--><section>updated outlet fallback</section><!--v-if--><!--v-if--><!--]-->
+      <!--]-->
+      "
+    `,
+    )
+
+    data.local = 'updated local fallback'
+    data.mode = 'local'
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[-->
+      <!--[--><div>updated local fallback</div><!--]-->
+      <!--]-->
+      "
+    `,
+    )
+  })
+
   test('hydrate interop vapor slot with fallback should preserve valid slot branches', async () => {
     const data = reactive({
       slot: 'bar',

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1278,6 +1278,78 @@ describe('vdomInterop', () => {
       expect(html()).toBe('<span>updated</span>')
     })
 
+    test('falls through to outlet fallback when vdom local fallback is invalidated or removed from VaporSlot', async () => {
+      const mode = ref<'local' | 'empty' | 'none'>('local')
+      const localText = ref('local fallback')
+      const outletText = ref('outlet fallback')
+      const localFallback = () =>
+        mode.value === 'empty' ? [] : [h('div', localText.value)]
+
+      const VDomOuterSlot = defineComponent({
+        setup(_, { slots }) {
+          return () =>
+            renderSlot(slots, 'foo', {}, () => [h('section', outletText.value)])
+        },
+      })
+
+      const VDomInnerSlot = defineComponent({
+        setup(_, { slots }) {
+          return () =>
+            h(VDomOuterSlot, null, {
+              foo: () => [
+                renderSlot(
+                  slots,
+                  'bar',
+                  {},
+                  mode.value === 'none' ? undefined : localFallback,
+                ),
+              ],
+              _: 3 /* FORWARDED */,
+            })
+        },
+      })
+
+      const VaporBridge = defineVaporComponent({
+        setup() {
+          return createComponent(
+            VDomInnerSlot as any,
+            null,
+            {
+              bar: withVaporCtx(() => createSlot('bar', null)),
+            },
+            true,
+          )
+        },
+      })
+
+      const root = document.createElement('div')
+      createVaporApp(VaporBridge).use(vaporInteropPlugin).mount(root)
+      expect(root.innerHTML).toBe('<div>local fallback</div><!--slot-->')
+
+      mode.value = 'empty'
+      await nextTick()
+      expect(root.innerHTML).toBe(
+        '<section>outlet fallback</section><!--slot-->',
+      )
+
+      localText.value = 'stale local fallback'
+      outletText.value = 'updated outlet fallback'
+      await nextTick()
+      expect(root.innerHTML).toBe(
+        '<section>updated outlet fallback</section><!--slot-->',
+      )
+
+      mode.value = 'local'
+      await nextTick()
+      expect(root.innerHTML).toBe('<div>stale local fallback</div><!--slot-->')
+
+      mode.value = 'none'
+      await nextTick()
+      expect(root.innerHTML).toBe(
+        '<section>updated outlet fallback</section><!--slot-->',
+      )
+    })
+
     test('preserves normalized VDOM slot functions passed to Vapor', async () => {
       const msg = ref('default slot')
       const VaporChild = defineVaporComponent(() => createSlot('default', null))

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -77,9 +77,18 @@ export function isValidBlock(block: Block | null | undefined): boolean {
     return isValidBlock(block.block)
   } else if (isArray(block)) {
     return block.length > 0 && block.some(isValidBlock)
-  } else if (block.validityPending) {
-    return true
   } else {
+    const isBlockValid = (
+      block as VaporFragment & {
+        isBlockValid?: () => boolean
+      }
+    ).isBlockValid
+    if (isBlockValid) {
+      return isBlockValid.call(block)
+    }
+    if (block.validityPending) {
+      return true
+    }
     const getEffectiveOutput = (
       block as VaporFragment & {
         getEffectiveOutput?: () => Block

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -200,6 +200,8 @@ export function createSlot(
   const slotProps = rawProps
     ? new Proxy(rawProps, rawPropsProxyHandlers)
     : EMPTY_OBJ
+  const scopeId = !noSlotted && instance.type.__scopeId
+  const slotScopeIds = scopeId ? [`${scopeId}-s`] : null
 
   let fragment: VaporFragment
   if (isRef(rawSlots._) && isInteropEnabled) {
@@ -218,15 +220,6 @@ export function createSlot(
     slotFragment.forwarded =
       currentSlotOwner != null && currentSlotOwner !== currentInstance
     const isDynamicName = isFunction(name)
-
-    // Calculate slotScopeIds once (for vdom interop)
-    const slotScopeIds: string[] = []
-    if (!noSlotted) {
-      const scopeId = instance.type.__scopeId
-      if (scopeId) {
-        slotScopeIds.push(`${scopeId}-s`)
-      }
-    }
 
     const renderSlot = () => {
       const slotName = isFunction(name) ? name() : name
@@ -275,9 +268,7 @@ export function createSlot(
       if (slot !== cachedSlot) {
         cachedSlot = slot
         cachedBoundSlot = () => {
-          const prevSlotScopeIds = setCurrentSlotScopeIds(
-            slotScopeIds.length > 0 ? slotScopeIds : null,
-          )
+          const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
           const prev = inOnceSlot
           try {
             if (once) inOnceSlot = true
@@ -300,11 +291,8 @@ export function createSlot(
   }
 
   if (!isHydrating) {
-    if (!noSlotted) {
-      const scopeId = instance.type.__scopeId
-      if (scopeId) {
-        setScopeId(fragment, [`${scopeId}-s`])
-      }
+    if (slotScopeIds) {
+      setScopeId(fragment, slotScopeIds)
     }
 
     if (_insertionParent) insert(fragment, _insertionParent, _insertionAnchor)

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -22,7 +22,6 @@ import {
   isHydrating,
 } from './dom/hydration'
 import {
-  type DynamicFragment,
   SlotFragment,
   type VaporFragment,
   withOwnedSlotBoundary,
@@ -104,12 +103,7 @@ export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
   deleteProperty: NO,
 }
 
-export function getSlot(
-  target: RawSlots,
-  key: string,
-):
-  | (VaporSlot & { _boundMap?: WeakMap<DynamicFragment, VaporSlot> })
-  | undefined {
+export function getSlot(target: RawSlots, key: string): VaporSlot | undefined {
   if (key === '$') return
   const dynamicSources = target.$
   if (dynamicSources) {
@@ -269,32 +263,32 @@ export function createSlot(
 
       const slot = getSlot(rawSlots, slotName)
       if (slot) {
-        // Create and cache bound slot to keep it stable and avoid unnecessary
-        // updates when it resolves to the same slot. Cache per-fragment
-        // (v-for creates multiple fragments) so each fragment keeps its own
-        // slotProps without cross-talk.
-        const boundMap = slot._boundMap || (slot._boundMap = new WeakMap())
-        let bound = boundMap.get(slotFragment)
-        if (!bound) {
-          bound = () => {
-            const prevSlotScopeIds = setCurrentSlotScopeIds(
-              slotScopeIds.length > 0 ? slotScopeIds : null,
-            )
-            const prev = inOnceSlot
-            try {
-              if (once) inOnceSlot = true
-              return slot(slotProps)
-            } finally {
-              inOnceSlot = prev
-              setCurrentSlotScopeIds(prevSlotScopeIds)
-            }
-          }
-          boundMap.set(slotFragment, bound)
-        }
-        slotFragment.updateSlot(bound, fallback)
+        slotFragment.updateSlot(getBoundSlot(slot), fallback)
       } else {
         slotFragment.updateSlot(undefined, fallback)
       }
+    }
+
+    let cachedSlot: VaporSlot | undefined
+    let cachedBoundSlot: VaporSlot | undefined
+    const getBoundSlot = (slot: VaporSlot): VaporSlot => {
+      if (slot !== cachedSlot) {
+        cachedSlot = slot
+        cachedBoundSlot = () => {
+          const prevSlotScopeIds = setCurrentSlotScopeIds(
+            slotScopeIds.length > 0 ? slotScopeIds : null,
+          )
+          const prev = inOnceSlot
+          try {
+            if (once) inOnceSlot = true
+            return slot(slotProps)
+          } finally {
+            inOnceSlot = prev
+            setCurrentSlotScopeIds(prevSlotScopeIds)
+          }
+        }
+      }
+      return cachedBoundSlot!
     }
 
     // dynamic slot name or has dynamicSlots

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1256,6 +1256,7 @@ export class SlotFragment
   extends DynamicFragment
   implements SlotFallbackOutlet
 {
+  private disposed = false
   forwarded = false
   parentSlotBoundary: SlotBoundaryContext | null = getCurrentSlotBoundary()
   // Custom elements with `shadowRoot: false` replace their native slot outlet
@@ -1315,6 +1316,7 @@ export class SlotFragment
   }
 
   private insertSlot(parent: ParentNode, anchor: Node | null): void {
+    this.disposed = false
     if (this.fallbackBlock) {
       insert(this.fallbackBlock, parent, anchor)
       mutateSlotFallbackCarrier(this.nodes, block =>
@@ -1326,6 +1328,7 @@ export class SlotFragment
   }
 
   private removeSlot(parent?: ParentNode): void {
+    this.disposed = true
     if (this.fallbackBlock) {
       mutateSlotFallbackCarrier(this.nodes, block => remove(block, parent))
     } else {
@@ -1411,6 +1414,10 @@ export class SlotFragment
 
   isBusy(): boolean {
     return this.isUpdatingSlot
+  }
+
+  isDisposed(): boolean {
+    return this.disposed
   }
 
   notifyFallbackValidityChange(): void {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -854,7 +854,7 @@ export function mutateSlotFallbackCarrier(
   )
 }
 
-function hasSlotFallback(
+export function hasSlotFallback(
   boundary: SlotBoundaryContext | null | undefined,
 ): boolean {
   while (boundary) {
@@ -899,265 +899,260 @@ function renderSlotFallbackBlock(
   ]
 }
 
-export interface SlotFallbackControllerHost {
-  getParentBoundary: () => SlotBoundaryContext | null
-  getLocalFallback: () => BlockFn | undefined
-  getContent: () => Block
-  getParentNode: () => ParentNode | null
-  getAnchor: () => Node | null
-  runWithRenderCtx: <R>(fn: () => R) => R
-  isBusy?: () => boolean
-  isDisposed?: () => boolean
-  onValidityChange: () => void
-  // Interop-only hooks:
-  // - plain SlotFragment validity is just `isValidBlock(getContent())`
-  // - plain SlotFragment consumes pending rechecks itself in updateSlot(), so it
-  //   opts out of the controller's post-fallback same-stack rerun
-  isContentValid?: () => boolean
+export interface SlotFallbackOutlet {
+  boundary: SlotBoundaryContext
+  activeFallback: Block | null
+  fallbackScope?: EffectScope
+  pendingRecheck: boolean
+  isRenderingFallback: boolean
   rerunRecheckAfterFallbackRender?: boolean
-  syncEffectiveOutput?: () => void
+
+  getContent(): Block
+  getParentNode(): ParentNode | null
+  getAnchor(): Node | null
+  runWithRenderCtx<R>(fn: () => R): R
+  isBusy?(): boolean
+  isDisposed?(): boolean
+  isContentValid?(): boolean
+  syncEffectiveOutput?(): void
+  notifyFallbackValidityChange(): void
 }
 
-export class SlotFallbackController {
-  private activeFallback: Block | null = null
-  private fallbackScope: EffectScope | undefined
-  private pendingRecheck = false
-  private isRenderingFallback = false
-  private readonly rerunRecheckAfterFallbackRender: boolean
-
-  readonly boundary: SlotBoundaryContext
-
-  constructor(private readonly host: SlotFallbackControllerHost) {
-    this.rerunRecheckAfterFallbackRender =
-      host.rerunRecheckAfterFallbackRender !== false
-    this.boundary = {
-      get parent() {
-        return host.getParentBoundary()
-      },
-      getLocalFallback: host.getLocalFallback,
-      markDirty: () => {
-        if (host.isDisposed && host.isDisposed()) {
-          return
-        }
-        if (this.isRenderingFallback) {
-          if (isHydrating) {
-            this.pendingRecheck = true
-          }
-          return
-        }
-        if (host.isBusy && host.isBusy()) {
-          this.pendingRecheck = true
-          return
-        }
-        this.recheck(true)
-      },
+type SlotFallbackResult =
+  | {
+      found: true
+      block: Block
+      scope: EffectScope
     }
+  | {
+      found: false
+    }
+
+export function getSlotEffectiveOutput(outlet: SlotFallbackOutlet): Block {
+  return outlet.activeFallback || outlet.getContent()
+}
+
+function isSlotFallbackContentValid(outlet: SlotFallbackOutlet): boolean {
+  return outlet.isContentValid
+    ? outlet.isContentValid()
+    : isValidBlock(outlet.getContent())
+}
+
+export function markSlotFallbackDirty(outlet: SlotFallbackOutlet): void {
+  if (outlet.isDisposed && outlet.isDisposed()) {
+    return
+  }
+  if (outlet.isRenderingFallback) {
+    if (isHydrating) {
+      outlet.pendingRecheck = true
+    }
+    return
+  }
+  if (outlet.isBusy && outlet.isBusy()) {
+    outlet.pendingRecheck = true
+    return
+  }
+  recheckSlotFallback(outlet, true)
+}
+
+function clearSlotFallback(outlet: SlotFallbackOutlet): void {
+  if (outlet.activeFallback) {
+    const parentNode = outlet.getParentNode()
+    if (parentNode) {
+      remove(outlet.activeFallback, parentNode)
+    }
+    outlet.activeFallback = null
+  }
+  if (outlet.fallbackScope) {
+    outlet.fallbackScope.stop()
+    outlet.fallbackScope = undefined
+  }
+}
+
+function renderSlotFallbackForOutlet(
+  outlet: SlotFallbackOutlet,
+): SlotFallbackResult {
+  const scope = new EffectScope()
+  let renderedFallback: Block | undefined
+  outlet.isRenderingFallback = true
+  try {
+    renderedFallback =
+      outlet.runWithRenderCtx(
+        () => scope.run(() => renderSlotFallback(outlet.boundary)) || undefined,
+      ) || undefined
+  } catch (err) {
+    scope.stop()
+    throw err
+  } finally {
+    outlet.isRenderingFallback = false
   }
 
-  getEffectiveOutput(): Block {
-    return this.activeFallback || this.host.getContent()
+  if (!renderedFallback) {
+    scope.stop()
+    return { found: false }
   }
 
-  getActiveFallback(): Block | null {
-    return this.activeFallback
+  return {
+    found: true,
+    block: renderedFallback,
+    scope,
+  }
+}
+
+function syncSlotFallbackOrder(outlet: SlotFallbackOutlet, block: Block): void {
+  if (!isFragment(block) || !isArray(block.nodes) || block.nodes.length < 2) {
+    return
   }
 
-  hasFallback(): boolean {
-    return hasSlotFallback(this.boundary)
+  const carrierNodes = collectBlockNodes(outlet.getContent(), [], true)
+  const fallbackNodes = collectBlockNodes(block, [], true)
+  const lastNode = fallbackNodes[fallbackNodes.length - 1]
+  if (!carrierNodes.length || !lastNode) {
+    return
   }
 
-  wrapFallback(fallback: BlockFn): BlockFn {
-    return (...args: any[]) =>
-      // Wrapped fallbacks can be invoked later under another owner's render
-      // path, so re-establish this boundary before resolving local fallback.
-      this.host.runWithRenderCtx(() =>
-        withSlotFallbackBoundary(this.boundary, () => fallback(...args)),
-      )
+  const parentNode = carrierNodes[0].parentNode
+  if (!parentNode || lastNode.parentNode !== parentNode) {
+    return
   }
 
-  clearPendingRecheck(): void {
-    this.pendingRecheck = false
-  }
-
-  takePendingRecheck(): boolean {
-    const shouldRecheck = this.pendingRecheck
-    this.pendingRecheck = false
-    return shouldRecheck
-  }
-
-  dispose(): void {
-    this.clearActiveFallback()
-    this.pendingRecheck = false
-  }
-
-  relocate(): void {
-    if (isHydrating || !this.activeFallback) {
+  let inOrder = true
+  let nextNode = lastNode.nextSibling
+  for (const carrierNode of carrierNodes) {
+    if (carrierNode.parentNode !== parentNode) {
       return
     }
-    const parentNode = this.host.getParentNode()
-    if (!parentNode) {
-      return
+    if (carrierNode !== nextNode) {
+      inOrder = false
+      break
     }
-    const carrierAnchor = findFirstSlotFallbackCarrierNode(
-      this.host.getContent(),
-    )
-    insert(
-      this.activeFallback,
-      parentNode,
-      carrierAnchor && carrierAnchor.parentNode === parentNode
-        ? carrierAnchor
-        : this.host.getAnchor(),
-    )
+    nextNode = carrierNode.nextSibling
   }
 
-  syncActiveFallback(): void {
-    if (!this.activeFallback) {
-      return
-    }
-    const activeFallback = this.activeFallback
-    queuePostFlushCb(() => {
-      this.syncActiveFallbackOrder(activeFallback)
-    })
+  if (inOrder) {
+    return
   }
 
-  recheck(force: boolean = false): void {
-    const prevValid = this.activeFallback
-      ? isValidBlock(this.activeFallback)
-      : this.isContentValid()
-    const contentValid = this.isContentValid()
+  let anchor = lastNode.nextSibling
+  for (let i = carrierNodes.length - 1; i >= 0; i--) {
+    const carrierNode = carrierNodes[i]
+    parentNode.insertBefore(carrierNode, anchor)
+    anchor = carrierNode as ChildNode
+  }
+}
 
-    if (contentValid) {
-      this.clearActiveFallback()
-    } else if (!this.ensureFallback(force)) {
-      this.clearActiveFallback()
-    }
-
-    const nextValid = this.activeFallback
-      ? isValidBlock(this.activeFallback)
-      : this.isContentValid()
-    if (this.host.syncEffectiveOutput) {
-      this.host.syncEffectiveOutput()
-    }
-    if (prevValid !== nextValid) {
-      this.host.onValidityChange()
-    }
+function ensureSlotFallbackOrderHook(
+  outlet: SlotFallbackOutlet,
+  block: Block,
+): void {
+  if (!isFragment(block)) {
+    return
   }
 
-  private isContentValid(): boolean {
-    return this.host.isContentValid
-      ? this.host.isContentValid()
-      : isValidBlock(this.host.getContent())
+  const fragment = block as VaporFragment<Block> & {
+    hasSlotFallbackOrderHook?: boolean
+  }
+  if (fragment.hasSlotFallbackOrderHook) {
+    return
   }
 
-  private clearActiveFallback(): void {
-    if (this.activeFallback) {
-      const parentNode = this.host.getParentNode()
-      if (parentNode) {
-        remove(this.activeFallback, parentNode)
-      }
-      this.activeFallback = null
-    }
-    if (this.fallbackScope) {
-      this.fallbackScope.stop()
-      this.fallbackScope = undefined
-    }
+  ;(fragment.onUpdated || (fragment.onUpdated = [])).push(() =>
+    syncSlotFallbackOrder(outlet, fragment),
+  )
+  fragment.hasSlotFallbackOrderHook = true
+}
+
+export function insertActiveSlotFallback(outlet: SlotFallbackOutlet): void {
+  if (isHydrating || !outlet.activeFallback) {
+    return
+  }
+  const parentNode = outlet.getParentNode()
+  if (!parentNode) {
+    return
+  }
+  const carrierAnchor = findFirstSlotFallbackCarrierNode(outlet.getContent())
+  insert(
+    outlet.activeFallback,
+    parentNode,
+    carrierAnchor && carrierAnchor.parentNode === parentNode
+      ? carrierAnchor
+      : outlet.getAnchor(),
+  )
+}
+
+function commitSlotFallback(
+  outlet: SlotFallbackOutlet,
+  block: Block,
+  scope: EffectScope,
+): void {
+  outlet.activeFallback = block
+  outlet.fallbackScope = scope
+  ensureSlotFallbackOrderHook(outlet, block)
+  insertActiveSlotFallback(outlet)
+}
+
+export function syncActiveSlotFallback(outlet: SlotFallbackOutlet): void {
+  if (!outlet.activeFallback) {
+    return
+  }
+  const activeFallback = outlet.activeFallback
+  queuePostFlushCb(() => {
+    syncSlotFallbackOrder(outlet, activeFallback)
+  })
+}
+
+export function disposeSlotFallback(outlet: SlotFallbackOutlet): void {
+  clearSlotFallback(outlet)
+  outlet.pendingRecheck = false
+}
+
+export function recheckSlotFallback(
+  outlet: SlotFallbackOutlet,
+  force: boolean = false,
+): void {
+  if (outlet.isRenderingFallback) {
+    outlet.pendingRecheck = true
+    return
   }
 
-  private ensureFallback(force: boolean): boolean {
+  const prevValid = outlet.activeFallback
+    ? isValidBlock(outlet.activeFallback)
+    : isSlotFallbackContentValid(outlet)
+  const contentValid = isSlotFallbackContentValid(outlet)
+
+  if (contentValid) {
+    clearSlotFallback(outlet)
+  } else {
     if (force) {
-      this.clearActiveFallback()
+      clearSlotFallback(outlet)
     }
-    if (this.activeFallback) return true
-
-    const scope = new EffectScope()
-    let renderedFallback: Block | undefined
-    this.isRenderingFallback = true
-    try {
-      renderedFallback =
-        this.host.runWithRenderCtx(
-          () => scope.run(() => renderSlotFallback(this.boundary)) || undefined,
-        ) || undefined
-    } catch (err) {
-      scope.stop()
-      throw err
-    } finally {
-      this.isRenderingFallback = false
-    }
-    if (!renderedFallback) {
-      scope.stop()
-      return false
-    }
-
-    this.fallbackScope = scope
-    this.activeFallback = renderedFallback
-    this.ensureActiveFallbackOrderHook(renderedFallback)
-    if (this.pendingRecheck && this.rerunRecheckAfterFallbackRender) {
-      this.pendingRecheck = false
-      this.recheck(true)
-      return true
-    }
-
-    this.relocate()
-    return true
-  }
-  private syncActiveFallbackOrder(block: Block): void {
-    if (!isFragment(block) || !isArray(block.nodes) || block.nodes.length < 2) {
-      return
-    }
-
-    const carrierNodes = collectBlockNodes(this.host.getContent(), [], true)
-    const fallbackNodes = collectBlockNodes(block, [], true)
-    const lastNode = fallbackNodes[fallbackNodes.length - 1]
-    if (!carrierNodes.length || !lastNode) {
-      return
-    }
-
-    const parentNode = carrierNodes[0].parentNode
-    if (!parentNode || lastNode.parentNode !== parentNode) {
-      return
-    }
-
-    let inOrder = true
-    let nextNode = lastNode.nextSibling
-    for (const carrierNode of carrierNodes) {
-      if (carrierNode.parentNode !== parentNode) {
-        return
+    if (outlet.activeFallback) {
+      insertActiveSlotFallback(outlet)
+    } else {
+      const result = renderSlotFallbackForOutlet(outlet)
+      if (result.found) {
+        commitSlotFallback(outlet, result.block, result.scope)
+        if (
+          outlet.pendingRecheck &&
+          outlet.rerunRecheckAfterFallbackRender !== false
+        ) {
+          outlet.pendingRecheck = false
+          recheckSlotFallback(outlet, true)
+        }
+      } else {
+        clearSlotFallback(outlet)
       }
-      if (carrierNode !== nextNode) {
-        inOrder = false
-        break
-      }
-      nextNode = carrierNode.nextSibling
-    }
-
-    if (inOrder) {
-      return
-    }
-
-    let anchor = lastNode.nextSibling
-    for (let i = carrierNodes.length - 1; i >= 0; i--) {
-      const carrierNode = carrierNodes[i]
-      parentNode.insertBefore(carrierNode, anchor)
-      anchor = carrierNode as ChildNode
     }
   }
 
-  private ensureActiveFallbackOrderHook(block: Block): void {
-    if (!isFragment(block)) {
-      return
-    }
-
-    const fragment = block as VaporFragment<Block> & {
-      hasSlotFallbackOrderHook?: boolean
-    }
-    if (fragment.hasSlotFallbackOrderHook) {
-      return
-    }
-
-    ;(fragment.onUpdated || (fragment.onUpdated = [])).push(() =>
-      this.syncActiveFallbackOrder(fragment),
-    )
-    fragment.hasSlotFallbackOrderHook = true
+  const nextValid = outlet.activeFallback
+    ? isValidBlock(outlet.activeFallback)
+    : isSlotFallbackContentValid(outlet)
+  if (outlet.syncEffectiveOutput) {
+    outlet.syncEffectiveOutput()
+  }
+  if (prevValid !== nextValid) {
+    outlet.notifyFallbackValidityChange()
   }
 }
 
@@ -1254,36 +1249,35 @@ function isReusableDynamicFragmentAnchor(
   )
 }
 
-export class SlotFragment extends DynamicFragment {
+export class SlotFragment
+  extends DynamicFragment
+  implements SlotFallbackOutlet
+{
   forwarded = false
   parentSlotBoundary: SlotBoundaryContext | null = getCurrentSlotBoundary()
   // Custom elements with `shadowRoot: false` replace their native slot outlet
   // after mount. Keep the live fallback owner on the fragment so CE slot sync
   // can preserve block ownership after the outlet node is gone.
   customElementFallback?: Block
+  activeFallback: Block | null = null
+  fallbackScope?: EffectScope
+  pendingRecheck = false
+  isRenderingFallback = false
+  readonly rerunRecheckAfterFallbackRender = false
   private localFallback?: BlockFn
   private isUpdatingSlot = false
-  private readonly controller: SlotFallbackController
   readonly slotFallbackBoundary: SlotBoundaryContext
 
   constructor() {
     super(isHydrating || __DEV__ ? 'slot' : undefined, false, false)
-    this.controller = new SlotFallbackController({
-      getParentBoundary: () => this.parentSlotBoundary,
-      getLocalFallback: () => this.localFallback,
-      getContent: () => this.nodes,
-      getParentNode: () => (this.anchor ? this.anchor.parentNode : null),
-      getAnchor: () => this.anchor || null,
-      runWithRenderCtx: fn => this.runWithRenderCtx(fn),
-      isBusy: () => this.isUpdatingSlot,
-      rerunRecheckAfterFallbackRender: false,
-      onValidityChange: () => {
-        if (this.parentSlotBoundary) {
-          this.parentSlotBoundary.markDirty()
-        }
+    const owner = this
+    this.slotFallbackBoundary = {
+      get parent() {
+        return owner.parentSlotBoundary
       },
-    })
-    this.slotFallbackBoundary = this.controller.boundary
+      getLocalFallback: () => this.localFallback,
+      markDirty: () => markSlotFallbackDirty(this),
+    }
     if (!isHydrating) {
       this.insert = (parent, anchor) => this.insertSlot(parent, anchor)
     }
@@ -1295,11 +1289,15 @@ export class SlotFragment extends DynamicFragment {
   protected registerSlotBoundaryDirty(): void {}
 
   get fallbackBlock(): Block | null {
-    return this.controller.getActiveFallback()
+    return this.activeFallback
+  }
+
+  get boundary(): SlotBoundaryContext {
+    return this.slotFallbackBoundary
   }
 
   getEffectiveOutput(): Block {
-    return this.controller.getEffectiveOutput()
+    return getSlotEffectiveOutput(this)
   }
 
   private insertSlot(parent: ParentNode, anchor: Node | null): void {
@@ -1319,7 +1317,7 @@ export class SlotFragment extends DynamicFragment {
     } else {
       remove(this.nodes, parent)
     }
-    this.controller.dispose()
+    disposeSlotFallback(this)
   }
 
   updateSlot(
@@ -1335,27 +1333,26 @@ export class SlotFragment extends DynamicFragment {
       : () => []
     const slotKey = key === undefined ? slotRender : key
     this.isUpdatingSlot = true
-    this.controller.clearPendingRecheck()
+    this.pendingRecheck = false
 
     try {
-      const shouldForce =
-        fallbackChanged || this.controller.takePendingRecheck()
+      const shouldForce = fallbackChanged
       if (isHydrating) {
         withHydratingSlotBoundary(() => {
           const prev = isHydratingSlotFallbackActive()
           try {
-            if (this.controller.hasFallback()) {
+            if (hasSlotFallback(this.slotFallbackBoundary)) {
               setCurrentHydratingSlotFallbackActive(true)
             }
             this.update(slotRender, slotKey)
             const contentValid = isValidBlock(this.nodes)
-            this.controller.recheck(shouldForce)
+            recheckSlotFallback(this, shouldForce)
             // Updates run under the temporary fallback-active marker so empty
             // inner branches can materialize their own anchors if fallback
             // takes over. If recheck resolves back to content, restore the
             // outer state before hydrate(); the surrounding finally still
             // restores nested callers when we leave this boundary.
-            if (!this.controller.hasFallback() || contentValid) {
+            if (!hasSlotFallback(this.slotFallbackBoundary) || contentValid) {
               setCurrentHydratingSlotFallbackActive(prev)
             }
             this.hydrate(!isValidBlock(this.getEffectiveOutput()), true)
@@ -1365,11 +1362,37 @@ export class SlotFragment extends DynamicFragment {
         })
       } else {
         this.update(slotRender, slotKey)
-        this.controller.recheck(shouldForce)
+        recheckSlotFallback(this, shouldForce)
       }
     } finally {
-      this.controller.clearPendingRecheck()
+      this.pendingRecheck = false
       this.isUpdatingSlot = false
+    }
+  }
+
+  getContent(): Block {
+    return this.nodes
+  }
+
+  getParentNode(): ParentNode | null {
+    return this.anchor ? this.anchor.parentNode : null
+  }
+
+  getAnchor(): Node | null {
+    return this.anchor || null
+  }
+
+  public override runWithRenderCtx<R>(fn: () => R, scope?: EffectScope): R {
+    return super.runWithRenderCtx(fn, scope)
+  }
+
+  isBusy(): boolean {
+    return this.isUpdatingSlot
+  }
+
+  notifyFallbackValidityChange(): void {
+    if (this.parentSlotBoundary) {
+      this.parentSlotBoundary.markDirty()
     }
   }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -675,8 +675,10 @@ export class DynamicFragment extends VaporFragment {
 
 export interface SlotBoundaryContext {
   parent: SlotBoundaryContext | null
-  getLocalFallback: () => BlockFn | undefined
+  getFallback: () => BlockFn | undefined
+  run<R>(fn: () => R, scope?: EffectScope): R
   markDirty: () => void
+  redirected?: SlotBoundaryContext
 }
 
 let currentSlotBoundary: SlotBoundaryContext | null = null
@@ -707,34 +709,20 @@ export function withOwnedSlotBoundary<R>(
   }
 }
 
-const slotFallbackBoundaryCache = new WeakMap<
-  SlotBoundaryContext,
-  SlotBoundaryContext
->()
-
-// Render a fallback body on behalf of `boundary`.
-// Nested slots inside the fallback must look up from the grandparent to avoid
-// fallback -> <slot> -> same fallback recursion, but dirty notifications from
-// dynamic children must still reach the owning boundary so the slot can
-// re-check its effective output when the fallback becomes valid/invalid.
-export function withSlotFallbackBoundary<R>(
+function getRedirectedBoundary(
   boundary: SlotBoundaryContext,
-  fn: () => R,
-): R {
-  let fallbackBoundary = slotFallbackBoundaryCache.get(boundary)
-  if (!fallbackBoundary) {
-    slotFallbackBoundaryCache.set(
-      boundary,
-      (fallbackBoundary = {
-        get parent() {
-          return boundary.parent
-        },
-        getLocalFallback: () => undefined,
-        markDirty: () => boundary.markDirty(),
-      }),
-    )
+): SlotBoundaryContext {
+  if (boundary.redirected) {
+    return boundary.redirected
   }
-  return withOwnedSlotBoundary(fallbackBoundary, fn)
+  return (boundary.redirected = {
+    get parent() {
+      return boundary.parent
+    },
+    getFallback: () => undefined,
+    run: (fn, scope) => boundary.run(fn, scope),
+    markDirty: () => boundary.markDirty(),
+  })
 }
 
 // Dynamic children (`v-if`, `v-for`, interop fragments) created under a slot
@@ -858,7 +846,7 @@ export function hasSlotFallback(
   boundary: SlotBoundaryContext | null | undefined,
 ): boolean {
   while (boundary) {
-    if (boundary.getLocalFallback()) {
+    if (boundary.getFallback()) {
       return true
     }
     boundary = boundary.parent
@@ -868,31 +856,44 @@ export function hasSlotFallback(
 
 export function renderSlotFallback(
   boundary: SlotBoundaryContext | null | undefined,
+  scope?: EffectScope,
   ...args: any[]
 ): Block | undefined {
-  const [block, hasFallback] = renderSlotFallbackBlock(boundary || null, args)
+  const [block, hasFallback] = renderSlotFallbackBlock(
+    boundary || null,
+    scope,
+    args,
+  )
   return hasFallback ? block : undefined
 }
 
 function renderSlotFallbackBlock(
   boundary: SlotBoundaryContext | null,
+  scope: EffectScope | undefined,
   args: any[],
 ): [Block, boolean] {
   if (!boundary) {
     return [[], false]
   }
 
-  const localFallback = boundary.getLocalFallback()
+  const localFallback = boundary.getFallback()
   if (!localFallback) {
-    return renderSlotFallbackBlock(boundary.parent, args)
+    return renderSlotFallbackBlock(boundary.parent, scope, args)
   }
 
-  const local = withSlotFallbackBoundary(boundary, () => localFallback(...args))
+  const renderFallback = () =>
+    withOwnedSlotBoundary(getRedirectedBoundary(boundary), () =>
+      localFallback(...args),
+    )
+  const local = boundary.run(
+    () => (scope ? scope.run(renderFallback) : renderFallback()) || [],
+    scope,
+  )
   if (isValidBlock(local)) {
     return [local, true]
   }
 
-  const [inherited] = renderSlotFallbackBlock(boundary.parent, args)
+  const [inherited] = renderSlotFallbackBlock(boundary.parent, scope, args)
   return [
     resolveSlotFallbackCarrierOwner(local) ? [inherited, local] : inherited,
     true,
@@ -903,6 +904,7 @@ export interface SlotFallbackOutlet {
   boundary: SlotBoundaryContext
   activeFallback: Block | null
   fallbackScope?: EffectScope
+  lastEffectiveValid?: boolean
   pendingRecheck: boolean
   isRenderingFallback: boolean
   rerunRecheckAfterFallbackRender?: boolean
@@ -910,7 +912,6 @@ export interface SlotFallbackOutlet {
   getContent(): Block
   getParentNode(): ParentNode | null
   getAnchor(): Node | null
-  runWithRenderCtx<R>(fn: () => R): R
   isBusy?(): boolean
   isDisposed?(): boolean
   isContentValid?(): boolean
@@ -976,10 +977,7 @@ function renderSlotFallbackForOutlet(
   let renderedFallback: Block | undefined
   outlet.isRenderingFallback = true
   try {
-    renderedFallback =
-      outlet.runWithRenderCtx(
-        () => scope.run(() => renderSlotFallback(outlet.boundary)) || undefined,
-      ) || undefined
+    renderedFallback = renderSlotFallback(outlet.boundary, scope) || undefined
   } catch (err) {
     scope.stop()
     throw err
@@ -1115,9 +1113,12 @@ export function recheckSlotFallback(
     return
   }
 
-  const prevValid = outlet.activeFallback
-    ? isValidBlock(outlet.activeFallback)
-    : isSlotFallbackContentValid(outlet)
+  const prevValid =
+    outlet.lastEffectiveValid === undefined
+      ? outlet.activeFallback
+        ? isValidBlock(outlet.activeFallback)
+        : isSlotFallbackContentValid(outlet)
+      : outlet.lastEffectiveValid
   const contentValid = isSlotFallbackContentValid(outlet)
 
   if (contentValid) {
@@ -1151,6 +1152,7 @@ export function recheckSlotFallback(
   if (outlet.syncEffectiveOutput) {
     outlet.syncEffectiveOutput()
   }
+  outlet.lastEffectiveValid = nextValid
   if (prevValid !== nextValid) {
     outlet.notifyFallbackValidityChange()
   }
@@ -1266,22 +1268,29 @@ export class SlotFragment
   readonly rerunRecheckAfterFallbackRender = false
   private localFallback?: BlockFn
   private isUpdatingSlot = false
-  readonly slotFallbackBoundary: SlotBoundaryContext
+  private _slotFallbackBoundary?: SlotBoundaryContext
 
   constructor() {
     super(isHydrating || __DEV__ ? 'slot' : undefined, false, false)
-    const owner = this
-    this.slotFallbackBoundary = {
-      get parent() {
-        return owner.parentSlotBoundary
-      },
-      getLocalFallback: () => this.localFallback,
-      markDirty: () => markSlotFallbackDirty(this),
-    }
     if (!isHydrating) {
       this.insert = (parent, anchor) => this.insertSlot(parent, anchor)
     }
     this.remove = parent => this.removeSlot(parent)
+  }
+
+  private ensureSlotFallbackBoundary(): SlotBoundaryContext {
+    if (this._slotFallbackBoundary) {
+      return this._slotFallbackBoundary
+    }
+    const owner = this
+    return (this._slotFallbackBoundary = {
+      get parent() {
+        return owner.parentSlotBoundary
+      },
+      getFallback: () => this.localFallback,
+      run: (fn, scope) => this.runWithRenderCtx(fn, scope),
+      markDirty: () => markSlotFallbackDirty(this),
+    })
   }
 
   // SlotFragment propagates dirty selectively via recheck() (only when
@@ -1294,6 +1303,10 @@ export class SlotFragment
 
   get boundary(): SlotBoundaryContext {
     return this.slotFallbackBoundary
+  }
+
+  get slotFallbackBoundary(): SlotBoundaryContext {
+    return this.ensureSlotFallbackBoundary()
   }
 
   getEffectiveOutput(): Block {
@@ -1328,8 +1341,21 @@ export class SlotFragment
     const prevLocalFallback = this.localFallback
     this.localFallback = fallback
     const fallbackChanged = prevLocalFallback !== fallback
+    const fastSlotKey = key === undefined ? render : key
+
+    if (
+      !isHydrating &&
+      !fallback &&
+      !this.parentSlotBoundary &&
+      !this._slotFallbackBoundary
+    ) {
+      this.update(render, fastSlotKey)
+      return
+    }
+
+    const boundary = this.slotFallbackBoundary
     const slotRender = render
-      ? () => withOwnedSlotBoundary(this.slotFallbackBoundary, render)
+      ? () => withOwnedSlotBoundary(boundary, render)
       : () => []
     const slotKey = key === undefined ? slotRender : key
     this.isUpdatingSlot = true
@@ -1341,7 +1367,7 @@ export class SlotFragment
         withHydratingSlotBoundary(() => {
           const prev = isHydratingSlotFallbackActive()
           try {
-            if (hasSlotFallback(this.slotFallbackBoundary)) {
+            if (hasSlotFallback(boundary)) {
               setCurrentHydratingSlotFallbackActive(true)
             }
             this.update(slotRender, slotKey)
@@ -1352,7 +1378,7 @@ export class SlotFragment
             // takes over. If recheck resolves back to content, restore the
             // outer state before hydrate(); the surrounding finally still
             // restores nested callers when we leave this boundary.
-            if (!hasSlotFallback(this.slotFallbackBoundary) || contentValid) {
+            if (!hasSlotFallback(boundary) || contentValid) {
               setCurrentHydratingSlotFallbackActive(prev)
             }
             this.hydrate(!isValidBlock(this.getEffectiveOutput()), true)
@@ -1380,10 +1406,6 @@ export class SlotFragment
 
   getAnchor(): Node | null {
     return this.anchor || null
-  }
-
-  public override runWithRenderCtx<R>(fn: () => R, scope?: EffectScope): R {
-    return super.runWithRenderCtx(fn, scope)
   }
 
   isBusy(): boolean {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1102,6 +1102,7 @@ export function syncActiveSlotFallback(outlet: SlotFallbackOutlet): void {
 export function disposeSlotFallback(outlet: SlotFallbackOutlet): void {
   clearSlotFallback(outlet)
   outlet.pendingRecheck = false
+  outlet.lastEffectiveValid = undefined
 }
 
 export function recheckSlotFallback(

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -107,18 +107,26 @@ import {
   setInsertionState,
 } from './insertionState'
 import {
-  SlotFallbackController,
+  type SlotBoundaryContext,
+  type SlotFallbackOutlet,
   SlotFragment,
   VaporFragment,
+  disposeSlotFallback,
   findFirstSlotFallbackCarrierNode,
   getCurrentSlotEndAnchor,
+  getSlotEffectiveOutput,
+  hasSlotFallback,
+  insertActiveSlotFallback,
   isFragment,
+  markSlotFallbackDirty,
   mutateSlotFallbackCarrier,
-  resolveSlotFallbackCarrierOwner,
+  recheckSlotFallback,
+  syncActiveSlotFallback,
   trackSlotBoundaryDirtying,
   withHydratingSlotBoundary,
   withHydratingSlotFallbackActive,
   withOwnedSlotBoundary,
+  withSlotFallbackBoundary,
 } from './fragment'
 import type { NodeRef } from './apiTemplateRef'
 import {
@@ -1343,33 +1351,38 @@ function renderVDOMSlot(
   let disposed = false
   const scope = effectScope()
   const inheritedBoundary = frag.inheritedSlotBoundary
-  const controller: SlotFallbackController = new SlotFallbackController({
-    getParentBoundary: () => inheritedBoundary,
-    getLocalFallback: (): BlockFn | undefined => wrappedLocalFallback,
-    getContent: () => contentState.nodes,
-    getParentNode: () => {
-      if (currentParentNode) {
-        return currentParentNode
-      }
-      const carrierAnchor = findFirstSlotFallbackCarrierNode(contentState.nodes)
-      return carrierAnchor
-        ? (carrierAnchor.parentNode as ParentNode | null)
-        : null
+  let wrappedLocalFallback: BlockFn | undefined
+  let outlet!: SlotFallbackOutlet
+  const boundary: SlotBoundaryContext = {
+    get parent() {
+      return inheritedBoundary
     },
+    getLocalFallback: (): BlockFn | undefined => wrappedLocalFallback,
+    markDirty: () => markSlotFallbackDirty(outlet),
+  }
+  outlet = {
+    boundary,
+    activeFallback: null,
+    pendingRecheck: false,
+    isRenderingFallback: false,
+    getContent: () => contentState.nodes,
+    getParentNode: () =>
+      getSlotFallbackParentNode(currentParentNode, contentState.nodes),
     getAnchor: () => currentAnchor || null,
-    isContentValid: () => contentState.valid,
     runWithRenderCtx: fn => runWithFragmentRenderCtx(frag, fn),
     isDisposed: () => disposed,
+    isContentValid: () => contentState.valid,
+    syncEffectiveOutput: () => {
+      frag.nodes = getSlotEffectiveOutput(outlet)
+    },
     // `frag.onUpdated` already notifies the parent boundary.
-    onValidityChange: () => {},
-  })
-  const wrappedLocalFallback: BlockFn | undefined = fallback
-    ? controller.wrapFallback(() => fallback(internals, parentComponent))
-    : undefined
-
-  const updateNodes = (): void => {
-    frag.nodes = controller.getEffectiveOutput()
+    notifyFallbackValidityChange: NOOP,
   }
+  wrappedLocalFallback = fallback
+    ? wrapSlotFallback(frag, boundary, () =>
+        fallback(internals, parentComponent),
+      )
+    : undefined
 
   const setRenderedContent = (rendered: VNode | Block | null): void => {
     contentState.rendered = rendered
@@ -1391,8 +1404,7 @@ function renderVDOMSlot(
   }
 
   const finishContentUpdate = (forceFallbackRecheck = false): void => {
-    controller.recheck(forceFallbackRecheck)
-    updateNodes()
+    recheckSlotFallback(outlet, forceFallbackRecheck)
     notifyUpdated()
   }
 
@@ -1419,7 +1431,7 @@ function renderVDOMSlot(
         insert(contentState.rendered, parentNode, anchor)
       }
 
-      controller.relocate()
+      insertActiveSlotFallback(outlet)
     }
 
     notifyUpdated()
@@ -1442,7 +1454,7 @@ function renderVDOMSlot(
     } else if (contentState.rendered) {
       remove(contentState.rendered, parentNode)
     }
-    controller.dispose()
+    disposeSlotFallback(outlet)
   }
 
   const render = () => {
@@ -1451,7 +1463,7 @@ function renderVDOMSlot(
     try {
       renderEffect(() => {
         runWithFragmentRenderCtx(frag, () =>
-          withOwnedSlotBoundary(controller.boundary, () => {
+          withOwnedSlotBoundary(boundary, () => {
             let slotContent: VNode | Block | undefined
             let slotContentValid = false
 
@@ -1487,7 +1499,7 @@ function renderVDOMSlot(
               // that content so later updates can patch inside the existing
               // range instead of mounting before it.
               const hydratedContent =
-                slotContent && (slotContentValid || !controller.hasFallback())
+                slotContent && (slotContentValid || !hasSlotFallback(boundary))
                   ? slotContent
                   : undefined
               if (isVNode(hydratedContent)) {
@@ -1526,8 +1538,7 @@ function renderVDOMSlot(
                 const prevValid = contentState.valid
                 const prevOutput = frag.nodes
                 setRenderedContent(slotContent)
-                controller.recheck()
-                updateNodes()
+                recheckSlotFallback(outlet)
                 if (
                   contentState.valid !== prevValid ||
                   !isSameResolvedOutput(prevOutput, frag.nodes)
@@ -1696,6 +1707,28 @@ function runWithFragmentRenderCtx<R>(fragment: VaporFragment, fn: () => R): R {
   }
 }
 
+function wrapSlotFallback(
+  fragment: VaporFragment,
+  boundary: SlotBoundaryContext,
+  fallback: BlockFn,
+): BlockFn {
+  return (...args: any[]) =>
+    runWithFragmentRenderCtx(fragment, () =>
+      withSlotFallbackBoundary(boundary, () => fallback(...args)),
+    )
+}
+
+function getSlotFallbackParentNode(
+  currentParentNode: ParentNode | null | undefined,
+  content: Block,
+): ParentNode | null {
+  if (currentParentNode) {
+    return currentParentNode
+  }
+  const carrierAnchor = findFirstSlotFallbackCarrierNode(content)
+  return carrierAnchor ? (carrierAnchor.parentNode as ParentNode | null) : null
+}
+
 type InteropSlotFallback = {
   (): any
   __vdom?: boolean
@@ -1704,22 +1737,6 @@ type InteropSlotFallback = {
 interface InteropVaporSlotState {
   localFallback: ShallowRef<InteropSlotFallback | undefined>
   outletFallback: ShallowRef<InteropSlotFallback | undefined>
-}
-
-function composeInteropLocalFallback(
-  localFallback?: BlockFn,
-  outletFallback?: BlockFn,
-): BlockFn | undefined {
-  if (!localFallback) return outletFallback
-  if (!outletFallback) return localFallback
-  return (...args: any[]) => {
-    const local = localFallback(...args)
-    if (isValidBlock(local)) {
-      return local
-    }
-    const outlet = outletFallback(...args)
-    return resolveSlotFallbackCarrierOwner(local) ? [outlet, local] : outlet
-  }
 }
 
 function resolveInteropVaporSlotState(vnode: VNode): InteropVaporSlotState {
@@ -1808,48 +1825,65 @@ function renderVaporSlot(
     let currentAnchor: Node | null = null
     let slotScope: ReturnType<typeof effectScope> | undefined
     let disposed = false
-    const controller = new SlotFallbackController({
-      getParentBoundary: () => inheritedBoundary,
-      getLocalFallback: () =>
-        composeInteropLocalFallback(
-          slotState.localFallback.value ? wrappedLocalFallback : undefined,
-          slotState.outletFallback.value ? wrappedOutletFallback : undefined,
-        ),
-      getContent: () => contentNodes,
-      getParentNode: () => {
-        if (currentParentNode) return currentParentNode
-        const carrierAnchor = findFirstSlotFallbackCarrierNode(contentNodes)
-        return carrierAnchor
-          ? (carrierAnchor.parentNode as ParentNode | null)
-          : null
+    let outlet!: SlotFallbackOutlet
+    const outletFallbackBoundary: SlotBoundaryContext = {
+      get parent() {
+        return inheritedBoundary
       },
+      getLocalFallback: () =>
+        slotState.outletFallback.value ? wrappedOutletFallback : undefined,
+      markDirty: () => markSlotFallbackDirty(outlet),
+    }
+    const localFallbackBoundary: SlotBoundaryContext = {
+      get parent() {
+        return outletFallbackBoundary
+      },
+      getLocalFallback: () =>
+        slotState.localFallback.value ? wrappedLocalFallback : undefined,
+      markDirty: () => markSlotFallbackDirty(outlet),
+    }
+    outlet = {
+      boundary: localFallbackBoundary,
+      activeFallback: null,
+      pendingRecheck: false,
+      isRenderingFallback: false,
+      getContent: () => contentNodes,
+      getParentNode: () =>
+        getSlotFallbackParentNode(currentParentNode, contentNodes),
       getAnchor: () => currentAnchor,
       runWithRenderCtx: fn => runWithFragmentRenderCtx(frag, fn),
       isBusy: () => isResolvingContent,
       isDisposed: () => disposed,
       syncEffectiveOutput: () => {
-        frag.nodes = controller.getEffectiveOutput()
+        frag.nodes = getSlotEffectiveOutput(outlet)
         frag.validityPending = false
       },
-      onValidityChange: () => {
+      notifyFallbackValidityChange: () => {
         if (inheritedBoundary) {
           inheritedBoundary.markDirty()
         }
       },
-    })
+    }
+    const takePendingRecheck = (): boolean => {
+      const shouldRecheck = outlet.pendingRecheck
+      outlet.pendingRecheck = false
+      return shouldRecheck
+    }
 
     const dispose = (parentNode?: ParentNode): void => {
       if (disposed) return
       currentParentNode = parentNode || currentParentNode
       disposed = true
-      controller.dispose()
+      disposeSlotFallback(outlet)
       slotScope = undefined
       currentParentNode = null
       currentAnchor = null
     }
 
     try {
-      wrappedLocalFallback = controller.wrapFallback(
+      wrappedLocalFallback = wrapSlotFallback(
+        frag,
+        localFallbackBoundary,
         createFallback(
           () => (slotState.localFallback.value || renderEmptyVNodes)(),
           parentComponent,
@@ -1858,7 +1892,9 @@ function renderVaporSlot(
             !!slotState.localFallback.value.__vdom,
         ),
       )
-      wrappedOutletFallback = controller.wrapFallback(
+      wrappedOutletFallback = wrapSlotFallback(
+        frag,
+        outletFallbackBoundary,
         createFallback(
           () => (slotState.outletFallback.value || renderEmptyVNodes)(),
           parentComponent,
@@ -1869,7 +1905,7 @@ function renderVaporSlot(
       )
       const preferSlotFragmentOwnership =
         !!slotState.localFallback.value || !!slotState.outletFallback.value
-      controller.clearPendingRecheck()
+      outlet.pendingRecheck = false
       const finalizeResolvedContent = (
         resolvedContent: Block | undefined,
       ): Block | undefined => {
@@ -1880,7 +1916,7 @@ function renderVaporSlot(
           return resolvedContent
         }
         contentNodes = resolvedContent || []
-        controller.recheck(controller.takePendingRecheck())
+        recheckSlotFallback(outlet, takePendingRecheck())
         return resolvedContent
       }
       let resolvedContent: Block | undefined
@@ -1891,10 +1927,10 @@ function renderVaporSlot(
             finalizeResolvedContent(
               runWithFragmentRenderCtx(frag, () => {
                 const renderSlot = () =>
-                  withOwnedSlotBoundary(controller.boundary, () =>
+                  withOwnedSlotBoundary(localFallbackBoundary, () =>
                     invokeVaporSlot(vnode),
                   )
-                return controller.hasFallback()
+                return hasSlotFallback(localFallbackBoundary)
                   ? withHydratingSlotFallbackActive(renderSlot)
                   : renderSlot()
               }),
@@ -1903,7 +1939,7 @@ function renderVaporSlot(
         } else {
           resolvedContent = finalizeResolvedContent(
             runWithFragmentRenderCtx(frag, () =>
-              withOwnedSlotBoundary(controller.boundary, () =>
+              withOwnedSlotBoundary(localFallbackBoundary, () =>
                 invokeVaporSlot(vnode),
               ),
             ),
@@ -1927,12 +1963,12 @@ function renderVaporSlot(
         return resolvedContent
       }
 
-      controller.clearPendingRecheck()
+      outlet.pendingRecheck = false
       frag.insert = (parentNode, anchor) => {
         currentParentNode = parentNode
         currentAnchor = anchor
-        if (controller.getActiveFallback()) {
-          controller.relocate()
+        if (outlet.activeFallback) {
+          insertActiveSlotFallback(outlet)
           mutateSlotFallbackCarrier(contentNodes, block =>
             insert(block, parentNode, anchor),
           )
@@ -1941,7 +1977,7 @@ function renderVaporSlot(
         }
       }
       frag.remove = parentNode => {
-        if (controller.getActiveFallback()) {
+        if (outlet.activeFallback) {
           mutateSlotFallbackCarrier(contentNodes, block =>
             remove(block, parentNode),
           )
@@ -1951,8 +1987,8 @@ function renderVaporSlot(
         dispose(parentNode)
       }
       trackInteropFallbackChanges(vnode.vs!.scope, slotState, () => {
-        controller.recheck(true)
-        controller.syncActiveFallback()
+        recheckSlotFallback(outlet, true)
+        syncActiveSlotFallback(outlet)
       })
 
       return frag

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -126,7 +126,6 @@ import {
   withHydratingSlotBoundary,
   withHydratingSlotFallbackActive,
   withOwnedSlotBoundary,
-  withSlotFallbackBoundary,
 } from './fragment'
 import type { NodeRef } from './apiTemplateRef'
 import {
@@ -1351,13 +1350,15 @@ function renderVDOMSlot(
   let disposed = false
   const scope = effectScope()
   const inheritedBoundary = frag.inheritedSlotBoundary
-  let wrappedLocalFallback: BlockFn | undefined
+  let isContentUpdateRecheck = false
+  let localFallback: BlockFn | undefined
   let outlet!: SlotFallbackOutlet
   const boundary: SlotBoundaryContext = {
     get parent() {
       return inheritedBoundary
     },
-    getLocalFallback: (): BlockFn | undefined => wrappedLocalFallback,
+    getFallback: (): BlockFn | undefined => localFallback,
+    run: fn => runWithFragmentRenderCtx(frag, fn),
     markDirty: () => markSlotFallbackDirty(outlet),
   }
   outlet = {
@@ -1369,19 +1370,19 @@ function renderVDOMSlot(
     getParentNode: () =>
       getSlotFallbackParentNode(currentParentNode, contentState.nodes),
     getAnchor: () => currentAnchor || null,
-    runWithRenderCtx: fn => runWithFragmentRenderCtx(frag, fn),
     isDisposed: () => disposed,
     isContentValid: () => contentState.valid,
     syncEffectiveOutput: () => {
       frag.nodes = getSlotEffectiveOutput(outlet)
     },
-    // `frag.onUpdated` already notifies the parent boundary.
-    notifyFallbackValidityChange: NOOP,
+    notifyFallbackValidityChange: () => {
+      if (!isContentUpdateRecheck && inheritedBoundary) {
+        inheritedBoundary.markDirty()
+      }
+    },
   }
-  wrappedLocalFallback = fallback
-    ? wrapSlotFallback(frag, boundary, () =>
-        fallback(internals, parentComponent),
-      )
+  localFallback = fallback
+    ? () => fallback(internals, parentComponent)
     : undefined
 
   const setRenderedContent = (rendered: VNode | Block | null): void => {
@@ -1403,8 +1404,17 @@ function renderVDOMSlot(
     if (isMounted && frag.onUpdated) frag.onUpdated.forEach(m => m())
   }
 
+  const recheckAfterContentUpdate = (forceFallbackRecheck = false): void => {
+    isContentUpdateRecheck = true
+    try {
+      recheckSlotFallback(outlet, forceFallbackRecheck)
+    } finally {
+      isContentUpdateRecheck = false
+    }
+  }
+
   const finishContentUpdate = (forceFallbackRecheck = false): void => {
-    recheckSlotFallback(outlet, forceFallbackRecheck)
+    recheckAfterContentUpdate(forceFallbackRecheck)
     notifyUpdated()
   }
 
@@ -1482,7 +1492,7 @@ function renderVDOMSlot(
                   // valid, so preserve it on the forwarded branch itself.
                   ensureVaporSlotFallback(
                     children,
-                    wrappedLocalFallback as () => VNodeArrayChildren,
+                    localFallback as () => VNodeArrayChildren,
                   )
                   slotContentValid = hasValidVNodeContent(slotContent)
                 } else {
@@ -1538,7 +1548,7 @@ function renderVDOMSlot(
                 const prevValid = contentState.valid
                 const prevOutput = frag.nodes
                 setRenderedContent(slotContent)
-                recheckSlotFallback(outlet)
+                recheckAfterContentUpdate()
                 if (
                   contentState.valid !== prevValid ||
                   !isSameResolvedOutput(prevOutput, frag.nodes)
@@ -1707,17 +1717,6 @@ function runWithFragmentRenderCtx<R>(fragment: VaporFragment, fn: () => R): R {
   }
 }
 
-function wrapSlotFallback(
-  fragment: VaporFragment,
-  boundary: SlotBoundaryContext,
-  fallback: BlockFn,
-): BlockFn {
-  return (...args: any[]) =>
-    runWithFragmentRenderCtx(fragment, () =>
-      withSlotFallbackBoundary(boundary, () => fallback(...args)),
-    )
-}
-
 function getSlotFallbackParentNode(
   currentParentNode: ParentNode | null | undefined,
   content: Block,
@@ -1819,28 +1818,48 @@ function renderVaporSlot(
     const inheritedBoundary = frag.inheritedSlotBoundary
     let contentNodes: Block = []
     let isResolvingContent = false
-    let wrappedLocalFallback!: BlockFn
-    let wrappedOutletFallback!: BlockFn
+    let localFallback!: BlockFn
+    let outletFallback!: BlockFn
     let currentParentNode: ParentNode | null = null
     let currentAnchor: Node | null = null
     let slotScope: ReturnType<typeof effectScope> | undefined
     let disposed = false
     let outlet!: SlotFallbackOutlet
+    let ownedSlotFragment: SlotFragment | undefined
+    let ownedSlotFragmentDirtyQueued = false
+    const markInteropFallbackDirty = (): void => {
+      const target = ownedSlotFragment
+      if (!target) {
+        markSlotFallbackDirty(outlet)
+        return
+      }
+      if (ownedSlotFragmentDirtyQueued) {
+        return
+      }
+      ownedSlotFragmentDirtyQueued = true
+      queuePostFlushCb(() => {
+        ownedSlotFragmentDirtyQueued = false
+        markSlotFallbackDirty(target)
+        syncActiveSlotFallback(target)
+      })
+    }
     const outletFallbackBoundary: SlotBoundaryContext = {
       get parent() {
         return inheritedBoundary
       },
-      getLocalFallback: () =>
-        slotState.outletFallback.value ? wrappedOutletFallback : undefined,
-      markDirty: () => markSlotFallbackDirty(outlet),
+      getFallback: () =>
+        slotState.outletFallback.value ? outletFallback : undefined,
+      run: fn => runWithFragmentRenderCtx(frag, fn),
+      markDirty: markInteropFallbackDirty,
     }
     const localFallbackBoundary: SlotBoundaryContext = {
       get parent() {
         return outletFallbackBoundary
       },
-      getLocalFallback: () =>
-        slotState.localFallback.value ? wrappedLocalFallback : undefined,
-      markDirty: () => markSlotFallbackDirty(outlet),
+      getFallback: () =>
+        slotState.localFallback.value ? localFallback : undefined,
+      run: fn => runWithFragmentRenderCtx(frag, fn),
+      markDirty: markInteropFallbackDirty,
     }
     outlet = {
       boundary: localFallbackBoundary,
@@ -1851,7 +1870,6 @@ function renderVaporSlot(
       getParentNode: () =>
         getSlotFallbackParentNode(currentParentNode, contentNodes),
       getAnchor: () => currentAnchor,
-      runWithRenderCtx: fn => runWithFragmentRenderCtx(frag, fn),
       isBusy: () => isResolvingContent,
       isDisposed: () => disposed,
       syncEffectiveOutput: () => {
@@ -1881,27 +1899,19 @@ function renderVaporSlot(
     }
 
     try {
-      wrappedLocalFallback = wrapSlotFallback(
-        frag,
-        localFallbackBoundary,
-        createFallback(
-          () => (slotState.localFallback.value || renderEmptyVNodes)(),
-          parentComponent,
-          () =>
-            !!slotState.localFallback.value &&
-            !!slotState.localFallback.value.__vdom,
-        ),
+      localFallback = createFallback(
+        () => (slotState.localFallback.value || renderEmptyVNodes)(),
+        parentComponent,
+        () =>
+          !!slotState.localFallback.value &&
+          !!slotState.localFallback.value.__vdom,
       )
-      wrappedOutletFallback = wrapSlotFallback(
-        frag,
-        outletFallbackBoundary,
-        createFallback(
-          () => (slotState.outletFallback.value || renderEmptyVNodes)(),
-          parentComponent,
-          () =>
-            !!slotState.outletFallback.value &&
-            !!slotState.outletFallback.value.__vdom,
-        ),
+      outletFallback = createFallback(
+        () => (slotState.outletFallback.value || renderEmptyVNodes)(),
+        parentComponent,
+        () =>
+          !!slotState.outletFallback.value &&
+          !!slotState.outletFallback.value.__vdom,
       )
       const preferSlotFragmentOwnership =
         !!slotState.localFallback.value || !!slotState.outletFallback.value
@@ -1959,6 +1969,10 @@ function renderVaporSlot(
         preferSlotFragmentOwnership &&
         resolvedContent instanceof SlotFragment
       ) {
+        ownedSlotFragment = resolvedContent
+        trackInteropFallbackChanges(vnode.vs!.scope, slotState, () =>
+          markInteropFallbackDirty(),
+        )
         dispose()
         return resolvedContent
       }
@@ -2108,16 +2122,24 @@ function createVNodeChildrenFragment(
   const suspense =
     currentParentSuspense || (parentComponent && parentComponent.suspense)
   const frag = new VaporFragment<Block>([])
+  let contentValid = false
   frag.validityPending = !isHydrating
+  ;(
+    frag as VaporFragment<Block> & {
+      isBlockValid: () => boolean
+    }
+  ).isBlockValid = () => (frag.validityPending ? true : contentValid)
   let currentVNode: VNode | null = null
   let currentChildren: VNode[] = []
   let currentParentNode: ParentNode | null = null
   let currentAnchor: Node | null = null
   let isMounted = false
+  let isRenderEffectStarted = false
   const scope = effectScope()
 
   const syncResolvedNodes = (children: VNode[] = currentChildren): boolean => {
-    const prevValid = frag.validityPending ? true : isValidBlock(frag.nodes)
+    const prevValid = frag.validityPending ? true : contentValid
+    contentValid = !!ensureValidVNode(children)
     if (children.length === 0) {
       frag.nodes = []
     } else if (children.length === 1) {
@@ -2126,7 +2148,7 @@ function createVNodeChildrenFragment(
       frag.nodes = children.map(resolveVNodeNodes) as Block[]
     }
     frag.validityPending = false
-    return prevValid !== isValidBlock(frag.nodes)
+    return prevValid !== contentValid
   }
 
   const notifyUpdated = (validityChanged = false): void => {
@@ -2165,6 +2187,12 @@ function createVNodeChildrenFragment(
             ) {
               currentAnchor = currentAnchor.nextSibling
             }
+          } else if (!isMounted) {
+            currentChildren = nextChildren
+            currentVNode = createVNode(Fragment, null, nextChildren)
+            contentValid = !!ensureValidVNode(nextChildren)
+            frag.validityPending = false
+            return
           } else if (!currentVNode) {
             currentChildren = nextChildren
             currentVNode = createVNode(Fragment, null, nextChildren)
@@ -2218,12 +2246,42 @@ function createVNodeChildrenFragment(
     }
   }
 
+  const startRenderEffect = (): void => {
+    if (isRenderEffectStarted) {
+      return
+    }
+    isRenderEffectStarted = true
+    scope.run(renderContent)
+  }
+
+  if (!isHydrating) {
+    startRenderEffect()
+  }
+
   frag.insert = (parentNode, anchor) => {
     if (isHydrating) return
     currentParentNode = parentNode
     currentAnchor = anchor
     if (!isMounted) {
-      scope.run(renderContent)
+      startRenderEffect()
+      if (currentVNode) {
+        trackSlotVNodeUpdatesWithRefresh(currentVNode, () => {
+          notifyUpdated(syncResolvedNodes(currentChildren))
+        })
+      }
+      if (currentChildren.length) {
+        internals.mc(
+          currentChildren,
+          currentParentNode,
+          currentAnchor,
+          parentComponent,
+          suspense,
+          undefined,
+          null,
+          false,
+        )
+      }
+      syncResolvedNodes()
       isMounted = true
     } else {
       currentChildren.forEach(vnode => {
@@ -2247,7 +2305,7 @@ function createVNodeChildrenFragment(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    scope.run(renderContent)
+    startRenderEffect()
     isMounted = true
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed slot fallback behavior when local fallbacks become invalid in nested component scenarios.
  * Improved interoperability between VDOM and Vapor slot systems, particularly for fallback rendering.
  * Enhanced hydration support for interop slot fallback transitions.

* **Tests**
  * Expanded slot fallback test coverage for various fallback scenarios.
  * Added tests for nested fallback validity transitions and outlet-driven behavior.
  * Added hydration interop tests validating slot fallback behavior across mode changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14819)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->