### PR TITLE
fix(compiler-core): prefix key with v-memo outside v-for

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vMemo.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vMemo.spec.ts
@@ -21,6 +21,12 @@ describe('compiler: v-memo transform', () => {
     expect(compile(`<div v-memo="[x]"></div>`)).toMatchSnapshot()
   })
 
+  test('on normal element with key', () => {
+    expect(
+      compile(`<div :key="updateKey" v-memo="[updateKey]"></div>`),
+    ).toContain(`key: _ctx.updateKey`)
+  })
+
   test('on component', () => {
     expect(compile(`<Comp v-memo="[x]"></Comp>`)).toMatchSnapshot()
   })

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -55,6 +55,7 @@ export const transformExpression: NodeTransform = (node, context) => {
   } else if (node.type === NodeTypes.ELEMENT) {
     // handle directives on element
     const memo = findDir(node, 'memo')
+    const vFor = findDir(node, 'for')
     for (let i = 0; i < node.props.length; i++) {
       const dir = node.props[i]
       // do not process for v-on & v-for since they are special handled
@@ -70,6 +71,7 @@ export const transformExpression: NodeTransform = (node, context) => {
           // key has been processed in transformFor(vMemo + vFor)
           !(
             memo &&
+            vFor &&
             arg &&
             arg.type === NodeTypes.SIMPLE_EXPRESSION &&
             arg.content === 'key'


### PR DESCRIPTION
Fixes #14920.\n\nThis narrows the special-case skip for v-memo + :key expression processing to the scenario where v-for is also present. transformFor already processes that key expression eagerly, but plain elements with v-memo still need the normal transformExpression pass so identifiers are prefixed correctly.\n\nTest: pnpm vitest packages/compiler-core/__tests__/transforms/vMemo.spec.ts --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue compiler's treatment of `v-memo` directive when combined with `v-for` to correctly handle key binding processing, preventing unintended optimizations in these scenarios.

* **Tests**
  * Added test coverage for `v-memo` directive with `:key` binding to ensure templates with this combination compile with the expected output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->