### PR TITLE
perf(runtime-vapor): avoid retaining fragment classes in app-only bundles

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -126,7 +126,7 @@ import type {
   DefineVaporComponent,
   VaporRenderResult,
 } from './apiDefineComponent'
-import { DynamicFragment, isFragment } from './fragment'
+import { DynamicFragment, isDynamicFragment, isFragment } from './fragment'
 import type { VaporElement } from './apiDefineCustomElement'
 import {
   isSuspenseEnabled,
@@ -1204,7 +1204,7 @@ export function getRootElement(
   }
 
   if (isFragment(block) && !(isTeleportEnabled && isTeleportFragment(block))) {
-    if (block instanceof DynamicFragment && onDynamicFragment) {
+    if (isDynamicFragment(block) && onDynamicFragment) {
       onDynamicFragment(block)
     }
     const { nodes } = block
@@ -1369,7 +1369,7 @@ interface DynamicRootChain {
 // non-single-root still keep the outer fragment hook for future branch updates,
 // but report hasNonSingleRoot so the current render can warn.
 function getSingleDynamicRootChain(block: Block): DynamicRootChain | undefined {
-  if (block instanceof DynamicFragment) {
+  if (isDynamicFragment(block)) {
     const { nodes } = block
     const nested = getSingleDynamicRootChain(nodes)
     return {

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -73,7 +73,7 @@ export class TeleportFragment extends VaporFragment {
    * @internal marker for duck typing to avoid direct instanceof check
    * which prevents tree-shaking of TeleportFragment
    */
-  readonly __isTeleportFragment = true
+  readonly __tf = true
   anchor?: Node
   private resolvedProps?: TeleportProps
   private rawSlots?: RawSlots | null

--- a/packages/runtime-vapor/src/directives/vShow.ts
+++ b/packages/runtime-vapor/src/directives/vShow.ts
@@ -41,15 +41,17 @@ export function applyVShow(target: Block, source: () => any): void {
 
   if (isDynamicFragment(target)) {
     const update = target.update
-    target.update = (render, key) => {
-      update.call(target, render, key)
+    target.update = (...args) => {
+      const res = update.call(target, ...args)
       setDisplay(target, source())
+      return res
     }
   } else if (isFragment(target) && target.insert) {
     const insert = target.insert
-    target.insert = (parent, anchor) => {
-      insert.call(target, parent, anchor)
+    target.insert = (...args) => {
+      const res = insert.call(target, ...args)
       setDisplay(target, source())
+      return res
     }
   }
 

--- a/packages/runtime-vapor/src/directives/vShow.ts
+++ b/packages/runtime-vapor/src/directives/vShow.ts
@@ -11,7 +11,7 @@ import { isVaporComponent } from '../component'
 import type { Block, TransitionBlock } from '../block'
 import { isArray } from '@vue/shared'
 import { isHydrating, logMismatchError } from '../dom/hydration'
-import { DynamicFragment, VaporFragment, isFragment } from '../fragment'
+import { isDynamicFragment, isFragment } from '../fragment'
 
 export interface PendingVShow {
   target: Block
@@ -39,13 +39,13 @@ export function applyVShow(target: Block, source: () => any): void {
     return applyVShow(target[0], source)
   }
 
-  if (target instanceof DynamicFragment) {
+  if (isDynamicFragment(target)) {
     const update = target.update
     target.update = (render, key) => {
       update.call(target, render, key)
       setDisplay(target, source())
     }
-  } else if (target instanceof VaporFragment && target.insert) {
+  } else if (isFragment(target) && target.insert) {
     const insert = target.insert
     target.insert = (parent, anchor) => {
       insert.call(target, parent, anchor)

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -62,6 +62,11 @@ const EMPTY_BLOCK = EMPTY_ARR as unknown as Block[]
 export class VaporFragment<
   T extends Block = Block,
 > implements TransitionOptions {
+  /**
+   * @internal marker for duck typing to avoid direct instanceof check
+   * which prevents tree-shaking of VaporFragment
+   */
+  readonly __vf = true
   $key?: any
   $transition?: VaporTransitionHooks | undefined
   nodes: T
@@ -249,6 +254,11 @@ function queueAnchorInsert(
 }
 
 export class DynamicFragment extends VaporFragment {
+  /**
+   * @internal marker for duck typing to avoid direct instanceof check
+   * which prevents tree-shaking of DynamicFragment
+   */
+  readonly __df = true
   // @ts-expect-error - assigned in hydrate()
   anchor: Node
   scope: EffectScope | undefined
@@ -1341,8 +1351,8 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
   }
 }
 
-export function isFragment(val: NonNullable<unknown>): val is VaporFragment {
-  return val instanceof VaporFragment
+export function isFragment(val: unknown): val is VaporFragment {
+  return !!(val && (val as any).__vf)
 }
 
 export type InteropFragment<T extends Block = Block> = VaporFragment<T> & {
@@ -1350,15 +1360,13 @@ export type InteropFragment<T extends Block = Block> = VaporFragment<T> & {
 }
 
 export function isInteropFragment(val: unknown): val is InteropFragment {
-  return val instanceof VaporFragment && val.vnode !== undefined
+  return isFragment(val) && val.vnode !== undefined
 }
 
-export function isDynamicFragment(
-  val: NonNullable<unknown>,
-): val is DynamicFragment {
-  return val instanceof DynamicFragment
+export function isDynamicFragment(val: unknown): val is DynamicFragment {
+  return !!(val && (val as any).__df)
 }
 
 export function isSlotFragment(val: unknown): val is DynamicFragment {
-  return val instanceof DynamicFragment && !!val.isSlot
+  return isDynamicFragment(val) && !!val.isSlot
 }

--- a/packages/runtime-vapor/src/teleport.ts
+++ b/packages/runtime-vapor/src/teleport.ts
@@ -18,5 +18,5 @@ export function isVaporTeleport(value: unknown): value is VaporTeleportLike {
 }
 
 export function isTeleportFragment(value: unknown): value is TeleportFragment {
-  return !!(value && (value as any).__isTeleportFragment)
+  return !!(value && (value as any).__tf)
 }


### PR DESCRIPTION
Use short duck-typing markers for VaporFragment, DynamicFragment, and TeleportFragment checks instead of instanceof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved fragment detection mechanism across the Vapor runtime by updating type identification to use consistent markers, enhancing internal consistency for fragment handling including teleport, dynamic, and slot fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->