### PR TITLE
fix(compiler-sfc): handle vue-ignore on leading intersection type

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -45,6 +45,21 @@ const bar = 1
   props: propsModel,`)
   })
 
+  // #12254
+  test('w/ leading intersection type ignore', () => {
+    const { content, bindings } = compile(`<script setup lang="ts">
+type Foo = { foo: number }
+type Bar = { bar: boolean }
+defineProps</* @vue-ignore */ Foo & Bar>()
+</script>`)
+
+    expect(content).not.toMatch(`foo: { type`)
+    expect(content).toMatch(`bar: { type: Boolean, required: true }`)
+    expect(bindings).toStrictEqual({
+      bar: BindingTypes.PROPS,
+    })
+  })
+
   // #4764
   test('w/ leading code', () => {
     const { content } = compile(`

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -165,6 +165,18 @@ describe('resolveType', () => {
     })
   })
 
+  test('leading union type with ignore', () => {
+    expect(
+      resolve(`
+    type Foo = { foo: number }
+    type Bar = { bar: boolean }
+    defineProps</* @vue-ignore */ Foo | Bar>()
+    `).props,
+    ).toStrictEqual({
+      bar: ['Boolean'],
+    })
+  })
+
   test('TSPropertySignature with ignore', () => {
     expect(
       resolve(`

--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -153,6 +153,18 @@ describe('resolveType', () => {
     })
   })
 
+  test('leading intersection type with ignore', () => {
+    expect(
+      resolve(`
+    type Foo = { foo: number }
+    type Bar = { bar: boolean }
+    defineProps</* @vue-ignore */ Foo & Bar>()
+    `).props,
+    ).toStrictEqual({
+      bar: ['Boolean'],
+    })
+  })
+
   test('TSPropertySignature with ignore', () => {
     expect(
       resolve(`

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -191,10 +191,23 @@ function innerResolveTypeElements(
   scope: TypeScope,
   typeParameters?: Record<string, Node>,
 ): ResolvedElements {
-  if (
-    node.leadingComments &&
-    node.leadingComments.some(c => c.value.includes('@vue-ignore'))
-  ) {
+  if (hasVueIgnore(node)) {
+    if (
+      (node.type === 'TSIntersectionType' || node.type === 'TSUnionType') &&
+      node.types.length > 1
+    ) {
+      // Babel attaches comments before the first member to the parent node.
+      // Treat them as applying to the first member only.
+      return mergeElements(
+        [
+          { props: {} },
+          ...node.types
+            .slice(1)
+            .map(t => resolveTypeElements(ctx, t, scope, typeParameters)),
+        ],
+        node.type,
+      )
+    }
     return { props: {} }
   }
   switch (node.type) {
@@ -377,6 +390,13 @@ function typeElementsToMap(
     }
   }
   return res
+}
+
+function hasVueIgnore(node: Node): boolean {
+  return !!(
+    node.leadingComments &&
+    node.leadingComments.some(c => c.value.includes('@vue-ignore'))
+  )
 }
 
 function mergeElements(


### PR DESCRIPTION
Fixes #12254.

When `@vue-ignore` is placed before the first member of an intersection type, Babel attaches the leading comment to the parent `TSIntersectionType` instead of the first type reference. The SFC type resolver then treats the whole intersection as ignored, so later members are skipped and their runtime prop types are not generated.

This changes that specific case so a leading `@vue-ignore` on an intersection/union parent is treated as applying to the first member only. Other members continue to be resolved normally, preserving boolean runtime prop inference for cases like `defineProps</* @vue-ignore */ A & B>()`.

### Test

- `pnpm vitest run packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts packages/compiler-sfc/__tests__/compileScript.spec.ts`
- `pnpm exec prettier --check packages/compiler-sfc/src/script/resolveType.ts packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts`
- `pnpm exec eslint packages/compiler-sfc/src/script/resolveType.ts packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts`
- `pnpm check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of the ignore directive for composite prop types so leading ignored members are skipped and only remaining members are recognized as props.

* **Tests**
  * Added coverage for leading-ignored intersection and union scenarios to ensure only non-ignored members are treated as component props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->