### PR TITLE
fix(compiler-sfc): scope nested deep selector (fix #13159)

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -63,6 +63,14 @@ describe('SFC scoped CSS', () => {
     expect(compileScoped(`h1 { color: red; .foo { color: red; } }`)).toMatch(
       `h1 {\n&[data-v-test] { color: red;\n}\n.foo[data-v-test] { color: red;`,
     )
+    // #13159
+    expect(compileScoped(`.base { :deep(.foo) { color: red; } }`))
+      .toMatchInlineSnapshot(`
+      ".base {
+      &[data-v-test] .foo { color: red;
+      }
+      }"
+    `)
   })
 
   test('nesting selector with atrule and comment', () => {

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -326,6 +326,10 @@ function rewriteSelector(
 
   if (shouldInject) {
     const idToAdd = slotted ? id + '-s' : id
+    if (!node && (rule as any).__deep && rule.parent?.type === 'rule') {
+      node = selectorParser.nesting()
+      selector.prepend(node)
+    }
     selector.insertAfter(
       // If node is null it means we need to inject [id] at the start
       // insertAfter can handle `null` here


### PR DESCRIPTION
## Description

Fixes scoped CSS output for nested standalone :deep() selectors. When :deep() appears inside a CSS nesting rule, the generated scope attribute needs to be anchored to the parent selector with &; otherwise the compiled selector becomes [data-v-*] .foo inside the nested block and scopes the wrong element.

## Test

- pnpm run test-unit compiler-sfc --run
- pnpm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scoped CSS selector processing for `:deep()` pseudo-elements to ensure correct nesting behavior and proper anchor positioning.

* **Tests**
  * Extended test coverage for `:deep()` syntax in scoped CSS styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->