### PR TITLE
perf(server-renderer): avoid materializing iterables in ssrRenderList

### DIFF
--- a/packages/server-renderer/__tests__/ssrRenderList.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderList.spec.ts
@@ -65,6 +65,45 @@ describe('ssr: renderList', () => {
     expect(stack).toEqual(['node 0: 1', 'node 1: 2', 'node 2: 3'])
   })
 
+  it('should render items in a Set', () => {
+    ssrRenderList(new Set(['a', 'b', 'c']), (item, index) =>
+      stack.push(`node ${index}: ${item}`),
+    )
+    expect(stack).toEqual(['node 0: a', 'node 1: b', 'node 2: c'])
+  })
+
+  it('should render items in a Map', () => {
+    const map = new Map<string, number>([
+      ['x', 1],
+      ['y', 2],
+    ])
+    ssrRenderList(map, (item, index) =>
+      stack.push(`node ${index}: ${(item as [string, number]).join('=')}`),
+    )
+    expect(stack).toEqual(['node 0: x=1', 'node 1: y=2'])
+  })
+
+  it('should iterate iterables lazily without intermediate allocation', () => {
+    const yielded: number[] = []
+    const rendered: number[] = []
+
+    function* gen() {
+      for (let i = 0; i < 3; i++) {
+        yielded.push(i)
+        yield i
+      }
+    }
+
+    ssrRenderList(gen(), (item, index) => {
+      rendered.push(item as number)
+      // each item should be yielded by the time it is rendered
+      expect(yielded.length).toBe(rendered.length)
+    })
+
+    expect(yielded).toEqual([0, 1, 2])
+    expect(rendered).toEqual([0, 1, 2])
+  })
+
   it('should not render items when source is 0', () => {
     ssrRenderList(0, (item, index) => stack.push(`node ${index}: ${item}`))
     expect(stack).toEqual([])

--- a/packages/server-renderer/src/helpers/ssrRenderList.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderList.ts
@@ -21,9 +21,9 @@ export function ssrRenderList(
     }
   } else if (isObject(source)) {
     if (source[Symbol.iterator as any]) {
-      const arr = Array.from(source as Iterable<any>)
-      for (let i = 0, l = arr.length; i < l; i++) {
-        renderItem(arr[i], i)
+      let i = 0
+      for (const item of source as Iterable<any>) {
+        renderItem(item, i++)
       }
     } else {
       const keys = Object.keys(source)


### PR DESCRIPTION
## Summary

This PR removes an unnecessary intermediate array allocation in `ssrRenderList` when iterating over iterable sources (generators, `Set`, `Map`, custom iterables).

## Problem

`ssrRenderList` handles `v-for` iteration during SSR. When the source is an object implementing `Symbol.iterator`, the current code calls `Array.from(source)` to eagerly materialize the **entire** iterable into an in-memory array before rendering any items:

```typescript
// Before (packages/server-renderer/src/helpers/ssrRenderList.ts)
if (source[Symbol.iterator as any]) {
  const arr = Array.from(source as Iterable<any>) // <-- problem here
  for (let i = 0, l = arr.length; i < l; i++) {
    renderItem(arr[i], i)
  }
}
```

Since `ssrRenderList` is `void` (it calls `renderItem` for side effects, not to collect results), the intermediate array is completely unnecessary. For large iterables (e.g., a generator yielding millions of items from a database cursor), this causes:

- **O(n) extra memory** for the intermediate array, on top of whatever the `renderItem` callback produces.
- A blocking materialization phase before any rendering can begin.
- Potential memory exhaustion or hangs for very large or infinite iterables.

## Solution

Replace `Array.from(source)` with a `for...of` loop that lazily iterates the iterable and calls `renderItem` for each item as it is produced:

```typescript
// After
if (source[Symbol.iterator as any]) {
  let i = 0
  for (const item of source as Iterable<any>) {
    renderItem(item, i++)
  }
}
```

This reduces the memory overhead of the rendering loop from O(n) to O(1), while producing identical output.

### Why the client-side `renderList` is not changed

The client-side `renderList` (`packages/runtime-core/src/helpers/renderList.ts`) already uses the two-argument form `Array.from(source, mapFn)`, which maps during iteration in a single pass without creating an intermediate array. Since it must return a `VNodeChild[]`, it needs the result array regardless — there is no unnecessary allocation to eliminate.

## Test Plan

- All 294 existing server-renderer tests pass without modification.
- Added 3 new test cases in `packages/server-renderer/__tests__/ssrRenderList.spec.ts`:
  - **`Set` iteration** — verifies items and indices are correct for `Set` sources.
  - **`Map` iteration** — verifies items and indices are correct for `Map` sources.
  - **Lazy iteration verification** — uses a generator with side effects to confirm that items are yielded and rendered one at a time (not materialized upfront).

Co-authored-by: Grok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Server-side rendering now efficiently handles Sets, Maps, and generator functions through direct iteration
  * Reduced memory usage by eliminating unnecessary array conversions for iterables
  * Enabled lazy evaluation of generators without intermediate buffering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14821)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->