### PR TITLE
refactor(compiler-vapor): emit static slot props directly

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
@@ -40,7 +40,7 @@ exports[`compiler: transform <slot> outlets > default slot outlet with props 1`]
 
 export function render(_ctx) {
   const n0 = _createSlot("default", {
-    foo: () => ("bar"),
+    foo: "bar",
     baz: () => (_ctx.qux),
     fooBar: () => (_ctx.foo-_ctx.bar)
   })
@@ -152,7 +152,7 @@ exports[`compiler: transform <slot> outlets > statically named slot outlet with 
 
 export function render(_ctx) {
   const n0 = _createSlot("foo", {
-    foo: () => ("bar"),
+    foo: "bar",
     baz: () => (_ctx.qux)
   })
   return n0
@@ -164,7 +164,7 @@ exports[`compiler: transform <slot> outlets > statically named slot outlet with 
 
 export function render(_ctx) {
   const n0 = _createSlot("foo", {
-    foo: () => ("bar"),
+    foo: "bar",
     $: [
       () => (_ctx.obj),
       { baz: () => (_ctx.qux) }

--- a/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
@@ -92,6 +92,9 @@ describe('compiler: transform <slot> outlets', () => {
     const { ir, code } = compileWithSlotsOutlet(
       `<slot foo="bar" :baz="qux" :foo-bar="foo-bar" />`,
     )
+    expect(code).toContain(`foo: "bar"`)
+    expect(code).toContain(`baz: () => (_ctx.qux)`)
+    expect(code).toContain(`fooBar: () => (_ctx.foo-_ctx.bar)`)
     expect(code).toMatchSnapshot()
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.SLOT_OUTLET_NODE,
@@ -110,6 +113,8 @@ describe('compiler: transform <slot> outlets', () => {
     const { ir, code } = compileWithSlotsOutlet(
       `<slot name="foo" foo="bar" :baz="qux" />`,
     )
+    expect(code).toContain(`foo: "bar"`)
+    expect(code).toContain(`baz: () => (_ctx.qux)`)
     expect(code).toMatchSnapshot()
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.SLOT_OUTLET_NODE,

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -18,7 +18,7 @@ export function genSlotOutlet(
     fallbackArg = genBlock(fallback, context)
   }
   const createSlot = helper('createSlot')
-  const rawPropsArg = genRawProps(oper.props, context)
+  const rawPropsArg = genRawProps(oper.props, context, true)
   const omitDefaultName =
     name.isStatic &&
     name.content === 'default' &&

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -953,7 +953,7 @@ describe('component: slots', () => {
       const Comp = defineVaporComponent(() => {
         const n0 = template('<div></div>')()
         insert(
-          createSlot('header', { title: () => src.value }),
+          createSlot('header', { prefix: 'static', title: () => src.value }),
           n0 as any as ParentNode,
         )
         return n0
@@ -964,18 +964,22 @@ describe('component: slots', () => {
           header: props => {
             const el = template('<h1></h1>')()
             renderEffect(() => {
-              setElementText(el, props.title)
+              setElementText(el, `${props.prefix}:${props.title}`)
             })
             return el
           },
         })
       }).render()
 
-      expect(host.innerHTML).toBe('<div><h1>header</h1><!--slot--></div>')
+      expect(host.innerHTML).toBe(
+        '<div><h1>static:header</h1><!--slot--></div>',
+      )
 
       src.value = 'footer'
       await nextTick()
-      expect(host.innerHTML).toBe('<div><h1>footer</h1><!--slot--></div>')
+      expect(host.innerHTML).toBe(
+        '<div><h1>static:footer</h1><!--slot--></div>',
+      )
     })
 
     test('plain slot without fallback does not enter fallback boundary', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot outlet prop generation and handling for component slots.

* **Tests**
  * Strengthened test assertions for slot outlet prop compilation and rendering to ensure correct behavior with static and dynamic props.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->