### PR TITLE
fix(server-renderer): omit nullish class and style attrs

### DIFF
--- a/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
@@ -133,6 +133,19 @@ describe('ssr: renderClass', () => {
     ).toBe(` class="foo bar"`)
   })
 
+  test('ignore nullish class values via renderProps', () => {
+    expect(
+      ssrRenderAttrs({
+        class: undefined,
+      }),
+    ).toBe(``)
+    expect(
+      ssrRenderAttrs({
+        class: null,
+      }),
+    ).toBe(``)
+  })
+
   test('standalone', () => {
     expect(ssrRenderClass(`foo`)).toBe(`foo`)
     expect(ssrRenderClass([`foo`, `bar`])).toBe(`foo bar`)
@@ -169,6 +182,19 @@ describe('ssr: renderStyle', () => {
         },
       }),
     ).toBe(` style="color:red;--a:2;-webkit-line-clamp:1;"`)
+  })
+
+  test('ignore nullish style values via renderProps', () => {
+    expect(
+      ssrRenderAttrs({
+        style: undefined,
+      }),
+    ).toBe(``)
+    expect(
+      ssrRenderAttrs({
+        style: null,
+      }),
+    ).toBe(``)
   })
 
   test('standalone', () => {

--- a/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
@@ -43,9 +43,13 @@ export function ssrRenderAttrs(
     // force as attribute
     if (key.startsWith('^')) key = key.slice(1)
     if (key === 'class') {
-      ret += ` class="${ssrRenderClass(value)}"`
+      if (value != null) {
+        ret += ` class="${ssrRenderClass(value)}"`
+      }
     } else if (key === 'style') {
-      ret += ` style="${ssrRenderStyle(value)}"`
+      if (value != null) {
+        ret += ` style="${ssrRenderStyle(value)}"`
+      }
     } else if (key === 'className') {
       // className should not go through ssrRenderClass which normalizes non-string
       // values into strings. it should coerce directly into strings


### PR DESCRIPTION
Fixes #13228.\n\nssrRenderAttrs already skips nullish values for regular attrs, but class and style are special-cased and were rendered as empty attributes. This skips class/style when their raw value is null or undefined while preserving existing array/object normalization for non-nullish values.\n\nTest: pnpm vitest packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side rendering to properly handle `null` and `undefined` values for `class` and `style` attributes, preventing empty attribute emissions in the rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->