### PR TITLE
refactor(runtime-vapor): stabilize template ref update hooks

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -134,6 +134,45 @@ describe('api: template ref', () => {
     expect(fooEl.value).toBe(null)
   })
 
+  it('dynamic component ref binding keeps a stable update hook', async () => {
+    const Child = defineVaporComponent({
+      setup() {
+        return template('<div>child</div>')()
+      },
+    })
+    const fooEl = ref(null)
+    const barEl = ref(null)
+    const refKey = ref('foo')
+    let frag: any
+
+    const { render } = define({
+      setup() {
+        return {
+          foo: fooEl,
+          bar: barEl,
+        }
+      },
+      render() {
+        const n0 = createDynamicComponent(() => Child)
+        frag = n0
+        setTemplateRefBinding(n0, () => refKey.value)
+        return n0
+      },
+    })
+    render()
+    const updateHook = frag.onUpdated![0]
+
+    expect(frag.onUpdated).toHaveLength(1)
+
+    refKey.value = 'bar'
+    await nextTick()
+
+    expect(frag.onUpdated).toHaveLength(1)
+    expect(frag.onUpdated![0]).toBe(updateHook)
+    expect(fooEl.value).toBe(null)
+    expect(barEl.value).not.toBe(null)
+  })
+
   it('dynamic ref can be null or undefined without warning', async () => {
     const t0 = template('<div></div>')
     const el = ref(null)

--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -212,6 +212,39 @@ describe('api: template ref', () => {
     expect('Invalid template ref type:').not.toHaveBeenWarned()
   })
 
+  it('dynamic direct refs with ref_keys clear the old ref', async () => {
+    const t0 = template('<div></div>')
+    const refKey = ref<'foo' | 'bar'>('foo')
+    let tRefs!: Record<'foo' | 'bar', ShallowRef>
+
+    const { render } = define({
+      setup() {
+        tRefs = {
+          foo: useTemplateRef('foo'),
+          bar: useTemplateRef('bar'),
+        }
+      },
+      render() {
+        const n0 = t0()
+        const setRef = createTemplateRefSetter()
+        renderEffect(() => {
+          const key = refKey.value
+          setRef(n0 as Element, tRefs[key], false, key)
+        })
+        return n0
+      },
+    })
+    const { host } = render()
+    expect(tRefs.foo.value).toBe(host.children[0])
+    expect(tRefs.bar.value).toBe(null)
+
+    refKey.value = 'bar'
+    await nextTick()
+
+    expect(tRefs.foo.value).toBe(null)
+    expect(tRefs.bar.value).toBe(host.children[0])
+  })
+
   it('string ref unmount', async () => {
     const t0 = template('<div></div>')
     const el = ref(null)

--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -173,6 +173,49 @@ describe('api: template ref', () => {
     expect(barEl.value).not.toBe(null)
   })
 
+  it('dynamic component ref binding handles component and ref key switching together', async () => {
+    const One = defineVaporComponent({
+      setup(_, { expose }) {
+        expose({ name: 'one' })
+        return template('<div>one</div>')()
+      },
+    })
+    const Two = defineVaporComponent({
+      setup(_, { expose }) {
+        expose({ name: 'two' })
+        return template('<div>two</div>')()
+      },
+    })
+
+    const views = [One, Two]
+    const view = ref(0)
+    const refKey = ref<'foo' | 'bar'>('foo')
+    const foo = ref<any>(null)
+    const bar = ref<any>(null)
+
+    const { render } = define({
+      setup() {
+        return { foo, bar }
+      },
+      render() {
+        const n0 = createDynamicComponent(() => views[view.value])
+        setTemplateRefBinding(n0, () => refKey.value)
+        return n0
+      },
+    })
+
+    render()
+    expect(foo.value).toMatchObject({ name: 'one' })
+    expect(bar.value).toBe(null)
+
+    view.value = 1
+    refKey.value = 'bar'
+    await nextTick()
+
+    expect(foo.value).toBe(null)
+    expect(bar.value).toMatchObject({ name: 'two' })
+  })
+
   it('dynamic ref can be null or undefined without warning', async () => {
     const t0 = template('<div></div>')
     const el = ref(null)

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -60,10 +60,11 @@ export type setRefFn = (
 
 interface TemplateRefState {
   oldRef?: NodeRef
+  oldRefKey?: string
   ref: NodeRef
   refFor?: boolean
   refKey?: string
-  registered?: boolean
+  registeredFrag?: DynamicFragment
 }
 
 function getTemplateRefUpdateFragment(el: RefEl): DynamicFragment | undefined {
@@ -125,8 +126,8 @@ function setTemplateRefWithState(
 
   // Re-apply refs after DynamicFragment updates.
   const frag = getTemplateRefUpdateFragment(el)
-  if (frag && !state.registered) {
-    state.registered = true
+  if (frag && state.registeredFrag !== frag) {
+    state.registeredFrag = frag
     ;(frag.onUpdated ||= []).push(() => {
       // KeepAlive clears refs on deactivation but keeps this fragment update
       // callback alive. Skip re-applying refs for async/offscreen updates
@@ -139,18 +140,24 @@ function setTemplateRefWithState(
         state.oldRef,
         state.refFor,
         state.refKey,
+        state.oldRefKey,
       )
+      state.oldRefKey = state.oldRef != null ? state.refKey : undefined
     })
   }
 
-  return (state.oldRef = setRef(
+  const oldRef = setRef(
     instance,
     el,
     ref,
     state.oldRef,
     refFor,
     refKey,
-  ))
+    state.oldRefKey,
+  )
+  state.oldRef = oldRef
+  state.oldRefKey = oldRef != null ? refKey : undefined
+  return oldRef
 }
 
 export function setStaticTemplateRef(
@@ -193,6 +200,7 @@ function setRef(
   oldRef?: NodeRef,
   refFor = false,
   refKey?: string,
+  oldRefKey?: string,
 ): NodeRef | undefined {
   if (!instance || instance.isUnmounted) return
 
@@ -239,7 +247,8 @@ function setRef(
         setupState[oldRef] = null
       }
     } else if (isRef(oldRef)) {
-      if (canSetRef(oldRef)) oldRef.value = null
+      if (canSetRef(oldRef, oldRefKey)) oldRef.value = null
+      if (oldRefKey) refs[oldRefKey] = null
     } else if (isFunction(oldRef) && isDynamicFragment(el)) {
       callWithErrorHandling(oldRef, instance, ErrorCodes.FUNCTION_REF, [
         null,

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -58,6 +58,14 @@ export type setRefFn = (
   refKey?: string,
 ) => NodeRef | undefined
 
+interface TemplateRefState {
+  oldRef?: NodeRef
+  ref: NodeRef
+  refFor?: boolean
+  refKey?: string
+  registered?: boolean
+}
+
 function getTemplateRefUpdateFragment(el: RefEl): DynamicFragment | undefined {
   if (isDynamicFragment(el)) return el
   if (isVaporComponent(el) && isAsyncWrapper(el)) {
@@ -80,33 +88,69 @@ function ensureCleanup(el: RefEl): RefCleanupState {
 
 export function createTemplateRefSetter(): setRefFn {
   const instance = currentInstance as VaporComponentInstance
-  const oldRefMap = new WeakMap<RefEl, NodeRef | undefined>()
-  const setRefMap = new WeakMap<DynamicFragment, () => void>()
+  const stateMap = new WeakMap<RefEl, TemplateRefState>()
 
   return (el, ref, refFor, refKey) => {
-    // Re-apply refs after DynamicFragment updates.
-    const frag = getTemplateRefUpdateFragment(el)
-    if (frag) {
-      const doSet = () => {
-        // KeepAlive clears refs on deactivation but keeps this fragment update
-        // callback alive. Skip re-applying refs for async/offscreen updates
-        // until the component is activated again.
-        if (isVaporComponent(el) && el.isDeactivated) return
-        oldRefMap.set(
-          el,
-          setRef(instance, el, ref, oldRefMap.get(el), refFor, refKey),
-        )
-      }
-      const prevSet = setRefMap.get(frag)
-      if (prevSet && frag.onUpdated) remove(frag.onUpdated, prevSet)
-      ;(frag.onUpdated || (frag.onUpdated = [])).push(doSet)
-      setRefMap.set(frag, doSet)
+    let state = stateMap.get(el)
+    if (!state) {
+      stateMap.set(el, (state = { ref }))
     }
-
-    const oldRef = setRef(instance, el, ref, oldRefMap.get(el), refFor, refKey)
-    oldRefMap.set(el, oldRef)
-    return oldRef
+    return setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
   }
+}
+
+function createSingleTemplateRefSetter(): setRefFn {
+  const instance = currentInstance as VaporComponentInstance
+  let state: TemplateRefState | undefined
+
+  return (el, ref, refFor, refKey) => {
+    if (!state) {
+      state = { ref }
+    }
+    return setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
+  }
+}
+
+function setTemplateRefWithState(
+  instance: VaporComponentInstance,
+  el: RefEl,
+  state: TemplateRefState,
+  ref: NodeRef,
+  refFor?: boolean,
+  refKey?: string,
+): NodeRef | undefined {
+  state.ref = ref
+  state.refFor = refFor
+  state.refKey = refKey
+
+  // Re-apply refs after DynamicFragment updates.
+  const frag = getTemplateRefUpdateFragment(el)
+  if (frag && !state.registered) {
+    state.registered = true
+    ;(frag.onUpdated ||= []).push(() => {
+      // KeepAlive clears refs on deactivation but keeps this fragment update
+      // callback alive. Skip re-applying refs for async/offscreen updates
+      // until the component is activated again.
+      if (isVaporComponent(el) && el.isDeactivated) return
+      state.oldRef = setRef(
+        instance,
+        el,
+        state.ref,
+        state.oldRef,
+        state.refFor,
+        state.refKey,
+      )
+    })
+  }
+
+  return (state.oldRef = setRef(
+    instance,
+    el,
+    ref,
+    state.oldRef,
+    refFor,
+    refKey,
+  ))
 }
 
 export function setStaticTemplateRef(
@@ -132,7 +176,7 @@ export function setStaticTemplateRef(
 export function setTemplateRefBinding(
   el: RefEl,
   getter: () => any,
-  setter: setRefFn = createTemplateRefSetter(),
+  setter: setRefFn = createSingleTemplateRefSetter(),
   refFor?: boolean,
   refKey?: string,
 ): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template ref binding in dynamic components now correctly manages ref state transitions without duplicating update handlers.
  * Improved ref clearing and application behavior during ref key changes.

* **Tests**
  * Added test coverage for dynamic component template refs and ref key switching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->