### PR TITLE
fix(compat): suppress disabled enumerated attr warning

### DIFF
--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -66,7 +66,7 @@ export function compatCoerceAttr(
           : 'true'
     if (
       v2CoercedValue &&
-      compatUtils.softAssertCompatEnabled(
+      compatUtils.checkCompatEnabled(
         DeprecationTypes.ATTR_ENUMERATED_COERCION,
         instance,
         key,

--- a/packages/vue-compat/__tests__/misc.spec.ts
+++ b/packages/vue-compat/__tests__/misc.spec.ts
@@ -296,3 +296,35 @@ test('ATTR_ENUMERATED_COERCION, coercing "false"', () => {
     )('spellcheck', 'false', 'false'),
   ).toHaveBeenWarned()
 })
+
+test('ATTR_ENUMERATED_COERCION disabled', () => {
+  Vue.configureCompat({
+    ATTR_ENUMERATED_COERCION: false,
+  })
+
+  const vm = new Vue({
+    template: `<div :draggable="null" :spellcheck="false" contenteditable="foo" />`,
+  }).$mount()
+
+  expect(vm.$el.hasAttribute('draggable')).toBe(false)
+  expect(vm.$el.getAttribute('spellcheck')).toBe('false')
+  expect(vm.$el.getAttribute('contenteditable')).toBe('foo')
+  expect(
+    (
+      deprecationData[DeprecationTypes.ATTR_ENUMERATED_COERCION]
+        .message as Function
+    )('draggable', null, 'false'),
+  ).not.toHaveBeenWarned()
+  expect(
+    (
+      deprecationData[DeprecationTypes.ATTR_ENUMERATED_COERCION]
+        .message as Function
+    )('spellcheck', false, 'false'),
+  ).not.toHaveBeenWarned()
+  expect(
+    (
+      deprecationData[DeprecationTypes.ATTR_ENUMERATED_COERCION]
+        .message as Function
+    )('contenteditable', 'foo', 'true'),
+  ).not.toHaveBeenWarned()
+})


### PR DESCRIPTION
Fixes #12443.\n\nATTR_ENUMERATED_COERCION used softAssertCompatEnabled, which warns even when the compat behavior is disabled. Use checkCompatEnabled so the warning is emitted only when the compat coercion is active, matching the deprecation message that configureCompat({ ATTR_ENUMERATED_COERCION: false }) suppresses the warning.\n\nTest: pnpm vitest packages/vue-compat/__tests__/misc.spec.ts --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility mode handling for enumerated attribute coercion

* **Tests**
  * Added test coverage for disabled enumerated attribute coercion behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->