### PR TITLE
fix(reactivity): handle objects with custom Symbol.toStringTag (fix #10483)

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -112,6 +112,51 @@ describe('reactivity/reactive', () => {
     expect(dummy).toBe(false)
   })
 
+  // #10483
+  test('observing object with custom Symbol.toStringTag', () => {
+    const original = { [Symbol.toStringTag]: 'Custom', foo: 1 }
+    const observed = reactive(original)
+
+    expect(isReactive(observed)).toBe(true)
+
+    let dummy
+    effect(() => (dummy = observed.foo))
+    expect(dummy).toBe(1)
+    observed.foo = 2
+    expect(dummy).toBe(2)
+  })
+
+  // #10483
+  test('observing collection subtypes with custom Symbol.toStringTag', () => {
+    class CustomMap extends Map {
+      get [Symbol.toStringTag]() {
+        return 'CustomMap'
+      }
+    }
+    const cmap = reactive(new CustomMap())
+    expect(isReactive(cmap)).toBe(true)
+
+    let dummy
+    effect(() => (dummy = cmap.has('key')))
+    expect(dummy).toBe(false)
+    cmap.set('key', 'value')
+    expect(dummy).toBe(true)
+
+    class CustomArray extends Array {
+      get [Symbol.toStringTag]() {
+        return 'CustomArray'
+      }
+    }
+    const carr = reactive(new CustomArray())
+    expect(isReactive(carr)).toBe(true)
+
+    let len
+    effect(() => (len = carr.length))
+    expect(len).toBe(0)
+    carr.push(1)
+    expect(len).toBe(1)
+  })
+
   // #8647
   test('observing Set with reactive initial value', () => {
     const observed = reactive({})

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -40,8 +40,8 @@ enum TargetType {
   COLLECTION = 2,
 }
 
-function targetTypeMap(rawType: string) {
-  switch (rawType) {
+function targetTypeMap(value: Target) {
+  switch (toRawType(value)) {
     case 'Object':
     case 'Array':
       return TargetType.COMMON
@@ -51,14 +51,32 @@ function targetTypeMap(rawType: string) {
     case 'WeakSet':
       return TargetType.COLLECTION
     default:
+      // a custom `Symbol.toStringTag` changes the result of `toRawType`, so
+      // fall back to prototype checks to detect built-in types and subtypes.
+      if (
+        value instanceof Map ||
+        value instanceof Set ||
+        value instanceof WeakMap ||
+        value instanceof WeakSet
+      ) {
+        return TargetType.COLLECTION
+      }
+      if (value instanceof Array || isPlainObject(value)) {
+        return TargetType.COMMON
+      }
       return TargetType.INVALID
   }
+}
+
+function isPlainObject(value: Target) {
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
 }
 
 function getTargetType(value: Target) {
   return value[ReactiveFlags.SKIP] || !Object.isExtensible(value)
     ? TargetType.INVALID
-    : targetTypeMap(toRawType(value))
+    : targetTypeMap(value)
 }
 
 // only unwrap nested ref


### PR DESCRIPTION
Fixes #10483

### Problem

`reactive()` / `ref()` silently fail to make an object reactive when that object (or a subclass of a built-in collection) defines a custom `Symbol.toStringTag`.

`getTargetType` decides whether a value should be wrapped in a proxy based on `toRawType(value)`, which derives the type from `Object.prototype.toString.call(value)`. When a custom `Symbol.toStringTag` is present, that call returns e.g. `"[object Goat]"` instead of `"[object Object]"`, so `toRawType` returns `"Goat"`, `targetTypeMap` falls through to `INVALID`, and the value is returned untouched (not reactive).

This is a real-world issue because such tags can come from third-party libraries, where the consumer cannot remove them. The object is mutated correctly but the UI never updates.

```js
const original = { [Symbol.toStringTag]: 'Goat', foo: 1 }
const state = reactive(original)
isReactive(state) // false  (expected: true)
```

The same applies to subclasses of `Map`/`Set` that expose a custom tag, which are detected as `INVALID` rather than `COLLECTION`.

### Fix

When `toRawType` does not match one of the known built-in types, fall back to prototype-based checks (`instanceof` for collections/arrays, prototype comparison for plain objects) to determine the correct `TargetType`. The fast path for normal objects/arrays/collections is unchanged, so there is no overhead for the common case.

### Tests

Added cases in `reactive.spec.ts` covering a plain object with a custom `Symbol.toStringTag`, and `Map`/`Array` subclasses that define a tag. They fail on `main` and pass with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reactivity handling to ensure consistent detection of Map, Set, Array, and plain objects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->