### PR TITLE
fix(runtime-vapor): preserve scope id on dynamic root updates

### DIFF
--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -48,6 +48,9 @@ export function renderSlot(
   if (vaporSlot) {
     const ret = (openBlock(), createBlock(VaporSlot, props))
     ret.vs = { slot: vaporSlot, fallback }
+    if (!noSlotted && ret.scopeId) {
+      ret.slotScopeIds = [ret.scopeId + '-s']
+    }
     return ret
   }
 

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -2395,6 +2395,48 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test('dynamic slot outlet update preserves slotted scope id', async () => {
+      const data = ref({ slotName: 'one' })
+      const childCode = `<template><slot :name="data.slotName" /></template>`
+      const appCode = `<script setup vapor>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <template #one><div>one</div></template>
+          <template #two><section>two</section></template>
+        </components.Child>
+      </template>`
+
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      container.innerHTML = `<!--[--><div child-s="">one</div><!--]-->`
+
+      const clientComponents: Record<string, any> = {}
+      clientComponents.Child = compile(childCode, data, clientComponents, {
+        vapor: true,
+        ssr: false,
+      })
+      clientComponents.Child.__scopeId = 'child'
+      const ClientApp = compile(appCode, data, clientComponents, {
+        vapor: true,
+        ssr: false,
+      })
+      createVaporSSRApp(ClientApp).mount(container)
+
+      expect(formatHtml(container.innerHTML)).toContain(
+        `<div child-s="">one</div>`,
+      )
+
+      data.value = { slotName: 'two' }
+      await nextTick()
+
+      expect(formatHtml(container.innerHTML)).toContain(
+        `<section child-s="">two</section>`,
+      )
+    })
+
     test('named slot', async () => {
       const { data, container } = await testHydration(
         `<template>

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -23,10 +23,17 @@ import {
   ref,
   withDirectives,
 } from '@vue/runtime-dom'
+import { BindingTypes } from '@vue/compiler-dom'
 import { Namespaces, isString } from '@vue/shared'
 import type { VaporComponentInstance } from '../src/component'
 import type { TeleportFragment } from '../src/components/Teleport'
-import { VueServerRenderer, compile, runtimeDom, runtimeVapor } from './_utils'
+import {
+  VueServerRenderer,
+  compile,
+  compileToVaporRender,
+  runtimeDom,
+  runtimeVapor,
+} from './_utils'
 import {
   hydrateNode,
   setIsHydratingEnabled,
@@ -438,6 +445,49 @@ describe('Vapor Mode hydration', () => {
         ref({ beforeMount }),
       )
       expect(beforeMount).toHaveBeenCalledTimes(1)
+    })
+
+    test('dynamic child component root preserves inherited scopeId after hydration update', async () => {
+      const showAlt = ref(false)
+      const Child = defineVaporComponent({
+        __scopeId: 'child',
+        render: compileToVaporRender(
+          `<section v-if="showAlt">alt</section><div v-else>base</div>`,
+          {
+            bindingMetadata: {
+              showAlt: BindingTypes.SETUP_REF,
+            },
+            scopeId: 'child',
+          },
+        ),
+        setup() {
+          return { showAlt }
+        },
+      })
+
+      const Parent = defineVaporComponent({
+        __scopeId: 'parent',
+        setup() {
+          return createComponent(Child)
+        },
+      })
+
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      container.innerHTML = `<div child="" parent="">base</div>`
+
+      createVaporSSRApp(Parent).mount(container)
+
+      expect(container.innerHTML).toBe(
+        `<div child="" parent="">base</div><!--if-->`,
+      )
+
+      showAlt.value = true
+      await nextTick()
+
+      expect(container.innerHTML).toBe(
+        `<section child="" parent="">alt</section><!--if-->`,
+      )
     })
 
     test('basic component', async () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -2487,6 +2487,100 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test('v-for slot content added after mount preserves slotted scope id', async () => {
+      const data = ref(0)
+      const childCode = `<template><slot /></template>`
+      const appCode = `<script setup vapor>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <div v-for="i in data">item</div>
+          <i>tail</i>
+        </components.Child>
+      </template>`
+
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      container.innerHTML = `<!--[--><!--[--><!--]--><i child-s="">tail</i><!--]-->`
+
+      const clientComponents: Record<string, any> = {}
+      clientComponents.Child = compile(childCode, data, clientComponents, {
+        vapor: true,
+        ssr: false,
+      })
+      clientComponents.Child.__scopeId = 'child'
+      const ClientApp = compile(appCode, data, clientComponents, {
+        vapor: true,
+        ssr: false,
+      })
+      createVaporSSRApp(ClientApp).mount(container)
+
+      expect(formatHtml(container.innerHTML)).toContain(
+        `<i child-s="">tail</i>`,
+      )
+
+      data.value++
+      await nextTick()
+
+      expect(formatHtml(container.innerHTML)).toContain(
+        `<div child-s="">item</div>`,
+      )
+    })
+
+    test('vdom slot owner vapor slot content added after mount preserves slotted scope id', async () => {
+      const show = ref(false)
+      const childCode = `<template><div><slot /></div></template>`
+      const appCode = `<script setup vapor>
+        const show = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <button v-if="show">item</button>
+        </components.Child>
+      </template>`
+
+      const ssrComponents: Record<string, any> = {}
+      ssrComponents.Child = compile(childCode, show, ssrComponents, {
+        vapor: false,
+        ssr: true,
+      })
+      ssrComponents.Child.__scopeId = 'child'
+      const ServerApp = compile(appCode, show, ssrComponents, {
+        vapor: true,
+        ssr: true,
+      })
+      const serverHtml = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(ServerApp),
+      )
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      container.innerHTML = serverHtml
+
+      const clientComponents: Record<string, any> = {}
+      clientComponents.Child = compile(childCode, show, clientComponents, {
+        vapor: false,
+        ssr: false,
+      })
+      clientComponents.Child.__scopeId = 'child'
+      const ClientApp = compile(appCode, show, clientComponents, {
+        vapor: true,
+        ssr: false,
+      })
+      createVaporSSRApp(ClientApp)
+        .use(runtimeVapor.vaporInteropPlugin)
+        .mount(container)
+
+      show.value = true
+      await nextTick()
+
+      expect(formatHtml(container.innerHTML)).toContain(
+        `<button child-s="">item</button>`,
+      )
+    })
+
     test('named slot', async () => {
       const { data, container } = await testHydration(
         `<template>

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -9,6 +9,7 @@ import {
 import { VaporDynamicComponentFlags, VaporSlotFlags } from '@vue/shared'
 import { BindingTypes } from '@vue/compiler-dom'
 import {
+  VaporTeleport,
   VaporTransition,
   createComponent,
   createDynamicComponent,
@@ -26,6 +27,22 @@ import {
 import { compile, compileToVaporRender, makeRender } from './_utils'
 
 const define = makeRender()
+const slottedScopeProbeConnections = ((
+  globalThis as any
+).__slottedScopeProbeConnections ||= []) as boolean[]
+
+function defineSlottedScopeProbe() {
+  if (!customElements.get('slotted-scope-probe')) {
+    customElements.define(
+      'slotted-scope-probe',
+      class extends HTMLElement {
+        connectedCallback() {
+          slottedScopeProbeConnections.push(this.hasAttribute('child-s'))
+        }
+      },
+    )
+  }
+}
 
 describe('scopeId', () => {
   test('should attach scopeId to child component', () => {
@@ -395,6 +412,204 @@ describe('scopeId', () => {
     await nextTick()
 
     expect(html()).toBe(`<section child-s="">two</section><!--slot-->`)
+  })
+
+  test(':slotted on v-for content added after mount', async () => {
+    const count = ref(0)
+    const Child = compile(`<template><slot /></template>`, count)
+    Child.__scopeId = 'child'
+
+    const Parent = compile(
+      `<template>
+        <components.Child>
+          <div v-for="i in data">item</div>
+        </components.Child>
+      </template>`,
+      count,
+      { Child },
+    )
+
+    const { html } = define(Parent).render()
+
+    expect(html()).toBe(`<!--for--><!--slot-->`)
+
+    count.value++
+    await nextTick()
+
+    expect(html()).toBe(`<div child-s="">item</div><!--for--><!--slot-->`)
+
+    count.value++
+    await nextTick()
+
+    expect(html()).toBe(
+      `<div child-s="">item</div><div child-s="">item</div><!--for--><!--slot-->`,
+    )
+  })
+
+  test(':slotted on v-for content applies scope id before insertion', async () => {
+    defineSlottedScopeProbe()
+    slottedScopeProbeConnections.length = 0
+
+    const count = ref(0)
+    const Child = defineVaporComponent({
+      __scopeId: 'child',
+      setup() {
+        return createSlot('default')
+      },
+    })
+
+    const { html } = define({
+      setup() {
+        return createComponent(
+          Child,
+          null,
+          {
+            default: () =>
+              createFor(
+                () => count.value,
+                () =>
+                  template(
+                    '<slotted-scope-probe>item</slotted-scope-probe>',
+                    1,
+                  )(),
+              ),
+          },
+          true,
+        )
+      },
+    }).render()
+
+    count.value++
+    await nextTick()
+
+    expect(slottedScopeProbeConnections).toEqual([true])
+    expect(html()).toBe(
+      `<slotted-scope-probe child-s="">item</slotted-scope-probe><!--for--><!--slot-->`,
+    )
+  })
+
+  test(':slotted on v-for content inside v-if added after mount', async () => {
+    const data = ref({ show: false, count: 1 })
+    const Child = compile(`<template><slot /></template>`, data)
+    Child.__scopeId = 'child'
+
+    const Parent = compile(
+      `<template>
+        <components.Child>
+          <template v-if="data.show">
+            <div v-for="i in data.count">item</div>
+          </template>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+
+    const { html } = define(Parent).render()
+
+    expect(html()).toBe(`<!--if--><!--slot-->`)
+
+    data.value = { show: true, count: 1 }
+    await nextTick()
+
+    expect(html()).toBe(
+      `<div child-s="">item</div><!--for--><!--if--><!--slot-->`,
+    )
+
+    data.value = { show: true, count: 2 }
+    await nextTick()
+
+    expect(html()).toBe(
+      `<div child-s="">item</div><div child-s="">item</div><!--for--><!--if--><!--slot-->`,
+    )
+  })
+
+  test(':slotted on teleported content added after mount', async () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const show = ref(false)
+
+    try {
+      const Child = defineVaporComponent({
+        __scopeId: 'child',
+        setup() {
+          return createSlot('default')
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return createComponent(
+            Child,
+            null,
+            {
+              default: () =>
+                createComponent(
+                  VaporTeleport,
+                  { to: () => target },
+                  {
+                    default: () =>
+                      createIf(
+                        () => show.value,
+                        () => template('<div>item</div>')(),
+                      ),
+                  },
+                ),
+            },
+            true,
+          )
+        },
+      }).render()
+
+      expect(html()).toBe(`<!--teleport start--><!--teleport end--><!--slot-->`)
+      expect(target.innerHTML).toBe(`<!--if-->`)
+
+      show.value = true
+      await nextTick()
+
+      expect(target.innerHTML).toBe(`<div child-s="">item</div><!--if-->`)
+    } finally {
+      target.remove()
+    }
+  })
+
+  test(':slotted on initial teleported content', () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+
+    try {
+      const Child = defineVaporComponent({
+        __scopeId: 'child',
+        setup() {
+          return createSlot('default')
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return createComponent(
+            Child,
+            null,
+            {
+              default: () =>
+                createComponent(
+                  VaporTeleport,
+                  { to: () => target },
+                  {
+                    default: () => template('<div>item</div>')(),
+                  },
+                ),
+            },
+            true,
+          )
+        },
+      }).render()
+
+      expect(html()).toBe(`<!--teleport start--><!--teleport end--><!--slot-->`)
+      expect(target.innerHTML).toBe(`<div child-s="">item</div>`)
+    } finally {
+      target.remove()
+    }
   })
 
   test('nested components with slots', async () => {
@@ -813,6 +1028,160 @@ describe('vdom interop', () => {
     expect(slottedRoot.root.innerHTML).toBe(
       `<div vdom-slot-owner="" vdom-parent="">` +
         `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">1</button>` +
+        `</div>`,
+    )
+  })
+
+  test('vdom slot owner > vapor slot content preserves slot scopeIds on dynamic root update', async () => {
+    const showAlt = ref(false)
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createIf(
+          () => showAlt.value,
+          () => template('<span>alt</span>', 1)(),
+          () => template('<button>base</button>', 1)(),
+        )
+      },
+    })
+
+    const VdomSlotOwner = {
+      __scopeId: 'vdom-slot-owner',
+      setup(_props: unknown, { slots }: any) {
+        return () => h('div', null, renderSlot(slots, 'default'))
+      },
+    }
+
+    const VdomParent = {
+      __scopeId: 'vdom-parent',
+      setup() {
+        return () =>
+          h(VdomSlotOwner, null, {
+            default: () => h(VaporChild as any),
+          })
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => h(VdomParent)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(
+      `<div vdom-slot-owner="" vdom-parent="">` +
+        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">base</button><!--if-->` +
+        `</div>`,
+    )
+
+    showAlt.value = true
+    await nextTick()
+
+    expect(root.innerHTML).toBe(
+      `<div vdom-slot-owner="" vdom-parent="">` +
+        `<span vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">alt</span><!--if-->` +
+        `</div>`,
+    )
+  })
+
+  test('vdom slot owner > vapor v-if slot content added after mount', async () => {
+    const show = ref(false)
+    const VdomSlotOwner = {
+      __scopeId: 'vdom-slot-owner',
+      setup(_props: unknown, { slots }: any) {
+        return () => h('div', null, renderSlot(slots, 'default'))
+      },
+    }
+
+    const VaporParent = defineVaporComponent({
+      setup() {
+        return createComponent(
+          VdomSlotOwner as any,
+          null,
+          {
+            default: () =>
+              createIf(
+                () => show.value,
+                () => template('<button>item</button>', 1)(),
+              ),
+          },
+          true,
+        )
+      },
+    })
+
+    const App = {
+      setup() {
+        return () => h(VaporParent as any)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<div vdom-slot-owner=""><!--if--></div>`)
+
+    show.value = true
+    await nextTick()
+
+    expect(root.innerHTML).toBe(
+      `<div vdom-slot-owner="">` +
+        `<button vdom-slot-owner-s="">item</button><!--if-->` +
+        `</div>`,
+    )
+  })
+
+  test('vdom slot owner > vapor v-if slot vdom child added after mount', async () => {
+    const show = ref(false)
+    const VdomChild = {
+      __scopeId: 'vdom-child',
+      setup() {
+        return () => h('button', 'item')
+      },
+    }
+    const VdomSlotOwner = {
+      __scopeId: 'vdom-slot-owner',
+      setup(_props: unknown, { slots }: any) {
+        return () => h('div', null, renderSlot(slots, 'default'))
+      },
+    }
+
+    const VaporParent = defineVaporComponent({
+      setup() {
+        return createComponent(
+          VdomSlotOwner as any,
+          null,
+          {
+            default: () =>
+              createIf(
+                () => show.value,
+                () => createComponent(VdomChild as any),
+              ),
+          },
+          true,
+        )
+      },
+    })
+
+    const App = {
+      setup() {
+        return () => h(VaporParent as any)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(`<div vdom-slot-owner=""><!--if--></div>`)
+
+    show.value = true
+    await nextTick()
+
+    expect(root.innerHTML).toBe(
+      `<div vdom-slot-owner="">` +
+        `<button vdom-child="" vdom-slot-owner-s="">item</button><!--if-->` +
         `</div>`,
     )
   })
@@ -1259,6 +1628,66 @@ describe('vdom interop', () => {
       `<div vapor-slot="" vapor-parent="">` +
         `<div vapor-parent="" vapor-slot-s=""></div>` +
         `<span vdom-child="" vapor-parent="" vapor-slot-s=""></span>` +
+        `<!--slot-->` +
+        `</div>`,
+    )
+  })
+
+  test('vapor parent > vapor slot > vdom dynamic child', async () => {
+    const showAlt = ref(false)
+    const VaporSlot = defineVaporComponent({
+      __scopeId: 'vapor-slot',
+      setup() {
+        const n1 = template('<div vapor-slot></div>', 1)() as any
+        setInsertionState(n1)
+        createSlot('default', null)
+        return n1
+      },
+    })
+
+    const VdomChild = {
+      __scopeId: 'vdom-child',
+      setup() {
+        return () => (showAlt.value ? h('span', 'alt') : h('button', 'base'))
+      },
+    }
+
+    const VaporParent = defineVaporComponent({
+      __scopeId: 'vapor-parent',
+      setup() {
+        return createComponent(
+          VaporSlot,
+          null,
+          {
+            default: () => createComponent(VdomChild),
+          },
+          true,
+        )
+      },
+    })
+
+    const App = {
+      setup() {
+        return () => h(VaporParent as any)
+      },
+    }
+
+    const root = document.createElement('div')
+    createApp(App).use(vaporInteropPlugin).mount(root)
+
+    expect(root.innerHTML).toBe(
+      `<div vapor-slot="" vapor-parent="">` +
+        `<button vdom-child="" vapor-parent="" vapor-slot-s="">base</button>` +
+        `<!--slot-->` +
+        `</div>`,
+    )
+
+    showAlt.value = true
+    await nextTick()
+
+    expect(root.innerHTML).toBe(
+      `<div vapor-slot="" vapor-parent="">` +
+        `<span vdom-child="" vapor-parent="" vapor-slot-s="">alt</span>` +
         `<!--slot-->` +
         `</div>`,
     )

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -24,7 +24,7 @@ import {
   vaporInteropPlugin,
   withVaporCtx,
 } from '../src'
-import { compileToVaporRender, makeRender } from './_utils'
+import { compile, compileToVaporRender, makeRender } from './_utils'
 
 const define = makeRender()
 
@@ -357,6 +357,35 @@ describe('scopeId', () => {
         `<!--slot--><!--slot-->` +
         `</div>`,
     )
+  })
+
+  test(':slotted on dynamic slot outlet update', async () => {
+    const data = ref({ slotName: 'one' })
+    const Child = compile(
+      `<template><slot :name="data.slotName" /></template>`,
+      data,
+    )
+    Child.__scopeId = 'child'
+
+    const Parent = compile(
+      `<template>
+        <components.Child>
+          <template #one><div>one</div></template>
+          <template #two><section>two</section></template>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+
+    const { html } = define(Parent).render()
+
+    expect(html()).toBe(`<div child-s="">one</div><!--slot-->`)
+
+    data.value = { slotName: 'two' }
+    await nextTick()
+
+    expect(html()).toBe(`<section child-s="">two</section><!--slot-->`)
   })
 
   test('nested components with slots', async () => {

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -7,6 +7,7 @@ import {
   renderSlot,
 } from '@vue/runtime-dom'
 import { VaporSlotFlags } from '@vue/shared'
+import { BindingTypes } from '@vue/compiler-dom'
 import {
   VaporTransition,
   createComponent,
@@ -23,7 +24,7 @@ import {
   vaporInteropPlugin,
   withVaporCtx,
 } from '../src'
-import { makeRender } from './_utils'
+import { compileToVaporRender, makeRender } from './_utils'
 
 const define = makeRender()
 
@@ -43,6 +44,39 @@ describe('scopeId', () => {
       },
     }).render()
     expect(html()).toBe(`<div child="" parent=""></div>`)
+  })
+
+  test('should attach scopeId to updated dynamic child component root', async () => {
+    const showAlt = ref(false)
+    const Child = defineVaporComponent({
+      __scopeId: 'child',
+      render: compileToVaporRender(
+        `<section v-if="showAlt">alt</section><div v-else>base</div>`,
+        {
+          bindingMetadata: {
+            showAlt: BindingTypes.SETUP_REF,
+          },
+          scopeId: 'child',
+        },
+      ),
+      setup() {
+        return { showAlt }
+      },
+    })
+
+    const { html } = define({
+      __scopeId: 'parent',
+      setup() {
+        return createComponent(Child)
+      },
+    }).render()
+
+    expect(html()).toBe(`<div child="" parent="">base</div><!--if-->`)
+
+    showAlt.value = true
+    await nextTick()
+
+    expect(html()).toBe(`<section child="" parent="">alt</section><!--if-->`)
   })
 
   test('should attach scopeId to child component with insertion state', () => {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -469,7 +469,11 @@ export const createFor = (
       applyTransitionHooks(block.nodes, frag.$transition)
     }
 
-    if (parent) insertForBlock(block, anchor)
+    if (parent) {
+      const onBeforeInsert = frag.onBeforeInsert
+      if (onBeforeInsert) onBeforeInsert.forEach(fn => fn(block.nodes))
+      insertForBlock(block, anchor)
+    }
 
     return block
   }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -138,7 +138,11 @@ import {
   isCollectingVdomSlotVNodes,
   isInteropEnabled,
 } from './vdomInteropState'
-import { setComponentScopeId, setScopeId } from './scopeId'
+import {
+  setComponentScopeId,
+  setScopeId,
+  trackComponentScopeId,
+} from './scopeId'
 import { isTransitionEnabled, isVaporTransition } from './transition'
 
 export { currentInstance } from '@vue/runtime-dom'
@@ -1131,6 +1135,10 @@ export function mountComponent(
   if (!isHydrating) {
     insert(instance.block, parent, anchor)
     setComponentScopeId(instance)
+  } else {
+    // Hydrated roots already have SSR scope attrs. Track dynamic roots so
+    // client-only branch switches keep inherited scope ids.
+    trackComponentScopeId(instance)
   }
   if (instance.m) queuePostFlushCb(instance.m!)
   if (

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -139,6 +139,7 @@ import {
   isInteropEnabled,
 } from './vdomInteropState'
 import {
+  getCurrentScopeId,
   setComponentScopeId,
   setScopeId,
   trackComponentScopeId,
@@ -1296,11 +1297,6 @@ function handleSetupResult(
   if (__DEV__) {
     popWarningContext()
   }
-}
-
-export function getCurrentScopeId(): string | undefined {
-  const scopeOwner = getScopeOwner()
-  return scopeOwner ? scopeOwner.type.__scopeId : undefined
 }
 
 // Attach fallthrough attrs to the single root element. When the root is a

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -38,7 +38,7 @@ import {
   SlotFragment,
   type VaporFragment,
   getCurrentSlotBoundary,
-  isDynamicFragment,
+  isInteropFragment,
   withOwnedSlotBoundary,
 } from './fragment'
 import { createElement } from './dom/node'
@@ -413,12 +413,12 @@ export function createSlot(
 
     if (_insertionParent) insert(fragment, _insertionParent, _insertionAnchor)
   } else {
-    if (fragment.insert) {
-      ;(fragment as VaporFragment).hydrate!()
+    if (isInteropEnabled && isInteropFragment(fragment)) {
+      fragment.hydrate!()
     }
     // Hydrated slot roots already have SSR scope attrs. Only register tracking
     // so future client-inserted slot branches receive the same ids.
-    if (slotScopeIds && isDynamicFragment(fragment)) {
+    if (slotScopeIds) {
       trackScopeIdFragment(fragment, slotScopeIds)
     }
     exitHydrationCursor(hydrationCursor)

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -36,6 +36,7 @@ import {
 import {
   SlotFragment,
   type VaporFragment,
+  isDynamicFragment,
   withOwnedSlotBoundary,
 } from './fragment'
 import { createElement } from './dom/node'
@@ -44,7 +45,7 @@ import {
   isCollectingVdomSlotVNodes,
   isInteropEnabled,
 } from './vdomInteropState'
-import { setScopeId } from './scopeId'
+import { setScopeId, trackScopeIdFragment } from './scopeId'
 
 /**
  * Flag to indicate if we are executing a once slot.
@@ -331,6 +332,11 @@ export function createSlot(
   } else {
     if (fragment.insert) {
       ;(fragment as VaporFragment).hydrate!()
+    }
+    // Hydrated slot roots already have SSR scope attrs. Only register tracking
+    // so future client-inserted slot branches receive the same ids.
+    if (slotScopeIds && isDynamicFragment(fragment)) {
+      trackScopeIdFragment(fragment, slotScopeIds)
     }
     exitHydrationCursor(hydrationCursor)
   }

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -33,7 +33,12 @@ import {
 import { ShapeFlags, invokeArrayFns, isArray } from '@vue/shared'
 import { createElement } from '../dom/node'
 import { unsetRef } from '../refCleanup'
-import { type VaporFragment, isDynamicFragment, isFragment } from '../fragment'
+import {
+  type VaporFragment,
+  isDynamicFragment,
+  isFragment,
+  isInteropFragment,
+} from '../fragment'
 import type { EffectScope } from '@vue/reactivity'
 import { isInteropEnabled } from '../vdomInteropState'
 import {
@@ -529,10 +534,6 @@ function getInnerBlock(block: Block): InnerBlockResult {
     return getInnerBlock(block.nodes)
   }
   return [undefined, false]
-}
-
-function isInteropFragment(block: Block): block is VaporFragment {
-  return !!(isFragment(block) && block.vnode)
 }
 
 function getInstanceFromCache(

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -191,7 +191,10 @@ export class TeleportFragment extends VaporFragment {
     // teardown previous nodes
     remove(this.nodes, this.mountContainer!)
     // mount new nodes
-    insert((this.nodes = children), this.mountContainer!, this.mountAnchor!)
+    this.nodes = children
+    const onBeforeInsert = this.onBeforeInsert
+    if (onBeforeInsert) onBeforeInsert.forEach(fn => fn(this.nodes))
+    insert(children, this.mountContainer!, this.mountAnchor!)
     this.bindChildren(this.nodes)
     updateCssVars(this)
   }
@@ -210,6 +213,8 @@ export class TeleportFragment extends VaporFragment {
         MoveType.REORDER,
       )
     } else {
+      const onBeforeInsert = this.onBeforeInsert
+      if (onBeforeInsert) onBeforeInsert.forEach(fn => fn(this.nodes))
       insert(
         this.nodes,
         (this.mountContainer = parent),

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1343,6 +1343,14 @@ export function isFragment(val: NonNullable<unknown>): val is VaporFragment {
   return val instanceof VaporFragment
 }
 
+export type InteropFragment<T extends Block = Block> = VaporFragment<T> & {
+  vnode: VNode | null
+}
+
+export function isInteropFragment(val: unknown): val is InteropFragment {
+  return val instanceof VaporFragment && val.vnode !== undefined
+}
+
 export function isDynamicFragment(
   val: NonNullable<unknown>,
 ): val is DynamicFragment {

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -1,7 +1,11 @@
 import { isArray } from '@vue/shared'
-import { type VaporComponentInstance, isVaporComponent } from './component'
+import {
+  type VaporComponentInstance,
+  getRootElement,
+  isVaporComponent,
+} from './component'
 import { getInheritedScopeIds } from '@vue/runtime-dom'
-import { isFragment } from './fragment'
+import { type DynamicFragment, isFragment } from './fragment'
 import type { Block } from './block'
 import { isInteropEnabled } from './vdomInteropState'
 
@@ -21,37 +25,62 @@ export function setScopeId(block: Block, scopeIds: string[]): void {
   }
 }
 
+const trackedInheritedScopeIdFragments = new WeakMap<
+  DynamicFragment,
+  WeakSet<VaporComponentInstance>
+>()
+
+function trackInheritedScopeIdFragment(
+  instance: VaporComponentInstance,
+  frag: DynamicFragment,
+): void {
+  // A dynamic root can inherit scope ids from multiple ancestor component
+  // instances, so the de-dupe key must include the instance, not just the frag.
+  let trackedInstances = trackedInheritedScopeIdFragments.get(frag)
+  if (!trackedInstances) {
+    trackedInstances = new WeakSet()
+    trackedInheritedScopeIdFragments.set(frag, trackedInstances)
+  } else if (trackedInstances.has(instance)) {
+    return
+  }
+  trackedInstances.add(instance)
+  ;(frag.onUpdated ||= []).push(() => applyInheritedScopeIdToRoot(instance))
+}
+
+function applyInheritedScopeIdToRoot(
+  instance: VaporComponentInstance,
+): Element | undefined {
+  const { scopeId } = instance
+  if (!scopeId) return
+  // Re-resolve the effective single root on each dynamic update. This keeps
+  // comment roots and multi-root branches aligned with VDOM root semantics.
+  const root = getRootElement(instance, frag =>
+    trackInheritedScopeIdFragment(instance, frag),
+  )
+  if (root) {
+    root.setAttribute(scopeId, '')
+  }
+  return root
+}
+
 export function setComponentScopeId(instance: VaporComponentInstance): void {
   const { parent, scopeId } = instance
   if (!parent || !scopeId) return
 
-  // prevent setting scopeId on multi-root fragments
-  if (isArray(instance.block) && instance.block.length > 1) return
-
-  const scopeIds: string[] = []
-  const parentScopeId = parent && parent.type.__scopeId
-  // if parent scopeId is different from scopeId, this means scopeId
-  // is inherited from slot owner, so we need to set it to the component
-  // scopeIds. the `parentScopeId-s` is handled in createSlot
-  if (parentScopeId !== scopeId) {
-    scopeIds.push(scopeId)
-  } else {
-    if (parentScopeId) scopeIds.push(parentScopeId)
-  }
+  const root = applyInheritedScopeIdToRoot(instance)
 
   // inherit scopeId from vdom parent
   if (
     isInteropEnabled &&
+    root &&
     parent.subTree &&
     (parent.subTree.component as any) === instance &&
     parent.vnode!.scopeId
   ) {
-    scopeIds.push(parent.vnode!.scopeId)
+    root.setAttribute(parent.vnode!.scopeId, '')
     const inheritedScopeIds = getInheritedScopeIds(parent.vnode!, parent.parent)
-    scopeIds.push(...inheritedScopeIds)
-  }
-
-  if (scopeIds.length > 0) {
-    setScopeId(instance.block, scopeIds)
+    for (let i = 0; i < inheritedScopeIds.length; i++) {
+      root.setAttribute(inheritedScopeIds[i], '')
+    }
   }
 }

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -5,9 +5,16 @@ import {
   isVaporComponent,
 } from './component'
 import { getInheritedScopeIds } from '@vue/runtime-dom'
-import { type DynamicFragment, isDynamicFragment, isFragment } from './fragment'
+import {
+  type DynamicFragment,
+  type InteropFragment,
+  type VaporFragment,
+  isFragment,
+  isInteropFragment,
+} from './fragment'
 import type { Block } from './block'
 import { isInteropEnabled } from './vdomInteropState'
+import { getScopeOwner } from './componentSlots'
 
 export function setScopeId(block: Block, scopeIds: string[]): void {
   if (block instanceof Element) {
@@ -21,31 +28,74 @@ export function setScopeId(block: Block, scopeIds: string[]): void {
       setScopeId(b, scopeIds)
     }
   } else if (isFragment(block)) {
-    if (isDynamicFragment(block)) {
-      trackScopeIdFragment(block, scopeIds)
-    }
+    trackScopeIdFragment(block, scopeIds, false)
     setScopeId(block.nodes, scopeIds)
   }
 }
 
-const trackedScopeIdFragments = new WeakMap<DynamicFragment, Set<string>>()
+const trackedScopeIdFragments = new WeakMap<VaporFragment, Set<string>>()
 
 export function trackScopeIdFragment(
-  frag: DynamicFragment,
+  frag: VaporFragment,
   scopeIds: string[],
+  recursive = true,
 ): void {
-  // Static scope ids applied to a dynamic fragment must follow future branches,
-  // e.g. dynamic slot outlets swapping their rendered slot content.
+  // VDOM interop fragments apply scope ids through their backing VNode instead
+  // of the fragment insert hook.
+  if (isInteropEnabled && isInteropFragment(frag)) {
+    setInteropFragmentScopeIds(frag, scopeIds)
+  } else if (trackFragmentScopeIds(frag, scopeIds)) {
+    ;(frag.onBeforeInsert ||= []).push(nodes => setScopeId(nodes, scopeIds))
+  }
+  if (recursive) {
+    trackScopeIdsInBlock(frag.nodes, scopeIds)
+  }
+}
+
+function trackFragmentScopeIds(
+  frag: VaporFragment,
+  scopeIds: string[],
+): boolean {
   const key = scopeIds.join(' ')
   let trackedScopeIds = trackedScopeIdFragments.get(frag)
   if (!trackedScopeIds) {
     trackedScopeIds = new Set()
     trackedScopeIdFragments.set(frag, trackedScopeIds)
   } else if (trackedScopeIds.has(key)) {
-    return
+    return false
   }
   trackedScopeIds.add(key)
-  ;(frag.onBeforeInsert ||= []).push(nodes => setScopeId(nodes, scopeIds))
+  return true
+}
+
+function setInteropFragmentScopeIds(
+  frag: InteropFragment,
+  scopeIds: string[],
+): void {
+  const vnode = frag.vnode
+  if (!vnode) return
+  const existing = vnode.slotScopeIds
+  if (!existing) {
+    vnode.slotScopeIds = scopeIds
+    return
+  }
+  for (let i = 0; i < scopeIds.length; i++) {
+    if (!existing.includes(scopeIds[i])) {
+      existing.push(scopeIds[i])
+    }
+  }
+}
+
+function trackScopeIdsInBlock(block: Block, scopeIds: string[]): void {
+  if (isVaporComponent(block)) {
+    trackScopeIdsInBlock(block.block, scopeIds)
+  } else if (isArray(block)) {
+    for (const b of block) {
+      trackScopeIdsInBlock(b, scopeIds)
+    }
+  } else if (isFragment(block)) {
+    trackScopeIdFragment(block, scopeIds)
+  }
 }
 
 const trackedInheritedScopeIdFragments = new WeakMap<
@@ -114,4 +164,8 @@ export function setComponentScopeId(instance: VaporComponentInstance): void {
       root.setAttribute(inheritedScopeIds[i], '')
     }
   }
+}
+export function getCurrentScopeId(): string | undefined {
+  const scopeOwner = getScopeOwner()
+  return scopeOwner ? scopeOwner.type.__scopeId : undefined
 }

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -86,6 +86,14 @@ function applyInheritedScopeIdToRoot(
   return root
 }
 
+export function trackComponentScopeId(instance: VaporComponentInstance): void {
+  const { parent, scopeId } = instance
+  if (!parent || !scopeId) return
+  getRootElement(instance, frag =>
+    trackInheritedScopeIdFragment(instance, frag),
+  )
+}
+
 export function setComponentScopeId(instance: VaporComponentInstance): void {
   const { parent, scopeId } = instance
   if (!parent || !scopeId) return

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -5,7 +5,7 @@ import {
   isVaporComponent,
 } from './component'
 import { getInheritedScopeIds } from '@vue/runtime-dom'
-import { type DynamicFragment, isFragment } from './fragment'
+import { type DynamicFragment, isDynamicFragment, isFragment } from './fragment'
 import type { Block } from './block'
 import { isInteropEnabled } from './vdomInteropState'
 
@@ -21,8 +21,28 @@ export function setScopeId(block: Block, scopeIds: string[]): void {
       setScopeId(b, scopeIds)
     }
   } else if (isFragment(block)) {
+    if (isDynamicFragment(block)) {
+      trackScopeIdFragment(block, scopeIds)
+    }
     setScopeId(block.nodes, scopeIds)
   }
+}
+
+const trackedScopeIdFragments = new WeakMap<DynamicFragment, Set<string>>()
+
+function trackScopeIdFragment(frag: DynamicFragment, scopeIds: string[]): void {
+  // Static scope ids applied to a dynamic fragment must follow future branches,
+  // e.g. dynamic slot outlets swapping their rendered slot content.
+  const key = scopeIds.join(' ')
+  let trackedScopeIds = trackedScopeIdFragments.get(frag)
+  if (!trackedScopeIds) {
+    trackedScopeIds = new Set()
+    trackedScopeIdFragments.set(frag, trackedScopeIds)
+  } else if (trackedScopeIds.has(key)) {
+    return
+  }
+  trackedScopeIds.add(key)
+  ;(frag.onBeforeInsert ||= []).push(nodes => setScopeId(nodes, scopeIds))
 }
 
 const trackedInheritedScopeIdFragments = new WeakMap<

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -30,7 +30,10 @@ export function setScopeId(block: Block, scopeIds: string[]): void {
 
 const trackedScopeIdFragments = new WeakMap<DynamicFragment, Set<string>>()
 
-function trackScopeIdFragment(frag: DynamicFragment, scopeIds: string[]): void {
+export function trackScopeIdFragment(
+  frag: DynamicFragment,
+  scopeIds: string[],
+): void {
   // Static scope ids applied to a dynamic fragment must follow future branches,
   // e.g. dynamic slot outlets swapping their rendered slot content.
   const key = scopeIds.join(' ')

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -57,12 +57,12 @@ import {
   type VaporComponent,
   VaporComponentInstance,
   createComponent,
-  getCurrentScopeId,
   getRootElement,
   isVaporComponent,
   mountComponent,
   unmountComponent,
 } from './component'
+import { getCurrentScopeId, setScopeId } from './scopeId'
 import type { LooseRawSlots } from './componentSlots'
 import {
   type Block,
@@ -873,8 +873,7 @@ function createVNodeFragment(vnode: VNode): {
   frag: VaporFragment<Block>
   syncNodes: () => void
 } {
-  const frag = new VaporFragment<Block>(EMPTY_BLOCK)
-  frag.vnode = vnode
+  const frag = createInteropFragment(EMPTY_BLOCK, vnode)
   frag.$key = vnode.key
   let validityPending = !isHydrating
   const syncNodes = () => {
@@ -1393,7 +1392,7 @@ function renderVDOMSlot(
   slotRoot?: boolean,
 ): VaporFragment {
   const suspense = currentParentSuspense || parentComponent.suspense
-  const frag = new VaporFragment<Block>(EMPTY_BLOCK)
+  const frag = createInteropFragment()
   let validityPending = !isHydrating
   const instance = currentInstance
 
@@ -1916,11 +1915,12 @@ function renderVaporSlot(
       return EMPTY_BLOCK
     }
     const slotState = resolveInteropVaporSlotState(vnode)
+    const scopeIds = getInteropVaporSlotScopeIds(vnode, parentComponent)
     // Most of the interop setup is shared, but slots that start with a local
     // VDOM fallback still need to let an inner SlotFragment own the active
     // fallback lifecycle. Forcing the interop wrapper to own that branch breaks
     // fallback blocks that can later resolve to an empty vnode list.
-    const frag = new VaporFragment<Block>(EMPTY_BLOCK)
+    const frag = createInteropFragment()
     let validityPending = !isHydrating
     frag.isBlockValid = () =>
       validityPending ? true : isValidBlock(frag.nodes)
@@ -2029,6 +2029,9 @@ function renderVaporSlot(
       const finalizeResolvedContent = (
         resolvedContent: Block | undefined,
       ): Block | undefined => {
+        if (resolvedContent && scopeIds) {
+          setScopeId(resolvedContent, scopeIds)
+        }
         if (hasInteropFallback && resolvedContent instanceof SlotFragment) {
           return resolvedContent
         }
@@ -2229,7 +2232,7 @@ function createVNodeChildrenFragment(
 ): VaporFragment {
   const suspense =
     currentParentSuspense || (parentComponent && parentComponent.suspense)
-  const frag = new VaporFragment<Block>(EMPTY_BLOCK)
+  const frag = createInteropFragment()
   let contentValid = false
   let validityPending = !isHydrating
   frag.isBlockValid = () => (validityPending ? true : contentValid)
@@ -2574,12 +2577,40 @@ function setInteropVnodeScopeId(
   if (interopScopeIdRootMap.get(instance) === root) return
   interopScopeIdRootMap.set(instance, root)
 
-  const scopeIds: string[] = []
-  if (vnode.scopeId) scopeIds.push(vnode.scopeId)
-  if (vnode.slotScopeIds) scopeIds.push(...vnode.slotScopeIds)
-  scopeIds.push(...getInheritedScopeIds(vnode, parentComponent))
+  const scopeIds = getInteropVnodeScopeIds(vnode, parentComponent)
+  if (!scopeIds) return
 
   for (let i = 0; i < scopeIds.length; i++) {
     root.setAttribute(scopeIds[i], '')
   }
+}
+
+function getInteropVnodeScopeIds(
+  vnode: VNode,
+  parentComponent: ComponentInternalInstance | null,
+): string[] | undefined {
+  const scopeIds: string[] = []
+  if (vnode.scopeId) scopeIds.push(vnode.scopeId)
+  if (vnode.slotScopeIds) scopeIds.push(...vnode.slotScopeIds)
+  scopeIds.push(...getInheritedScopeIds(vnode, parentComponent))
+  return scopeIds.length ? scopeIds : undefined
+}
+
+function getInteropVaporSlotScopeIds(
+  vnode: VNode,
+  parentComponent: ComponentInternalInstance | null,
+): string[] | undefined {
+  const scopeIds: string[] = []
+  if (vnode.slotScopeIds) scopeIds.push(...vnode.slotScopeIds)
+  scopeIds.push(...getInheritedScopeIds(vnode, parentComponent))
+  return scopeIds.length ? scopeIds : undefined
+}
+
+function createInteropFragment(
+  nodes: Block = EMPTY_BLOCK,
+  vnode: VNode | null = null,
+): VaporFragment<Block> {
+  const frag = new VaporFragment<Block>(nodes)
+  frag.vnode = vnode
+  return frag
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope ID preservation during component hydration and dynamic branch switching
  * Improved slot scope ID application for dynamically switched and conditionally rendered slot content
  * Enhanced scope ID tracking across interop fragments and teleported content
  * Fixed scope ID inheritance for dynamically rendered child components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->