### PR TITLE
fix(runtime-vapor): skip disabled delegated direct handlers

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/event.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/event.spec.ts
@@ -109,6 +109,24 @@ describe('dom event', () => {
     expect(handler).toHaveBeenCalled()
   })
 
+  test('delegate skips disabled direct handlers', () => {
+    const handler = vi.fn()
+
+    const Comp = defineVaporComponent({
+      setup() {
+        const button = template('<button disabled></button>')() as any
+        button.$evtclick = handler
+        return button
+      },
+    })
+
+    const { host } = define(Comp).render()
+    const button = host.querySelector('button')!
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
   test('delegate', () => {
     const handler = vi.fn()
     const el = renderWithElement(el => {

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -108,7 +108,7 @@ const delegatedEventHandler = (e: Event) => {
             if (e.cancelBubble) return
           }
         }
-      } else {
+      } else if (!node.disabled) {
         handlers(e)
         if (e.cancelBubble) return
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event handlers incorrectly firing on disabled elements, ensuring proper interaction blocking for disabled form controls and buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->