### PR TITLE
fix(reactivity): trigger immediate watch for empty sources

### DIFF
--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -243,6 +243,7 @@ export function watch(
       if (
         deep ||
         forceTrigger ||
+        immediateFirstRun ||
         (isMultiSource
           ? (newValue as any[]).some((v, i) => hasChanged(v, oldValue[i]))
           : hasChanged(newValue, oldValue))

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -312,6 +312,13 @@ describe('api: watch', () => {
     expect(called).toBe(true)
   })
 
+  it('watching multiple sources: empty array and immediate: true', () => {
+    const cb = vi.fn()
+    watch([], cb, { immediate: true })
+
+    expect(cb).toHaveBeenCalledWith([], [], expect.any(Function))
+  })
+
   it('watching multiple sources: readonly array', async () => {
     const state = reactive({ count: 1 })
     const status = ref(false)


### PR DESCRIPTION
Fixes #14898.\n\nWhen watching an empty array of sources with immediate: true, the multi-source change check used Array#some(), which never passes for an empty array. Treat the first immediate job as a callback trigger so empty multi-source watchers follow the same immediate semantics as other sources.\n\nTest: pnpm vitest packages/runtime-core/__tests__/apiWatch.spec.ts --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the watch API to properly invoke callbacks when the immediate option is enabled, ensuring callbacks execute as expected during initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->