### PR TITLE
fix(runtime-vapor): apply interop scope ids to vapor roots

### DIFF
--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -1,9 +1,18 @@
-import { createApp, h, nextTick, ref } from '@vue/runtime-dom'
+import {
+  createApp,
+  h,
+  nextTick,
+  onUpdated,
+  ref,
+  renderSlot,
+} from '@vue/runtime-dom'
 import {
   createComponent,
   createDynamicComponent,
   createFor,
+  createIf,
   createSlot,
+  defineVaporAsyncComponent,
   defineVaporComponent,
   setInsertionState,
   template,
@@ -472,6 +481,286 @@ describe('vdom interop', () => {
 
     expect(root.innerHTML).toBe(
       `<button vapor-child="" vdom-parent=""></button>`,
+    )
+  })
+
+  test('vdom parent > vapor child with updated dynamic root', async () => {
+    const useAltRoot = ref(false)
+    const updatedSpy = vi.fn((vnode: any) => {
+      expect((vnode.el as Element).hasAttribute('vdom-parent')).toBe(true)
+    })
+
+    const VaporChild = defineVaporComponent({
+      __scopeId: 'vapor-child',
+      props: {
+        alt: Boolean,
+      },
+      setup(props: any) {
+        return createIf(
+          () => props.alt,
+          () => template('<section>alt</section>', 1)(),
+          () => template('<div>base</div>', 1)(),
+        )
+      },
+    })
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () =>
+          h(VaporChild as any, {
+            alt: useAltRoot.value,
+            onVnodeUpdated: updatedSpy,
+          })
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<div vdom-parent="">base</div><!--if-->`)
+
+    useAltRoot.value = true
+    await nextTick()
+
+    expect(root.innerHTML).toBe(
+      `<section vdom-parent="">alt</section><!--if-->`,
+    )
+    expect(updatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('vdom parent > vapor child with internally updated dynamic root', async () => {
+    const useAltRoot = ref(false)
+    const calls: string[] = []
+    let root!: HTMLDivElement
+
+    const VaporChild = defineVaporComponent({
+      __scopeId: 'vapor-child',
+      setup() {
+        onUpdated(() => {
+          const el = root.firstChild as Element
+          calls.push(`component:${el.hasAttribute('vdom-parent')}`)
+        })
+        return createIf(
+          () => useAltRoot.value,
+          () => template('<section>alt</section>', 1)(),
+          () => template('<div>base</div>', 1)(),
+        )
+      },
+    })
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () =>
+          h(VaporChild as any, {
+            onVnodeUpdated(vnode: any) {
+              calls.push(
+                `vnode:${(vnode.el as Element).hasAttribute('vdom-parent')}`,
+              )
+            },
+          })
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    useAltRoot.value = true
+    await nextTick()
+
+    expect(root.innerHTML).toBe(
+      `<section vdom-parent="">alt</section><!--if-->`,
+    )
+    expect(calls).toEqual(['component:true', 'vnode:true'])
+  })
+
+  test('vdom HOC parent > vapor child inherits scopeId on mount', () => {
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return template('<button></button>', 1)()
+      },
+    })
+
+    function Child() {
+      return h(Child2, { class: 'foo' })
+    }
+
+    function Child2() {
+      return h(VaporChild as any)
+    }
+    Child2.inheritAttrs = false
+
+    const App = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () => h(Child)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<button vdom-parent=""></button>`)
+  })
+
+  test('vdom slot owner > vapor slot content applies slot scopeId', () => {
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return template('<button></button>', 1)()
+      },
+    })
+
+    const VdomSlotOwner = {
+      __scopeId: 'vdom-slot-owner',
+      setup(_props: unknown, { slots }: any) {
+        return () => h('div', null, renderSlot(slots, 'default'))
+      },
+    }
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () =>
+          h(VdomSlotOwner, null, {
+            default: () => h(VaporChild as any),
+          })
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(
+      `<div vdom-slot-owner="" vdom-parent="">` +
+        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s=""></button>` +
+        `</div>`,
+    )
+  })
+
+  test('vdom parent > vapor child with comment and single root', () => {
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return [document.createComment('v-if'), template('<button></button>')()]
+      },
+    })
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () => h(VaporChild as any)
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<!--v-if--><button vdom-parent=""></button>`)
+  })
+
+  test('vdom parent > vapor child with updated multi-root dynamic fragment', async () => {
+    const useMultiRoot = ref(false)
+
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createIf(
+          () => useMultiRoot.value,
+          () => [
+            template('<span>a</span>', 1)(),
+            template('<span>b</span>', 1)(),
+          ],
+          () => template('<div>base</div>', 1)(),
+        )
+      },
+    })
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () => h(VaporChild as any)
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<div vdom-parent="">base</div><!--if-->`)
+
+    useMultiRoot.value = true
+    await nextTick()
+
+    expect(root.innerHTML).toBe(`<span>a</span><span>b</span><!--if-->`)
+  })
+
+  test('vdom parent > async vapor child applies scopeId after resolve', async () => {
+    let resolve!: (component: any) => void
+    const VaporAsyncChild = defineVaporAsyncComponent({
+      loader: () =>
+        new Promise<any>(_resolve => {
+          resolve = _resolve
+        }),
+    })
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () => h(VaporAsyncChild as any)
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<!--async component-->`)
+
+    resolve(
+      defineVaporComponent({
+        setup() {
+          return template('<button>resolved</button>', 1)()
+        },
+      }),
+    )
+    await new Promise(resolve => setTimeout(resolve))
+    await nextTick()
+
+    expect(root.innerHTML).toBe(
+      `<button vdom-parent="">resolved</button><!--async component-->`,
     )
   })
 

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -14,6 +14,8 @@ import {
   createSlot,
   defineVaporAsyncComponent,
   defineVaporComponent,
+  renderEffect,
+  setElementText,
   setInsertionState,
   template,
   vaporInteropPlugin,
@@ -652,6 +654,91 @@ describe('vdom interop', () => {
     expect(root.innerHTML).toBe(
       `<div vdom-slot-owner="" vdom-parent="">` +
         `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s=""></button>` +
+        `</div>`,
+    )
+  })
+
+  test('vdom slot owner > vapor slot content preserves slot scopeIds on same root update', async () => {
+    function mount(initialNoSlotted: boolean) {
+      const noSlotted = ref(initialNoSlotted)
+      const count = ref(0)
+      const VaporChild = defineVaporComponent({
+        props: {
+          count: Number,
+        },
+        setup(props: any) {
+          const n0 = template('<button></button>', 1)()
+          renderEffect(() => setElementText(n0, props.count))
+          return n0
+        },
+      })
+
+      const VdomSlotOwner = {
+        __scopeId: 'vdom-slot-owner',
+        setup(_props: unknown, { slots }: any) {
+          return () =>
+            h(
+              'div',
+              null,
+              renderSlot(slots, 'default', {}, undefined, noSlotted.value),
+            )
+        },
+      }
+
+      const VdomParent = {
+        __scopeId: 'vdom-parent',
+        setup() {
+          return () =>
+            h(VdomSlotOwner, null, {
+              default: () => h(VaporChild as any, { count: count.value }),
+            })
+        },
+      }
+
+      const App = {
+        setup() {
+          return () => h(VdomParent)
+        },
+      }
+
+      const root = document.createElement('div')
+      createApp(App).use(vaporInteropPlugin).mount(root)
+      return { count, noSlotted, root }
+    }
+
+    const noSlottedRoot = mount(true)
+
+    expect(noSlottedRoot.root.innerHTML).toBe(
+      `<div vdom-slot-owner="" vdom-parent="">` +
+        `<button vdom-slot-owner="" vdom-parent="">0</button>` +
+        `</div>`,
+    )
+
+    noSlottedRoot.noSlotted.value = false
+    noSlottedRoot.count.value++
+    await nextTick()
+
+    expect(noSlottedRoot.root.innerHTML).toBe(
+      `<div vdom-slot-owner="" vdom-parent="">` +
+        `<button vdom-slot-owner="" vdom-parent="">1</button>` +
+        `</div>`,
+    )
+
+    const slottedRoot = mount(false)
+
+    expect(slottedRoot.root.innerHTML).toBe(
+      `<div vdom-slot-owner="" vdom-parent="">` +
+        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">0</button>` +
+        `</div>`,
+    )
+
+    slottedRoot.noSlotted.value = true
+    slottedRoot.count.value++
+    await nextTick()
+
+    expect(slottedRoot.root.innerHTML).toBe(
+      `<div vdom-slot-owner="" vdom-parent="">` +
+        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">1</button>` +
         `</div>`,
     )
   })

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -7,6 +7,7 @@ import {
   renderSlot,
 } from '@vue/runtime-dom'
 import {
+  VaporTransition,
   createComponent,
   createDynamicComponent,
   createFor,
@@ -767,6 +768,70 @@ describe('vdom interop', () => {
     createApp(App).use(vaporInteropPlugin).mount(root)
 
     expect(root.innerHTML).toBe(`<!--v-if--><button vdom-parent=""></button>`)
+  })
+
+  test('vdom parent > vapor child applies scopeId to out-in transition delayed root', async () => {
+    const show = ref(true)
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      setTimeout(done, 0)
+    })
+    let interopVnode: any
+
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createComponent(
+          VaporTransition,
+          {
+            mode: () => 'out-in',
+            onLeave: () => onLeave,
+          },
+          {
+            default: withVaporCtx(() =>
+              createIf(
+                () => show.value,
+                () => template('<div>A</div>', 1)(),
+                () => template('<section>B</section>', 1)(),
+              ),
+            ),
+          },
+        )
+      },
+    })
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () =>
+          h(VaporChild as any, {
+            onVnodeMounted(vnode: any) {
+              interopVnode = vnode
+            },
+          })
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<div vdom-parent="">A</div><!--if-->`)
+    expect(interopVnode.el).toBe(root.firstChild)
+
+    show.value = false
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledTimes(1)
+    expect(root.innerHTML).toBe(
+      `<section class="v-enter-from v-enter-active" vdom-parent="">B</section><!--if-->`,
+    )
+    expect(interopVnode.el).toBe(root.firstChild)
   })
 
   test('vdom parent > vapor child with updated multi-root dynamic fragment', async () => {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -108,6 +108,7 @@ import {
   setInsertionState,
 } from './insertionState'
 import {
+  type DynamicFragment,
   type SlotBoundaryContext,
   type SlotFallbackOutlet,
   SlotFragment,
@@ -2450,13 +2451,37 @@ function createInteropRawSlots(slotsRef: ShallowRef<Slots>): RawSlots {
 }
 
 const interopScopeIdRootMap = new WeakMap<VaporComponentInstance, Element>()
+const interopScopeIdFragmentMap = new WeakMap<
+  DynamicFragment,
+  VaporComponentInstance
+>()
+
+function trackInteropScopeIdFragment(
+  instance: VaporComponentInstance,
+  frag: DynamicFragment,
+): void {
+  if (interopScopeIdFragmentMap.get(frag) === instance) return
+  interopScopeIdFragmentMap.set(frag, instance)
+  ;(frag.onUpdated || (frag.onUpdated = [])).push(() => {
+    const state = vnodeHookStateMap.get(instance)
+    if (!state) return
+    syncVNodeEl(state.vnode, instance)
+    setInteropVnodeScopeId(
+      instance,
+      state.vnode,
+      instance.parent as ComponentInternalInstance | null,
+    )
+  })
+}
 
 function setInteropVnodeScopeId(
   instance: VaporComponentInstance,
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null,
 ): void {
-  const root = getRootElement(instance)
+  const root = getRootElement(instance, frag =>
+    trackInteropScopeIdFragment(instance, frag),
+  )
   if (!root) {
     interopScopeIdRootMap.delete(instance)
     return

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -29,6 +29,7 @@ import {
   ensureRenderer,
   ensureValidVNode,
   ensureVaporSlotFallback,
+  getInheritedScopeIds,
   invokeDirectiveHook,
   isEmitListener,
   isKeepAlive,
@@ -221,7 +222,14 @@ const vaporInteropImpl: Omit<
     ))
     instance.rawPropsRef = propsRef
     instance.rawSlotsRef = slotsRef
-    ensureVNodeHookState(instance, vnode)
+    const vnodeHookState = ensureVNodeHookState(instance, vnode)
+    const applyScopeId = (vnode: VNode) =>
+      setInteropVnodeScopeId(
+        instance,
+        vnode,
+        instance.parent as ComponentInternalInstance | null,
+      )
+    vnodeHookState.postRootSyncHooks.push(applyScopeId)
 
     // copy the shape flag from the vdom component if inside a keep-alive
     if (parentComponent && isKeepAlive(parentComponent)) {
@@ -263,6 +271,7 @@ const vaporInteropImpl: Omit<
     }
 
     mountComponent(instance, container, selfAnchor)
+    if (!isHydrating) applyScopeId(vnodeHookState.vnode)
 
     simpleSetCurrentInstance(prev)
     return instance
@@ -296,6 +305,11 @@ const vaporInteropImpl: Omit<
       instance.rawSlotsRef!.value = normalizeInteropSlots(n2.children)
       queuePostFlushCb(() => {
         syncVNodeEl(n2, instance)
+        setInteropVnodeScopeId(
+          instance,
+          n2,
+          instance.parent as ComponentInternalInstance | null,
+        )
         if (!instance.isUpdating) {
           vnodeHookState.skipVnodeHooks = false
         }
@@ -2059,6 +2073,7 @@ function syncVNodeEl(vnode: VNode, instance: VaporComponentInstance): void {
 interface VNodeHookState {
   vnode: VNode
   skipVnodeHooks: boolean
+  postRootSyncHooks: ((vnode: VNode) => void)[]
 }
 
 const vnodeHookStateMap = new WeakMap<VaporComponentInstance, VNodeHookState>()
@@ -2072,6 +2087,7 @@ function ensureVNodeHookState(
     state = {
       vnode,
       skipVnodeHooks: false,
+      postRootSyncHooks: [],
     }
     vnodeHookStateMap.set(instance, state)
     ;(instance.bu || (instance.bu = [])).push(() => {
@@ -2088,11 +2104,16 @@ function ensureVNodeHookState(
       }
     })
 
-    // Sync the outer component vnode before running any updated hooks so
-    // both component updated hooks and onVnodeUpdated see the latest root el.
-    ;(instance.u || (instance.u = [])).unshift(() =>
-      syncVNodeEl(state!.vnode, instance),
-    )
+    // Sync the outer component vnode before running any updated hooks. Hooks
+    // that depend on the latest root, like scoped CSS interop, run immediately
+    // after the sync and before component updated hooks / onVnodeUpdated.
+    ;(instance.u || (instance.u = [])).unshift(() => {
+      syncVNodeEl(state!.vnode, instance)
+      const hooks = state!.postRootSyncHooks
+      for (let i = 0; i < hooks.length; i++) {
+        hooks[i](state!.vnode)
+      }
+    })
     instance.u.push(() => {
       if (state!.skipVnodeHooks) {
         state!.skipVnodeHooks = false
@@ -2426,4 +2447,22 @@ function createInteropRawSlots(slotsRef: ShallowRef<Slots>): RawSlots {
     configurable: true,
   })
   return rawSlots as RawSlots
+}
+
+function setInteropVnodeScopeId(
+  instance: VaporComponentInstance,
+  vnode: VNode,
+  parentComponent: ComponentInternalInstance | null,
+): void {
+  const root = getRootElement(instance)
+  if (!root) return
+
+  const scopeIds: string[] = []
+  if (vnode.scopeId) scopeIds.push(vnode.scopeId)
+  if (vnode.slotScopeIds) scopeIds.push(...vnode.slotScopeIds)
+  scopeIds.push(...getInheritedScopeIds(vnode, parentComponent))
+
+  for (let i = 0; i < scopeIds.length; i++) {
+    root.setAttribute(scopeIds[i], '')
+  }
 }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -2449,13 +2449,21 @@ function createInteropRawSlots(slotsRef: ShallowRef<Slots>): RawSlots {
   return rawSlots as RawSlots
 }
 
+const interopScopeIdRootMap = new WeakMap<VaporComponentInstance, Element>()
+
 function setInteropVnodeScopeId(
   instance: VaporComponentInstance,
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null,
 ): void {
   const root = getRootElement(instance)
-  if (!root) return
+  if (!root) {
+    interopScopeIdRootMap.delete(instance)
+    return
+  }
+  // VDOM applies scope ids when an element is mounted, not on same-root patch.
+  if (interopScopeIdRootMap.get(instance) === root) return
+  interopScopeIdRootMap.set(instance, root)
 
   const scopeIds: string[] = []
   if (vnode.scopeId) scopeIds.push(vnode.scopeId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope ID handling in vdom-Vapor component interoperability, ensuring correct style scoping across mixed rendering scenarios and dynamic root updates.

* **Tests**
  * Expanded test coverage for vdom-Vapor component scope ID interoperability across various interaction patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->