### PR TITLE
perf(reactivity): skip type checks for cached proxies

### DIFF
--- a/packages/reactivity/__benchmarks__/reactiveObject.bench.ts
+++ b/packages/reactivity/__benchmarks__/reactiveObject.bench.ts
@@ -6,9 +6,24 @@ bench('create reactive obj', () => {
 })
 
 {
+  const raw = { a: 1 }
+  reactive(raw)
+  bench('return cached reactive obj', () => {
+    reactive(raw)
+  })
+}
+
+{
   const r = reactive({ a: 1 })
   bench('read reactive obj property', () => {
     r.a
+  })
+}
+
+{
+  const r = reactive({ a: { b: 1 } })
+  bench('read nested reactive obj property', () => {
+    r.a.b
   })
 }
 

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -55,12 +55,6 @@ function targetTypeMap(rawType: string) {
   }
 }
 
-function getTargetType(value: Target) {
-  return value[ReactiveFlags.SKIP] || !Object.isExtensible(value)
-    ? TargetType.INVALID
-    : targetTypeMap(toRawType(value))
-}
-
 // only unwrap nested ref
 export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>
 
@@ -291,14 +285,17 @@ function createReactiveObject(
     return target
   }
   // only specific value types can be observed.
-  const targetType = getTargetType(target)
-  if (targetType === TargetType.INVALID) {
+  if (target[ReactiveFlags.SKIP] || !Object.isExtensible(target)) {
     return target
   }
   // target already has corresponding Proxy
   const existingProxy = proxyMap.get(target)
   if (existingProxy) {
     return existingProxy
+  }
+  const targetType = targetTypeMap(toRawType(target))
+  if (targetType === TargetType.INVALID) {
+    return target
   }
   const proxy = new Proxy(
     target,


### PR DESCRIPTION
## Summary

- Check the existing proxy cache before computing the target raw type in createReactiveObject.
- Preserve the markRaw / non-extensible early return before the cache lookup.
- Add benchmarks for cached reactive objects and nested reactive property access.

## Test Plan

- pnpm exec vitest run --project=unit packages/reactivity/__tests__/reactive.spec.ts
- pnpm exec prettier --check packages/reactivity/src/reactive.ts packages/reactivity/__benchmarks__/reactiveObject.bench.ts
- pnpm exec eslint packages/reactivity/src/reactive.ts packages/reactivity/__benchmarks__/reactiveObject.bench.ts
- pnpm run prebench
- pnpm exec vitest bench --project=unit packages/reactivity/__benchmarks__/reactiveObject.bench.ts --outputJson=/tmp/vue-patched-nested-reactiveObject.json

Representative local benchmark run after the latest change:

- return cached reactive obj: 3.46M hz
- read nested reactive obj property: 1.60M hz