### PR TITLE
perf(runtime-vapor): use numeric keys for createIf branches

### DIFF
--- a/packages/runtime-vapor/__tests__/if.spec.ts
+++ b/packages/runtime-vapor/__tests__/if.spec.ts
@@ -279,7 +279,7 @@ describe('createIf', () => {
       ),
     ).render()
 
-    expect(branch.$key).toBe('00')
+    expect(branch.$key).toBe(0)
   })
 
   // vapor custom directives have no lifecycle hooks.

--- a/packages/runtime-vapor/src/apiCreateIf.ts
+++ b/packages/runtime-vapor/src/apiCreateIf.ts
@@ -62,7 +62,7 @@ export function createIf(
       }
       ;(frag as DynamicFragment).update(
         ok ? b1 : b2,
-        keyed ? `${index}${ok ? 0 : 1}` : undefined,
+        keyed ? index * 2 + (ok ? 0 : 1) : undefined,
       )
     })
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transition behavior for conditional rendering with keyed fragments during component hydration to ensure correct state updates and proper fragment handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14827)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->