### PR TITLE
perf(compiler-vapor): use onBinding helper for reactive events

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
@@ -36,31 +36,38 @@ export function render(_ctx) {
 `;
 
 exports[`v-on > dynamic arg 1`] = `
-"import { createInvoker as _createInvoker, on as _on, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { createInvoker as _createInvoker, onBinding as _onBinding, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => {
-    
-    _on(n0, _ctx.event, _createInvoker(e => _ctx.handler(e)), {
-      effect: true
-    })
-  })
+  _renderEffect(() => _onBinding(n0, _ctx.event, _createInvoker(e => _ctx.handler(e))))
   return n0
 }"
 `;
 
 exports[`v-on > dynamic arg with complex exp prefixing 1`] = `
-"import { createInvoker as _createInvoker, on as _on, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { createInvoker as _createInvoker, onBinding as _onBinding, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _onBinding(n0, _ctx.event(_ctx.foo), _createInvoker(e => _ctx.handler(e))))
+  return n0
+}"
+`;
+
+exports[`v-on > dynamic arg with event options 1`] = `
+"import { createInvoker as _createInvoker, onBinding as _onBinding, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
   _renderEffect(() => {
     
-    _on(n0, _ctx.event(_ctx.foo), _createInvoker(e => _ctx.handler(e)), {
-      effect: true
+    _onBinding(n0, _ctx.event, _createInvoker(e => _ctx.handler(e)), {
+      capture: true,
+      once: true
     })
   })
   return n0
@@ -68,17 +75,12 @@ export function render(_ctx) {
 `;
 
 exports[`v-on > dynamic arg with prefixing 1`] = `
-"import { createInvoker as _createInvoker, on as _on, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { createInvoker as _createInvoker, onBinding as _onBinding, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => {
-    
-    _on(n0, _ctx.event, _createInvoker(e => _ctx.handler(e)), {
-      effect: true
-    })
-  })
+  _renderEffect(() => _onBinding(n0, _ctx.event, _createInvoker(e => _ctx.handler(e))))
   return n0
 }"
 `;
@@ -385,17 +387,12 @@ export function render(_ctx) {
 `;
 
 exports[`v-on > should transform click.middle 2`] = `
-"import { createInvoker as _createInvoker, withModifiers as _withModifiers, on as _on, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { createInvoker as _createInvoker, withModifiers as _withModifiers, onBinding as _onBinding, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => {
-    
-    _on(n0, (_ctx.event) === "click" ? "mouseup" : (_ctx.event), _createInvoker(_withModifiers(e => _ctx.test(e), ["middle"])), {
-      effect: true
-    })
-  })
+  _renderEffect(() => _onBinding(n0, (_ctx.event) === "click" ? "mouseup" : (_ctx.event), _createInvoker(_withModifiers(e => _ctx.test(e), ["middle"]))))
   return n0
 }"
 `;
@@ -413,17 +410,12 @@ export function render(_ctx) {
 `;
 
 exports[`v-on > should transform click.right 2`] = `
-"import { createInvoker as _createInvoker, withModifiers as _withModifiers, withKeys as _withKeys, on as _on, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { createInvoker as _createInvoker, withModifiers as _withModifiers, withKeys as _withKeys, onBinding as _onBinding, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => {
-    
-    _on(n0, (_ctx.event) === "click" ? "contextmenu" : (_ctx.event), _createInvoker(_withKeys(_withModifiers(e => _ctx.test(e), ["right"]), ["right"])), {
-      effect: true
-    })
-  })
+  _renderEffect(() => _onBinding(n0, (_ctx.event) === "click" ? "contextmenu" : (_ctx.event), _createInvoker(_withKeys(_withModifiers(e => _ctx.test(e), ["right"]), ["right"]))))
   return n0
 }"
 `;
@@ -441,17 +433,12 @@ export function render(_ctx) {
 `;
 
 exports[`v-on > should wrap both for dynamic key event w/ left/right modifiers 1`] = `
-"import { createInvoker as _createInvoker, withModifiers as _withModifiers, withKeys as _withKeys, on as _on, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { createInvoker as _createInvoker, withModifiers as _withModifiers, withKeys as _withKeys, onBinding as _onBinding, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => {
-    
-    _on(n0, _ctx.e, _createInvoker(_withKeys(_withModifiers(e => _ctx.test(e), ["left"]), ["left"])), {
-      effect: true
-    })
-  })
+  _renderEffect(() => _onBinding(n0, _ctx.e, _createInvoker(_withKeys(_withModifiers(e => _ctx.test(e), ["left"]), ["left"]))))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -87,7 +87,7 @@ describe('v-on', () => {
       `<div v-on:[event]="handler"/>`,
     )
 
-    expect(helpers).contains('on')
+    expect(helpers).contains('onBinding')
     expect(helpers).contains('renderEffect')
     expect(ir.block.operation).toMatchObject([])
 
@@ -107,6 +107,9 @@ describe('v-on', () => {
     })
 
     expect(code).matchSnapshot()
+    expect(code).contains(
+      `_onBinding(n0, _ctx.event, _createInvoker(e => _ctx.handler(e)))`,
+    )
   })
 
   test('dynamic arg with prefixing', () => {
@@ -117,6 +120,24 @@ describe('v-on', () => {
     expect(code).matchSnapshot()
   })
 
+  test('dynamic arg with event options', () => {
+    const { code, helpers } = compileWithVOn(
+      `<div v-on:[event].capture.once="handler"/>`,
+      {
+        prefixIdentifiers: true,
+      },
+    )
+
+    expect(helpers).contains('onBinding')
+    expect(code).matchSnapshot()
+    expect(code).contains(
+      `_onBinding(n0, _ctx.event, _createInvoker(e => _ctx.handler(e)), {`,
+    )
+    expect(code).contains('capture: true')
+    expect(code).contains('once: true')
+    expect(code).not.contains('effect: true')
+  })
+
   test('dynamic arg with complex exp prefixing', () => {
     const { ir, code, helpers } = compileWithVOn(
       `<div v-on:[event(foo)]="handler"/>`,
@@ -125,7 +146,7 @@ describe('v-on', () => {
       },
     )
 
-    expect(helpers).contains('on')
+    expect(helpers).contains('onBinding')
     expect(helpers).contains('renderEffect')
     expect(ir.block.operation).toMatchObject([])
 

--- a/packages/compiler-vapor/src/generators/event.ts
+++ b/packages/compiler-vapor/src/generators/event.ts
@@ -50,7 +50,7 @@ export function genSetEvent(
   return [
     NEWLINE,
     ...genCall(
-      helper(delegate ? 'delegate' : 'on'),
+      helper(effect ? 'onBinding' : delegate ? 'delegate' : 'on'),
       `n${element}`,
       name,
       handler,
@@ -73,11 +73,10 @@ export function genSetEvent(
 
   function genEventOptions(): CodeFragment[] | undefined {
     let { options } = modifiers
-    if (!options.length && !effect) return
+    if (!options.length) return
 
     return genMulti(
       DELIMITERS_OBJECT_NEWLINE,
-      effect && ['effect: true'],
       ...options.map((option): CodeFragment[] => [`${option}: true`]),
     )
   }

--- a/packages/runtime-vapor/__tests__/dom/event.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/event.spec.ts
@@ -1,8 +1,10 @@
-import { effectScope } from '@vue/reactivity'
+import { effectScope, ref } from '@vue/reactivity'
+import { nextTick } from '@vue/runtime-dom'
 import {
   delegate,
   delegateEvents,
   on,
+  onBinding,
   renderEffect,
   setDynamicEvents,
 } from '../../src'
@@ -16,6 +18,56 @@ describe('dom event', () => {
     on(el, 'click', handler)
     el.click()
     expect(handler).toHaveBeenCalled()
+  })
+
+  test('onBinding', () => {
+    const el = document.createElement('div')
+    const handler = vi.fn()
+    const scope = effectScope()
+    scope.run(() => {
+      renderEffect(() => {
+        onBinding(el, 'click', handler)
+      })
+    })
+    el.click()
+    expect(handler).toHaveBeenCalledTimes(1)
+    scope.stop()
+    el.click()
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('onBinding cleans previous listener on update', async () => {
+    const el = document.createElement('div')
+    const event = ref('click')
+    const clickHandler = vi.fn()
+    const mouseupHandler = vi.fn()
+    const scope = effectScope()
+    scope.run(() => {
+      renderEffect(() => {
+        onBinding(
+          el,
+          event.value,
+          event.value === 'click' ? clickHandler : mouseupHandler,
+        )
+      })
+    })
+
+    el.click()
+    expect(clickHandler).toHaveBeenCalledTimes(1)
+    expect(mouseupHandler).not.toHaveBeenCalled()
+
+    event.value = 'mouseup'
+    await nextTick()
+
+    el.click()
+    expect(clickHandler).toHaveBeenCalledTimes(1)
+
+    el.dispatchEvent(new MouseEvent('mouseup'))
+    expect(mouseupHandler).toHaveBeenCalledTimes(1)
+
+    scope.stop()
+    el.dispatchEvent(new MouseEvent('mouseup'))
+    expect(mouseupHandler).toHaveBeenCalledTimes(1)
   })
 
   test('delegate with direct attachment', () => {
@@ -100,7 +152,49 @@ describe('dom event', () => {
       })
     })
     el.click()
-    expect(handler).toHaveBeenCalled()
+    expect(handler).toHaveBeenCalledTimes(1)
+    scope.stop()
+    el.click()
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('setDynamicEvents with multiple handlers', () => {
+    const el = document.createElement('div')
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+    const scope = effectScope()
+    scope.run(() => {
+      renderEffect(() => {
+        setDynamicEvents(el, {
+          click: [handler1, handler2],
+        })
+      })
+    })
+
+    el.click()
+    expect(handler1).toHaveBeenCalledTimes(1)
+    expect(handler2).toHaveBeenCalledTimes(1)
+
+    scope.stop()
+    el.click()
+    expect(handler1).toHaveBeenCalledTimes(1)
+    expect(handler2).toHaveBeenCalledTimes(1)
+  })
+
+  test('setDynamicEvents accepts narrowed event handlers', () => {
+    const el = document.createElement('div')
+    const handler = vi.fn()
+    const scope = effectScope()
+    scope.run(() => {
+      renderEffect(() => {
+        setDynamicEvents(el, {
+          click: (e: MouseEvent) => handler(e.clientX),
+        })
+      })
+    })
+
+    el.click()
+    expect(handler).toHaveBeenCalledTimes(1)
     scope.stop()
   })
 })

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -20,7 +20,14 @@ import {
   createComponent,
   isApplyingFallthroughProps,
 } from '../../src/component'
-import { ref, setCurrentInstance, svgNS, xlinkNS } from '@vue/runtime-dom'
+import {
+  effectScope,
+  nextTick,
+  ref,
+  setCurrentInstance,
+  svgNS,
+  xlinkNS,
+} from '@vue/runtime-dom'
 import { makeRender } from '../_utils'
 import {
   createDynamicComponent,
@@ -656,6 +663,35 @@ describe('patchProp', () => {
 
       applyFallthroughProps(el, { ['.bar']: 'next' })
       expect(fallthroughSetCount).toBe(2)
+    })
+
+    test('should clean dynamic event props on effect update and stop', async () => {
+      const el = document.createElement('button')
+      const active = ref(true)
+      const handler = vi.fn()
+      const scope = effectScope()
+      scope.run(() => {
+        renderEffect(() => {
+          setDynamicProps(el, [active.value ? { onClick: handler } : {}])
+        })
+      })
+
+      el.click()
+      expect(handler).toHaveBeenCalledTimes(1)
+
+      active.value = false
+      await nextTick()
+      el.click()
+      expect(handler).toHaveBeenCalledTimes(1)
+
+      active.value = true
+      await nextTick()
+      el.click()
+      expect(handler).toHaveBeenCalledTimes(2)
+
+      scope.stop()
+      el.click()
+      expect(handler).toHaveBeenCalledTimes(2)
     })
 
     test('should restore fallthrough state when dynamic props throw', () => {

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -6,6 +6,9 @@ import {
   currentInstance,
 } from '@vue/runtime-dom'
 
+type EventHandler = (...args: any[]) => any
+type EventHandlerValue = EventHandler | EventHandler[]
+
 export function addEventListener(
   el: Element,
   event: string,
@@ -19,19 +22,31 @@ export function addEventListener(
 export function on(
   el: Element,
   event: string,
-  handler: (e: Event) => any | ((e: Event) => any)[],
-  options: AddEventListenerOptions & { effect?: boolean } = {},
+  handler: EventHandlerValue,
+  options: AddEventListenerOptions = {},
 ): void {
   if (isArray(handler)) {
     handler.forEach(fn => on(el, event, fn, options))
   } else {
     if (!handler) return
     addEventListener(el, event, handler, options)
-    if (options.effect) {
-      onEffectCleanup(() => {
-        el.removeEventListener(event, handler, options)
-      })
-    }
+  }
+}
+
+export function onBinding(
+  el: Element,
+  event: string,
+  handler: EventHandlerValue,
+  options: AddEventListenerOptions = {},
+): void {
+  if (isArray(handler)) {
+    handler.forEach(fn => onBinding(el, event, fn, options))
+  } else {
+    if (!handler) return
+    addEventListener(el, event, handler, options)
+    onEffectCleanup(() => {
+      el.removeEventListener(event, handler, options)
+    })
   }
 }
 
@@ -111,10 +126,10 @@ const delegatedEventHandler = (e: Event) => {
 
 export function setDynamicEvents(
   el: HTMLElement,
-  events: Record<string, (...args: any[]) => any>,
+  events: Record<string, EventHandlerValue>,
 ): void {
   for (const name in events) {
-    on(el, name, events[name], { effect: true })
+    onBinding(el, name, events[name])
   }
 }
 

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -14,7 +14,7 @@ import {
   stringifyStyle,
   toDisplayString,
 } from '@vue/shared'
-import { on } from './event'
+import { onBinding } from './event'
 import {
   type GenericComponentInstance,
   MismatchTypes,
@@ -568,7 +568,7 @@ export function setDynamicProp(
   } else if (key === 'style') {
     setStyle(el, value)
   } else if (isOn(key)) {
-    on(el, key[2].toLowerCase() + key.slice(3), value, { effect: true })
+    onBinding(el, key[2].toLowerCase() + key.slice(3), value)
   } else if (
     // force hydrate v-bind with .prop modifiers
     (forceHydrate = key[0] === '.')

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -51,6 +51,7 @@ export {
 } from './dom/prop'
 export {
   on,
+  onBinding,
   delegate,
   delegateEvents,
   setDynamicEvents,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `onBinding` event API is now publicly exported and available for use.

* **Bug Fixes**
  * Improved reactive event binding behavior; event handlers now properly clean up and update when reactive dependencies change.

* **Tests**
  * Added test coverage for reactive event binding within effect scopes.
  * Added test coverage for dynamic event property updates and cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->