### PR TITLE
fix(compiler-core): skip v-memo key optimization only when v-for is present

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vMemo.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vMemo.spec.ts.snap
@@ -12,6 +12,18 @@ export function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: v-memo transform > on element with :key but without v-for 1`] = `
+"import { createTextVNode as _createTextVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, withMemo as _withMemo } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    _withMemo([_ctx.y], () => (_openBlock(), _createElementBlock("div", { key: _ctx.x }, [
+      _createTextVNode("foo")
+    ])), _cache, 0)
+  ]))
+}"
+`;
+
 exports[`compiler: v-memo transform > on normal element 1`] = `
 "import { openBlock as _openBlock, createElementBlock as _createElementBlock, withMemo as _withMemo } from "vue"
 

--- a/packages/compiler-core/__tests__/transforms/vMemo.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vMemo.spec.ts
@@ -34,6 +34,10 @@ describe('compiler: v-memo transform', () => {
     ).toMatchSnapshot()
   })
 
+  test('on element with :key but without v-for', () => {
+    expect(compile(`<div :key="x" v-memo="[y]">foo</div>`)).toMatchSnapshot()
+  })
+
   test('on v-for', () => {
     expect(
       compile(

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -55,6 +55,7 @@ export const transformExpression: NodeTransform = (node, context) => {
   } else if (node.type === NodeTypes.ELEMENT) {
     // handle directives on element
     const memo = findDir(node, 'memo')
+    const hasFor = findDir(node, 'for')
     for (let i = 0; i < node.props.length; i++) {
       const dir = node.props[i]
       // do not process for v-on & v-for since they are special handled
@@ -68,8 +69,10 @@ export const transformExpression: NodeTransform = (node, context) => {
           exp.type === NodeTypes.SIMPLE_EXPRESSION &&
           !(dir.name === 'on' && arg) &&
           // key has been processed in transformFor(vMemo + vFor)
+          // only skip when both v-memo and v-for are present
           !(
             memo &&
+            hasFor &&
             arg &&
             arg.type === NodeTypes.SIMPLE_EXPRESSION &&
             arg.content === 'key'


### PR DESCRIPTION
## Description

When `v-memo` is used on an element with `:key` but without `v-for`, the key expression is incorrectly skipped during `transformExpression`.

The current condition only checks for the presence of `v-memo`, but the key optimization should only apply when both `v-memo` and `v-for` are present on the same element. Without `v-for`, the key expression is skipped and never transformed, resulting in incorrect render output.

This PR adds a `hasFor` check so the key is only skipped when both directives coexist:

```ts
// Before
if (memo && arg && arg.type === NodeTypes.SIMPLE_EXPRESSION && arg.content === 'key') {
```

```ts
// After
if (memo && hasFor && arg && arg.type === NodeTypes.SIMPLE_EXPRESSION && arg.content === 'key') {
```

## Changes

* added `hasFor = findDir(node, 'for')` and included it in the skip condition
* added a test case for `:key` used with `v-memo` but without `v-for`
* updated snapshot

## Test Plan

* verified that `<div :key="x" v-memo="[y]">foo</div>` compiles correctly and preserves the key expression as `{ key: _ctx.x }`
* all existing `v-memo` tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `v-memo` directive with `:key` attribute in elements without `v-for`.

* **Bug Fixes**
  * Improved compiler handling of directive expressions when `v-memo`, `v-for`, and `:key` directives are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->