### PR TITLE
fix(runtime-vapor): preserve v-for item keys in transition group

### DIFF
--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -1,6 +1,7 @@
 import {
   VaporTransitionGroup,
   createComponent,
+  createFor,
   createIf,
   defineVaporAsyncComponent,
   defineVaporComponent,
@@ -8,7 +9,7 @@ import {
   template,
   withVaporCtx,
 } from '../../src'
-import { nextTick } from '@vue/runtime-dom'
+import { nextTick, ref } from '@vue/runtime-dom'
 import { makeRender } from '../_utils'
 
 const define = makeRender()
@@ -151,5 +152,29 @@ describe('TransitionGroup', () => {
     expect(child.block.nodes.$key).toBe('foo')
     expect(child.block.nodes.block.$key).toBe('foo')
     expect(child.block.nodes.block.$transition).toBeDefined()
+  })
+
+  test('inherits v-for item key when applying transition hooks to new items', async () => {
+    const items = ref([1])
+    let list: any
+
+    define({
+      setup() {
+        list = createFor(
+          () => items.value,
+          item => template(`<div></div>`)(),
+          item => item,
+        )
+        return createComponent(VaporTransitionGroup, null, {
+          default: withVaporCtx(() => list),
+        })
+      },
+    }).render()
+
+    items.value = [1, 2]
+    await nextTick()
+
+    expect(list.nodes[0][1].nodes.$key).toBe(2)
+    expect(list.nodes[0][1].nodes.$transition).toBeDefined()
   })
 })

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -62,6 +62,7 @@ import {
   resetInsertionState,
 } from './insertionState'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
+import { setBlockKey } from './helpers/setKey'
 
 type Source = any[] | Record<any, any> | number | Set<any> | Map<any, any>
 
@@ -461,6 +462,7 @@ export const createFor = (
 
     // apply transition for new nodes
     if (isTransitionEnabled && frag.$transition) {
+      if (frag.$transition.applyGroup) setBlockKey(block.nodes, block.key)
       applyTransitionHooks(block.nodes, frag.$transition)
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proper transition support for v-for loops, ensuring animated elements correctly inherit per-item keys during dynamic list updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->