### PR TITLE
fix(runtime-core): add dev warning for silent catch in compat mode and fix test description typo

### DIFF
--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -631,7 +631,11 @@ function defineReactive(obj: any, key: string, val: any) {
       Object.keys(val).forEach(key => {
         try {
           defineReactiveSimple(val, key, val[key])
-        } catch (e: any) {}
+        } catch (e: any) {
+          if (__DEV__) {
+            warn(`Failed making property "${key}" reactive:`, e)
+          }
+        }
       })
     }
   }

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -190,7 +190,7 @@ describe('compiler + runtime integration', () => {
     expect('[Vue warn]: invalid template option:').toHaveBeenWarned()
   })
 
-  it('should warn when template is is not found', () => {
+  it('should warn when template is not found', () => {
     const app = createApp({
       template: '#not-exist-id',
     })


### PR DESCRIPTION
## Summary

### Bug fix: silent error swallowing in compat mode
- `packages/runtime-core/src/compat/global.ts:634` — empty `catch (e: any) {}` silently swallowed all errors from `defineReactiveSimple`
- Added `__DEV__` warning to match existing pattern in `props.ts:100-108`
- Errors from non-configurable properties are now visible in development

### Typo fix
- `packages/vue/__tests__/index.spec.ts:193` — "template is is not found" → "template is not found"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected a test description to accurately reflect the expected warning behavior.

* **Bug Fixes (development)**
  * Improved runtime diagnostics: when setting up reactive properties fails, a warning with error details is emitted in development builds (may surface additional dev-time warnings).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/core/pull/14891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->