### PR TITLE
fix(runtime-core): skip normalizeStyle for component VNodes

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -589,24 +589,6 @@ function _createVNode(
     type = convertLegacyComponent(type, currentRenderingInstance)
   }
 
-  // class & style normalization.
-  if (props) {
-    // for reactive or proxy objects, we need to clone it to enable mutation.
-    props = guardReactiveProps(props)!
-    let { class: klass, style } = props
-    if (klass && !isString(klass)) {
-      props.class = normalizeClass(klass)
-    }
-    if (isObject(style)) {
-      // reactive state objects need to be cloned since they are likely to be
-      // mutated
-      if (isProxy(style) && !isArray(style)) {
-        style = extend({}, style)
-      }
-      props.style = normalizeStyle(style)
-    }
-  }
-
   // encode the vnode type information into a bitmap
   const shapeFlag = isString(type)
     ? ShapeFlags.ELEMENT
@@ -619,6 +601,26 @@ function _createVNode(
           : isFunction(type)
             ? ShapeFlags.FUNCTIONAL_COMPONENT
             : 0
+
+  // class & style normalization.
+  if (props) {
+    // for reactive or proxy objects, we need to clone it to enable mutation.
+    props = guardReactiveProps(props)!
+    let { class: klass, style } = props
+    if (klass && !isString(klass)) {
+      props.class = normalizeClass(klass)
+    }
+    // Only normalize style for non-component VNodes.
+    // For components, style might be a declared prop (not a CSS style attribute).
+    if (isObject(style) && !(shapeFlag & ShapeFlags.COMPONENT)) {
+      // reactive state objects need to be cloned since they are likely to be
+      // mutated
+      if (isProxy(style) && !isArray(style)) {
+        style = extend({}, style)
+      }
+      props.style = normalizeStyle(style)
+    }
+  }
 
   if (__DEV__ && shapeFlag & ShapeFlags.STATEFUL_COMPONENT && isProxy(type)) {
     type = toRaw(type)


### PR DESCRIPTION
fixes #14923

  I traced the issue to packages/runtime-core/src/vnode.ts, specifically the _createVNode function. The problem is at
  line 592-607 where normalizeStyle() is applied to the style prop before the shapeFlag is even calculated (line
  610-621). So Vue has no way to know if this VNode is a component or a plain element.

  What happens is: when you pass an array like [{ level: 'A' }] to a component's style prop, normalizeStyle() converts
  it to a CSS string like "0:[object Object]". The component never gets the original array.

  I moved the normalization block after the shapeFlag calculation and added a condition to skip it for component VNodes.
  This way elements still get their styles normalized, but components can receive any type of value in their style
  prop.

  Also checked normalizeClass - it works fine for both cases so no change needed there.