### PR TITLE
fix(compiler-dom): preserve empty dynamic event names

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
@@ -93,6 +93,40 @@ describe('compiler-dom: transform v-on', () => {
     })
   })
 
+  it('should preserve nullish dynamic event names with event options', () => {
+    const {
+      props: [prop],
+    } = parseWithVOn(`<div @[event].once="test"/>`, {
+      prefixIdentifiers: true,
+    })
+    expect(prop).toMatchObject({
+      key: {
+        type: NodeTypes.COMPOUND_EXPRESSION,
+        children: [
+          `(`,
+          {
+            type: NodeTypes.COMPOUND_EXPRESSION,
+            children: [
+              `_${helperNameMap[TO_HANDLER_KEY]}(`,
+              { content: `_ctx.event` },
+              `)`,
+            ],
+          },
+          `) && (`,
+          {
+            type: NodeTypes.COMPOUND_EXPRESSION,
+            children: [
+              `_${helperNameMap[TO_HANDLER_KEY]}(`,
+              { content: `_ctx.event` },
+              `)`,
+            ],
+          },
+          `) + "Once"`,
+        ],
+      },
+    })
+  })
+
   it('should wrap keys guard for keyboard events or dynamic events', () => {
     const {
       props: [prop],

--- a/packages/compiler-dom/src/transforms/vOn.ts
+++ b/packages/compiler-dom/src/transforms/vOn.ts
@@ -144,7 +144,13 @@ export const transformOn: DirectiveTransform = (dir, node, context) => {
       const modifierPostfix = eventOptionModifiers.map(capitalize).join('')
       key = isStaticExp(key)
         ? createSimpleExpression(`${key.content}${modifierPostfix}`, true)
-        : createCompoundExpression([`(`, key, `) + "${modifierPostfix}"`])
+        : createCompoundExpression([
+            `(`,
+            key,
+            `) && (`,
+            key,
+            `) + "${modifierPostfix}"`,
+          ])
     }
 
     return {


### PR DESCRIPTION
Fixes #13056.\n\nDynamic event names with option modifiers currently append the modifier suffix even when the normalized handler key is empty, so @[event].once can become an "Once" attribute when event is nullish or empty. This keeps the generated key empty unless the dynamic handler key exists.\n\nTest: pnpm vitest packages/compiler-dom/__tests__/transforms/vOn.spec.ts --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of dynamic event names with event option modifiers (e.g., `@[event].once`) in Vue template compilation.

* **Tests**
  * Added test coverage for dynamic event names with event option modifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->