### PR TITLE
fix(runtime-vapor): restore transition group hooks after skipped move

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -205,6 +205,32 @@ describe('Transition', () => {
     expect(onAppear).toHaveBeenCalledTimes(1)
   })
 
+  test('direct child with initial shown v-show should call appear after insertion', async () => {
+    const calls: boolean[] = []
+    const data = ref({
+      show: true,
+      onBeforeAppear: (el: Element) => calls.push(el.isConnected),
+      onAppear: (el: Element) => calls.push(el.isConnected),
+    })
+    const App = compile(
+      `<template>
+        <Transition
+          appear
+          @before-appear="data.onBeforeAppear"
+          @appear="data.onAppear"
+        >
+          <div v-show="data.show">foo</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    define(App as any).render()
+
+    await nextTick()
+
+    expect(calls).toEqual([false, true])
+  })
+
   test('direct slot child with initial hidden v-show should not trigger appear hooks', async () => {
     const { data, onBeforeAppear, onAppear } = createAppearTestState(false)
     const Child = compile(`<template><slot /></template>`, data)

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -179,6 +179,56 @@ describe('Transition', () => {
     expect(child.block[2].$key).toBe('foo1')
   })
 
+  test('treats null group owner key as absent', () => {
+    const Child = defineVaporComponent({
+      setup() {
+        return [
+          template(`<div>a</div>`)() as any,
+          template(`<div>b</div>`)() as any,
+        ]
+      },
+    })
+
+    let child: any
+    define({
+      setup() {
+        child = createComponent(Child)
+        setBlockKey(child, null)
+        return child
+      },
+    }).render()
+
+    resolveTransitionBlocks(child)
+
+    expect(child.block[0].$key).toBeUndefined()
+    expect(child.block[1].$key).toBeUndefined()
+  })
+
+  test('composes nested group key prefixes', () => {
+    const data = ref({ items: [{ key: 'bar' }] })
+    const Child = compile(
+      `<template>
+        <span></span>
+        <div v-for="item in data.items" :key="item.key">child</div>
+      </template>`,
+      data,
+    )
+
+    let child: any
+    define({
+      setup() {
+        child = createComponent(Child)
+        setBlockKey(child, 'foo')
+        return child
+      },
+    }).render()
+
+    const resolved = resolveTransitionBlocks(child)
+
+    expect(resolved[0].$key).toBe('foo0')
+    expect(resolved[1].$key).toBe('foobar')
+  })
+
   test('allows empty transition content', async () => {
     const App = compile(`<template><Transition /></template>`, ref({}))
     const { host } = define(App as any).render()

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -150,6 +150,35 @@ describe('Transition', () => {
     expect(child.block[2].$key).toBe('foo1')
   })
 
+  test('keeps inherited group keys stable across repeated resolutions', () => {
+    const Child = defineVaporComponent({
+      setup() {
+        return [
+          document.createComment('anchor'),
+          template(`<div>a</div>`)() as any,
+          template(`<div>b</div>`)() as any,
+        ]
+      },
+    })
+
+    let child: any
+    define({
+      setup() {
+        child = createComponent(Child)
+        setBlockKey(child, 'foo')
+        child.block[1].$key = undefined
+        child.block[2].$key = undefined
+        return child
+      },
+    }).render()
+
+    resolveTransitionBlocks(child)
+    resolveTransitionBlocks(child)
+
+    expect(child.block[1].$key).toBe('foo0')
+    expect(child.block[2].$key).toBe('foo1')
+  })
+
   test('allows empty transition content', async () => {
     const App = compile(`<template><Transition /></template>`, ref({}))
     const { host } = define(App as any).render()

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -4,7 +4,10 @@ import {
   setBlockKey,
   template,
 } from '../../src'
-import { resolveTransitionBlock } from '../../src/components/Transition'
+import {
+  resolveTransitionBlock,
+  resolveTransitionBlocks,
+} from '../../src/components/Transition'
 import { nextTick, ref } from 'vue'
 import { compile, makeInteropRender, makeRender } from '../_utils'
 
@@ -117,6 +120,34 @@ describe('Transition', () => {
 
     const resolved = resolveTransitionBlock(child)!
     expect(resolved.$key).toBe(child.uid)
+  })
+
+  test('collects group leaves with component key prefixes', () => {
+    const Child = defineVaporComponent({
+      setup() {
+        return [
+          document.createComment('anchor'),
+          template(`<div>a</div>`)() as any,
+          template(`<div>b</div>`)() as any,
+        ]
+      },
+    })
+
+    let child: any
+    define({
+      setup() {
+        child = createComponent(Child)
+        setBlockKey(child, 'foo')
+        child.block[1].$key = undefined
+        child.block[2].$key = undefined
+        return child
+      },
+    }).render()
+
+    const resolved = resolveTransitionBlocks(child)
+    expect(resolved).toEqual([child.block[1], child.block[2]])
+    expect(child.block[1].$key).toBe('foo0')
+    expect(child.block[2].$key).toBe('foo1')
   })
 
   test('allows empty transition content', async () => {

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -177,6 +177,31 @@ describe('TransitionGroup', () => {
     expect(list.nodes[0][1].nodes.$transition).toBeDefined()
   })
 
+  test('preserves unique keys for multi-root v-for items', () => {
+    const items = ref([1])
+    let list: any
+
+    define({
+      setup() {
+        list = createFor(
+          () => items.value,
+          () => [template(`<div></div>`)(), template(`<span></span>`)()],
+          item => item,
+        )
+        return createComponent(VaporTransitionGroup, null, {
+          default: () => list,
+        })
+      },
+    }).render()
+
+    const nodes = list.nodes[0][0].nodes
+
+    expect(nodes[0].$key).toBe('1:0')
+    expect(nodes[1].$key).toBe('1:1')
+    expect(nodes[0].$transition).toBeDefined()
+    expect(nodes[1].$transition).toBeDefined()
+  })
+
   test('restores disabled transition hooks when no move transform is available', async () => {
     const items = ref([1, 2])
     let list: any

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -176,4 +176,34 @@ describe('TransitionGroup', () => {
     expect(list.nodes[0][1].nodes.$key).toBe(2)
     expect(list.nodes[0][1].nodes.$transition).toBeDefined()
   })
+
+  test('restores disabled transition hooks when no move transform is available', async () => {
+    const items = ref([1, 2])
+    let list: any
+
+    define({
+      setup() {
+        list = createFor(
+          () => items.value,
+          item => {
+            const el = template(`<div></div>`)()
+            el.textContent = String(item.value)
+            return el
+          },
+          item => item,
+        )
+        return createComponent(VaporTransitionGroup, null, {
+          default: () => list,
+        })
+      },
+    }).render()
+
+    const first = list.nodes[0][0].nodes
+
+    items.value = [2, 1]
+    await nextTick()
+    await nextTick()
+
+    expect(first.$transition.disabled).toBe(false)
+  })
 })

--- a/packages/runtime-vapor/__tests__/helpers/setKey.spec.ts
+++ b/packages/runtime-vapor/__tests__/helpers/setKey.spec.ts
@@ -7,6 +7,7 @@ import {
   template,
 } from '../../src'
 import { makeRender } from '../_utils'
+import { setInteropEnabled } from '../../src/vdomInteropState'
 
 const define = makeRender()
 
@@ -39,6 +40,7 @@ describe('helpers: setBlockKey', () => {
   })
 
   test('syncs interop fragment vnode.key', () => {
+    setInteropEnabled()
     const frag = new VaporFragment(template(`<div></div>`)() as any)
     frag.vnode = h('div', { key: 'old' })
 

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -28,7 +28,8 @@ export interface VaporTransitionHooks extends TransitionHooks {
   state: TransitionState
   props: TransitionProps
   instance: VaporComponentInstance
-  // mark transition hooks as disabled
+  // Temporarily skips enter/move during TransitionGroup FLIP measurement.
+  // Leave transitions intentionally ignore this flag.
   disabled?: boolean
   // TransitionGroup sets this to handle applying hooks to list children
   applyGroup?: (

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -201,7 +201,7 @@ function getTransitionType(block: ResolvedTransitionBlock): any {
   const type = transitionTypeMap.get(block)
   if (type !== undefined) return type
   if (block instanceof Element) return block.localName
-  if (isFragment(block) && block.vnode) {
+  if (isInteropEnabled && isFragment(block) && block.vnode) {
     const children = getTransitionRawChildren([block.vnode])
     if (children.length === 1) return children[0].type
   }
@@ -669,7 +669,10 @@ export function getTransitionElementFromVNode(
 export function isValidTransitionBlock(
   block: Block,
 ): block is ResolvedTransitionBlock {
-  return !!(block instanceof Element || (isFragment(block) && block.vnode))
+  return !!(
+    block instanceof Element ||
+    (isInteropEnabled && isFragment(block) && block.vnode)
+  )
 }
 
 export function getTransitionElement(

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -650,7 +650,7 @@ export function getVNodeKey(
   return children.length === 1 ? children[0].key : undefined
 }
 
-export function getTransitionElementFromVNode(
+function getTransitionElementFromVNode(
   vnode: VNode | undefined,
 ): Element | undefined {
   if (!vnode) return
@@ -724,11 +724,19 @@ function applyPendingVShows(
   }
 
   onBeforeMount(() => {
-    // Flush the deferred initial v-show writes right before mount so the
-    // DOM is still not inserted, but transition hooks are already ready.
-    for (const pending of pendingVShows) {
-      pending.setDisplay()
-    }
+    // Flush the deferred initial v-show display writes before mount so hooks are
+    // ready, then run enter after DOM insertion but before mounted state flips.
+    let enterCbs: (() => void)[] | undefined
+    pendingVShows.forEach(pending => {
+      const enterCb = pending.apply()
+      if (enterCb) {
+        ;(enterCbs ||= []).push(enterCb)
+      }
+    })
     pendingVShows.length = 0
+    if (enterCbs) {
+      const cbs = enterCbs
+      queuePostFlushCb(() => cbs.forEach(cb => cb()), -1)
+    }
   })
 }

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -196,6 +196,10 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
   })
 
 const transitionTypeMap = new WeakMap<ResolvedTransitionBlock, any>()
+const inheritedTransitionBaseKeyMap = new WeakMap<
+  ResolvedTransitionBlock,
+  any
+>()
 
 function getTransitionType(block: ResolvedTransitionBlock): any {
   const type = transitionTypeMap.get(block)
@@ -628,8 +632,12 @@ function inheritTransitionKey(
   if (key === undefined || start === children.length) return
   for (let i = start; i < children.length; i++) {
     const child = children[i]
-    child.$key =
-      String(key) + String(child.$key != null ? child.$key : i - start)
+    let baseKey = inheritedTransitionBaseKeyMap.get(child)
+    if (baseKey === undefined) {
+      baseKey = child.$key != null ? child.$key : i - start
+      inheritedTransitionBaseKeyMap.set(child, baseKey)
+    }
+    child.$key = String(key) + String(baseKey)
   }
 }
 

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -546,8 +546,10 @@ function collectArrayTransitionBlocks(
       const start = children.length
       collectTransitionBlocks(c, options, children)
       if (c instanceof ForBlock) {
+        const count = children.length - start
         for (let j = start; j < children.length; j++) {
-          children[j].$key = c.key
+          children[j].$key =
+            c.key != null && count > 1 ? `${c.key}:${j - start}` : c.key
         }
       }
     }

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -11,7 +11,6 @@ import {
   baseResolveTransitionHooks,
   checkTransitionMode,
   currentInstance,
-  getComponentName,
   getTransitionRawChildren,
   isAsyncWrapper,
   isTemplateNode,
@@ -39,6 +38,7 @@ import { isArray } from '@vue/shared'
 import { renderEffect } from '../renderEffect'
 import {
   DynamicFragment,
+  ForBlock,
   ForFragment,
   type VaporFragment,
   isFragment,
@@ -58,6 +58,12 @@ export type ResolvedTransitionBlock = (
   | DynamicFragment
 ) &
   TransitionOptions
+
+type ResolveTransitionBlocksOptions = {
+  mode: 'single' | 'group'
+  onFragment?: (frag: VaporFragment) => void
+  onUpdateOwner?: (owner: VaporFragment | VaporComponentInstance) => void
+}
 
 let registered = false
 export const ensureTransitionHooksRegistered = (): void => {
@@ -219,13 +225,8 @@ function getLeavingNodesForType(
 function getLeaveElement(
   block: ResolvedTransitionBlock,
 ): TransitionElement | undefined {
-  if (block instanceof Element) {
-    return block as TransitionElement
-  }
-  if (isInteropEnabled && isFragment(block) && block.vnode) {
-    const el = getTransitionElementFromVNode(block.vnode)
-    if (el) return el as TransitionElement
-  }
+  const el = getTransitionElement(block)
+  if (el) return el as TransitionElement
   if (
     isFragment(block) &&
     !isArray(block.nodes) &&
@@ -440,73 +441,194 @@ export function resolveTransitionBlock(
   block: Block,
   onFragment?: (frag: VaporFragment) => void,
 ): ResolvedTransitionBlock | undefined {
-  let child: ResolvedTransitionBlock | undefined
+  return resolveTransitionChildren(block, { mode: 'single', onFragment })[0]
+}
+
+export function resolveTransitionBlocks(
+  block: Block,
+  onFragment?: (frag: VaporFragment) => void,
+  onUpdateOwner?: (owner: VaporFragment | VaporComponentInstance) => void,
+): ResolvedTransitionBlock[] {
+  return resolveTransitionChildren(block, {
+    mode: 'group',
+    onFragment,
+    onUpdateOwner,
+  })
+}
+
+function resolveTransitionChildren(
+  block: Block,
+  options: ResolveTransitionBlocksOptions,
+): ResolvedTransitionBlock[] {
+  const children: ResolvedTransitionBlock[] = []
+  collectTransitionBlocks(block, options, children)
+  return children
+}
+
+function collectTransitionBlocks(
+  block: Block,
+  options: ResolveTransitionBlocksOptions,
+  children: ResolvedTransitionBlock[],
+): void {
   if (block instanceof Node) {
     // transition can only be applied on Element child
-    if (block instanceof Element) child = block
+    if (block instanceof Element) children.push(block)
   } else if (isVaporComponent(block)) {
-    if (isAsyncWrapper(block)) {
-      // for unresolved async wrapper, set transition hooks on inner fragment
-      if (!block.type.__asyncResolved) {
-        onFragment && onFragment(block.block! as DynamicFragment)
-      } else {
-        child = resolveTransitionBlock(
-          (block.block! as DynamicFragment).nodes,
-          onFragment,
-        )
-        if (child) {
-          if (child.$key == null) {
-            child.$key = block.$key ?? block.uid
-          }
-          // align with normal component branches so leaving cache can
-          // distinguish different resolved async wrapper types.
-          transitionTypeMap.set(child, block.type)
-        }
-      }
-    } else {
-      // stop searching if encountering nested Transition component
-      if (getComponentName(block.type) === displayName) return undefined
-      child = resolveTransitionBlock(block.block, onFragment)
-      if (child) {
-        if (child.$key == null) {
-          // prefer explicit component key, otherwise fall back to uid.
-          child.$key = block.$key ?? block.uid
-        }
-        transitionTypeMap.set(child, block.type)
-      }
-    }
+    collectComponentTransitionBlocks(block, options, children)
   } else if (isArray(block)) {
-    let hasFound = false
-    for (const c of block) {
-      if (c instanceof Comment) continue
-      const item = resolveTransitionBlock(c, onFragment)
-      if (__DEV__ && hasFound) {
-        // warn more than one non-comment child
-        warn(
-          '<transition> can only be used on a single element or component. ' +
-            'Use <transition-group> for lists.',
-        )
-        break
-      }
-      child = item
-      hasFound = true
-      if (!__DEV__) break
-    }
+    collectArrayTransitionBlocks(block, options, children)
   } else if (isFragment(block)) {
-    if (isInteropEnabled && block.vnode) {
-      child = block
-      const children = getTransitionRawChildren([block.vnode])
-      if (children.length === 1) {
-        transitionTypeMap.set(child, children[0].type)
-      }
-    } else {
-      // collect fragments for setting transition hooks
-      if (onFragment) onFragment(block)
-      child = resolveTransitionBlock(block.nodes, onFragment)
-    }
+    collectFragmentTransitionBlocks(block, options, children)
+  }
+}
+
+function collectComponentTransitionBlocks(
+  block: VaporComponentInstance,
+  options: ResolveTransitionBlocksOptions,
+  children: ResolvedTransitionBlock[],
+): void {
+  if (options.mode === 'group') {
+    // A normal component child can move when parent-driven props update its
+    // root layout without re-running the surrounding v-for fragment.
+    // When the component root is a slot, the TransitionGroup children are the
+    // slotted blocks, so track the slot fragment instead of the component.
+    const isRootSlot = block.block && isSlotFragment(block.block)
+    if (options.onUpdateOwner && !isRootSlot) options.onUpdateOwner(block)
+
+    const start = children.length
+    collectTransitionBlocks(
+      block.block,
+      isRootSlot
+        ? options
+        : {
+            mode: options.mode,
+            onFragment: options.onFragment,
+          },
+      children,
+    )
+    inheritTransitionKey(children, start, block.$key)
+    return
   }
 
-  return child
+  if (isAsyncWrapper(block)) {
+    // for unresolved async wrapper, set transition hooks on inner fragment
+    if (!block.type.__asyncResolved) {
+      if (options.onFragment)
+        options.onFragment(block.block! as DynamicFragment)
+      return
+    }
+
+    const start = children.length
+    collectTransitionBlocks(
+      (block.block! as DynamicFragment).nodes,
+      options,
+      children,
+    )
+    inheritSingleComponentKey(children[start], block)
+    return
+  }
+
+  // stop searching if encountering nested Transition component
+  if (block.type === VaporTransition) return
+
+  const start = children.length
+  collectTransitionBlocks(block.block, options, children)
+  inheritSingleComponentKey(children[start], block)
+}
+
+function collectArrayTransitionBlocks(
+  block: Block[],
+  options: ResolveTransitionBlocksOptions,
+  children: ResolvedTransitionBlock[],
+): void {
+  if (options.mode === 'group') {
+    for (const c of block) {
+      const start = children.length
+      collectTransitionBlocks(c, options, children)
+      if (c instanceof ForBlock) {
+        for (let j = start; j < children.length; j++) {
+          children[j].$key = c.key
+        }
+      }
+    }
+    return
+  }
+
+  let hasFound = false
+  for (const c of block) {
+    if (c instanceof Comment) continue
+    const nested: ResolvedTransitionBlock[] = []
+    collectTransitionBlocks(c, options, nested)
+    if (__DEV__ && hasFound) {
+      // warn more than one non-comment child
+      warn(
+        '<transition> can only be used on a single element or component. ' +
+          'Use <transition-group> for lists.',
+      )
+      break
+    }
+    if (nested.length) children.push(nested[0])
+    hasFound = true
+    if (!__DEV__) break
+  }
+}
+
+function collectFragmentTransitionBlocks(
+  block: VaporFragment,
+  options: ResolveTransitionBlocksOptions,
+  children: ResolvedTransitionBlock[],
+): void {
+  if (options.mode === 'group') {
+    if (options.onFragment) options.onFragment(block)
+    if (options.onUpdateOwner) options.onUpdateOwner(block)
+    if (isInteropEnabled && block.vnode) {
+      // vdom component
+      children.push(block)
+    } else {
+      const start = children.length
+      collectTransitionBlocks(block.nodes, options, children)
+      inheritTransitionKey(children, start, block.$key)
+    }
+    return
+  }
+
+  if (isInteropEnabled && block.vnode) {
+    children.push(block)
+    const rawChildren = getTransitionRawChildren([block.vnode])
+    if (rawChildren.length === 1) {
+      transitionTypeMap.set(block, rawChildren[0].type)
+    }
+    return
+  }
+
+  // collect fragments for setting transition hooks
+  if (options.onFragment) options.onFragment(block)
+  collectTransitionBlocks(block.nodes, options, children)
+}
+
+function inheritSingleComponentKey(
+  child: ResolvedTransitionBlock | undefined,
+  block: VaporComponentInstance,
+): void {
+  if (!child) return
+  if (child.$key == null) {
+    // prefer explicit component key, otherwise fall back to uid.
+    child.$key = block.$key ?? block.uid
+  }
+  transitionTypeMap.set(child, block.type)
+}
+
+function inheritTransitionKey(
+  children: ResolvedTransitionBlock[],
+  start: number,
+  key: any,
+): void {
+  if (key === undefined || start === children.length) return
+  for (let i = start; i < children.length; i++) {
+    const child = children[i]
+    child.$key =
+      String(key) + String(child.$key != null ? child.$key : i - start)
+  }
 }
 
 export function setTransitionHooks(
@@ -541,6 +663,23 @@ export function getTransitionElementFromVNode(
   const children = getTransitionRawChildren([vnode])
   if (children.length === 1 && children[0] !== vnode) {
     return getTransitionElementFromVNode(children[0])
+  }
+}
+
+export function isValidTransitionBlock(
+  block: Block,
+): block is ResolvedTransitionBlock {
+  return !!(block instanceof Element || (isFragment(block) && block.vnode))
+}
+
+export function getTransitionElement(
+  block: ResolvedTransitionBlock,
+): Element | undefined {
+  if (block instanceof Element) return block
+
+  // vdom interop
+  if (isInteropEnabled && isFragment(block) && block.vnode) {
+    return getTransitionElementFromVNode(block.vnode)
   }
 }
 

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -196,10 +196,19 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
   })
 
 const transitionTypeMap = new WeakMap<ResolvedTransitionBlock, any>()
-const inheritedTransitionBaseKeyMap = new WeakMap<
+const inheritedTransitionKeyMap = new WeakMap<
   ResolvedTransitionBlock,
-  any
+  InheritedTransitionKeyRecord
 >()
+
+type InheritedTransitionKeyRecord = {
+  generation: number
+  rawBaseKey: any
+  inheritedKey: string
+}
+
+let transitionKeyGeneration = 0
+let currentTransitionKeyGeneration = 0
 
 function getTransitionType(block: ResolvedTransitionBlock): any {
   const type = transitionTypeMap.get(block)
@@ -465,8 +474,14 @@ function resolveTransitionChildren(
   options: ResolveTransitionBlocksOptions,
 ): ResolvedTransitionBlock[] {
   const children: ResolvedTransitionBlock[] = []
-  collectTransitionBlocks(block, options, children)
-  return children
+  const prevGeneration = currentTransitionKeyGeneration
+  currentTransitionKeyGeneration = ++transitionKeyGeneration
+  try {
+    collectTransitionBlocks(block, options, children)
+    return children
+  } finally {
+    currentTransitionKeyGeneration = prevGeneration
+  }
 }
 
 function collectTransitionBlocks(
@@ -629,15 +644,30 @@ function inheritTransitionKey(
   start: number,
   key: any,
 ): void {
-  if (key === undefined || start === children.length) return
+  if (key == null || start === children.length) return
   for (let i = start; i < children.length; i++) {
     const child = children[i]
-    let baseKey = inheritedTransitionBaseKeyMap.get(child)
-    if (baseKey === undefined) {
+    let record = inheritedTransitionKeyMap.get(child)
+    let baseKey
+    // Match VDOM parentKey + (child.key ?? index) composition, while reusing
+    // the raw base key across resolutions to avoid repeating prefixes.
+    if (record && record.generation === currentTransitionKeyGeneration) {
       baseKey = child.$key != null ? child.$key : i - start
-      inheritedTransitionBaseKeyMap.set(child, baseKey)
+    } else {
+      if (!record || !Object.is(child.$key, record.inheritedKey)) {
+        record = {
+          generation: currentTransitionKeyGeneration,
+          rawBaseKey: child.$key != null ? child.$key : i - start,
+          inheritedKey: '',
+        }
+        inheritedTransitionKeyMap.set(child, record)
+      } else {
+        record.generation = currentTransitionKeyGeneration
+      }
+      baseKey = record.rawBaseKey
     }
-    child.$key = String(key) + String(baseKey)
+    record.inheritedKey = String(key) + String(baseKey)
+    child.$key = record.inheritedKey
   }
 }
 

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -187,28 +187,28 @@ const VaporTransitionGroupImpl = defineVaporComponent({
       isUpdatedPending = false
       if (!isUpdatePending) return
       isUpdatePending = false
-      if (!prevChildren.length) {
-        return
-      }
+      if (!prevChildren.length) return
+
       const moveClass = props.moveClass || `${props.name || 'v'}-move`
       const firstChild = getFirstConnectedChild(prevChildren)
-      if (
-        !firstChild ||
-        !hasCSSTransform(
+      const hasMove = !!(
+        firstChild &&
+        hasCSSTransform(
           firstChild as ElementWithTransition,
           firstChild.parentNode as Node,
           moveClass,
         )
-      ) {
+      )
+      prevChildren.forEach(child => {
+        child.$transition!.disabled = false
+        if (hasMove) callPendingCbs(child)
+      })
+      if (!hasMove) {
         prevChildren = []
         return
       }
 
-      prevChildren.forEach(callPendingCbs)
-      prevChildren.forEach(child => {
-        child.$transition!.disabled = false
-        recordPosition(child)
-      })
+      prevChildren.forEach(recordPosition)
       const movedChildren = prevChildren.filter(applyTranslation)
 
       // force reflow to put everything in position

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -21,7 +21,7 @@ import {
   vShowHidden,
   warn,
 } from '@vue/runtime-dom'
-import { extend, isArray } from '@vue/shared'
+import { extend } from '@vue/shared'
 import {
   type Block,
   type BlockFn,
@@ -32,30 +32,25 @@ import { renderEffect } from '../renderEffect'
 import {
   type ResolvedTransitionBlock,
   ensureTransitionHooksRegistered,
-  getTransitionElementFromVNode,
+  getTransitionElement,
+  isValidTransitionBlock,
+  resolveTransitionBlocks,
   resolveTransitionHooks,
   setTransitionHooks,
 } from './Transition'
-import {
-  type VaporComponentInstance,
-  type VaporComponentOptions,
-  isVaporComponent,
+import type {
+  VaporComponentInstance,
+  VaporComponentOptions,
 } from '../component'
 import { resolveDynamicProps } from '../componentProps'
-import { isForBlock, setForHydrationAnchorResolver } from '../apiCreateFor'
+import { setForHydrationAnchorResolver } from '../apiCreateFor'
 import { createComment, createElement, createTextNode } from '../dom/node'
-import {
-  DynamicFragment,
-  type VaporFragment,
-  isFragment,
-  isSlotFragment,
-} from '../fragment'
+import { DynamicFragment, type VaporFragment, isFragment } from '../fragment'
 import {
   type DefineVaporComponent,
   defineVaporComponent,
 } from '../apiDefineComponent'
 import { watch } from '@vue/reactivity'
-import { isInteropEnabled } from '../vdomInteropState'
 import {
   adoptTemplate,
   cleanupHydrationTail,
@@ -161,7 +156,7 @@ const VaporTransitionGroupImpl = defineVaporComponent({
       if (isUpdatePending) return
       isUpdatePending = true
       prevChildren = []
-      const children = getTransitionBlocks(slottedBlock)
+      const children = resolveTransitionBlocks(slottedBlock)
       for (let i = 0; i < children.length; i++) {
         const child = children[i]
         const el =
@@ -174,9 +169,8 @@ const VaporTransitionGroupImpl = defineVaporComponent({
           !(el as VShowElement)[vShowHidden]
         ) {
           prevChildren.push(child)
-          // disabled transition during enter, so the children will be
-          // inserted into the correct position immediately. this prevents
-          // `recordPosition` from getting incorrect positions in `onUpdated`
+          // Skip enter/move while children are placed for FLIP measurement.
+          // Leave still needs to run for removed children.
           child.$transition!.disabled = true
           positionMap.set(child, el.getBoundingClientRect())
         }
@@ -318,7 +312,7 @@ function applyGroupTransitionHooks(
   updateHooks: TransitionGroupUpdateHookRef,
 ): ResolvedTransitionBlock[] {
   const fragments: VaporFragment[] = []
-  const children = getTransitionBlocks(
+  const children = resolveTransitionBlocks(
     block,
     frag => fragments.push(frag),
     owner => trackTransitionGroupUpdate(owner, updateHooks),
@@ -393,78 +387,6 @@ function trackTransitionGroupUpdate(
         },
       )
     })
-  }
-}
-
-function inheritKey(children: TransitionBlock[], key: any): void {
-  if (key === undefined || children.length === 0) return
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i]
-    child.$key = String(key) + String(child.$key != null ? child.$key : i)
-  }
-}
-
-function getTransitionBlocks(
-  block: Block,
-  onFragment?: (frag: VaporFragment) => void,
-  onUpdateOwner?: (owner: TransitionGroupUpdateOwner) => void,
-): ResolvedTransitionBlock[] {
-  let children: ResolvedTransitionBlock[] = []
-  if (block instanceof Element) {
-    children.push(block)
-  } else if (isVaporComponent(block)) {
-    // A normal component child can move when parent-driven props update its
-    // root layout without re-running the surrounding v-for fragment.
-    // When the component root is a slot, the TransitionGroup children are the
-    // slotted blocks, so track the slot fragment instead of the component.
-    const isRootSlot = block.block && isSlotFragment(block.block)
-    if (onUpdateOwner && !isRootSlot) onUpdateOwner(block)
-    const blocks = getTransitionBlocks(
-      block.block,
-      onFragment,
-      // Only a root slot exposes nested blocks as TransitionGroup children.
-      // Other component internals should not trigger group move bookkeeping.
-      isRootSlot ? onUpdateOwner : undefined,
-    )
-    inheritKey(blocks, block.$key)
-    children.push(...blocks)
-  } else if (isArray(block)) {
-    for (let i = 0; i < block.length; i++) {
-      const b = block[i]
-      const blocks = getTransitionBlocks(b, onFragment, onUpdateOwner)
-      if (isForBlock(b)) blocks.forEach(block => (block.$key = b.key))
-      children.push(...blocks)
-    }
-  } else if (isFragment(block)) {
-    if (onFragment) onFragment(block)
-    if (onUpdateOwner) onUpdateOwner(block)
-    if (isInteropEnabled && block.vnode) {
-      // vdom component
-      children.push(block)
-    } else {
-      const blocks = getTransitionBlocks(block.nodes, onFragment, onUpdateOwner)
-      inheritKey(blocks, block.$key)
-      children.push(...blocks)
-    }
-  }
-
-  return children
-}
-
-function isValidTransitionBlock(
-  block: Block,
-): block is ResolvedTransitionBlock {
-  return !!(block instanceof Element || (isFragment(block) && block.vnode))
-}
-
-function getTransitionElement(
-  block: ResolvedTransitionBlock,
-): Element | undefined {
-  if (block instanceof Element) return block
-
-  // vdom interop
-  if (isInteropEnabled && isFragment(block) && block.vnode) {
-    return getTransitionElementFromVNode(block.vnode)
   }
 }
 

--- a/packages/runtime-vapor/src/directives/vShow.ts
+++ b/packages/runtime-vapor/src/directives/vShow.ts
@@ -15,7 +15,7 @@ import { DynamicFragment, VaporFragment, isFragment } from '../fragment'
 
 export interface PendingVShow {
   target: Block
-  setDisplay: () => void
+  apply: () => (() => void) | undefined
 }
 
 export let currentPendingVShows: PendingVShow[] | null = null
@@ -61,7 +61,7 @@ export function applyVShow(target: Block, source: () => any): void {
       // enter through the transition-aware branch.
       currentPendingVShows.push({
         target,
-        setDisplay: () => setDisplay(target, value),
+        apply: () => setDisplay(target, value, true),
       })
       return
     }
@@ -69,16 +69,20 @@ export function applyVShow(target: Block, source: () => any): void {
   })
 }
 
-function setDisplay(target: Block, value: unknown): void {
+function setDisplay(
+  target: Block,
+  value: unknown,
+  deferEnter = false,
+): (() => void) | undefined {
   if (isVaporComponent(target)) {
-    return setDisplay(target.block, value)
+    return setDisplay(target.block, value, deferEnter)
   }
   if (isArray(target)) {
     if (target.length === 0) return
-    if (target.length === 1) return setDisplay(target[0], value)
+    if (target.length === 1) return setDisplay(target[0], value, deferEnter)
   }
   if (isFragment(target)) {
-    return setDisplay(target.nodes, value)
+    return setDisplay(target.nodes, value, deferEnter)
   }
 
   if (target instanceof Element) {
@@ -93,6 +97,9 @@ function setDisplay(target: Block, value: unknown): void {
       if (value) {
         $transition.beforeEnter(target)
         el.style.display = el[vShowOriginalDisplay]!
+        if (deferEnter) {
+          return () => $transition.enter(target)
+        }
         $transition.enter(target)
       } else {
         // during initial render, the element is not yet inserted into the

--- a/packages/runtime-vapor/src/helpers/setKey.ts
+++ b/packages/runtime-vapor/src/helpers/setKey.ts
@@ -3,6 +3,7 @@ import { isKeepAlive } from '@vue/runtime-dom'
 import type { Block } from '../block'
 import { isVaporComponent } from '../component'
 import { isKeepAliveEnabled } from '../keepAlive'
+import { isInteropEnabled } from '../vdomInteropState'
 
 export function setBlockKey(
   block: (Block & { $key?: any }) | null | undefined,
@@ -26,7 +27,7 @@ export function setBlockKey(
     }
   } else {
     block.$key = key
-    if (block.vnode) block.vnode.key = key
+    if (isInteropEnabled && block.vnode) block.vnode.key = key
     setBlockKey(block.nodes, key)
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transition handling for moved elements in lists, restoring disabled state correctly.
  * Enhanced v-show deferred enter behavior during transition initialization.

* **Refactor**
  * Consolidated transition resolution utilities for improved consistency across Transition and TransitionGroup components.
  * Updated interop support for element key assignment.

* **Tests**
  * Added comprehensive test coverage for transition group behavior and element key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->