### PR TITLE
fix(scheduler): reset job queue length after flush

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -110,6 +110,44 @@ describe('scheduler', () => {
       await nextTick()
       expect(calls).toEqual(['job1', 'job2'])
     })
+
+    it('keeps the backing queue length bounded when splicing jobs after flush', async () => {
+      const splicedQueueLengths: number[] = []
+      const originalSplice = Array.prototype.splice
+      const spliceSpy = vi
+        .spyOn(Array.prototype, 'splice')
+        .mockImplementation(function (
+          this: unknown[],
+          ...args: [start: number, deleteCount?: number, ...items: unknown[]]
+        ) {
+          const job = args[2]
+          if (
+            args[1] === 0 &&
+            typeof job === 'function' &&
+            (job as SchedulerJob).order !== undefined
+          ) {
+            splicedQueueLengths.push(this.length)
+          }
+          return originalSplice.apply(this, args as any)
+        })
+
+      try {
+        for (let i = 0; i < 5; i++) {
+          queueJob(() => {}, i)
+        }
+        await nextTick()
+
+        for (let i = 0; i < 3; i++) {
+          queueJob(() => {}, 2)
+          queueJob(() => {}, 1)
+          await nextTick()
+        }
+      } finally {
+        spliceSpy.mockRestore()
+      }
+
+      expect(splicedQueueLengths).toEqual([1, 1, 1])
+    })
   })
 
   describe('pre flush jobs', () => {

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -294,6 +294,7 @@ function flushJobs(seen?: CountMap) {
 
     flushIndex = 0
     jobsLength = 0
+    jobs.length = 0
 
     flushPostFlushCbs(seen)
 


### PR DESCRIPTION
Closes #14903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler job queue memory management to ensure proper cleanup after flush operations.

* **Tests**
  * Added test case to verify the job queue remains bounded during splice operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->