### PR TITLE
perf(compiler-vapor): inline single-use DOM lookup placeholders

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -270,8 +270,7 @@ export function render(_ctx) {
   const n6 = t1()
   const n5 = _next(_child(n6), 1)
   const n7 = _nthChild(n6, 3)
-  const p0 = _next(n7, 4)
-  const n4 = _child(p0)
+  const n4 = _child(_next(n7, 4))
   _setInsertionState(n6, n5, 1)
   const n0 = _createAssetComponent("Comp")
   _setInsertionState(n6, n7, 3)
@@ -459,17 +458,23 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 }"
 `;
 
-exports[`compile > gen unique node variables > should bump placeholder var (p*) on conflict 1`] = `
-"import { child as _child, setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
-const t0 = _template("<div><div><div><span>", 1)
+exports[`compile > gen unique node variables > should bump placeholder cursor var (p*) on conflict 1`] = `
+"import { child as _child, next as _next, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div><div>x</div><div><span> </div><div><span> ", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
-  const n1 = t0()
-  const p1 = _child(n1)
-  const p3 = _child(p1)
-  const n0 = _child(p3)
-  _renderEffect(() => _setProp(n0, "id", _ctx.foo))
-  return n1
+  const n2 = t0()
+  let p1 = _next(_child(n2), 1)
+  const n0 = _child(p1)
+  const n1 = _child((p1 = _next(p1, 2)))
+  const x0 = _txt(n0)
+  const x1 = _txt(n1)
+  _renderEffect(() => {
+    const _foo = _ctx.foo
+    _setText(x0, _toDisplayString(_foo))
+    _setText(x1, _toDisplayString(_foo))
+  })
+  return n2
 }"
 `;
 

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -454,9 +454,13 @@ describe('compile', () => {
       expect(code).contains('const t4 = _template("<p>", 2)')
     })
 
-    test('should bump placeholder var (p*) on conflict', () => {
+    test('should bump placeholder cursor var (p*) on conflict', () => {
       const code = compile(
-        `<div><div><div><span :id="foo" /></div></div></div>`,
+        `<div>
+          <div>x</div>
+          <div><span>{{ foo }}</span></div>
+          <div><span>{{ foo }}</span></div>
+        </div>`,
         {
           bindingMetadata: {
             p0: BindingTypes.SETUP_REF,
@@ -467,10 +471,11 @@ describe('compile', () => {
       )
 
       expect(code).matchSnapshot()
-      expect(code).not.contains('const p0 = ')
-      expect(code).not.contains('const p2 = ')
-      expect(code).contains('const p1 = ')
-      expect(code).contains('const p3 = ')
+      expect(code).not.contains('let p0 = ')
+      expect(code).not.contains('let p2 = ')
+      expect(code).contains('let p1 = _next(_child(n2), 1)')
+      expect(code).contains('const n0 = _child(p1)')
+      expect(code).contains('const n1 = _child((p1 = _next(p1, 2)))')
     })
   })
 })

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/logicalIndex.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/logicalIndex.spec.ts.snap
@@ -15,6 +15,21 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: logicalIndex > child/nthChild/next with logicalIndex > inline placeholder keeps logicalIndex when it differs from element index 1`] = `
+"import { setInsertionState as _setInsertionState, createAssetComponent as _createAssetComponent, child as _child, nthChild as _nthChild, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div><i></i><b></b><section><span> ", 1)
+
+export function render(_ctx) {
+  const n2 = t0()
+  const n1 = _child(_nthChild(n2, 2, 3))
+  _setInsertionState(n2, 0, 0)
+  const n0 = _createAssetComponent("Comp")
+  const x1 = _txt(n1)
+  _renderEffect(() => _setText(x1, _toDisplayString(_ctx.msg)))
+  return n2
+}"
+`;
+
 exports[`compiler: logicalIndex > child/nthChild/next with logicalIndex > multiple prepends affect logicalIndex 1`] = `
 "import { setInsertionState as _setInsertionState, createAssetComponent as _createAssetComponent, child as _child, next as _next, template as _template } from 'vue';
 const t0 = _template("<div><div></div><!><span>", 1)
@@ -52,16 +67,15 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: logicalIndex > child/nthChild/next with logicalIndex > nthChild keeps logicalIndex when it differs from element index 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, child as _child, nthChild as _nthChild, createIf as _createIf, template as _template } from 'vue';
+"import { setInsertionState as _setInsertionState, createAssetComponent as _createAssetComponent, child as _child, nthChild as _nthChild, createIf as _createIf, template as _template } from 'vue';
 const t0 = _template("<div>", 2)
 const t1 = _template("<div><div></div><span></span><!><div><button>", 1)
 
 export function render(_ctx) {
-  const _component_Comp = _resolveComponent("Comp")
   const n4 = t1()
   const n5 = _nthChild(n4, 2, 3)
   _setInsertionState(n4, 0, 0)
-  const n0 = _createComponentWithFallback(_component_Comp)
+  const n0 = _createAssetComponent("Comp")
   _setInsertionState(n4, n5, 3)
   const n1 = _createIf(() => (true), () => {
     const n3 = t0()

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformChildren.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformChildren.spec.ts.snap
@@ -56,12 +56,10 @@ const t0 = _template("<div><div>x</div><div><span> </div><div><span> </div><div>
 
 export function render(_ctx) {
   const n3 = t0()
-  const p0 = _next(_child(n3), 1)
+  let p0 = _next(_child(n3), 1)
   const n0 = _child(p0)
-  const p1 = _next(p0, 2)
-  const n1 = _child(p1)
-  const p2 = _next(p1, 3)
-  const n2 = _child(p2)
+  const n1 = _child((p0 = _next(p0, 2)))
+  const n2 = _child((p0 = _next(p0, 3)))
   const x0 = _txt(n0)
   const x1 = _txt(n1)
   const x2 = _txt(n2)
@@ -72,5 +70,79 @@ export function render(_ctx) {
     _setText(x2, _toDisplayString(_msg))
   })
   return n3
+}"
+`;
+
+exports[`compiler: children transform > inline placeholder when branching access paths share one parent access 1`] = `
+"import { child as _child, next as _next, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div><div><section><span> </section><section><span> ", 1)
+
+export function render(_ctx) {
+  const n2 = t0()
+  let p0 = _child(_child(n2))
+  const n0 = _child(p0)
+  const n1 = _child((p0 = _next(p0, 1)))
+  const x0 = _txt(n0)
+  const x1 = _txt(n1)
+  _renderEffect(() => {
+    _setText(x0, _toDisplayString(_ctx.first))
+    _setText(x1, _toDisplayString(_ctx.second))
+  })
+  return n2
+}"
+`;
+
+exports[`compiler: children transform > keep nested operation parent as node variable before sibling lookup 1`] = `
+"import { child as _child, setInsertionState as _setInsertionState, createAssetComponent as _createAssetComponent, next as _next, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div><section></section><section><span> ", 1)
+
+export function render(_ctx) {
+  const n3 = t0()
+  const n1 = _child(n3)
+  const n2 = _child(_next(n1, 1))
+  _setInsertionState(n1, null, 0)
+  const n0 = _createAssetComponent("Comp")
+  const x2 = _txt(n2)
+  _renderEffect(() => _setText(x2, _toDisplayString(_ctx.msg)))
+  return n3
+}"
+`;
+
+exports[`compiler: children transform > materialize placeholder when inline would duplicate parent access 1`] = `
+"import { child as _child, nthChild as _nthChild, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div><section><div><span> </div><i></i><div><span> ", 1)
+
+export function render(_ctx) {
+  const n2 = t0()
+  let p0 = _child(n2)
+  let p1 = _child(p0)
+  const n0 = _child(p1)
+  const n1 = _child((p1 = _nthChild(p0, 2)))
+  const x0 = _txt(n0)
+  const x1 = _txt(n1)
+  _renderEffect(() => {
+    _setText(x0, _toDisplayString(_ctx.first))
+    _setText(x1, _toDisplayString(_ctx.second))
+  })
+  return n2
+}"
+`;
+
+exports[`compiler: children transform > reuse cursor assignment for non-adjacent following access path 1`] = `
+"import { child as _child, nthChild as _nthChild, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div><div><span> </div><i></i><div><span> ", 1)
+
+export function render(_ctx) {
+  const n2 = t0()
+  let p0 = _child(n2)
+  const n0 = _child(p0)
+  const n1 = _child((p0 = _nthChild(n2, 2)))
+  const x0 = _txt(n0)
+  const x1 = _txt(n1)
+  _renderEffect(() => {
+    _setText(x0, _toDisplayString(_ctx.first))
+    _setText(x1, _toDisplayString(_ctx.second))
+  })
+  return n2
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/logicalIndex.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/logicalIndex.spec.ts
@@ -81,6 +81,22 @@ describe('compiler: logicalIndex', () => {
       expect(code).toMatchSnapshot()
     })
 
+    test('inline placeholder keeps logicalIndex when it differs from element index', () => {
+      // <div><Comp /><i /><b /><section><span>{{ msg }}</span></section></div>
+      // Comp is prepended and not part of the template, so the section is
+      // elementIndex=2 but logicalIndex=3.
+      const { code } = compileWithTransforms(`
+        <div>
+          <Comp />
+          <i />
+          <b />
+          <section><span>{{ msg }}</span></section>
+        </div>
+      `)
+      expect(code).toMatch(/const n\d+ = _child\(_nthChild\(n\d+, 2, 3\)\)/)
+      expect(code).toMatchSnapshot()
+    })
+
     test('child with logicalIndex when prepend exists and insert anchor needed', () => {
       // <div><Comp1 /><div /><Comp2 /><span /></div>
       // Comp1: 0 (prepend), div: 1, Comp2: 2 (insert), span: 3

--- a/packages/compiler-vapor/__tests__/transforms/transformChildren.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformChildren.spec.ts
@@ -45,6 +45,12 @@ describe('compiler: children transform', () => {
     <div><span>{{ msg }}</span></div>
   </div>`,
     )
+    expect(code).toContain(`let p0 = _next(_child(n3), 1)`)
+    expect(code).toContain(`const n0 = _child(p0)`)
+    expect(code).toContain(`const n1 = _child((p0 = _next(p0, 2)))`)
+    expect(code).toContain(`const n2 = _child((p0 = _next(p0, 3)))`)
+    expect(code).not.toMatch(/const p\d =/)
+    expect(code).not.toMatch(/let p[1-9]\d* =/)
     expect(code).toMatchSnapshot()
   })
 
@@ -57,6 +63,67 @@ describe('compiler: children transform', () => {
       </div>`,
     )
     expect(code).contains(`const n0 = _nthChild(n1, 2)`)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('inline placeholder when branching access paths share one parent access', () => {
+    const { code } = compileWithElementTransform(
+      `<div>
+        <div>
+          <section><span>{{ first }}</span></section>
+          <section><span>{{ second }}</span></section>
+        </div>
+      </div>`,
+    )
+    expect(code).toMatch(/let p\d = _child\(_child\(n\d\)\)/)
+    expect(code).not.toMatch(/let p\d = _child\(n\d\)/)
+    expect(code).toMatch(/const n\d = _child\(p\d\)/)
+    expect(code).toMatch(/const n\d = _child\(\(p\d = _next\(p\d, 1\)\)\)/)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('reuse cursor assignment for non-adjacent following access path', () => {
+    const { code } = compileWithElementTransform(
+      `<div>
+        <div><span>{{ first }}</span></div>
+        <i></i>
+        <div><span>{{ second }}</span></div>
+      </div>`,
+    )
+    const pDecls = code.match(/let p\d =/g) || []
+    expect(pDecls).toHaveLength(1)
+    expect(code).toMatch(/let p\d = _child\(n\d\)/)
+    expect(code).toMatch(/const n\d = _child\(\(p\d = _nthChild\(n\d, 2\)\)\)/)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('materialize placeholder when inline would duplicate parent access', () => {
+    const { code } = compileWithElementTransform(
+      `<div>
+        <section>
+          <div><span>{{ first }}</span></div>
+          <i></i>
+          <div><span>{{ second }}</span></div>
+        </section>
+      </div>`,
+    )
+    expect(code).toMatch(/let p\d = _child\(n\d\)/)
+    expect(code).toMatch(/_nthChild\(p\d, 2\)/)
+    expect(code).not.toMatch(/_nthChild\(_child\(n\d\), 2\)/)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('keep nested operation parent as node variable before sibling lookup', () => {
+    const { code } = compileWithElementTransform(
+      `<div>
+        <section><Comp /></section>
+        <section><span>{{ msg }}</span></section>
+      </div>`,
+    )
+    expect(code).toContain('const n1 = _child(n3)')
+    expect(code).toContain('const n2 = _child(_next(n1, 1))')
+    expect(code).toContain('_setInsertionState(n1, null, 0)')
+    expect(code).not.toContain('p0 = _next')
     expect(code).toMatchSnapshot()
   })
 

--- a/packages/compiler-vapor/src/generators/template.ts
+++ b/packages/compiler-vapor/src/generators/template.ts
@@ -5,6 +5,7 @@ import { genDirectivesForElement } from './directive'
 import { genOperationWithInsertionState } from './operation'
 import {
   type CodeFragment,
+  type CodeFragments,
   IMPORT_EXPR_RE,
   NEWLINE,
   buildCodeFragment,
@@ -73,15 +74,20 @@ export function genChildren(
   dynamic: IRDynamicInfo,
   context: CodegenContext,
   pushBlock: (...items: CodeFragment[]) => number,
-  from: string = `n${dynamic.id}`,
+  from: CodeFragments = `n${dynamic.id}`,
   flushBeforeDynamic?: FlushBeforeDynamic,
 ): CodeFragment[] {
-  const { helper } = context
   const [frag, push] = buildCodeFragment()
   const { children } = dynamic
 
   let offset = 0
-  let prev: [variable: string, elementIndex: number] | undefined
+  /**
+   * `reusable` means the previous access target is a p* cursor that can be
+   * reassigned by the next lookup. Referenced n* variables must stay stable.
+   */
+  let prev:
+    | [variable: string, elementIndex: number, reusable: boolean]
+    | undefined
 
   for (const [index, child] of children.entries()) {
     if (child.flags & DynamicFlag.NON_TEMPLATE) {
@@ -110,53 +116,66 @@ export function genChildren(
     const elementIndex = index + offset
     const logicalIndex =
       child.logicalIndex !== undefined ? String(child.logicalIndex) : undefined
-    // nthChild defaults the logical index to the element index at runtime, so
-    // the third argument is only needed when hydration uses a different index.
-    const nthChildLogicalIndex =
-      child.logicalIndex === elementIndex ? undefined : logicalIndex
-    // p for "placeholder" variables that are meant for possible reuse by
-    // other access paths
-    const variable =
-      id === undefined ? context.pName(context.block.tempId++) : `n${id}`
-    pushBlock(NEWLINE, `const ${variable} = `)
+    const inlinePlaceholder =
+      id === undefined &&
+      canInlinePlaceholder(child) &&
+      child.template == null &&
+      child.operation === undefined &&
+      !(child.flags & (DynamicFlag.INSERT | DynamicFlag.NON_TEMPLATE))
+    const accessPath = genAccessPath(
+      context,
+      from,
+      child,
+      elementIndex,
+      logicalIndex,
+      prev,
+    )
 
-    if (prev) {
-      if (elementIndex - prev[1] === 1) {
-        pushBlock(...genCall(helper('next'), prev[0], logicalIndex))
-      } else {
-        pushBlock(
-          ...genCall(
-            helper('nthChild'),
-            from,
-            String(elementIndex),
-            nthChildLogicalIndex,
+    if (inlinePlaceholder) {
+      if (prev && prev[2]) {
+        push(
+          ...genChildren(
+            child,
+            context,
+            pushBlock,
+            ['(', prev[0], ' = ', ...accessPath, ')'],
+            flushBeforeDynamic,
           ),
         )
+        prev = [prev[0], elementIndex, true]
+        continue
       }
+
+      if (
+        !hasAdjacentFollowingAccessChild(children, index, elementIndex, offset)
+      ) {
+        push(
+          ...genChildren(
+            child,
+            context,
+            pushBlock,
+            accessPath,
+            flushBeforeDynamic,
+          ),
+        )
+        continue
+      }
+    }
+
+    let variable: string
+    if (id === undefined && prev && prev[2]) {
+      variable = prev[0]
+      pushBlock(NEWLINE, `${variable} = `, ...accessPath)
     } else {
-      if (elementIndex === 0) {
-        pushBlock(
-          ...genCall(
-            helper('child'),
-            from,
-            child.logicalIndex !== 0 ? logicalIndex : undefined,
-          ),
-        )
-      } else {
-        // check if there's a node that we can reuse from
-        let init = genCall(helper('child'), from)
-        if (elementIndex === 1) {
-          init = genCall(helper('next'), init, logicalIndex)
-        } else if (elementIndex > 1) {
-          init = genCall(
-            helper('nthChild'),
-            from,
-            String(elementIndex),
-            nthChildLogicalIndex,
-          )
-        }
-        pushBlock(...init)
-      }
+      // p for "placeholder" variables that are meant for possible reuse by
+      // other access paths
+      variable =
+        id === undefined ? context.pName(context.block.tempId++) : `n${id}`
+      pushBlock(
+        NEWLINE,
+        id === undefined ? `let ${variable} = ` : `const ${variable} = `,
+        ...accessPath,
+      )
     }
 
     if (id === child.anchor && !child.hasDynamicChild) {
@@ -168,11 +187,165 @@ export function genChildren(
       push(...genDirectivesForElement(id, context))
     }
 
-    prev = [variable, elementIndex]
+    prev = [variable, elementIndex, id === undefined]
     push(
       ...genChildren(child, context, pushBlock, variable, flushBeforeDynamic),
     )
   }
 
   return frag
+}
+
+/**
+ * Build one DOM lookup path while preserving the fast sibling walk:
+ * adjacent nodes use _next(prev), otherwise fall back to _nthChild(parent).
+ */
+function genAccessPath(
+  { helper }: CodegenContext,
+  from: CodeFragments,
+  child: IRDynamicInfo,
+  elementIndex: number,
+  logicalIndex: string | undefined,
+  prev: [variable: string, elementIndex: number, reusable: boolean] | undefined,
+): CodeFragment[] {
+  if (prev) {
+    return elementIndex - prev[1] === 1
+      ? genCall(helper('next'), prev[0], logicalIndex)
+      : genNthChild(helper('nthChild'), from, elementIndex, logicalIndex)
+  }
+
+  if (elementIndex === 0) {
+    return genCall(
+      helper('child'),
+      from,
+      child.logicalIndex !== 0 ? logicalIndex : undefined,
+    )
+  }
+
+  // check if there's a node that we can reuse from
+  const firstChild = genCall(helper('child'), from)
+  return elementIndex === 1
+    ? genCall(helper('next'), firstChild, logicalIndex)
+    : genNthChild(helper('nthChild'), from, elementIndex, logicalIndex)
+}
+
+/**
+ * Only inline a placeholder when materializing it would not save a parent
+ * lookup. If its child tree needs the parent more than once, keep p* so the
+ * generated code does not duplicate _child/_nthChild work.
+ */
+function canInlinePlaceholder(dynamic: IRDynamicInfo): boolean {
+  return (
+    dynamic.hasDynamicChild === true && countParentAccessUsages(dynamic) === 1
+  )
+}
+
+/**
+ * A following access can reuse the current placeholder cursor only when it is
+ * the next DOM sibling. Gapped siblings need _nthChild(parent, index) instead.
+ */
+function hasAdjacentFollowingAccessChild(
+  children: IRDynamicInfo[],
+  index: number,
+  elementIndex: number,
+  offset: number,
+): boolean {
+  let futureOffset = offset
+  for (let i = index + 1; i < children.length; i++) {
+    const child = children[i]
+    if (child.flags & DynamicFlag.NON_TEMPLATE) {
+      futureOffset--
+    }
+    if (
+      !(child.flags & DynamicFlag.INSERT && child.template != null) &&
+      (!!(child.flags & DynamicFlag.REFERENCED) || child.hasDynamicChild)
+    ) {
+      return i + futureOffset - elementIndex === 1
+    }
+  }
+
+  return false
+}
+
+/**
+ * Mirrors genChildren's traversal closely enough to count how many emitted
+ * access paths would start from this placeholder's parent. This is the guard
+ * that keeps inline placeholders from duplicating parent lookups.
+ */
+function countParentAccessUsages(dynamic: IRDynamicInfo): number {
+  let usages = 0
+  let offset = 0
+  let prev: [elementIndex: number, reusable: boolean] | undefined
+
+  for (const [index, child] of dynamic.children.entries()) {
+    if (child.flags & DynamicFlag.NON_TEMPLATE) {
+      offset--
+    }
+
+    if (child.flags & DynamicFlag.INSERT && child.template != null) {
+      continue
+    }
+
+    const id =
+      child.flags & DynamicFlag.REFERENCED
+        ? child.flags & DynamicFlag.INSERT
+          ? child.anchor
+          : child.id
+        : undefined
+
+    if (id === undefined && !child.hasDynamicChild) {
+      continue
+    }
+
+    const elementIndex = index + offset
+    const usesParent = !prev || elementIndex - prev[0] !== 1
+    const inlinePlaceholder =
+      id === undefined &&
+      canInlinePlaceholder(child) &&
+      child.template == null &&
+      child.operation === undefined &&
+      !(child.flags & (DynamicFlag.INSERT | DynamicFlag.NON_TEMPLATE))
+
+    if (inlinePlaceholder) {
+      if (prev && prev[1]) {
+        if (usesParent) usages++
+        prev = [elementIndex, true]
+        continue
+      }
+
+      if (
+        !hasAdjacentFollowingAccessChild(
+          dynamic.children,
+          index,
+          elementIndex,
+          offset,
+        )
+      ) {
+        if (usesParent) usages++
+        continue
+      }
+    }
+
+    if (usesParent) usages++
+    prev = [elementIndex, id === undefined]
+  }
+
+  return usages
+}
+
+function genNthChild(
+  nthChild: string,
+  from: CodeFragments,
+  elementIndex: number,
+  logicalIndex: string | undefined,
+): CodeFragment[] {
+  const index = String(elementIndex)
+  return genCall(
+    nthChild,
+    from,
+    index,
+    // nthChild defaults the logical index to the element index at runtime, so
+    // the third argument is only needed when hydration uses a different index.
+    logicalIndex === index ? undefined : logicalIndex,
+  )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded compiler test coverage for placeholder variable management and inline placeholder generation in complex template scenarios.

* **Refactor**
  * Optimized template code generation to enable more efficient inline placeholder creation and improve DOM element traversal, reducing redundant operations in compiled output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->