### PR TITLE
refactor(vapor): remove withVaporCtx slot wrapping

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -26,14 +26,14 @@ export function render(_ctx) {
 `;
 
 exports[`compile > custom directive > component 1`] = `
-"import { resolveComponent as _resolveComponent, resolveDirective as _resolveDirective, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, withVaporDirectives as _withVaporDirectives, createIf as _createIf, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, resolveDirective as _resolveDirective, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, withVaporDirectives as _withVaporDirectives, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
   const _component_Bar = _resolveComponent("Bar")
   const _directive_hello = _resolveDirective("hello")
   const _directive_test = _resolveDirective("test")
-  const n4 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
+  const n4 = _createAssetComponent("Comp", null, () => {
     const n0 = _createIf(() => (true), () => {
       const n3 = t0()
       _setInsertionState(n3, null, 0)
@@ -42,7 +42,7 @@ export function render(_ctx) {
       return n3
     }, null, 17 /* BLOCK_SHAPE, ONCE */)
     return n0
-  }), true)
+  }, true)
   _withVaporDirectives(n4, [[_directive_test]])
   return n4
 }"

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -126,32 +126,32 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 `;
 
 exports[`compiler: element transform > component > hoist asset component also used in component slot 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
   const _component_Child = _resolveComponent("Child")
   const n0 = _createComponentWithFallback(_component_Child)
-  const n2 = _createAssetComponent("Parent", null, _withVaporCtx(() => {
+  const n2 = _createAssetComponent("Parent", null, () => {
     const n1 = _createComponentWithFallback(_component_Child)
     return n1
-  }))
+  })
   return [n0, n2]
 }"
 `;
 
 exports[`compiler: element transform > component > hoist asset component also used in conditional component slot 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
   const _component_Child = _resolveComponent("Child")
   const n0 = _createComponentWithFallback(_component_Child)
-  const n5 = _createAssetComponent("Parent", null, _withVaporCtx(() => {
+  const n5 = _createAssetComponent("Parent", null, () => {
     const n1 = _createIf(() => (_ctx.ok), () => {
       const n3 = _createComponentWithFallback(_component_Child)
       return n3
     })
     return n1
-  }))
+  })
   return [n0, n5]
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -141,71 +141,71 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot w/ nested component> 1`] = `
-"import { resolveComponent as _resolveComponent, createSlot as _createSlot, withVaporCtx as _withVaporCtx, createComponentWithFallback as _createComponentWithFallback } from 'vue';
+"import { resolveComponent as _resolveComponent, createSlot as _createSlot, createComponentWithFallback as _createComponentWithFallback } from 'vue';
 
 export function render(_ctx) {
   const _component_Comp = _resolveComponent("Comp")
-  const n2 = _createComponentWithFallback(_component_Comp, null, _withVaporCtx(() => {
-    const n1 = _createComponentWithFallback(_component_Comp, null, _withVaporCtx(() => {
+  const n2 = _createComponentWithFallback(_component_Comp, null, () => {
+    const n1 = _createComponentWithFallback(_component_Comp, null, () => {
       const n0 = _createSlot()
       return n0
-    }))
+    })
     return n1
-  }), true)
+  }, true)
   return n2
 }"
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag only 1`] = `
-"import { createSlot as _createSlot, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n1 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
+  const n1 = _createAssetComponent("Comp", null, () => {
     const n0 = _createSlot()
     return n0
-  }), true)
+  }, true)
   return n1
 }"
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag w/ template 1`] = `
-"import { createSlot as _createSlot, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
+  const n2 = _createAssetComponent("Comp", null, () => {
     const n0 = _createSlot()
     return n0
-  }), true)
+  }, true)
   return n2
 }"
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-for 1`] = `
-"import { createSlot as _createSlot, createFor as _createFor, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, createFor as _createFor, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n3 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
+  const n3 = _createAssetComponent("Comp", null, () => {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
       const n2 = _createSlot()
       return n2
     }, undefined, 16)
     return n0
-  }), true)
+  }, true)
   return n3
 }"
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-if 1`] = `
-"import { createSlot as _createSlot, createIf as _createIf, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, createIf as _createIf, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n3 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
+  const n3 = _createAssetComponent("Comp", null, () => {
     const n0 = _createIf(() => (_ctx.ok), () => {
       const n2 = _createSlot()
       return n2
     })
     return n0
-  }), true)
+  }, true)
   return n3
 }"
 `;
@@ -246,7 +246,7 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > nested component should not inherit parent slots 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
   const _component_Bar = _resolveComponent("Bar")
@@ -254,35 +254,35 @@ export function render(_ctx) {
     "header": () => {
       return null
     },
-    "default": _withVaporCtx(() => {
+    "default": () => {
       const n1 = _createComponentWithFallback(_component_Bar)
       return n1
-    })
+    }
   }, true)
   return n2
 }"
 `;
 
 exports[`compiler: transform slot > nested component slot 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
   const _component_B = _resolveComponent("B")
-  const n1 = _createAssetComponent("A", null, _withVaporCtx(() => {
+  const n1 = _createAssetComponent("A", null, () => {
     const n0 = _createComponentWithFallback(_component_B)
     return n0
-  }), true)
+  }, true)
   return n1
 }"
 `;
 
 exports[`compiler: transform slot > nested slots scoping 1`] = `
-"import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createComponentWithFallback as _createComponentWithFallback, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template(" ")
 
 export function render(_ctx) {
   const _component_Inner = _resolveComponent("Inner")
-  const n5 = _createAssetComponent("Comp", null, _withVaporCtx((_slotProps0) => {
+  const n5 = _createAssetComponent("Comp", null, (_slotProps0) => {
     const n1 = _createComponentWithFallback(_component_Inner, null, (_slotProps1) => {
       const n0 = t0()
       _renderEffect(() => _setText(n0, _toDisplayString(_slotProps0.foo + _slotProps1.bar + _ctx.baz)))
@@ -291,7 +291,7 @@ export function render(_ctx) {
     const n3 = t0()
     _renderEffect(() => _setText(n3, " " + _toDisplayString(_slotProps0.foo + _ctx.bar + _ctx.baz)))
     return [n1, n3]
-  }), true)
+  }, true)
   return n5
 }"
 `;
@@ -379,6 +379,210 @@ export function render(_ctx) {
     return n5
   }, 21 /* BLOCK_SHAPE, ONCE */)
   return n6
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > dynamic slot source with slot outlet should not need withVaporCtx 1`] = `
+"import { createSlot as _createSlot, createForSlots as _createForSlots, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n2 = _createAssetComponent("Comp", null, {
+    $: [
+      () => (_createForSlots(_ctx.slots, (_, name) => ({
+        name: name,
+        fn: () => {
+          const n0 = _createSlot(() => (name))
+          return n0
+        }
+      })))
+    ]
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with component inside v-for should not need withVaporCtx 1`] = `
+"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createFor as _createFor, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const _component_ChildComp = _resolveComponent("ChildComp")
+  const n5 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
+      const n3 = t0()
+      _setInsertionState(n3, null, 0)
+      const n2 = _createComponentWithFallback(_component_ChildComp)
+      return n3
+    }, undefined, 8)
+    return n0
+  }, true)
+  return n5
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with component inside v-if should not need withVaporCtx 1`] = `
+"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const _component_ChildComp = _resolveComponent("ChildComp")
+  const n5 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createIf(() => (_ctx.show), () => {
+      const n3 = t0()
+      _setInsertionState(n3, null, 0)
+      const n2 = _createComponentWithFallback(_component_ChildComp)
+      return n3
+    })
+    return n0
+  }, true)
+  return n5
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with component should not need withVaporCtx 1`] = `
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const _component_ChildComp = _resolveComponent("ChildComp")
+  const n2 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createComponentWithFallback(_component_ChildComp)
+    return n0
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with custom element inside v-if should not need withVaporCtx 1`] = `
+"import { setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n5 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createIf(() => (_ctx.show), () => {
+      const n3 = t0()
+      _setInsertionState(n3, null, 0)
+      const n2 = _createPlainElement("my-element")
+      return n3
+    })
+    return n0
+  }, true)
+  return n5
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with custom element should not need withVaporCtx 1`] = `
+"import { createPlainElement as _createPlainElement, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n2 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createPlainElement("my-element")
+    return n0
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with nested v-if containing component should not need withVaporCtx 1`] = `
+"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<span>")
+const t1 = _template("<div>")
+
+export function render(_ctx) {
+  const _component_ChildComp = _resolveComponent("ChildComp")
+  const n8 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createIf(() => (_ctx.a), () => {
+      const n6 = t1()
+      _setInsertionState(n6, null, 0)
+      const n2 = _createIf(() => (_ctx.b), () => {
+        const n5 = t0()
+        _setInsertionState(n5, null, 0)
+        const n4 = _createComponentWithFallback(_component_ChildComp)
+        return n5
+      })
+      return n6
+    })
+    return n0
+  }, true)
+  return n8
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with only static elements should not need withVaporCtx 1`] = `
+"import { createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<div>static content", 2)
+
+export function render(_ctx) {
+  const n2 = _createAssetComponent("Comp", null, () => {
+    const n0 = t0()
+    return n0
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with only text interpolation should not need withVaporCtx 1`] = `
+"import { toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template(" ")
+
+export function render(_ctx) {
+  const n2 = _createAssetComponent("Comp", null, () => {
+    const n0 = t0()
+    _renderEffect(() => _setText(n0, _toDisplayString(_ctx.message)))
+    return n0
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with slot outlet should not need withVaporCtx 1`] = `
+"import { createSlot as _createSlot, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n2 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createSlot()
+    return n0
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with v-for but no component should not need withVaporCtx 1`] = `
+"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<div> ")
+
+export function render(_ctx) {
+  const n4 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
+      const n2 = t0()
+      const x2 = _txt(n2)
+      _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value)))
+      return n2
+    }, undefined, 8)
+    const x0 = _txt(n0)
+    _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
+    return n0
+  }, true)
+  return n4
+}"
+`;
+
+exports[`compiler: transform slot > slot owner context > slot with v-if but no component should not need withVaporCtx 1`] = `
+"import { createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<div>content", 2)
+const t1 = _template("<span>fallback", 2)
+
+export function render(_ctx) {
+  const n7 = _createAssetComponent("Comp", null, () => {
+    const n0 = _createIf(() => (_ctx.show), () => {
+      const n2 = t0()
+      return n2
+    }, () => {
+      const n4 = t1()
+      return n4
+    }, 133 /* BLOCK_SHAPE, INDEX_SHIFT */)
+    return n0
+  }, true)
+  return n7
 }"
 `;
 
@@ -553,209 +757,5 @@ export function render(_ctx) {
     }
   }, true)
   return n5
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > dynamic slot source with slot outlet should have withVaporCtx 1`] = `
-"import { createSlot as _createSlot, withVaporCtx as _withVaporCtx, createForSlots as _createForSlots, createAssetComponent as _createAssetComponent } from 'vue';
-
-export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, {
-    $: [
-      _withVaporCtx(() => (_createForSlots(_ctx.slots, (_, name) => ({
-        name: name,
-        fn: _withVaporCtx(() => {
-          const n0 = _createSlot(() => (name))
-          return n0
-        })
-      }))))
-    ]
-  }, true)
-  return n2
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with component inside v-for should have withVaporCtx 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createFor as _createFor, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<div>")
-
-export function render(_ctx) {
-  const _component_ChildComp = _resolveComponent("ChildComp")
-  const n5 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
-      const n3 = t0()
-      _setInsertionState(n3, null, 0)
-      const n2 = _createComponentWithFallback(_component_ChildComp)
-      return n3
-    }, undefined, 8)
-    return n0
-  }), true)
-  return n5
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with component inside v-if should have withVaporCtx 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<div>")
-
-export function render(_ctx) {
-  const _component_ChildComp = _resolveComponent("ChildComp")
-  const n5 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createIf(() => (_ctx.show), () => {
-      const n3 = t0()
-      _setInsertionState(n3, null, 0)
-      const n2 = _createComponentWithFallback(_component_ChildComp)
-      return n3
-    })
-    return n0
-  }), true)
-  return n5
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with component should have withVaporCtx 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
-
-export function render(_ctx) {
-  const _component_ChildComp = _resolveComponent("ChildComp")
-  const n2 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createComponentWithFallback(_component_ChildComp)
-    return n0
-  }), true)
-  return n2
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with custom element inside v-if should have withVaporCtx 1`] = `
-"import { setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, createIf as _createIf, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<div>")
-
-export function render(_ctx) {
-  const n5 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createIf(() => (_ctx.show), () => {
-      const n3 = t0()
-      _setInsertionState(n3, null, 0)
-      const n2 = _createPlainElement("my-element")
-      return n3
-    })
-    return n0
-  }), true)
-  return n5
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with custom element should have withVaporCtx 1`] = `
-"import { createPlainElement as _createPlainElement, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
-
-export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createPlainElement("my-element")
-    return n0
-  }), true)
-  return n2
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with nested v-if containing component should have withVaporCtx 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<span>")
-const t1 = _template("<div>")
-
-export function render(_ctx) {
-  const _component_ChildComp = _resolveComponent("ChildComp")
-  const n8 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createIf(() => (_ctx.a), () => {
-      const n6 = t1()
-      _setInsertionState(n6, null, 0)
-      const n2 = _createIf(() => (_ctx.b), () => {
-        const n5 = t0()
-        _setInsertionState(n5, null, 0)
-        const n4 = _createComponentWithFallback(_component_ChildComp)
-        return n5
-      })
-      return n6
-    })
-    return n0
-  }), true)
-  return n8
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with only static elements should not have withVaporCtx 1`] = `
-"import { createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<div>static content", 2)
-
-export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, () => {
-    const n0 = t0()
-    return n0
-  }, true)
-  return n2
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with only text interpolation should not have withVaporCtx 1`] = `
-"import { toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template(" ")
-
-export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, () => {
-    const n0 = t0()
-    _renderEffect(() => _setText(n0, _toDisplayString(_ctx.message)))
-    return n0
-  }, true)
-  return n2
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with slot outlet should have withVaporCtx 1`] = `
-"import { createSlot as _createSlot, withVaporCtx as _withVaporCtx, createAssetComponent as _createAssetComponent } from 'vue';
-
-export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, _withVaporCtx(() => {
-    const n0 = _createSlot()
-    return n0
-  }), true)
-  return n2
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with v-for but no component should not have withVaporCtx 1`] = `
-"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<div> ")
-
-export function render(_ctx) {
-  const n4 = _createAssetComponent("Comp", null, () => {
-    const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
-      const n2 = t0()
-      const x2 = _txt(n2)
-      _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value)))
-      return n2
-    }, undefined, 8)
-    const x0 = _txt(n0)
-    _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
-    return n0
-  }, true)
-  return n4
-}"
-`;
-
-exports[`compiler: transform slot > withVaporCtx optimization > slot with v-if but no component should not have withVaporCtx 1`] = `
-"import { createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<div>content", 2)
-const t1 = _template("<span>fallback", 2)
-
-export function render(_ctx) {
-  const n7 = _createAssetComponent("Comp", null, () => {
-    const n0 = _createIf(() => (_ctx.show), () => {
-      const n2 = t0()
-      return n2
-    }, () => {
-      const n4 = t1()
-      return n4
-    }, 133 /* BLOCK_SHAPE, INDEX_SHIFT */)
-    return n0
-  }, true)
-  return n7
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -375,7 +375,7 @@ describe('compiler: transform slot', () => {
     expect(code).toMatchSnapshot()
 
     expect(code).contains(
-      `_createAssetComponent("Comp", null, _withVaporCtx((_slotProps0) =>`,
+      `_createAssetComponent("Comp", null, (_slotProps0) =>`,
     )
     expect(code).contains(
       `_createComponentWithFallback(_component_Inner, null, (_slotProps1) =>`,
@@ -803,8 +803,8 @@ describe('compiler: transform slot', () => {
     })
   })
 
-  describe('withVaporCtx optimization', () => {
-    test('slot with only static elements should not have withVaporCtx', () => {
+  describe('slot owner context', () => {
+    test('slot with only static elements should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -816,7 +816,7 @@ describe('compiler: transform slot', () => {
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with component should have withVaporCtx', () => {
+    test('slot with component should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -824,11 +824,11 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain('withVaporCtx')
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with slot outlet should have withVaporCtx', () => {
+    test('slot with slot outlet should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -836,11 +836,11 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain('withVaporCtx')
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('dynamic slot source with slot outlet should have withVaporCtx', () => {
+    test('dynamic slot source with slot outlet should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template v-for="(_, name) in slots" #[name]>
@@ -849,12 +849,13 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`$: [
-      _withVaporCtx(() => (_createForSlots`)
-      expect(code).toContain(`fn: _withVaporCtx(() =>`)
+      () => (_createForSlots`)
+      expect(code).toContain(`fn: () =>`)
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with component inside v-if should have withVaporCtx', () => {
+    test('slot with component inside v-if should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -864,11 +865,11 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain('withVaporCtx')
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with component inside v-for should have withVaporCtx', () => {
+    test('slot with component inside v-for should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -878,11 +879,11 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain('withVaporCtx')
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with nested v-if containing component should have withVaporCtx', () => {
+    test('slot with nested v-if containing component should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -894,11 +895,11 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain('withVaporCtx')
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with only text interpolation should not have withVaporCtx', () => {
+    test('slot with only text interpolation should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -910,7 +911,7 @@ describe('compiler: transform slot', () => {
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with v-if but no component should not have withVaporCtx', () => {
+    test('slot with v-if but no component should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -923,7 +924,7 @@ describe('compiler: transform slot', () => {
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with v-for but no component should not have withVaporCtx', () => {
+    test('slot with v-for but no component should not need withVaporCtx', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -935,7 +936,7 @@ describe('compiler: transform slot', () => {
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with custom element should have withVaporCtx', () => {
+    test('slot with custom element should not need withVaporCtx', () => {
       const { code } = compileWithSlots(
         `
         <Comp>
@@ -948,11 +949,11 @@ describe('compiler: transform slot', () => {
           isCustomElement: tag => tag.startsWith('my-'),
         },
       )
-      expect(code).toContain('withVaporCtx')
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with custom element inside v-if should have withVaporCtx', () => {
+    test('slot with custom element inside v-if should not need withVaporCtx', () => {
       const { code } = compileWithSlots(
         `
         <Comp>
@@ -967,7 +968,7 @@ describe('compiler: transform slot', () => {
           isCustomElement: tag => tag.startsWith('my-'),
         },
       )
-      expect(code).toContain('withVaporCtx')
+      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
   })

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -7,12 +7,8 @@ import {
 } from '@vue/shared'
 import type { CodegenContext } from '../generate'
 import {
-  type BlockIRNode,
   type CreateComponentIRNode,
-  type ForIRNode,
-  type IRDynamicInfo,
   IRDynamicPropsKind,
-  IRNodeTypes,
   type IRProp,
   type IRProps,
   type IRPropsStatic,
@@ -23,8 +19,6 @@ import {
   IRSlotType,
   type IRSlots,
   type IRSlotsStatic,
-  type IfIRNode,
-  type OperationNode,
   type SlotBlockIRNode,
 } from '../ir'
 import {
@@ -41,7 +35,6 @@ import {
 import { genExpression, genVarName } from './expression'
 import { genPropKey, genPropValue } from './prop'
 import {
-  NodeTypes,
   type SimpleExpressionNode,
   createSimpleExpression,
   isMemberExpression,
@@ -636,23 +629,7 @@ function genDynamicSlot(
   }
   if (!withFunction) return frag
 
-  return needsDynamicSlotSourceCtx(slot)
-    ? [`${context.helper('withVaporCtx')}(() => (`, ...frag, '))']
-    : ['() => (', ...frag, ')']
-}
-
-function needsDynamicSlotSourceCtx(slot: IRSlotDynamic): boolean {
-  switch (slot.slotType) {
-    case IRSlotType.DYNAMIC:
-      return needsVaporCtx(slot.fn)
-    case IRSlotType.LOOP:
-      return needsVaporCtx(slot.fn)
-    case IRSlotType.CONDITIONAL:
-      return (
-        needsDynamicSlotSourceCtx(slot.positive) ||
-        (slot.negative ? needsDynamicSlotSourceCtx(slot.negative) : false)
-      )
-  }
+  return ['() => (', ...frag, ')']
 }
 
 function genBasicDynamicSlot(
@@ -730,7 +707,7 @@ function genSlotBlockWithProps(oper: SlotBlockIRNode, context: CodegenContext) {
   let propsName: string | undefined
   let exitScope: (() => void) | undefined
   let depth: number | undefined
-  const { props, node } = oper
+  const { props } = oper
   const idToPathMap: DestructureMap = props
     ? parseValueDestructure(props, context)
     : new Map<string, DestructureMapValue | null>()
@@ -764,88 +741,5 @@ function genSlotBlockWithProps(oper: SlotBlockIRNode, context: CodegenContext) {
   exitSlotBlock()
   exitScope && exitScope()
 
-  if (node.type === NodeTypes.ELEMENT) {
-    // wrap with withVaporCtx to track slot owner for:
-    // 1. createSlot to get correct rawSlots in forwarded slots
-    // 2. scopeId inheritance for components created inside slots
-    // Skip if slot content has no components or slot outlets
-    if (needsVaporCtx(oper)) {
-      blockFn = [`${context.helper('withVaporCtx')}(`, ...blockFn, `)`]
-    }
-  }
-
   return blockFn
-}
-
-/**
- * Check if a slot block needs withVaporCtx wrapper.
- * Returns true if the block contains:
- * - Component creation (needs scopeId inheritance)
- * - Slot outlet (needs rawSlots from slot owner)
- */
-function needsVaporCtx(block: BlockIRNode): boolean {
-  return hasComponentOrSlotInBlock(block)
-}
-
-function hasComponentOrSlotInBlock(block: BlockIRNode): boolean {
-  // Check operations array
-  if (hasComponentOrSlotInOperations(block.operation)) return true
-  // Check dynamic children (components are often stored here)
-  return hasComponentOrSlotInDynamic(block.dynamic)
-}
-
-function hasComponentOrSlotInDynamic(dynamic: IRDynamicInfo): boolean {
-  // Check operation in this dynamic node
-  if (dynamic.operation) {
-    const type = dynamic.operation.type
-    if (
-      type === IRNodeTypes.CREATE_COMPONENT_NODE ||
-      type === IRNodeTypes.SLOT_OUTLET_NODE
-    ) {
-      return true
-    }
-    if (type === IRNodeTypes.IF) {
-      if (hasComponentOrSlotInIf(dynamic.operation as IfIRNode)) return true
-    }
-    if (type === IRNodeTypes.FOR) {
-      if (hasComponentOrSlotInBlock((dynamic.operation as ForIRNode).render))
-        return true
-    }
-  }
-  // Recursively check children
-  for (const child of dynamic.children) {
-    if (hasComponentOrSlotInDynamic(child)) return true
-  }
-  return false
-}
-
-function hasComponentOrSlotInOperations(operations: OperationNode[]): boolean {
-  for (const op of operations) {
-    switch (op.type) {
-      case IRNodeTypes.CREATE_COMPONENT_NODE:
-      case IRNodeTypes.SLOT_OUTLET_NODE:
-        return true
-      case IRNodeTypes.IF:
-        if (hasComponentOrSlotInIf(op as IfIRNode)) return true
-        break
-      case IRNodeTypes.FOR:
-        if (hasComponentOrSlotInBlock((op as ForIRNode).render)) return true
-        break
-    }
-  }
-  return false
-}
-
-function hasComponentOrSlotInIf(node: IfIRNode): boolean {
-  if (hasComponentOrSlotInBlock(node.positive)) return true
-  if (node.negative) {
-    if ('positive' in node.negative) {
-      // nested IfIRNode
-      return hasComponentOrSlotInIf(node.negative as IfIRNode)
-    } else {
-      // BlockIRNode
-      return hasComponentOrSlotInBlock(node.negative as BlockIRNode)
-    }
-  }
-  return false
 }

--- a/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
@@ -17,7 +17,6 @@ import {
   setHtml,
   setInsertionState,
   template,
-  withVaporCtx,
 } from '../src'
 import { makeRender } from './_utils'
 
@@ -276,9 +275,7 @@ describe('api: createDynamicComponent', () => {
       components: { Foo },
       setup() {
         return createComponent(Child, null, {
-          default: withVaporCtx(() =>
-            createDynamicComponent(() => current.value),
-          ),
+          default: () => createDynamicComponent(() => current.value),
         })
       },
     }).render()

--- a/packages/runtime-vapor/__tests__/apiDefineAsyncComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiDefineAsyncComponent.spec.ts
@@ -9,7 +9,6 @@ import {
   defineVaporComponent,
   renderEffect,
   template,
-  withVaporCtx,
 } from '@vue/runtime-vapor'
 import { setElementText } from '../src/dom/prop'
 
@@ -900,13 +899,12 @@ describe('api: defineAsyncComponent', () => {
     const { html } = define({
       setup() {
         return createComponent(VaporKeepAlive, null, {
-          default: withVaporCtx(() =>
+          default: () =>
             createIf(
               () => toggle.value,
               () => createComponent(Foo),
               () => createComponent(Bar),
             ),
-          ),
         })
       },
     }).render()
@@ -950,7 +948,7 @@ describe('api: defineAsyncComponent', () => {
           VaporKeepAlive,
           { include: () => 'Foo' },
           {
-            default: withVaporCtx(() => createComponent(Foo)),
+            default: () => createComponent(Foo),
           },
         )
       },

--- a/packages/runtime-vapor/__tests__/apiInject.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiInject.spec.ts
@@ -23,7 +23,6 @@ import {
   renderEffect,
   template,
   vaporInteropPlugin,
-  withVaporCtx,
 } from '../src'
 import { makeRender } from './_utils'
 import { setElementText, setText } from '../src/dom/prop'
@@ -395,7 +394,7 @@ describe('api: provide/inject', () => {
     const { host } = define({
       setup() {
         return createComponent(Parent, null, {
-          default: withVaporCtx(() => createComponent(Child)),
+          default: () => createComponent(Child),
         })
       },
     }).render()
@@ -435,13 +434,12 @@ describe('api: provide/inject', () => {
             onLeave: () => onLeave,
           },
           {
-            default: withVaporCtx(() =>
+            default: () =>
               createIf(
                 () => toggle.value,
                 () => createComponent(ChildA),
                 () => createComponent(ChildB),
               ),
-            ),
           },
         )
       },

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -19,7 +19,6 @@ import {
   template,
   txt,
   vaporInteropPlugin,
-  withVaporCtx,
 } from '../src'
 import {
   type Ref,
@@ -1166,29 +1165,26 @@ describe('component: slots', () => {
       const Root = defineVaporComponent(() => {
         const slots = useSlots()
         return createComponent(Carrier, null, {
-          default: withVaporCtx(() =>
+          default: () =>
             createComponent(Leaf, null, {
               $: [
-                // required wrapped in withVaporCtx to preserve owner when create dynamic slot source
-                withVaporCtx(() =>
+                () =>
                   createForSlots(slots, (_slot, name) => ({
                     name,
-                    fn: withVaporCtx(() => createSlot(name)),
+                    fn: () => createSlot(name),
                   })),
-                ) as any,
               ],
             }),
-          ),
         })
       })
 
       const { host } = define(() =>
         createComponent(Root, null, {
-          late: withVaporCtx(() => {
+          late: () => {
             const n0 = template('<span></span>')()
             renderEffect(() => setElementText(n0, msg.value))
             return n0
-          }),
+          },
         }),
       ).render()
 
@@ -2286,9 +2282,9 @@ describe('component: slots', () => {
             Child,
             null,
             {
-              foo: withVaporCtx(() => {
+              foo: () => {
                 return createSlot('foo', null)
-              }),
+              },
             },
             true,
           )
@@ -2331,10 +2327,10 @@ describe('component: slots', () => {
       const Parent = defineVaporComponent({
         setup() {
           const n2 = createComponent(Child, null, {
-            foo: withVaporCtx(() => {
+            foo: () => {
               const n0 = createSlot('foo', null)
               return n0
-            }),
+            },
           })
           const n3 = createSlot('default', null)
           return [n2, n3]
@@ -2382,12 +2378,12 @@ describe('component: slots', () => {
       const Parent = defineVaporComponent({
         setup() {
           const n2 = createComponent(Child, null, {
-            default: withVaporCtx(() => {
+            default: () => {
               const n0 = createSlot('default', null, () => {
                 return template('<!-- <div></div> -->')()
               })
               return n0
-            }),
+            },
           })
           return n2
         },
@@ -2420,7 +2416,7 @@ describe('component: slots', () => {
             Child,
             null,
             {
-              default: withVaporCtx(() => {
+              default: () => {
                 const n0 = createIf(
                   () => props.show,
                   () => {
@@ -2434,7 +2430,7 @@ describe('component: slots', () => {
                   },
                 )
                 return n0
-              }),
+              },
             },
             true,
           )
@@ -2481,7 +2477,7 @@ describe('component: slots', () => {
       const Parent = defineVaporComponent({
         setup() {
           const n2 = createComponent(Child, null, {
-            default: withVaporCtx(() => {
+            default: () => {
               const n0 = createSlot('default', null, () => {
                 const n2 = createIf(
                   () => show.value,
@@ -2493,7 +2489,7 @@ describe('component: slots', () => {
                 return n2
               })
               return n0
-            }),
+            },
           })
           return n2
         },
@@ -2527,7 +2523,7 @@ describe('component: slots', () => {
       const Parent = defineVaporComponent({
         setup() {
           const n2 = createComponent(Child, null, {
-            default: withVaporCtx(() => {
+            default: () => {
               const n0 = createSlot('default', null, () => {
                 const n2 = createFor(
                   () => items.value,
@@ -2543,7 +2539,7 @@ describe('component: slots', () => {
                 return n2
               })
               return n0
-            }),
+            },
           })
           return n2
         },
@@ -2631,14 +2627,14 @@ describe('component: slots', () => {
               targetComponent,
               null,
               {
-                foo: withVaporCtx(() => {
+                foo: () => {
                   return fallbackText
                     ? createSlot('foo', null, () => {
                         const n2 = template(`<div>${fallbackText}</div>`)()
                         return n2
                       })
                     : createSlot('foo', null)
-                }),
+                },
               },
               true,
             )
@@ -3022,7 +3018,7 @@ describe('component: slots', () => {
               VdomSlotWithDynamicFallback,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -3054,7 +3050,7 @@ describe('component: slots', () => {
               VdomSlotWithCountingFallback,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -3090,7 +3086,7 @@ describe('component: slots', () => {
               VdomSlotWithTextFallback,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -3137,16 +3133,15 @@ describe('component: slots', () => {
                   to: () => to.value,
                 },
                 {
-                  default: withVaporCtx(() =>
+                  default: () =>
                     createComponent(
                       VdomSlotWithReactiveFallback,
                       null,
                       {
-                        foo: withVaporCtx(() => createSlot('foo', null)),
+                        foo: () => createSlot('foo', null),
                       },
                       true,
                     ),
-                  ),
                 },
               )
             },
@@ -3199,7 +3194,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -3232,7 +3227,7 @@ describe('component: slots', () => {
               VdomSlotWithReactiveFallback,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -3272,12 +3267,11 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() =>
+                foo: () =>
                   createIf(
                     () => false,
                     () => template('<span>content</span>')(),
                   ),
-                ),
               },
               true,
             )
@@ -3321,12 +3315,11 @@ describe('component: slots', () => {
               VdomForwardedSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() =>
+                foo: () =>
                   createIf(
                     () => false,
                     () => template('<span>content</span>')(),
                   ),
-                ),
               },
               true,
             )
@@ -3364,12 +3357,11 @@ describe('component: slots', () => {
               VdomSlotWithLocalFallback,
               null,
               {
-                bar: withVaporCtx(() =>
+                bar: () =>
                   createIf(
                     () => showContent.value,
                     () => template('<span>content</span>')(),
                   ),
-                ),
               },
               true,
             )
@@ -3382,9 +3374,7 @@ describe('component: slots', () => {
               OuterVaporSlot,
               null,
               {
-                foo: withVaporCtx(() =>
-                  createComponent(NestedInteropContainer, null, null),
-                ),
+                foo: () => createComponent(NestedInteropContainer, null, null),
               },
               true,
             )
@@ -3423,7 +3413,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -3467,7 +3457,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() => createComponent(Content, null, null)),
+                foo: () => createComponent(Content, null, null),
               },
               true,
             )
@@ -3518,7 +3508,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() => createComponent(Content, null, null)),
+                foo: () => createComponent(Content, null, null),
               },
               true,
             )
@@ -3563,7 +3553,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -3613,21 +3603,19 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() =>
+                foo: () =>
                   createComponent(
                     NestedSlotContainer,
                     null,
                     {
-                      bar: withVaporCtx(() =>
+                      bar: () =>
                         createIf(
                           () => showInner.value,
                           () => template('<i>inner</i>')(),
                         ),
-                      ),
                     },
                     true,
                   ),
-                ),
               },
               true,
             )
@@ -3682,21 +3670,19 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: withVaporCtx(() =>
+                foo: () =>
                   createComponent(
                     NestedSlotContainer,
                     null,
                     {
-                      bar: withVaporCtx(() =>
+                      bar: () =>
                         createIf(
                           () => showInner.value,
                           () => template('<i>inner</i>')(),
                         ),
-                      ),
                     },
                     true,
                   ),
-                ),
               },
               true,
             )
@@ -3806,7 +3792,7 @@ describe('component: slots', () => {
               NestedVdomSlot,
               null,
               {
-                bar: withVaporCtx(() => createSlot('bar', null)),
+                bar: () => createSlot('bar', null),
               },
               true,
             )
@@ -3983,7 +3969,7 @@ describe('component: slots', () => {
               InnerVdomSlot,
               null,
               {
-                bar: withVaporCtx(() => createSlot('bar', null)),
+                bar: () => createSlot('bar', null),
               },
               true,
             )
@@ -3996,7 +3982,7 @@ describe('component: slots', () => {
               OuterVdomSlot,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -4071,7 +4057,7 @@ describe('component: slots', () => {
               InnerVdomSlot,
               null,
               {
-                bar: withVaporCtx(() => createSlot('bar', null)),
+                bar: () => createSlot('bar', null),
               },
               true,
             )
@@ -4084,7 +4070,7 @@ describe('component: slots', () => {
               OuterVdomSlot,
               null,
               {
-                foo: withVaporCtx(() => createSlot('foo', null)),
+                foo: () => createSlot('foo', null),
               },
               true,
             )
@@ -4257,12 +4243,11 @@ describe('component: slots', () => {
               VdomSlot,
               null,
               {
-                foo: withVaporCtx(() =>
+                foo: () =>
                   createIf(
                     () => true,
                     () => template('<span>content</span>')(),
                   ),
-                ),
               },
               true,
             )

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -35,7 +35,6 @@ import {
   setText,
   template,
   vaporInteropPlugin,
-  withVaporCtx,
 } from '../../src'
 
 const define = makeRender()
@@ -285,10 +284,10 @@ describe('VaporKeepAlive', () => {
     const Comp = defineVaporComponent({
       setup() {
         return createComponent(VaporKeepAlive, null, {
-          default: withVaporCtx(() => {
+          default: () => {
             const n0 = createSlot('default', null)
             return n0
-          }),
+          },
         })
       },
     })
@@ -415,7 +414,7 @@ describe('VaporKeepAlive', () => {
     const ReusableKeepAlive = defineVaporComponent({
       setup() {
         return createComponent(VaporKeepAlive, null, {
-          default: withVaporCtx(() => createSlot('default', null)),
+          default: () => createSlot('default', null),
         })
       },
     })

--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -21,7 +21,6 @@ import {
   template,
   useVaporCssVars,
   vaporInteropPlugin,
-  withVaporCtx,
   withVaporDirectives,
 } from '@vue/runtime-vapor'
 import { makeRender } from '../_utils'
@@ -1462,9 +1461,9 @@ function runSharedTests(deferMode: boolean): void {
           () => show.value,
           () =>
             createComponent(Comp1 as any, null, {
-              default: withVaporCtx(() =>
+              default: () =>
                 createComponent(Comp2 as any, null, {
-                  default: withVaporCtx(() =>
+                  default: () =>
                     createComponent(
                       VaporTeleport,
                       {
@@ -1474,9 +1473,7 @@ function runSharedTests(deferMode: boolean): void {
                         default: () => template('<input>')(),
                       },
                     ),
-                  ),
                 }),
-              ),
             }),
         )
         return [n0, n1]

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -7,7 +7,6 @@ import {
   defineVaporComponent,
   setBlockKey,
   template,
-  withVaporCtx,
 } from '../../src'
 import { nextTick, ref } from '@vue/runtime-dom'
 import { makeRender } from '../_utils'
@@ -30,7 +29,7 @@ describe('TransitionGroup', () => {
         setBlockKey(child, 'foo')
         child.block.$key = undefined
         return createComponent(VaporTransitionGroup, null, {
-          default: withVaporCtx(() => child),
+          default: () => child,
         })
       },
     }).render()
@@ -50,7 +49,7 @@ describe('TransitionGroup', () => {
         setBlockKey(frag, 'foo')
         frag.nodes.$key = undefined
         return createComponent(VaporTransitionGroup, null, {
-          default: withVaporCtx(() => frag),
+          default: () => frag,
         })
       },
     }).render()
@@ -77,7 +76,7 @@ describe('TransitionGroup', () => {
         child.block[0].$key = undefined
         child.block[1].$key = undefined
         return createComponent(VaporTransitionGroup, null, {
-          default: withVaporCtx(() => child),
+          default: () => child,
         })
       },
     }).render()
@@ -105,7 +104,7 @@ describe('TransitionGroup', () => {
         child = createComponent(Child)
         setBlockKey(child, 'foo')
         return createComponent(VaporTransitionGroup, null, {
-          default: withVaporCtx(() => child),
+          default: () => child,
         })
       },
     }).render()
@@ -136,7 +135,7 @@ describe('TransitionGroup', () => {
         child = createComponent(AsyncChild)
         setBlockKey(child, 'foo')
         return createComponent(VaporTransitionGroup, null, {
-          default: withVaporCtx(() => child),
+          default: () => child,
         })
       },
     }).render()
@@ -166,7 +165,7 @@ describe('TransitionGroup', () => {
           item => item,
         )
         return createComponent(VaporTransitionGroup, null, {
-          default: withVaporCtx(() => list),
+          default: () => list,
         })
       },
     }).render()

--- a/packages/runtime-vapor/__tests__/customElement.spec.ts
+++ b/packages/runtime-vapor/__tests__/customElement.spec.ts
@@ -33,7 +33,6 @@ import {
   setValue,
   template,
   txt,
-  withVaporCtx,
 } from '../src'
 
 declare var __VUE_HMR_RUNTIME__: HMRRuntime
@@ -1831,11 +1830,10 @@ describe('defineVaporCustomElement', () => {
       const App = {
         setup() {
           return createPlainElement('my-parent', null, {
-            default: withVaporCtx(() =>
+            default: () =>
               createPlainElement('my-child', null, {
                 default: () => template('<span>default</span>')(),
               }),
-            ),
           })
         },
       }
@@ -1864,7 +1862,7 @@ describe('defineVaporCustomElement', () => {
               VaporTeleport,
               { to: () => target },
               {
-                default: withVaporCtx(() => createSlot('default')),
+                default: () => createSlot('default'),
               },
             )
           },
@@ -1885,11 +1883,10 @@ describe('defineVaporCustomElement', () => {
       const App = {
         setup() {
           return createPlainElement('my-el-teleport-parent', null, {
-            default: withVaporCtx(() =>
+            default: () =>
               createPlainElement('my-el-teleport-child', null, {
                 default: () => template('<span>default</span>')(),
               }),
-            ),
           })
         },
       }
@@ -1911,14 +1908,14 @@ describe('defineVaporCustomElement', () => {
                 VaporTeleport,
                 { to: () => target1 },
                 {
-                  default: withVaporCtx(() => createSlot('header')),
+                  default: () => createSlot('header'),
                 },
               ),
               createComponent(
                 VaporTeleport,
                 { to: () => target2 },
                 {
-                  default: withVaporCtx(() => createSlot('body')),
+                  default: () => createSlot('body'),
                 },
               ),
             ]
@@ -1962,14 +1959,14 @@ describe('defineVaporCustomElement', () => {
                 // with disabled: true
                 { to: () => target1, disabled: () => true },
                 {
-                  default: withVaporCtx(() => createSlot('header')),
+                  default: () => createSlot('header'),
                 },
               ),
               createComponent(
                 VaporTeleport,
                 { to: () => target2 },
                 {
-                  default: withVaporCtx(() => createSlot('body')),
+                  default: () => createSlot('body'),
                 },
               ),
             ]
@@ -2053,7 +2050,7 @@ describe('defineVaporCustomElement', () => {
             'my-el-parent-shadow-false',
             { isShown: () => props.isShown },
             {
-              default: withVaporCtx(() => createSlot('default')),
+              default: () => createSlot('default'),
             },
           )
         },
@@ -2066,7 +2063,7 @@ describe('defineVaporCustomElement', () => {
             ParentWrapper,
             { isShown: () => isShown.value },
             {
-              default: withVaporCtx(() => createComponent(ChildWrapper)),
+              default: () => createComponent(ChildWrapper),
             },
           )
         },

--- a/packages/runtime-vapor/__tests__/helpers/useCssVars.spec.ts
+++ b/packages/runtime-vapor/__tests__/helpers/useCssVars.spec.ts
@@ -10,7 +10,6 @@ import {
   setStyle,
   template,
   useVaporCssVars,
-  withVaporCtx,
 } from '@vue/runtime-vapor'
 import { nextTick, onMounted, reactive, ref } from '@vue/runtime-core'
 import { VaporBlockShape } from '@vue/shared'
@@ -211,7 +210,7 @@ describe('useVaporCssVars', () => {
       setup() {
         useVaporCssVars(() => state)
         return createComponent(Child, null, {
-          default: withVaporCtx(() =>
+          default: () =>
             createComponent(
               VaporTeleport,
               { to: () => target },
@@ -219,7 +218,6 @@ describe('useVaporCssVars', () => {
                 default: () => template('<div></div>', 1)(),
               },
             ),
-          ),
         })
       },
     }).render()
@@ -254,7 +252,7 @@ describe('useVaporCssVars', () => {
       setup() {
         useVaporCssVars(() => parentState)
         return createComponent(Child, null, {
-          default: withVaporCtx(() =>
+          default: () =>
             createComponent(
               VaporTeleport,
               { to: () => target },
@@ -267,7 +265,6 @@ describe('useVaporCssVars', () => {
                   ),
               },
             ),
-          ),
         })
       },
     }).render()

--- a/packages/runtime-vapor/__tests__/hmr.spec.ts
+++ b/packages/runtime-vapor/__tests__/hmr.spec.ts
@@ -26,7 +26,6 @@ import {
   setText,
   template,
   vaporInteropPlugin,
-  withVaporCtx,
 } from '@vue/runtime-vapor'
 import { BindingTypes } from '@vue/compiler-core'
 import type { VaporComponent } from '../src/component'
@@ -1030,9 +1029,9 @@ describe('hot module replacement', () => {
           Foo,
           {},
           {
-            default: withVaporCtx(() => {
+            default: () => {
               return createSlot('default')
-            }),
+            },
           },
         )
       },
@@ -1047,7 +1046,7 @@ describe('hot module replacement', () => {
           Parent,
           {},
           {
-            default: withVaporCtx(() => {
+            default: () => {
               return createComponent(
                 Foo,
                 {},
@@ -1055,7 +1054,7 @@ describe('hot module replacement', () => {
                   default: () => template('foo')(),
                 },
               )
-            }),
+            },
           },
         ),
     }

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -21,7 +21,6 @@ import {
   setInsertionState,
   template,
   vaporInteropPlugin,
-  withVaporCtx,
 } from '../src'
 import { makeRender } from './_utils'
 
@@ -240,11 +239,11 @@ describe('scopeId', () => {
           Child,
           null,
           {
-            default: withVaporCtx(() => {
+            default: () => {
               const n0 = template('<div parent></div>')()
               const n1 = createComponent(Child2)
               return [n0, n1]
-            }),
+            },
           },
           true,
         )
@@ -288,10 +287,10 @@ describe('scopeId', () => {
           Wrapper,
           null,
           {
-            default: withVaporCtx(() => {
+            default: () => {
               const n0 = createSlot('default', null)
               return n0
-            }),
+            },
           },
           true,
         )
@@ -341,12 +340,12 @@ describe('scopeId', () => {
           Child,
           null,
           {
-            default: withVaporCtx(() => {
+            default: () => {
               const n2 = createComponent(
                 Child,
                 null,
                 {
-                  default: withVaporCtx(() => {
+                  default: () => {
                     const n1 = createComponent(
                       Child,
                       null,
@@ -359,12 +358,12 @@ describe('scopeId', () => {
                       true,
                     )
                     return n1
-                  }),
+                  },
                 },
                 true,
               )
               return n2
-            }),
+            },
           },
           true,
         )
@@ -416,7 +415,7 @@ describe('scopeId', () => {
           Parent,
           null,
           {
-            default: withVaporCtx(() => {
+            default: () => {
               const n0 = createFor(
                 () => count.value,
                 _for_item0 => {
@@ -436,7 +435,7 @@ describe('scopeId', () => {
                 2,
               )
               return n0
-            }),
+            },
           },
           true,
         )
@@ -787,13 +786,12 @@ describe('vdom interop', () => {
             onLeave: () => onLeave,
           },
           {
-            default: withVaporCtx(() =>
+            default: () =>
               createIf(
                 () => show.value,
                 () => template('<div>A</div>', 1)(),
                 () => template('<section>B</section>', 1)(),
               ),
-            ),
           },
         )
       },
@@ -1158,11 +1156,11 @@ describe('vdom interop', () => {
           VaporSlot,
           null,
           {
-            default: withVaporCtx(() => {
+            default: () => {
               const n0 = template('<div vapor-parent></div>')()
               const n1 = createComponent(VdomChild)
               return [n0, n1]
-            }),
+            },
           },
           true,
         )

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -889,6 +889,46 @@ describe('vdomInterop', () => {
       expect(html()).toBe('default slot')
     })
 
+    test('does not expose Vapor dynamic slots marker to vdom slots', () => {
+      const keys: string[][] = []
+      const VDomChild = defineComponent({
+        setup(_, { slots }) {
+          return () => {
+            keys.push(Object.keys(slots))
+            return renderSlot(slots, 'default')
+          }
+        },
+      })
+
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return createComponent(
+            VDomChild as any,
+            null,
+            {
+              default: () => document.createTextNode('static slot'),
+              $: [
+                () => ({
+                  name: 'default',
+                  fn: () => document.createTextNode('dynamic slot'),
+                }),
+              ],
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporChild as any)
+        },
+      }).render()
+
+      expect(html()).toBe('dynamic slot')
+      expect(keys).toEqual([['default']])
+    })
+
     test('function rawSlots are normalized before mounting vdom component', () => {
       const VDomChild = defineComponent({
         setup(_, { slots }) {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -63,7 +63,6 @@ import {
   template,
   txt,
   vaporInteropPlugin,
-  withVaporCtx,
 } from '../src'
 
 const define = makeInteropRender()
@@ -1611,7 +1610,7 @@ describe('vdomInterop', () => {
             VDomInnerSlot as any,
             null,
             {
-              bar: withVaporCtx(() => createSlot('bar', null)),
+              bar: () => createSlot('bar', null),
             },
             true,
           )
@@ -1714,12 +1713,11 @@ describe('vdomInterop', () => {
         const slots = useSlots()
         return createComponent(Inner, null, {
           $: [
-            withVaporCtx(() =>
+            () =>
               createForSlots(slots, (_slot, name) => ({
                 name,
-                fn: withVaporCtx(() => createSlot(name)),
-              })),
-            ) as any,
+                fn: () => createSlot(name),
+              })) as any,
           ],
         })
       })
@@ -1778,13 +1776,13 @@ describe('vdomInterop', () => {
             VDomChild as any,
             null,
             {
-              default: withVaporCtx((props: any) => {
+              default: (props: any) => {
                 const span = document.createElement('span')
                 renderEffect(() => {
                   span.textContent = props.msg
                 })
                 return span
-              }),
+              },
             },
             true,
           )
@@ -3464,7 +3462,7 @@ describe('vdomInterop', () => {
       const App = defineVaporComponent({
         setup() {
           return createComponent(VaporKeepAlive, null, {
-            default: withVaporCtx(() =>
+            default: () =>
               createIf(
                 () => show.value,
                 () =>
@@ -3472,16 +3470,14 @@ describe('vdomInterop', () => {
                     VDomComp as any,
                     null,
                     {
-                      default: withVaporCtx(() =>
+                      default: () =>
                         createSlot('default', null, () =>
                           createComponent(VaporFallback as any),
                         ),
-                      ),
                     },
                     true,
                   ),
               ),
-            ),
           })
         },
       })
@@ -3546,9 +3542,9 @@ describe('vdomInterop', () => {
             () => show.value,
             () =>
               createComponent(VDomCommentWrapper as any, null, {
-                default: withVaporCtx(() =>
+                default: () =>
                   createComponent(VaporKeepAlive, null, {
-                    default: withVaporCtx(() =>
+                    default: () =>
                       createComponent(
                         VaporTeleport,
                         { to: () => '#keepalive-teleport-target' },
@@ -3556,9 +3552,7 @@ describe('vdomInterop', () => {
                           default: () => template('<input>')(),
                         },
                       ),
-                    ),
                   }),
-                ),
               }),
           )
         },
@@ -3596,9 +3590,9 @@ describe('vdomInterop', () => {
             () => show.value,
             () =>
               createComponent(VDomCommentWrapper as any, null, {
-                default: withVaporCtx(() =>
+                default: () =>
                   createComponent(VaporKeepAlive, null, {
-                    default: withVaporCtx(() =>
+                    default: () =>
                       createComponent(
                         VaporTeleport,
                         {
@@ -3609,9 +3603,7 @@ describe('vdomInterop', () => {
                           default: () => template('<input>')(),
                         },
                       ),
-                    ),
                   }),
-                ),
               }),
           )
         },
@@ -3654,9 +3646,9 @@ describe('vdomInterop', () => {
             () => show.value,
             () =>
               createComponent(VDomCommentWrapper as any, null, {
-                default: withVaporCtx(() =>
+                default: () =>
                   createComponent(VaporKeepAlive, null, {
-                    default: withVaporCtx(() =>
+                    default: () =>
                       createComponent(
                         VaporTeleport,
                         { to: () => to.value },
@@ -3664,9 +3656,7 @@ describe('vdomInterop', () => {
                           default: () => template('<input>')(),
                         },
                       ),
-                    ),
                   }),
-                ),
               }),
           )
         },
@@ -3710,7 +3700,7 @@ describe('vdomInterop', () => {
       const NestedKeepAlive = defineVaporComponent({
         setup() {
           return createComponent(VaporKeepAlive, null, {
-            default: withVaporCtx(() => createSlot('default')),
+            default: () => createSlot('default'),
           })
         },
       })
@@ -3721,9 +3711,9 @@ describe('vdomInterop', () => {
             () => show.value,
             () =>
               createComponent(VDomCommentWrapper as any, null, {
-                default: withVaporCtx(() =>
+                default: () =>
                   createComponent(NestedKeepAlive, null, {
-                    default: withVaporCtx(() =>
+                    default: () =>
                       createComponent(
                         VaporTeleport,
                         { to: () => '#nested-keepalive-teleport-target' },
@@ -3731,9 +3721,7 @@ describe('vdomInterop', () => {
                           default: () => template('<input>')(),
                         },
                       ),
-                    ),
                   }),
-                ),
               }),
           )
         },
@@ -3768,7 +3756,7 @@ describe('vdomInterop', () => {
       const VaporChild = defineVaporComponent({
         setup() {
           return createComponent(VaporKeepAlive, null, {
-            default: withVaporCtx(() =>
+            default: () =>
               createComponent(
                 VaporTeleport,
                 {
@@ -3778,7 +3766,6 @@ describe('vdomInterop', () => {
                   default: () => template('<input>')(),
                 },
               ),
-            ),
           })
         },
       })
@@ -4295,16 +4282,15 @@ describe('vdomInterop', () => {
                 to: () => to.value,
               },
               {
-                default: withVaporCtx(() =>
+                default: () =>
                   createComponent(
                     VDomSlotOutlet as any,
                     null,
                     {
-                      default: withVaporCtx(() => createSlot('default')),
+                      default: () => createSlot('default'),
                     },
                     true,
                   ),
-                ),
               },
             )
           },
@@ -4518,9 +4504,7 @@ describe('vdomInterop', () => {
                   VaporAsyncChild,
                   null,
                   {
-                    default: withVaporCtx(() =>
-                      template('<span>slot content</span>')(),
-                    ),
+                    default: () => template('<span>slot content</span>')(),
                   },
                   true,
                 ),

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -11,15 +11,17 @@ import {
 import { ShapeFlags } from '@vue/shared'
 import { insert, isBlock } from './block'
 import {
-  type LooseRawSlots,
   type VaporComponentInstance,
   createComponentWithFallback,
   emptyContext,
-  normalizeRawSlots,
 } from './component'
 import { renderEffect } from './renderEffect'
 import type { RawProps } from './componentProps'
-import { getScopeOwner } from './componentSlots'
+import {
+  type LooseRawSlots,
+  getScopeOwner,
+  normalizeRawSlots,
+} from './componentSlots'
 import {
   insertionAnchor,
   insertionParent,

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -77,14 +77,14 @@ import { type RenderEffect, renderEffect } from './renderEffect'
 import { emit, normalizeEmitsOptions } from './componentEmits'
 import { setDynamicProps } from './dom/prop'
 import {
-  type DynamicSlotSource,
+  type LooseRawSlots,
   type RawSlots,
   type StaticSlots,
-  type VaporSlot,
   dynamicSlotsProxyHandlers,
   getScopeOwner,
   getSlot,
   inOnceSlot,
+  normalizeRawSlots,
   setCurrentSlotOwner,
   withOnceSlot,
 } from './componentSlots'
@@ -241,20 +241,6 @@ interface SharedInternalOptions {
 // wider types to make `createComponent` ergonomic in tests and internal call sites.
 export type LooseRawProps = Record<string, unknown> & {
   $?: DynamicPropsSource[]
-}
-
-export type LooseRawSlots =
-  | VaporSlot
-  | (Record<string, VaporSlot | DynamicSlotSource[]> & {
-      $?: DynamicSlotSource[]
-    })
-
-export function normalizeRawSlots(
-  rawSlots?: LooseRawSlots | null,
-): RawSlots | null | undefined {
-  return rawSlots && isFunction(rawSlots)
-    ? { default: rawSlots }
-    : (rawSlots as RawSlots | null | undefined)
 }
 
 export function createComponent(
@@ -852,9 +838,7 @@ export class VaporComponentInstance<
     this.rawSlots = normalizedRawSlots || EMPTY_OBJ
     this.slots = (
       normalizedRawSlots
-        ? normalizedRawSlots.$
-          ? new Proxy(normalizedRawSlots, dynamicSlotsProxyHandlers)
-          : normalizedRawSlots
+        ? new Proxy(normalizedRawSlots, dynamicSlotsProxyHandlers)
         : EMPTY_OBJ
     ) as Slots
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -79,12 +79,77 @@ export type RawSlots = Record<string, VaporSlot> & {
   $?: DynamicSlotSource[]
 }
 
+export type LooseRawSlots =
+  | VaporSlot
+  | (Record<string, VaporSlot | DynamicSlotSource[]> & {
+      $?: DynamicSlotSource[]
+    })
+
 export type StaticSlots = Record<string, VaporSlot>
 
 export type VaporSlot = BlockFn
 export type DynamicSlot = { name: string; fn: VaporSlot }
 export type DynamicSlotFn = () => DynamicSlot | DynamicSlot[]
 export type DynamicSlotSource = StaticSlots | DynamicSlotFn
+
+const rawSlotsOwnerMap = new WeakMap<RawSlots, VaporComponentInstance | null>()
+const rawSlotWrappersCache = new WeakMap<
+  RawSlots,
+  Map<
+    string,
+    {
+      slot: VaporSlot
+      wrapped: VaporSlot
+    }
+  >
+>()
+
+export function normalizeRawSlots(
+  rawSlots?: LooseRawSlots | null,
+): RawSlots | null | undefined {
+  if (!rawSlots) return rawSlots
+  const normalized = isFunction(rawSlots)
+    ? ({ default: rawSlots } as RawSlots)
+    : (rawSlots as RawSlots)
+  if (!rawSlotsOwnerMap.has(normalized)) {
+    rawSlotsOwnerMap.set(normalized, getScopeOwner())
+  }
+  return normalized
+}
+
+function withSlotOwner<T>(slots: RawSlots, fn: () => T): T {
+  if (!rawSlotsOwnerMap.has(slots)) {
+    return fn()
+  }
+  const prevOwner = setCurrentSlotOwner(rawSlotsOwnerMap.get(slots) || null)
+  try {
+    return fn()
+  } finally {
+    setCurrentSlotOwner(prevOwner)
+  }
+}
+
+function getOwnedSlot(
+  slots: RawSlots,
+  key: string,
+  slot: VaporSlot,
+): VaporSlot {
+  if (!rawSlotsOwnerMap.has(slots)) {
+    return slot
+  }
+  let wrappers = rawSlotWrappersCache.get(slots)
+  if (!wrappers) {
+    rawSlotWrappersCache.set(slots, (wrappers = new Map()))
+  }
+  const cached = wrappers.get(key)
+  if (cached && cached.slot === slot) {
+    return cached.wrapped
+  }
+  const wrapped = ((...args: any[]) =>
+    withSlotOwner(slots, () => slot(...args))) as VaporSlot
+  wrappers.set(key, { slot, wrapped })
+  return wrapped
+}
 
 export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
   get: getSlot,
@@ -106,7 +171,9 @@ export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
       keys = keys.filter(k => k !== '$')
       for (const source of dynamicSources) {
         if (isFunction(source)) {
-          const slot = resolveFunctionSource(source)
+          const slot = withSlotOwner(target, () =>
+            resolveFunctionSource(source),
+          )
           if (slot) {
             if (isArray(slot)) {
               for (const s of slot) keys.push(String(s.name))
@@ -130,27 +197,31 @@ export function getSlot(target: RawSlots, key: string): VaporSlot | undefined {
   const dynamicSources = target.$
   if (dynamicSources) {
     let i = dynamicSources.length
-    let source
+    let source: DynamicSlotSource
     while (i--) {
       source = dynamicSources[i]
       if (isFunction(source)) {
-        const slot = resolveFunctionSource(source)
+        const slot = withSlotOwner(target, () =>
+          resolveFunctionSource(source as DynamicSlotFn),
+        )
         if (slot) {
           if (isArray(slot)) {
             for (let j = slot.length - 1; j >= 0; j--) {
-              if (String(slot[j].name) === key) return slot[j].fn
+              if (String(slot[j].name) === key) {
+                return getOwnedSlot(target, key, slot[j].fn)
+              }
             }
           } else if (String(slot.name) === key) {
-            return slot.fn
+            return getOwnedSlot(target, key, slot.fn)
           }
         }
       } else if (hasOwn(source, key)) {
-        return source[key]
+        return getOwnedSlot(target, key, source[key])
       }
     }
   }
   if (hasOwn(target, key)) {
-    return target[key]
+    return getOwnedSlot(target, key, target[key])
   }
 }
 
@@ -178,25 +249,6 @@ export function setCurrentSlotOwner(
  */
 export function getScopeOwner(): VaporComponentInstance | null {
   return (currentSlotOwner || currentInstance) as VaporComponentInstance | null
-}
-
-/**
- * Wrap a slot function to track the slot owner.
- *
- * This ensures:
- * 1. createSlot gets rawSlots from the correct instance (slot owner)
- * 2. elements inherit the slot owner's scopeId
- */
-export function withVaporCtx(fn: Function): BlockFn {
-  const owner = getScopeOwner()
-  return (...args: any[]) => {
-    const prevOwner = setCurrentSlotOwner(owner)
-    try {
-      return fn(...args)
-    } finally {
-      setCurrentSlotOwner(prevOwner)
-    }
-  }
 }
 
 export function createSlot(

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -165,10 +165,9 @@ export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
     }
   },
   ownKeys(target) {
-    let keys = Object.keys(target)
+    const keys = new Set(Object.keys(target).filter(k => k !== '$'))
     const dynamicSources = target.$
     if (dynamicSources) {
-      keys = keys.filter(k => k !== '$')
       for (const source of dynamicSources) {
         if (isFunction(source)) {
           const slot = withSlotOwner(target, () =>
@@ -176,17 +175,17 @@ export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
           )
           if (slot) {
             if (isArray(slot)) {
-              for (const s of slot) keys.push(String(s.name))
+              for (const s of slot) keys.add(String(s.name))
             } else {
-              keys.push(String(slot.name))
+              keys.add(String(slot.name))
             }
           }
         } else {
-          keys.push(...Object.keys(source))
+          for (const key of Object.keys(source)) keys.add(key)
         }
       }
     }
-    return keys
+    return [...keys]
   },
   set: NO,
   deleteProperty: NO,

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -31,7 +31,7 @@ export {
   type VaporComponentInstance,
 } from './component'
 export { renderEffect } from './renderEffect'
-export { createSlot, withVaporCtx } from './componentSlots'
+export { createSlot } from './componentSlots'
 export { template } from './dom/template'
 export { createTextNode, child, nthChild, next, txt } from './dom/node'
 export {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -54,7 +54,6 @@ import {
 import { effectScope } from '@vue/reactivity'
 import {
   type LooseRawProps,
-  type LooseRawSlots,
   type VaporComponent,
   VaporComponentInstance,
   createComponent,
@@ -64,6 +63,7 @@ import {
   mountComponent,
   unmountComponent,
 } from './component'
+import type { LooseRawSlots } from './componentSlots'
 import {
   type Block,
   type BlockFn,
@@ -82,11 +82,13 @@ import {
   isFunction,
   isObject,
   isReservedProp,
+  isString,
 } from '@vue/shared'
 import { type RawProps, rawPropsProxyHandlers } from './componentProps'
 import type { RawSlots, VaporSlot } from './componentSlots'
 import {
   currentSlotScopeIds,
+  getSlot,
   setCurrentSlotOwner,
   withOnceSlot,
 } from './componentSlots'
@@ -650,7 +652,10 @@ const vaporSlotWrappersCache = new WeakMap<
 
 const vaporSlotsProxyHandler: ProxyHandler<any> = {
   get(target, key) {
-    const slot = target[key]
+    const slot =
+      isString(key) && !isInternalSlotKey(key)
+        ? getSlot(target, key)
+        : target[key]
     if (isFunction(slot)) {
       slot.__vapor = true
       let wrappers = vaporSlotWrappersCache.get(target)
@@ -1012,7 +1017,7 @@ function createVDOMComponent(
   if (isCollectingVdomSlotVNodes) {
     collectedVdomSlotVNodes.set(
       frag,
-      createCollectedVDOMSlotVNode(component, rawProps, wrapper.slots),
+      createCollectedVDOMSlotVNode(component, rawProps, wrapper.rawSlots),
     )
   }
 
@@ -1048,9 +1053,9 @@ function createVDOMComponent(
     })
 
     instance.slots =
-      wrapper.slots === EMPTY_OBJ
+      wrapper.rawSlots === EMPTY_OBJ
         ? EMPTY_OBJ
-        : new Proxy(wrapper.slots, vaporSlotsProxyHandler)
+        : new Proxy(wrapper.rawSlots, vaporSlotsProxyHandler)
   }
 
   let rawRef: VNodeNormalizedRef | null = null

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -88,6 +88,7 @@ import { type RawProps, rawPropsProxyHandlers } from './componentProps'
 import type { RawSlots, VaporSlot } from './componentSlots'
 import {
   currentSlotScopeIds,
+  dynamicSlotsProxyHandlers,
   getSlot,
   setCurrentSlotOwner,
   withOnceSlot,
@@ -680,6 +681,15 @@ const vaporSlotsProxyHandler: ProxyHandler<any> = {
       return wrapped
     }
     return slot
+  },
+  ownKeys(target) {
+    return Array.from(dynamicSlotsProxyHandlers.ownKeys!(target)).filter(
+      key => isString(key) && !isInternalSlotKey(key),
+    )
+  },
+  getOwnPropertyDescriptor(target, key) {
+    if (!isString(key) || isInternalSlotKey(key)) return
+    return dynamicSlotsProxyHandlers.getOwnPropertyDescriptor!(target, key)
   },
 }
 
@@ -2441,7 +2451,7 @@ function normalizeInteropSlotValue(value: unknown): VNode[] {
 }
 
 const isInternalSlotKey = (key: string): boolean =>
-  key === '_' || key === '_ctx' || key === '$stable'
+  key === '_' || key === '_ctx' || key === '$stable' || key === '$'
 
 const interopSlotsSourceHandlers: ProxyHandler<ShallowRef<Slots>> = {
   get(target, key: any) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed `withVaporCtx` helper from the public API. Internal slot context management has been refactored to streamline implementation while maintaining backward compatibility for standard slot usage patterns and component functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->