### PR TITLE
perf(compiler-vapor): emit v-model modifiers as direct values

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -24,7 +24,7 @@ export function render(_ctx) {
     {
       modelValue: () => (_ctx.foo),
       "onUpdate:modelValue": () => _value => (_ctx.foo = _value),
-      modelModifiers: () => ({ trim: true })
+      modelModifiers: { trim: true }
     }
   ] }, null, true)
   return n0
@@ -39,7 +39,7 @@ export function render(_ctx) {
   const n0 = _createComponentWithFallback(_component_Comp, {
     modelValue: () => (_ctx.foo),
     "onUpdate:modelValue": () => _value => (_ctx.foo = _value),
-    modelModifiers: () => ({ trim: true, "bar-baz": true })
+    modelModifiers: { trim: true, "bar-baz": true }
   }, null, true)
   return n0
 }"
@@ -66,10 +66,10 @@ export function render(_ctx) {
   const n0 = _createComponentWithFallback(_component_Comp, {
     foo: () => (_ctx.foo),
     "onUpdate:foo": () => _value => (_ctx.foo = _value),
-    fooModifiers: () => ({ trim: true }),
+    fooModifiers: { trim: true },
     bar: () => (_ctx.bar),
     "onUpdate:bar": () => _value => (_ctx.bar = _value),
-    barModifiers: () => ({ number: true })
+    barModifiers: { number: true }
   }, null, true)
   return n0
 }"
@@ -132,7 +132,7 @@ export function render(_ctx) {
   const n0 = _createComponentWithFallback(_component_Comp, {
     model: () => (_ctx.foo),
     "onUpdate:model": () => _value => (_ctx.foo = _value),
-    modelModifiers$: () => ({ trim: true })
+    modelModifiers$: { trim: true }
   }, null, true)
   return n0
 }"

--- a/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
@@ -274,7 +274,8 @@ describe('compiler: vModel transform', () => {
         '<Comp v-model.trim.bar-baz="foo" />',
       )
       expect(code).toMatchSnapshot()
-      expect(code).contain(
+      expect(code).contain(`modelModifiers: { trim: true, "bar-baz": true }`)
+      expect(code).not.contain(
         `modelModifiers: () => ({ trim: true, "bar-baz": true })`,
       )
       expect(ir.block.dynamic.children[0].operation).toMatchObject({
@@ -303,8 +304,8 @@ describe('compiler: vModel transform', () => {
       expect(code).contains(
         `"onUpdate:modelValue": () => _value => (_ctx.foo = _value)`,
       )
-      expect(code).contains(`modelModifiers: () => ({ trim: true })`)
-      expect(code).not.contains(`modelModifiers: { trim: true }`)
+      expect(code).contains(`modelModifiers: { trim: true }`)
+      expect(code).not.contains(`modelModifiers: () => ({ trim: true })`)
     })
 
     test('v-model with arguments for component should generate modelModifiers', () => {
@@ -312,8 +313,10 @@ describe('compiler: vModel transform', () => {
         '<Comp v-model:foo.trim="foo" v-model:bar.number="bar" />',
       )
       expect(code).toMatchSnapshot()
-      expect(code).contain(`fooModifiers: () => ({ trim: true })`)
-      expect(code).contain(`barModifiers: () => ({ number: true })`)
+      expect(code).contain(`fooModifiers: { trim: true }`)
+      expect(code).contain(`barModifiers: { number: true }`)
+      expect(code).not.contain(`fooModifiers: () => ({ trim: true })`)
+      expect(code).not.contain(`barModifiers: () => ({ number: true })`)
       expect(ir.block.dynamic.children[0].operation).toMatchObject({
         type: IRNodeTypes.CREATE_COMPONENT_NODE,
         tag: 'Comp',
@@ -341,7 +344,8 @@ describe('compiler: vModel transform', () => {
         '<Comp v-model:model.trim="foo" />',
       )
       expect(code).toMatchSnapshot()
-      expect(code).contain(`modelModifiers$: () => ({ trim: true })`)
+      expect(code).contain(`modelModifiers$: { trim: true }`)
+      expect(code).not.contain(`modelModifiers$: () => ({ trim: true })`)
       expect(ir.block.dynamic.children[0].operation).toMatchObject({
         type: IRNodeTypes.CREATE_COMPONENT_NODE,
         tag: 'Comp',

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -331,7 +331,12 @@ function genStaticProps(
           ? [getModifierPropName(key.content)]
           : ['[', ...genExpression(key, context), ' + "Modifiers"]']
         const modifiersVal = genDirectiveModifiers(modelModifiers)
-        args.push([...modifiersKey, `: () => ({ ${modifiersVal} })`])
+        args.push([
+          ...modifiersKey,
+          directStaticLiteralProps
+            ? `: { ${modifiersVal} }`
+            : `: () => ({ ${modifiersVal} })`,
+        ])
       }
     }
   }
@@ -452,10 +457,9 @@ function genProp(
 }
 
 /**
- * Top-level raw props can carry literal values directly for static primitives.
- * The runtime accepts both literal values and getter functions, but literals
- * avoid re-evaluation overhead. Keep handlers, v-model, merged values, and
- * dynamic expressions as getter sources to maintain reactivity and merge semantics.
+ * Static literal values are safe to emit directly because reading them cannot
+ * touch reactive state. Keep handlers, v-model values, and dynamic expressions
+ * as getter sources to preserve lazy access and merge semantics.
  */
 function isDirectStaticLiteralProp(prop: IRProp): boolean {
   return (

--- a/packages/runtime-vapor/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentEmits.spec.ts
@@ -270,10 +270,10 @@ describe('component: emit', () => {
     const fn2 = vi.fn()
     render({
       modelValue: () => null,
-      modelModifiers: () => ({ number: true }),
+      modelModifiers: { number: true },
       ['onUpdate:modelValue']: () => fn1,
       foo: () => null,
-      fooModifiers: () => ({ number: true }),
+      fooModifiers: { number: true },
       ['onUpdate:foo']: () => fn2,
     })
     expect(fn1).toHaveBeenCalledTimes(1)
@@ -296,18 +296,14 @@ describe('component: emit', () => {
       modelValue() {
         return null
       },
-      modelModifiers() {
-        return { trim: true }
-      },
+      modelModifiers: { trim: true },
       ['onUpdate:modelValue']() {
         return fn1
       },
       foo() {
         return null
       },
-      fooModifiers() {
-        return { trim: true }
-      },
+      fooModifiers: { trim: true },
       'onUpdate:foo'() {
         return fn2
       },
@@ -332,18 +328,14 @@ describe('component: emit', () => {
       modelValue() {
         return null
       },
-      modelModifiers() {
-        return { trim: true, number: true }
-      },
+      modelModifiers: { trim: true, number: true },
       ['onUpdate:modelValue']() {
         return fn1
       },
       foo() {
         return null
       },
-      fooModifiers() {
-        return { trim: true, number: true }
-      },
+      fooModifiers: { trim: true, number: true },
       ['onUpdate:foo']() {
         return fn2
       },
@@ -366,9 +358,7 @@ describe('component: emit', () => {
       modelValue() {
         return null
       },
-      modelModifiers() {
-        return { trim: true }
-      },
+      modelModifiers: { trim: true },
       ['onUpdate:modelValue']() {
         return fn
       },
@@ -493,6 +483,36 @@ describe('component: emit', () => {
           fooModifiers: { trim: true },
           ['onUpdate:foo']: fn2,
         }),
+      ],
+    } as any)
+
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn1).toHaveBeenCalledWith(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledWith('two')
+  })
+
+  test('v-model modifiers should work from static object source', () => {
+    const { render } = define({
+      setup(_, { emit }) {
+        emit('update:modelValue', '1')
+        emit('update:foo', '  two  ')
+        return []
+      },
+    })
+
+    const fn1 = vi.fn()
+    const fn2 = vi.fn()
+    render({
+      $: [
+        {
+          modelValue: null,
+          modelModifiers: { number: true },
+          ['onUpdate:modelValue']: () => fn1,
+          foo: null,
+          fooModifiers: { trim: true },
+          ['onUpdate:foo']: () => fn2,
+        },
       ],
     } as any)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed v-model modifier handling for components. Modifiers like `.number` and `.trim` now work correctly across all binding scenarios, including combinations and static object sources, with optimized performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->