### PR TITLE
fix(runtime-vapor): apply transition hooks to slot fallbacks

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -409,6 +409,49 @@ describe('Transition', () => {
     expect(host.innerHTML).not.toContain('<div>fallback</div>')
   })
 
+  test('slot fallback should trigger enter hooks when slot content becomes empty', async () => {
+    const onBeforeEnter = vi.fn()
+    const onEnter = vi.fn()
+    const data = ref({
+      show: true,
+      onBeforeEnter,
+      onEnter,
+    })
+    const Child = compile(
+      `<template>
+        <Transition
+          @before-enter="data.onBeforeEnter"
+          @enter="data.onEnter"
+        >
+          <slot>
+            <div>22</div>
+          </slot>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<template>
+        <button @click="data.show = !data.show">Toggle</button>
+        <components.Child>
+          <div v-if="data.show">3</div>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+    const { host } = define(App as any).render()
+
+    host.querySelector('button')!.click()
+    await nextTick()
+
+    expect(host.innerHTML).toContain(
+      '<div class="v-enter-from v-enter-active">22</div>',
+    )
+    expect(onBeforeEnter).toHaveBeenCalledTimes(1)
+    expect(onEnter).toHaveBeenCalledTimes(1)
+  })
+
   test('dynamic default slot source should trigger enter hooks when toggled on', async () => {
     const onBeforeEnter = vi.fn()
     const onEnter = vi.fn()

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -446,6 +446,9 @@ describe('Transition', () => {
     await nextTick()
 
     expect(host.innerHTML).toContain(
+      '<div class="v-leave-from v-leave-active">3</div>',
+    )
+    expect(host.innerHTML).toContain(
       '<div class="v-enter-from v-enter-active">22</div>',
     )
     expect(onBeforeEnter).toHaveBeenCalledTimes(1)

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1133,6 +1133,9 @@ function commitSlotFallback(
   if (isTransitionEnabled) {
     const transitionOutlet = outlet as SlotFallbackOutlet & TransitionOptions
     if (transitionOutlet.$transition) {
+      // Match VDOM slot fallback branch identity so fallback enter does not
+      // early-remove the currently leaving slot content.
+      setBlockKey(block, '_fb')
       transitionOutlet.$transition = applyTransitionHooks(
         block,
         transitionOutlet.$transition,

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1130,6 +1130,15 @@ function commitSlotFallback(
   outlet.activeFallback = block
   outlet.fallbackScope = scope
   ensureSlotFallbackOrderHook(outlet, block)
+  if (isTransitionEnabled) {
+    const transitionOutlet = outlet as SlotFallbackOutlet & TransitionOptions
+    if (transitionOutlet.$transition) {
+      transitionOutlet.$transition = applyTransitionHooks(
+        block,
+        transitionOutlet.$transition,
+      )
+    }
+  }
   insertActiveSlotFallback(outlet)
 }
 


### PR DESCRIPTION
close #14851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for transitions with slot fallback content, including enter/leave animations and lifecycle hook execution.

* **New Features**
  * Enabled transition effects for slot fallback content, supporting both animation classes and component lifecycle hooks during show/hide transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->