### PR TITLE
fix(reactivity): preserve watch callback return value when wrapped for `once: true`

### DIFF
--- a/packages/reactivity/__tests__/watch.spec.ts
+++ b/packages/reactivity/__tests__/watch.spec.ts
@@ -116,6 +116,47 @@ describe('watch', () => {
     ])
   })
 
+  test('call option with async error handling', async () => {
+    const onError = vi.fn()
+    const call: WatchOptions['call'] = function call(fn, type, args) {
+      if (Array.isArray(fn)) {
+        fn.forEach(f => call(f, type, args))
+        return
+      }
+      fn.apply(null, args).catch((error: unknown) => {
+        onError(error)
+      })
+    }
+
+    const source1 = ref(0)
+    watch(
+      source1,
+      async () => {
+        throw 'oops in watch'
+      },
+      { call },
+    )
+
+    source1.value++
+    await nextTick()
+    expect(onError.mock.calls.length).toBe(1)
+    expect(onError.mock.calls[0]).toMatchObject(['oops in watch'])
+
+    const source2 = ref(0)
+    watch(
+      source2,
+      async () => {
+        throw 'oops in once watch'
+      },
+      { call, once: true },
+    )
+
+    source2.value++
+    await nextTick()
+    expect(onError.mock.calls.length).toBe(2)
+    expect(onError.mock.calls[1]).toMatchObject(['oops in once watch'])
+  })
+
   test('watch with onWatcherCleanup', async () => {
     let dummy = 0
     let source: Ref<number>

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -221,8 +221,9 @@ export function watch(
   if (once && cb) {
     const _cb = cb
     cb = (...args) => {
-      _cb(...args)
+      const res = _cb(...args)
       watchHandle()
+      return res
     }
   }
 


### PR DESCRIPTION
`watch` callbacks [are executed](https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/runtime-core/src/apiWatch.ts#L195-L196) via `callWithAsyncErrorHandling`, which [inspects the return value of the callback](https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/runtime-core/src/errorHandling.ts#L91-L95) to determine if promise rejection handling is required.

when passing `once: true` to `watch`'s options, the callback [is wrapped](https://github.com/vuejs/core/blob/main/packages/reactivity/src/watch.ts#L221-L227) to add the `watchHandle` call after the first execution - in the process, silently dropping any returned promises.

this pr is just a small tweak + test to preserve the original callback's result, returning it from the new wrapped method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `watch()` function to properly return callback values when the `once` option is used
  * Improved error handling for async callbacks in watchers to correctly surface errors through the error handler

<!-- end of auto-generated comment: release notes by coderabbit.ai -->