### PR TITLE
fix(runtime-vapor): avoid fast remove for component v-for

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -283,7 +283,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = t0()
     const x2 = _txt(n2)
-    _renderEffect(() => _setText(x2, _toDisplayString(_getDefaultValue(_for_item0.value.foo, _ctx.bar) + _ctx.bar + _ctx.baz + _getDefaultValue(_for_item0.value.baz[0], _ctx.quux) + _ctx.quux)))
+    _renderEffect(() => _setText(x2, _toDisplayString(_getDefaultValue(_for_item0.value.foo, () => (_ctx.bar)) + _ctx.bar + _ctx.baz + _getDefaultValue(_for_item0.value.baz[0], () => (_ctx.quux)) + _ctx.quux)))
     return n2
   }, undefined, 8)
   return n0

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -431,7 +431,7 @@ const t0 = _template(" ")
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, (_slotProps0) => {
     const n0 = t0()
-    _renderEffect(() => _setText(n0, _toDisplayString(_getDefaultValue(_slotProps0.foo, 1))))
+    _renderEffect(() => _setText(n0, _toDisplayString(_getDefaultValue(_slotProps0.foo, () => (1)))))
     return n0
   }, true)
   return n2
@@ -445,7 +445,7 @@ const t0 = _template(" ")
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, (_slotProps0) => {
     const n0 = t0()
-    _renderEffect(() => _setText(n0, _toDisplayString(_getDefaultValue(_slotProps0.foo[0], 1) + _getDefaultValue(_slotProps0.baz.qux, 2))))
+    _renderEffect(() => _setText(n0, _toDisplayString(_getDefaultValue(_slotProps0.foo[0], () => (1)) + _getDefaultValue(_slotProps0.baz.qux, () => (2)))))
     return n0
   }, true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
@@ -401,9 +401,11 @@ describe('compiler: v-for', () => {
       </div>`,
     )
     expect(code).matchSnapshot()
-    expect(code).toContain(`_getDefaultValue(_for_item0.value.foo, _ctx.bar)`)
     expect(code).toContain(
-      `_getDefaultValue(_for_item0.value.baz[0], _ctx.quux)`,
+      `_getDefaultValue(_for_item0.value.foo, () => (_ctx.bar))`,
+    )
+    expect(code).toContain(
+      `_getDefaultValue(_for_item0.value.baz[0], () => (_ctx.quux))`,
     )
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.FOR,

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -297,7 +297,7 @@ describe('compiler: transform slot', () => {
     expect(code).contains(
       `_createAssetComponent("Comp", null, (_slotProps0) =>`,
     )
-    expect(code).contains(`_getDefaultValue(_slotProps0.foo, 1)`)
+    expect(code).contains(`_getDefaultValue(_slotProps0.foo, () => (1))`)
   })
 
   test('slot prop nested default value', () => {
@@ -309,8 +309,8 @@ describe('compiler: transform slot', () => {
     expect(code).contains(
       `_createAssetComponent("Comp", null, (_slotProps0) =>`,
     )
-    expect(code).contains(`_getDefaultValue(_slotProps0.foo[0], 1)`)
-    expect(code).contains(`_getDefaultValue(_slotProps0.baz.qux, 2)`)
+    expect(code).contains(`_getDefaultValue(_slotProps0.foo[0], () => (1))`)
+    expect(code).contains(`_getDefaultValue(_slotProps0.baz.qux, () => (2))`)
   })
 
   test('slot prop rest with computed keys preserved', () => {

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -319,10 +319,10 @@ export function parseValueDestructure(
               ) {
                 isDynamic = true
                 helper = context.helper('getDefaultValue')
-                helperArgs = rawValue.slice(
+                helperArgs = `() => (${rawValue.slice(
                   child.right.start! - 1,
                   child.right.end! - 1,
-                )
+                )})`
               }
             }
             map.set(id.name, { path, dynamic: isDynamic, helper, helperArgs })

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -20,6 +20,7 @@ import {
   type Ref,
   nextTick,
   onScopeDispose,
+  onUnmounted,
   reactive,
   readonly,
   ref,
@@ -1728,6 +1729,34 @@ describe('createFor', () => {
         '<em>C</em><!--dynamic-component-->' +
           '<i>A</i><!--dynamic-component--><!--for-->',
       )
+    })
+
+    test('component blocks are unmounted when clearing with fast remove', async () => {
+      const items = ref([1, 2])
+      const unmounted = vi.fn()
+      const Child = defineVaporComponent({
+        setup() {
+          onUnmounted(unmounted)
+          return template('<span>child</span>')()
+        },
+      })
+
+      const { html } = define(() => {
+        return createFor(
+          () => items.value,
+          () => createComponent(Child),
+          undefined,
+          VaporVForFlags.FAST_REMOVE | VaporVForFlags.IS_COMPONENT,
+        )
+      }).render()
+
+      expect(html()).toBe('<span>child</span><span>child</span><!--for-->')
+
+      items.value = []
+      await nextTick()
+
+      expect(html()).toBe('<!--for-->')
+      expect(unmounted).toHaveBeenCalledTimes(2)
     })
 
     test('slot fallback fragments can be reordered and removed', async () => {

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -311,6 +311,55 @@ describe('createFor', () => {
     expect(host.innerHTML).toBe('<!--for-->')
   })
 
+  test('unkeyed object source updates key and index aliases', async () => {
+    const data = ref<Record<string, number>>({ a: 1 })
+
+    const { host } = define(() => {
+      return createFor(
+        () => data.value,
+        (item, key, index) => {
+          const span = document.createElement('li')
+          renderEffect(() => {
+            span.innerHTML = `${key.value}${index.value}. ${item.value}`
+          })
+          return span
+        },
+      )
+    }).render()
+
+    expect(host.innerHTML).toBe('<li>a0. 1</li><!--for-->')
+
+    data.value = { b: 2 }
+    await nextTick()
+
+    expect(host.innerHTML).toBe('<li>b0. 2</li><!--for-->')
+  })
+
+  test('keyed object source updates key and index aliases when reusing a block', async () => {
+    const data = ref<Record<string, number>>({ a: 1, c: 3 })
+
+    const { host } = define(() => {
+      return createFor(
+        () => data.value,
+        (item, key, index) => {
+          const span = document.createElement('li')
+          renderEffect(() => {
+            span.innerHTML = `${key.value}${index.value}. ${item.value}`
+          })
+          return span
+        },
+        item => item,
+      )
+    }).render()
+
+    expect(host.innerHTML).toBe('<li>a0. 1</li><li>c1. 3</li><!--for-->')
+
+    data.value = { b: 1, d: 4 }
+    await nextTick()
+
+    expect(host.innerHTML).toBe('<li>b0. 1</li><li>d1. 4</li><!--for-->')
+  })
+
   test('de-structured value', async () => {
     const list = ref([{ name: '1' }, { name: '2' }, { name: '3' }])
     function reverse() {

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -543,6 +543,7 @@ describe('createFor', () => {
 
   test('de-structured value (default value)', async () => {
     const list = ref<any[]>([{ name: '1' }, { name: '2' }, { name: '3' }])
+    const getDefault = vi.fn(() => '0')
 
     const { host } = define(() => {
       const n1 = createFor(
@@ -550,7 +551,7 @@ describe('createFor', () => {
         (item, _key, index) => {
           const span = document.createElement('li')
           renderEffect(() => {
-            span.innerHTML = getDefaultValue(item.value.x, '0')
+            span.innerHTML = getDefaultValue(item.value.x, getDefault)
             // index should be undefined if source is not an object
             expect(index.value).toBe(undefined)
           })
@@ -562,11 +563,13 @@ describe('createFor', () => {
     }).render()
 
     expect(host.innerHTML).toBe('<li>0</li><li>0</li><li>0</li><!--for-->')
+    expect(getDefault).toHaveBeenCalledTimes(3)
 
     // change
     list.value[0].x = 5
     await nextTick()
     expect(host.innerHTML).toBe('<li>5</li><li>0</li><li>0</li><!--for-->')
+    expect(getDefault).toHaveBeenCalledTimes(3)
 
     // clear
     list.value = []

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -247,6 +247,46 @@ describe('createFor', () => {
     expect(host.innerHTML).toBe('<!--for-->')
   })
 
+  test('non-integer number source warns and renders empty', () => {
+    const { host } = define(() => {
+      return createFor(
+        () => 3.1,
+        item => {
+          const span = document.createElement('li')
+          renderEffect(() => {
+            span.innerHTML = `${item.value}`
+          })
+          return span
+        },
+      )
+    }).render()
+
+    expect(host.innerHTML).toBe('<!--for-->')
+    expect(
+      `The v-for range expects a positive integer value but got 3.1.`,
+    ).toHaveBeenWarned()
+  })
+
+  test('negative number source warns and renders empty', () => {
+    const { host } = define(() => {
+      return createFor(
+        () => -1,
+        item => {
+          const span = document.createElement('li')
+          renderEffect(() => {
+            span.innerHTML = `${item.value}`
+          })
+          return span
+        },
+      )
+    }).render()
+
+    expect(host.innerHTML).toBe('<!--for-->')
+    expect(
+      `The v-for range expects a positive integer value but got -1.`,
+    ).toHaveBeenWarned()
+  })
+
   test('object source', async () => {
     const initial = () => ({ a: 1, b: 2, c: 3 })
     const data = ref<Record<string, number>>(initial())

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -160,12 +160,13 @@ export const createFor = (
     }
 
     const prevSub = setActiveSub()
-    if (isMounted && frag.onBeforeUpdate) {
+    const wasMounted = isMounted
+    if (wasMounted && frag.onBeforeUpdate) {
       for (let i = 0; i < frag.onBeforeUpdate.length; i++) {
         frag.onBeforeUpdate[i]()
       }
     }
-    if (!isMounted) {
+    if (!wasMounted) {
       isMounted = true
       if (isHydrating) {
         hydrateList(source, newLength)
@@ -399,7 +400,7 @@ export const createFor = (
     frag.nodes = [(oldBlocks = newBlocks)]
     if (parentAnchor) frag.nodes.push(parentAnchor)
 
-    if (isMounted && frag.onUpdated) frag.onUpdated.forEach(m => m())
+    if (wasMounted && frag.onUpdated) frag.onUpdated.forEach(m => m())
     setActiveSub(prevSub)
   }
 

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -119,8 +119,9 @@ export const createFor = (
 
   const frag = new ForFragment(oldBlocks)
   const instance = currentInstance!
-  const canUseFastRemove = !!(flags & VaporVForFlags.FAST_REMOVE)
   const isComponent = !!(flags & VaporVForFlags.IS_COMPONENT)
+  const canUseFastRemove =
+    !!(flags & VaporVForFlags.FAST_REMOVE) && !isComponent
   const isSingleNode = !!(flags & VaporVForFlags.IS_SINGLE_NODE)
   const isFragment = !!(flags & VaporVForFlags.IS_FRAGMENT)
 

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -764,11 +764,15 @@ function normalizeSource(source: any): ResolvedSource {
   } else if (isString(source)) {
     values = source.split('')
   } else if (typeof source === 'number') {
-    if (__DEV__ && !Number.isInteger(source)) {
-      warn(`The v-for range expect an integer value but got ${source}.`)
+    if (__DEV__ && (!Number.isInteger(source) || source < 0)) {
+      warn(
+        `The v-for range expects a positive integer value but got ${source}.`,
+      )
+      values = []
+    } else {
+      values = new Array(source)
+      for (let i = 0; i < source; i++) values[i] = i + 1
     }
-    values = new Array(source)
-    for (let i = 0; i < source; i++) values[i] = i + 1
   } else if (isObject(source)) {
     if (source[Symbol.iterator as any]) {
       values = Array.from(source as Iterable<any>)

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -848,8 +848,8 @@ export function getRestElement(val: any, keys: string[]): any {
   return res
 }
 
-export function getDefaultValue(val: any, defaultVal: any): any {
-  return val === undefined ? defaultVal : val
+export function getDefaultValue(val: any, getDefaultVal: () => any): any {
+  return val === undefined ? getDefaultVal() : val
 }
 
 export function isForBlock(block: Block): block is ForBlock {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -202,7 +202,8 @@ export const createFor = (
         // unkeyed fast path
         const commonLength = Math.min(newLength, oldLength)
         for (let i = 0; i < commonLength; i++) {
-          update((newBlocks[i] = oldBlocks[i]), getItem(source, i)[0])
+          const item = getItem(source, i)
+          update((newBlocks[i] = oldBlocks[i]), ...item)
         }
         for (let i = oldLength; i < newLength; i++) {
           mount(source, i)
@@ -261,7 +262,7 @@ export const createFor = (
           const oldBlock = oldBlocks[i]
           const oldKey = oldBlock.key
           if (oldKey === currentKey) {
-            update((newBlocks[i] = oldBlock), currentItem[0])
+            update((newBlocks[i] = oldBlock), ...currentItem)
           } else {
             queuedBlocks[queuedBlocksLength++] = [i, currentItem, currentKey]
             oldKeyIndexPairs[oldKeyIndexPairsLength++] = [oldKey, i]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed component unmounting issue when clearing v-for lists with fast removal optimization enabled.
  * Improved handling of default values in v-for destructuring patterns for correct updates.
  * Enhanced v-for source validation with warnings for non-integer or negative numeric values.

* **Tests**
  * Added comprehensive test coverage for v-for edge cases and slot default values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->