### PR TITLE
fix(compiler-core): avoid crash on CDATA at the document root

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
@@ -496,6 +496,35 @@ exports[`compiler: parse > Edge Cases > valid html 1`] = `
 }
 `;
 
+exports[`compiler: parse > Errors > CDATA_IN_HTML_CONTENT > <![CDATA[cdata]]> 1`] = `
+{
+  "cached": [],
+  "children": [],
+  "codegenNode": undefined,
+  "components": [],
+  "directives": [],
+  "helpers": Set {},
+  "hoists": [],
+  "imports": [],
+  "loc": {
+    "end": {
+      "column": 18,
+      "line": 1,
+      "offset": 17,
+    },
+    "source": "<![CDATA[cdata]]>",
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "source": "<![CDATA[cdata]]>",
+  "temps": 0,
+  "type": 0,
+}
+`;
+
 exports[`compiler: parse > Errors > CDATA_IN_HTML_CONTENT > <template><![CDATA[cdata]]></template> 1`] = `
 {
   "cached": [],

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2598,7 +2598,7 @@ describe('compiler: parse', () => {
           errors: [],
         },
         {
-          // CDATA at the root, with no enclosing element on the stack
+          // invalid root-level CDATA should report a parser error
           code: '<![CDATA[cdata]]>',
           errors: [
             {

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2597,6 +2597,16 @@ describe('compiler: parse', () => {
           code: '<template><svg><![CDATA[cdata]]></svg></template>',
           errors: [],
         },
+        {
+          // CDATA at the root, with no enclosing element on the stack
+          code: '<![CDATA[cdata]]>',
+          errors: [
+            {
+              type: ErrorCodes.CDATA_IN_HTML_CONTENT,
+              loc: { offset: 0, line: 1, column: 1 },
+            },
+          ],
+        },
       ],
       DUPLICATE_ATTRIBUTE: [
         {

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -470,7 +470,7 @@ const tokenizer = new Tokenizer(stack, {
   },
 
   oncdata(start, end) {
-    if (stack[0].ns !== Namespaces.HTML) {
+    if ((stack[0] ? stack[0].ns : currentOptions.ns) !== Namespaces.HTML) {
       onText(getSlice(start, end), start, end)
     } else {
       emitError(ErrorCodes.CDATA_IN_HTML_CONTENT, start - 9)


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bug fix.

### Description

A CDATA section with no open element on the stack — e.g. at the document root — crashes the parser:

```js
import { compile } from '@vue/compiler-dom'
compile('<![CDATA[x]]>')
// TypeError: Cannot read properties of undefined (reading 'ns')
```

`oncdata` reads `stack[0].ns` unconditionally, but `stack[0]` is `undefined` when there's no enclosing element. The same handler works inside an element (`<div><![CDATA[x]]></div>`), so this only affects top-level CDATA.

This falls back to the root namespace (`currentOptions.ns`) when the stack is empty — mirroring the existing `onprocessinginstruction` handler right below it — so top-level CDATA now reports `CDATA_IN_HTML_CONTENT` instead of throwing. Behavior inside elements and in SVG/foreign content is unchanged. Added a parser error-test case for the root position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash when encountering CDATA in certain parsing scenarios while preserving correct CDATA-in-HTML error reporting.

* **Tests**
  * Added coverage for root-level CDATA parsing to ensure the parser reports the expected error and remains stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->