### PR TITLE
refactor(vapor): omit bare default slot outlet name

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -289,7 +289,7 @@ export function render(_ctx) {
   const n3 = t0()
   const n1 = _child(n3)
   _setInsertionState(n1, null, 0)
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   _setInsertionState(n3, null, 1)
   const n2 = _createAssetComponent("Comp")
   return n3

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/logicalIndex.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/logicalIndex.spec.ts.snap
@@ -284,7 +284,7 @@ const t0 = _template("<div><span>A</span>", 1)
 export function render(_ctx) {
   const n1 = t0()
   _setInsertionState(n1, null, 1)
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   return n1
 }"
 `;
@@ -296,7 +296,7 @@ const t0 = _template("<div><span>A", 1)
 export function render(_ctx) {
   const n1 = t0()
   _setInsertionState(n1, 0, 0)
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   return n1
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`compiler: transform <slot> outlets > default slot outlet 1`] = `
 "import { createSlot as _createSlot } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   return n0
 }"
 `;
@@ -71,7 +71,7 @@ exports[`compiler: transform <slot> outlets > error on unexpected custom directi
 
 export function render(_ctx) {
   const _directive_foo = _resolveDirective("foo")
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   return n0
 }"
 `;
@@ -80,7 +80,7 @@ exports[`compiler: transform <slot> outlets > error on unexpected custom directi
 "import { createSlot as _createSlot } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   return n0
 }"
 `;
@@ -124,7 +124,7 @@ exports[`compiler: transform <slot> outlets > slot outlet with scopeId and slott
 "import { createSlot as _createSlot } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   return n0
 }"
 `;
@@ -133,7 +133,7 @@ exports[`compiler: transform <slot> outlets > slot outlet without scopeId should
 "import { createSlot as _createSlot } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createSlot("default")
+  const n0 = _createSlot()
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -147,7 +147,7 @@ export function render(_ctx) {
   const _component_Comp = _resolveComponent("Comp")
   const n2 = _createComponentWithFallback(_component_Comp, null, _withVaporCtx(() => {
     const n1 = _createComponentWithFallback(_component_Comp, null, _withVaporCtx(() => {
-      const n0 = _createSlot("default")
+      const n0 = _createSlot()
       return n0
     }))
     return n1
@@ -161,7 +161,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag only 1`] = `
 
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createSlot("default")
+    const n0 = _createSlot()
     return n0
   }), true)
   return n1
@@ -173,7 +173,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ template 1`]
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createSlot("default")
+    const n0 = _createSlot()
     return n0
   }), true)
   return n2
@@ -186,7 +186,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-for 1`] = 
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
-      const n2 = _createSlot("default")
+      const n2 = _createSlot()
       return n2
     }, undefined, 16)
     return n0
@@ -201,7 +201,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-if 1`] = `
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
     const n0 = _createIf(() => (_ctx.ok), () => {
-      const n2 = _createSlot("default")
+      const n2 = _createSlot()
       return n2
     })
     return n0
@@ -713,7 +713,7 @@ exports[`compiler: transform slot > withVaporCtx optimization > slot with slot o
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createSlot("default")
+    const n0 = _createSlot()
     return n0
   }), true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
@@ -29,6 +29,7 @@ const compileWithSlotsOutlet = makeCompile({
 describe('compiler: transform <slot> outlets', () => {
   test('default slot outlet', () => {
     const { ir, code, helpers } = compileWithSlotsOutlet(`<slot />`)
+    expect(code).toContain(`const n0 = _createSlot()`)
     expect(code).toMatchSnapshot()
     expect(helpers).toContain('createSlot')
     expect(ir.block.effect).toEqual([])

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -13,10 +13,6 @@ export function genSlotOutlet(
   const { id, name, fallback, flags } = oper
   const [frag, push] = buildCodeFragment()
 
-  const nameExpr = name.isStatic
-    ? genExpression(name, context)
-    : ['() => (', ...genExpression(name, context), ')']
-
   let fallbackArg: CodeFragment[] | undefined
   if (fallback) {
     fallbackArg = genBlock(fallback, context)
@@ -29,13 +25,18 @@ export function genSlotOutlet(
     !rawPropsArg &&
     !fallbackArg &&
     !flags
+  const nameArg = omitDefaultName
+    ? undefined
+    : name.isStatic
+      ? genExpression(name, context)
+      : ['() => (', ...genExpression(name, context), ')']
 
   push(
     NEWLINE,
     `const n${id} = `,
     ...genCall(
       createSlot,
-      omitDefaultName ? undefined : nameExpr,
+      nameArg,
       rawPropsArg,
       fallbackArg,
       flags ? String(flags) : undefined,

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -21,14 +21,22 @@ export function genSlotOutlet(
   if (fallback) {
     fallbackArg = genBlock(fallback, context)
   }
+  const createSlot = helper('createSlot')
+  const rawPropsArg = genRawProps(oper.props, context)
+  const omitDefaultName =
+    name.isStatic &&
+    name.content === 'default' &&
+    !rawPropsArg &&
+    !fallbackArg &&
+    !flags
 
   push(
     NEWLINE,
     `const n${id} = `,
     ...genCall(
-      helper('createSlot'),
-      nameExpr,
-      genRawProps(oper.props, context),
+      createSlot,
+      omitDefaultName ? undefined : nameExpr,
+      rawPropsArg,
       fallbackArg,
       flags ? String(flags) : undefined,
     ),

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -980,7 +980,7 @@ describe('component: slots', () => {
 
     test('plain slot without fallback does not enter fallback boundary', () => {
       let observedBoundary: SlotBoundaryContext | null | undefined
-      const Comp = defineVaporComponent(() => createSlot('default'))
+      const Comp = defineVaporComponent(() => createSlot())
 
       define(() =>
         createComponent(Comp, null, {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -200,7 +200,7 @@ export function withVaporCtx(fn: Function): BlockFn {
 }
 
 export function createSlot(
-  name: string | (() => string),
+  name: string | (() => string) = 'default',
   rawProps?: LooseRawProps | null,
   fallback?: VaporSlot,
   flags: number = 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Slot creation now accepts an omitted slot name, automatically defaulting to `'default'` for simplified slot declarations.
  * Compiler-generated code for default slot outlets is now optimized, reducing unnecessary overhead.

* **Tests**
  * Updated slot component tests to verify the new default slot name behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->