### PR TITLE
fix(watch): trigger immediate callback for empty sources (fix #14898)

### DIFF
--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -241,6 +241,7 @@ export function watch(
       // watch(source, cb)
       const newValue = effect.run()
       if (
+        immediateFirstRun ||
         deep ||
         forceTrigger ||
         (isMultiSource

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -312,6 +312,13 @@ describe('api: watch', () => {
     expect(called).toBe(true)
   })
 
+  it('watching empty multiple sources with immediate: true', () => {
+    const spy = vi.fn()
+    watch([], spy, { immediate: true })
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith([], [], expect.anything())
+  })
+
   it('watching multiple sources: readonly array', async () => {
     const state = reactive({ count: 1 })
     const status = ref(false)

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -316,7 +316,7 @@ describe('api: watch', () => {
     const spy = vi.fn()
     watch([], spy, { immediate: true })
     expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith([], [], expect.anything())
+    expect(spy).toHaveBeenCalledWith([], [], expect.any(Function))
   })
 
   it('watching multiple sources: readonly array', async () => {


### PR DESCRIPTION
## Summary

Fixes #14898.

- trigger the watcher callback on the explicit immediate first run before change detection can skip an empty multi-source array
- add regression coverage for `watch([], cb, { immediate: true })`

## Testing

- Red before fix: `pnpm test --run packages/runtime-core/__tests__/apiWatch.spec.ts -t "watching empty multiple sources with immediate: true"` failed with `expected "vi.fn()" to be called 1 times, but got 0 times`
- `pnpm test --run packages/runtime-core/__tests__/apiWatch.spec.ts -t "watching empty multiple sources with immediate: true"`
- `pnpm test --run packages/runtime-core/__tests__/apiWatch.spec.ts`
- `pnpm test --run packages/runtime-core/__tests__/apiWatch.spec.ts packages/reactivity/__tests__/watch.spec.ts`
- `pnpm exec prettier --check packages/reactivity/src/watch.ts packages/runtime-core/__tests__/apiWatch.spec.ts`
- `pnpm exec eslint packages/reactivity/src/watch.ts packages/runtime-core/__tests__/apiWatch.spec.ts --max-warnings=0`
- `git diff --check`
- `pnpm check`

AI-assisted, reviewed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed watcher initialization with the `immediate` option so callbacks run exactly once on setup (including when watching arrays), ensuring consistent and reliable initial callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->