### PR TITLE
fix(runtime-dom): insert children of a literal <template> into its content

### DIFF
--- a/packages/runtime-dom/__tests__/nodeOps.spec.ts
+++ b/packages/runtime-dom/__tests__/nodeOps.spec.ts
@@ -149,6 +149,46 @@ describe('runtime-dom: node-ops', () => {
       expect(nodes[1]).toBe(parent.childNodes[parent.childNodes.length - 2])
     })
 
+    // #6272 static content under a <template> must land in its content fragment
+    test('fresh insertion into a <template> parent uses its content', () => {
+      const content = `<div>one</div><div>two</div>three`
+      const parent = document.createElement('template') as HTMLTemplateElement
+      const [first, last] = nodeOps.insertStaticContent!(
+        content,
+        parent,
+        null,
+        undefined,
+      )
+      // nothing should be appended to the template element itself
+      expect(parent.childNodes.length).toBe(0)
+      expect(parent.content.childNodes.length).toBe(3)
+      expect(parent.innerHTML).toBe(content)
+      expect(first).toBe(parent.content.firstChild)
+      expect(last).toBe(parent.content.lastChild)
+    })
+
+    test('cached insertion into a <template> parent uses its content', () => {
+      const content = `<div>one</div><div>two</div>three`
+      const parent = document.createElement('template') as HTMLTemplateElement
+
+      const cached = document.createElement('div')
+      cached.innerHTML = content
+
+      const [first, last] = nodeOps.insertStaticContent!(
+        content,
+        parent,
+        null,
+        undefined,
+        cached.firstChild,
+        cached.lastChild,
+      )
+      expect(parent.childNodes.length).toBe(0)
+      expect(parent.content.childNodes.length).toBe(3)
+      expect(parent.innerHTML).toBe(content)
+      expect(first).toBe(parent.content.firstChild)
+      expect(last).toBe(parent.content.lastChild)
+    })
+
     test('The math elements should keep their MathML namespace', async () => {
       let root = document.createElement('div') as any
 

--- a/packages/runtime-dom/__tests__/nodeOps.spec.ts
+++ b/packages/runtime-dom/__tests__/nodeOps.spec.ts
@@ -18,6 +18,33 @@ describe('runtime-dom: node-ops', () => {
     expect(option2.selected).toBe(true)
   })
 
+  // #6272
+  test('children of a <template> element are inserted into its content', () => {
+    const el = nodeOps.createElement('template') as HTMLTemplateElement
+    const child = nodeOps.createElement('span')
+    nodeOps.insert(child, el)
+
+    expect(el.childNodes.length).toBe(0)
+    expect(el.content.childNodes.length).toBe(1)
+    expect(el.content.firstChild).toBe(child)
+
+    const anchor = child
+    const before = nodeOps.createElement('div')
+    nodeOps.insert(before, el, anchor)
+    expect(el.content.firstChild).toBe(before)
+    expect(el.content.childNodes.length).toBe(2)
+  })
+
+  // #6272
+  test('rendered <template> element retains its content', () => {
+    const root = document.createElement('div')
+    render(h('template', null, [h('span', 'hi')]), root)
+    const template = root.firstChild as HTMLTemplateElement
+    expect(template.tagName).toBe('TEMPLATE')
+    expect(template.content.childNodes.length).toBe(1)
+    expect(template.innerHTML).toBe('<span>hi</span>')
+  })
+
   test('create custom elements', () => {
     const spyCreateElement = vi.spyOn(document, 'createElement')
 

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -43,7 +43,16 @@ const templateContainer = doc && /*@__PURE__*/ doc.createElement('template')
 
 export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   insert: (child, parent, anchor) => {
-    parent.insertBefore(child, anchor || null)
+    // #6272 children of a literal <template> element must be inserted into its
+    // content document fragment, otherwise they are not rendered by the browser
+    if ((parent as Element).tagName === 'TEMPLATE') {
+      ;(parent as HTMLTemplateElement).content.insertBefore(
+        child,
+        anchor || null,
+      )
+    } else {
+      parent.insertBefore(child, anchor || null)
+    }
   },
 
   remove: child => {

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -106,15 +106,23 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   // Static content here can only come from compiled templates.
   // As long as the user only uses trusted templates, this is safe.
   insertStaticContent(content, parent, anchor, namespace, start, end) {
-    // <parent> before | first ... last | anchor </parent>
-    const before = anchor ? anchor.previousSibling : parent.lastChild
+    // #6272 when the parent is a literal <template> element, static content
+    // must be inserted into its content document fragment, mirroring `insert`.
+    // Otherwise the nodes land outside the template's content and the browser
+    // never renders them.
+    const target: Node =
+      (parent as Element).tagName === 'TEMPLATE'
+        ? (parent as HTMLTemplateElement).content
+        : parent
+    // <target> before | first ... last | anchor </target>
+    const before = anchor ? anchor.previousSibling : target.lastChild
     // #5308 can only take cached path if:
     // - has a single root node
     // - nextSibling info is still available
     if (start && (start === end || start.nextSibling)) {
       // cached
       while (true) {
-        parent.insertBefore(start!.cloneNode(true), anchor)
+        target.insertBefore(start!.cloneNode(true), anchor)
         if (start === end || !(start = start!.nextSibling)) break
       }
     } else {
@@ -136,13 +144,13 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
         }
         template.removeChild(wrapper)
       }
-      parent.insertBefore(template, anchor)
+      target.insertBefore(template, anchor)
     }
     return [
       // first
-      before ? before.nextSibling! : parent.firstChild!,
+      before ? before.nextSibling! : target.firstChild!,
       // last
-      anchor ? anchor.previousSibling! : parent.lastChild!,
+      anchor ? anchor.previousSibling! : target.lastChild!,
     ]
   },
 }


### PR DESCRIPTION
fix #6272

A plain `<template>` element used in a template, without a structural directive such as `v-if`/`v-for`/`v-slot`, compiles to a real `createElementVNode('template', ...)` and its children are mounted through `nodeOps.insert`. That op inserts the children directly onto the `<template>` element, so they end up outside `template.content`. The browser only renders nodes that live in a template's content fragment, so the element shows up empty.

This is most visible when a literal `<template>` is part of the output, for example a `<template>` used as the shadow content of a native custom element, as in the original report. The same template authored as plain HTML renders its children, but once it is re-created by Vue at runtime the content is dropped.

The fix detects when the insertion parent is a `<template>` element and inserts into its `content` document fragment instead, which is where the DOM stores `<template>` children. Children inserted this way have the content fragment as their parent node, so the existing `remove` / `nextSibling` / `parentNode` ops keep working for later patches.

Verification: `<template>` is only kept as a real element when it has no structural directive; with one it is compiled to a fragment and never reaches this path, so the change is scoped to genuine `HTMLTemplateElement` parents.

Tests: added a low-level `nodeOps.insert` test and an end-to-end render test in `packages/runtime-dom/__tests__/nodeOps.spec.ts`. Both fail before the change and pass after. The full `runtime-dom`, `runtime-core` and `server-renderer` suites pass with no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed insertion behavior so nodes and static HTML placed into `<template>` elements are inserted into the template’s `content` fragment, leaving the `<template>` element’s own children unchanged.

* **Tests**
  * Added regression coverage for `<template>` insertion and rendering, including assertions for correct placement in `content`, correct insertion with anchors, and behavior for both cached and fresh static content paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->