### PR TITLE
fix(runtime-vapor): preserve v-once raw prop getter shape

### DIFF
--- a/packages/runtime-vapor/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentEmits.spec.ts
@@ -441,6 +441,41 @@ describe('component: emit', () => {
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
+  test('v-once should not execute handlers during lookup', () => {
+    const Child = defineVaporComponent({
+      setup(_, { emit }) {
+        emit('click', 1)
+        return []
+      },
+    })
+    const staticHandler = vi.fn()
+    const objectSourceHandler = vi.fn()
+
+    define({
+      setup() {
+        return [
+          createComponent(
+            Child,
+            { onClick: () => staticHandler },
+            null,
+            true,
+            true,
+          ),
+          createComponent(
+            Child,
+            { $: [{ onClick: () => objectSourceHandler }] },
+            null,
+            true,
+            true,
+          ),
+        ]
+      },
+    }).render()
+
+    expect(staticHandler.mock.calls).toEqual([[1]])
+    expect(objectSourceHandler.mock.calls).toEqual([[1]])
+  })
+
   test('should trigger once handler from dynamic source', () => {
     const { render } = define({
       setup(_, { emit }) {

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -593,6 +593,31 @@ describe('component: props', () => {
     expect(`Invalid prop name: "$foo"`).toHaveBeenWarned()
   })
 
+  test('v-once preserves function-valued props', () => {
+    const cb = vi.fn(() => 'called')
+    const resolved: unknown[] = []
+    const Child = defineVaporComponent({
+      props: ['cb'],
+      setup(props: any) {
+        resolved.push(props.cb)
+        return []
+      },
+    })
+
+    define({
+      setup() {
+        return [
+          createComponent(Child, { cb: () => cb }, null, true, true),
+          createComponent(Child, { $: [{ cb: () => cb }] }, null, true, true),
+        ]
+      },
+    }).render()
+
+    expect(resolved[0]).toBe(cb)
+    expect(resolved[1]).toBe(cb)
+    expect(cb).not.toHaveBeenCalled()
+  })
+
   describe('dynamic props source caching', () => {
     test('v-bind object should be cached when child accesses multiple props', () => {
       let sourceCallCount = 0

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -81,7 +81,8 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
   const snapshot: RawProps = Object.create(null)
   for (const key in rawProps) {
     if (key !== '$') {
-      snapshot[key] = resolveSource(rawProps[key])
+      const value = resolveSource(rawProps[key])
+      snapshot[key] = () => value
     }
   }
 
@@ -103,7 +104,8 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
         snapshotSources[i] = () => value
       } else {
         for (const key in source) {
-          value[key] = resolveSource(source[key])
+          const resolved = resolveSource(source[key])
+          value[key] = () => resolved
         }
         snapshotSources[i] = value
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `v-once` directive with component emits to ensure handlers execute correctly.
  * Added test coverage for `v-once` directive with function-valued props to verify proper callback handling.

* **Improvements**
  * Enhanced how property values are resolved and stored during component rendering, optimizing snapshot handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->