### PR TITLE
fix(compiler-sfc): resolve script setup generic constraints

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -341,6 +341,27 @@ return { props, get x() { return x } }
 }"
 `;
 
+exports[`defineProps > w/ script setup generic constraint 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import type { Inputs } from './props'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'Input',
+  props: {
+    type: { type: String, required: true },
+    value: { type: [String, Number], required: true }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+
+
+return {  }
+}
+
+})"
+`;
+
 exports[`defineProps > w/ type 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 interface Test {}

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -81,6 +81,29 @@ defineProps<P>()
     })
   })
 
+  // #13787
+  test('w/ boolean props in generic component', () => {
+    const { content } = compile(
+      `<script setup lang="ts" generic="TMultiple extends boolean">
+type Nullable<T> = T | null
+type Props<T extends boolean> = {
+  primitive: boolean
+  wrapped: Nullable<boolean>
+  multiple: T
+  checked: T extends true ? boolean : never
+}
+defineProps<Props<TMultiple>>()
+</script>`,
+    )
+
+    expect(content).toMatch(`primitive: { type: Boolean, required: true }`)
+    expect(content).toMatch(
+      `wrapped: { type: [Boolean, null], required: true }`,
+    )
+    expect(content).toMatch(`multiple: { type: Boolean, required: true }`)
+    expect(content).toMatch(`checked: { type: Boolean, required: true }`)
+  })
+
   // #4764
   test('w/ leading code', () => {
     const { content } = compile(`

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -45,6 +45,42 @@ const bar = 1
   props: propsModel,`)
   })
 
+  // #8468
+  test('w/ script setup generic constraint', () => {
+    const files: Record<string, string> = {
+      '/props.ts': `
+type Text = { type: 'text', value: string }
+type NumberInput = { type: 'number', value: number }
+export type Inputs = Text | NumberInput
+`,
+    }
+    const { content, bindings } = compile(
+      `<script setup lang="ts" generic="P extends Inputs">
+import type { Inputs } from './props'
+defineProps<P>()
+</script>`,
+      {
+        fs: {
+          fileExists(file) {
+            return !!files[file]
+          },
+          readFile(file) {
+            return files[file]
+          },
+        },
+      },
+      { filename: '/Input.vue' },
+    )
+
+    assertCode(content)
+    expect(content).toMatch(`type: { type: String, required: true }`)
+    expect(content).toMatch(`value: { type: [String, Number], required: true }`)
+    expect(bindings).toStrictEqual({
+      type: BindingTypes.PROPS,
+      value: BindingTypes.PROPS,
+    })
+  })
+
   // #4764
   test('w/ leading code', () => {
     const { content } = compile(`

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -925,6 +925,19 @@ describe('resolveType', () => {
       })
     })
 
+    test('generic type /w conditional property', () => {
+      expect(
+        resolve(`
+        type Props<T extends boolean> = {
+          checked: T extends true ? boolean : never
+        }
+        defineProps<Props<boolean>>()
+      `).props,
+      ).toStrictEqual({
+        checked: ['Boolean'],
+      })
+    })
+
     test('generic from external-file', () => {
       const files = {
         '/foo.ts': 'export type P<T> = { foo: T }',

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -2001,6 +2001,18 @@ export function inferRuntimeType(
           typeParameters,
         ).filter(t => t !== UNKNOWN_TYPE)
       }
+      case 'TSConditionalType': {
+        const types = flattenTypes(
+          ctx,
+          [node.trueType, node.falseType].filter(
+            t => t.type !== 'TSNeverKeyword',
+          ),
+          scope,
+          isKeyOf,
+          typeParameters,
+        )
+        return types.length ? types : [UNKNOWN_TYPE]
+      }
       case 'TSMappedType': {
         // only support { [K in keyof T]: T[K] }
         const { typeAnnotation, typeParameter } = node

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -20,6 +20,7 @@ import type {
   TSTypeAnnotation,
   TSTypeElement,
   TSTypeLiteral,
+  TSTypeParameter,
   TSTypeQuery,
   TSTypeReference,
   TemplateLiteral,
@@ -1321,8 +1322,59 @@ function ctxToScope(ctx: TypeResolveContext): TypeScope {
   )
 
   recordTypes(ctx, body, scope)
+  recordScriptSetupGenericTypes(ctx, scope)
 
   return (ctx.scope = scope)
+}
+
+function recordScriptSetupGenericTypes(
+  ctx: TypeResolveContext,
+  scope: TypeScope,
+) {
+  if (!('descriptor' in ctx)) {
+    return
+  }
+  const scriptSetup = ctx.descriptor.scriptSetup
+  if (!scriptSetup) {
+    return
+  }
+  const generic = scriptSetup.attrs.generic
+  if (typeof generic !== 'string') {
+    return
+  }
+
+  let typeParameters: TSTypeParameter[] | undefined
+  try {
+    const genericAst = babelParse(`type __VUE_Generic<${generic}> = any`, {
+      plugins: resolveParserPlugins(
+        scriptSetup.lang || 'ts',
+        ctx.options.babelParserPlugins,
+      ),
+      sourceType: 'module',
+    }).program.body[0]
+    if (
+      genericAst.type === 'TSTypeAliasDeclaration' &&
+      genericAst.typeParameters
+    ) {
+      typeParameters = genericAst.typeParameters.params
+    }
+  } catch {
+    return
+  }
+
+  if (!typeParameters) {
+    return
+  }
+  for (const param of typeParameters) {
+    // Defaults do not constrain generic specializations, so they are not safe
+    // for runtime props inference.
+    const type = param.constraint
+    if (param.name && type) {
+      const node = type as ScopeTypeNode
+      node._ownerScope = scope
+      scope.types[param.name] = node
+    }
+  }
 }
 
 function moduleDeclToScope(


### PR DESCRIPTION
Fixes #8468 and #13787.

This registers constrained `<script setup generic>` parameters in the SFC type resolution scope, so `defineProps<P>()` can resolve `P` through its `extends` constraint, including constraints imported from external type files.

It also infers runtime prop types from TypeScript conditional property types by combining the possible runtime types from the true/false branches and ignoring `never` branches. This restores Boolean runtime prop inference for generic components like `checked: T extends true ? boolean : never`.

The implementation intentionally uses only generic constraints, not defaults, because a default type does not constrain every possible specialization and should not drive runtime props inference.

### Test

- `pnpm vitest run packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts packages/compiler-sfc/__tests__/compileScript.spec.ts packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts`
- `pnpm exec prettier --check packages/compiler-sfc/src/script/resolveType.ts packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts`
- `pnpm exec eslint packages/compiler-sfc/src/script/resolveType.ts packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts`
- `pnpm check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `<script setup>` type inference to support TypeScript generic constraints and conditional types for more accurate runtime prop/emits typing.

* **Tests**
  * Added tests covering `defineProps` with generic constraints and conditional-generic property inference to validate runtime type output and binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->