### PR TITLE
fix(runtime-vapor): avoid fallthrough attrs in multi-root dynamic branches

### DIFF
--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1081,6 +1081,67 @@ describe('attribute fallthrough', () => {
     expect(`Extraneous non-props attributes (id)`).toHaveBeenWarned()
   })
 
+  it('should not apply attrs to dynamic branch inside multi-root component', async () => {
+    const ok = ref(false)
+
+    const t0 = template('<div>one</div>', 1)
+    const t1 = template('<span>two</span>')
+
+    const { component: Child } = define({
+      setup() {
+        return [
+          createIf(
+            () => ok.value,
+            () => t0(),
+          ),
+          t1(),
+        ]
+      },
+    })
+
+    const { host } = define(() =>
+      createComponent(Child, { class: () => 'x' }),
+    ).render()
+
+    expect(`Extraneous non-props attributes (class)`).toHaveBeenWarned()
+
+    ok.value = true
+    await nextTick()
+
+    expect((host.querySelector('div') as HTMLElement).className).toBe('')
+  })
+
+  it('should warn for initially active multi-root dynamic root branch', async () => {
+    const ok = ref(true)
+
+    const t0 = template('<div>one</div>')
+    const t1 = template('<span>two</span>')
+    const t2 = template('<p>three</p>', 1)
+
+    const { component: Child } = define({
+      setup() {
+        return createIf(
+          () => ok.value,
+          () => [t0(), t1()],
+          () => t2(),
+        )
+      },
+    })
+
+    const { host } = define(() =>
+      createComponent(Child, { class: () => 'x' }),
+    ).render()
+
+    expect((host.querySelector('div') as HTMLElement).className).toBe('')
+    expect((host.querySelector('span') as HTMLElement).className).toBe('')
+    expect(`Extraneous non-props attributes (class)`).toHaveBeenWarned()
+
+    ok.value = false
+    await nextTick()
+
+    expect((host.querySelector('p') as HTMLElement).className).toBe('x')
+  })
+
   it('should not allow attrs to fallthrough on component with single comment root', async () => {
     const t0 = template('<!--comment-->')
     const { component: Child } = define({

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1310,12 +1310,27 @@ function applyFallthroughAttrs(
   scope?: EffectScope,
 ): void {
   let hasSlotFragment = false
+  let dynamicFragments: DynamicFragment[] | undefined
   const root = getRootElement(
     block,
     frag => {
       if (frag.isSlot) {
         hasSlotFragment = true
       } else {
+        ;(dynamicFragments ||= []).push(frag)
+      }
+    },
+    false,
+  )
+
+  const dynamicRoot = root ? undefined : getSingleDynamicRootChain(block)
+  const fragmentsToRegister = root
+    ? dynamicFragments
+    : dynamicRoot && dynamicRoot.fragments
+  if (fragmentsToRegister) {
+    for (const frag of fragmentsToRegister) {
+      // slot fragments warn instead of inheriting attrs, skip them
+      if (!frag.isSlot) {
         // Nested dynamic fragments need their own fallthrough hook.
         registerDynamicFragmentFallthroughAttrs(
           frag,
@@ -1323,9 +1338,8 @@ function applyFallthroughAttrs(
           getFallthroughAttrs,
         )
       }
-    },
-    false,
-  )
+    }
+  }
 
   if (root && !hasSlotFragment) {
     const applyEffect = () =>
@@ -1338,10 +1352,56 @@ function applyFallthroughAttrs(
   } else if (
     __DEV__ &&
     (hasSlotFragment ||
+      (dynamicRoot && dynamicRoot.hasNonSingleRoot) ||
       (isTeleportEnabled && containsTeleportFragment(block)) ||
       (!instance.accessedAttrs && isArray(block) && block.length))
   ) {
     warnExtraneousAttributes(instance.attrs)
+  }
+}
+
+interface DynamicRootChain {
+  fragments: DynamicFragment[]
+  hasNonSingleRoot: boolean
+}
+
+// Resolve the chain of dynamic fragments leading to a single root candidate.
+// Used when getRootElement finds no element root, so fallthrough attrs are
+// registered only for true single-root components rather than for any dynamic
+// fragment seen during traversal. Dynamic root branches that are currently
+// non-single-root still keep the outer fragment hook for future branch updates,
+// but report hasNonSingleRoot so the current render can warn.
+function getSingleDynamicRootChain(block: Block): DynamicRootChain | undefined {
+  if (block instanceof DynamicFragment) {
+    const { nodes } = block
+    const nested = getSingleDynamicRootChain(nodes)
+    return {
+      fragments: nested ? [block, ...nested.fragments] : [block],
+      hasNonSingleRoot: nested
+        ? nested.hasNonSingleRoot
+        : isArray(nodes) && nodes.some(child => !(child instanceof Comment)),
+    }
+  }
+
+  if (isFragment(block) && !(isTeleportEnabled && isTeleportFragment(block))) {
+    return getSingleDynamicRootChain(block.nodes)
+  }
+
+  if (isArray(block)) {
+    let singleRoot: DynamicRootChain | undefined
+    let hasComment = false
+    for (const child of block) {
+      if (child instanceof Comment) {
+        hasComment = true
+        continue
+      }
+      const childRoot = getSingleDynamicRootChain(child)
+      if (!childRoot || singleRoot) {
+        return
+      }
+      singleRoot = childRoot
+    }
+    return hasComment ? singleRoot : undefined
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined attribute fallthrough behavior for components with dynamic branches and multiple roots, ensuring proper attribute application and warning generation.
  * Enhanced developer warnings to better flag extraneous attributes in complex dynamic component scenarios.

* **Tests**
  * Added tests for attribute fallthrough in components with dynamic conditional branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->