### PR TITLE
fix(teleport): skip child unmount when pending mount discarded (#14876)

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -2520,6 +2520,54 @@ describe('Suspense', () => {
     expect(serializeInner(target)).toBe(``)
   })
 
+  // #14876
+  test('should not mount discarded teleport with component child after suspense is resolved', async () => {
+    const target = nodeOps.createElement('div')
+    const showTeleport = ref(true)
+
+    const Async = defineAsyncComponent({
+      render() {
+        return h('div', 'async')
+      },
+    })
+
+    const Inner = {
+      render() {
+        return h('div', 'inner')
+      },
+    }
+
+    const Comp = {
+      setup() {
+        return () => {
+          const children = [h(Async)]
+          if (showTeleport.value) {
+            children.push(h(Teleport, { to: target }, h(Inner)))
+          }
+          return h(Suspense, null, {
+            default: h('div', null, children),
+            fallback: h('div', 'fallback'),
+          })
+        }
+      },
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+    expect(serializeInner(target)).toBe(``)
+
+    showTeleport.value = false
+    await nextTick()
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+    expect(serializeInner(target)).toBe(``)
+
+    await Promise.all(deps)
+    await nextTick()
+    expect(serializeInner(root)).toBe(`<div><div>async</div></div>`)
+    expect(serializeInner(target)).toBe(``)
+  })
+
   test('should not process discarded disabled teleport update after suspense is resolved', async () => {
     const target = nodeOps.createElement('div')
     const showTeleport = ref(true)

--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -289,6 +289,60 @@ describe('renderer: teleport', () => {
       expect(target.innerHTML).toBe(``)
     })
 
+    // #14876
+    test('should not mount discarded teleport with component child after deferred updates', async () => {
+      const root = document.createElement('div')
+      const target = document.createElement('div')
+      target.id = 'targetId4-component'
+      document.body.appendChild(root)
+      document.body.appendChild(target)
+
+      const showTeleport = ref(false)
+      const phase = ref(0)
+
+      const Inner = {
+        render: () => h('div', 'inner'),
+      }
+
+      const Step1 = {
+        setup() {
+          phase.value = 1
+          return () => h('div', 'step1')
+        },
+      }
+
+      const Step2 = {
+        setup() {
+          showTeleport.value = false
+          return () => h('div', 'step2')
+        },
+      }
+
+      createDOMApp({
+        render() {
+          return showTeleport.value
+            ? [
+                h(
+                  Teleport,
+                  { to: '#targetId4-component', defer: true },
+                  h(Inner),
+                ),
+                phase.value === 0 ? h(Step1) : h(Step2),
+              ]
+            : [h('div', 'done')]
+        },
+      }).mount(root)
+
+      expect(root.innerHTML).toMatchInlineSnapshot(`"<div>done</div>"`)
+      expect(target.innerHTML).toBe(``)
+
+      showTeleport.value = true
+      await nextTick()
+
+      expect(root.innerHTML).toMatchInlineSnapshot(`"<div>done</div>"`)
+      expect(target.innerHTML).toBe(``)
+    })
+
     test('should not mount discarded disabled teleport after deferred updates', async () => {
       const root = document.createElement('div')
       const target = document.createElement('div')

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -331,19 +331,16 @@ export const TeleportImpl = {
       props,
     } = vnode
 
+    const shouldRemove = doRemove || !isTeleportDisabled(props)
     // A deferred teleport inside a pending suspense may be unmounted before its
-    // content is ever mounted. Clear the queued mount effect and return early:
-    // children were never mounted, and target anchors were never inserted
-    // (mountToTarget hasn't run, so target is undefined). #14876
+    // content is ever mounted. Clear the queued mount effect; the children
+    // loop below is skipped because nothing has been mounted yet.
     const pendingMount = pendingMounts.get(vnode)
     if (pendingMount) {
       pendingMount.flags! |= SchedulerJobFlags.DISPOSED
       pendingMounts.delete(vnode)
-      doRemove && hostRemove(anchor!)
-      return
     }
 
-    const shouldRemove = doRemove || !isTeleportDisabled(props)
     if (target) {
       hostRemove(targetStart!)
       hostRemove(targetAnchor!)
@@ -351,7 +348,8 @@ export const TeleportImpl = {
 
     // an unmounted teleport should always unmount its children whether it's disabled or not
     doRemove && hostRemove(anchor!)
-    if (shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
+    // #14876 don't unmount children if in pending mount (nothing was mounted)
+    if (!pendingMount && shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
       for (let i = 0; i < (children as VNode[]).length; i++) {
         const child = (children as VNode[])[i]
         unmount(

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -331,17 +331,19 @@ export const TeleportImpl = {
       props,
     } = vnode
 
-    let shouldRemove = doRemove || !isTeleportDisabled(props)
     // A deferred teleport inside a pending suspense may be unmounted before its
-    // content is ever mounted. Clear the queued mount effect and skip removing
-    // children because nothing has been mounted yet.
+    // content is ever mounted. Clear the queued mount effect and return early:
+    // children were never mounted, and target anchors were never inserted
+    // (mountToTarget hasn't run, so target is undefined). #14876
     const pendingMount = pendingMounts.get(vnode)
     if (pendingMount) {
       pendingMount.flags! |= SchedulerJobFlags.DISPOSED
       pendingMounts.delete(vnode)
-      shouldRemove = false
+      doRemove && hostRemove(anchor!)
+      return
     }
 
+    const shouldRemove = doRemove || !isTeleportDisabled(props)
     if (target) {
       hostRemove(targetStart!)
       hostRemove(targetAnchor!)


### PR DESCRIPTION
close #14876 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where deferred teleports inside Suspense could attempt to mount or unmount discarded content when removed before completion, preventing stray or duplicate DOM updates.

* **Tests**
  * Added regression tests covering Suspense + deferred Teleport scenarios to ensure discarded teleports never mount their content and resolved Suspense output is correct.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->