### PR TITLE
fix(compiler-core): avoid codegen crash on template with invalid structural directive

### DIFF
--- a/packages/compiler-core/__tests__/compile.spec.ts
+++ b/packages/compiler-core/__tests__/compile.spec.ts
@@ -1,4 +1,4 @@
-import { baseCompile as compile } from '../src'
+import { ErrorCodes, baseCompile as compile } from '../src'
 import { type RawSourceMap, SourceMapConsumer } from 'source-map-js'
 
 describe('compiler: integration tests', () => {
@@ -261,5 +261,36 @@ describe('compiler: integration tests', () => {
     expect(
       consumer.originalPositionFor(getPositionInCode(code, `value + index`)),
     ).toMatchObject(getPositionInCode(source, `value + index`))
+  })
+
+  // When a <template> carries a structural directive that is invalid in its
+  // position, the directive transform reports a compiler error but leaves the
+  // node in the tree without a codegenNode. With a non-throwing `onError` the
+  // node still reaches codegen, which used to crash with an internal
+  // "Codegen node is missing" error. It should degrade to a placeholder instead.
+  describe('codegen does not crash on invalid structural directive', () => {
+    test.each([
+      `<template v-else>x</template>`,
+      `<template v-else-if="a">x</template>`,
+      `<template #slot>x</template>`,
+      `<div><template #slot>x</template></div>`,
+    ])('%s', source => {
+      const onError = vi.fn()
+      let code!: string
+      expect(() => {
+        code = compile(source, { onError }).code
+      }).not.toThrow()
+      expect(code).toContain(`return`)
+    })
+
+    test('still reports the underlying error', () => {
+      const onError = vi.fn()
+      expect(() =>
+        compile(`<template v-else>x</template>`, { onError }),
+      ).not.toThrow()
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: ErrorCodes.X_V_ELSE_NO_ADJACENT_IF }),
+      )
+    })
   })
 })

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -660,13 +660,17 @@ function genNode(node: CodegenNode | symbol | string, context: CodegenContext) {
     case NodeTypes.ELEMENT:
     case NodeTypes.IF:
     case NodeTypes.FOR:
-      __DEV__ &&
-        assert(
-          node.codegenNode != null,
-          `Codegen node is missing for element/if/for node. ` +
-            `Apply appropriate transforms first.`,
-        )
-      genNode(node.codegenNode!, context)
+      // A codegenNode is normally produced by the structural transforms. It can
+      // legitimately be absent when the node carried an invalid structural
+      // directive (e.g. a misplaced v-slot, or a v-else/v-else-if with no
+      // adjacent v-if) whose transform reported a compiler error but left the
+      // node in the tree. With a non-throwing `onError`, that node still reaches
+      // codegen, so emit a placeholder instead of crashing.
+      if (node.codegenNode == null) {
+        context.push(`null`, NewlineType.None, node)
+        break
+      }
+      genNode(node.codegenNode, context)
       break
     case NodeTypes.TEXT:
       genText(node, context)


### PR DESCRIPTION
While fuzzing `baseCompile` with a non-throwing `onError`, I hit a raw internal crash on a few valid-to-parse templates.

A `<template>` that carries a structural directive which is invalid in its position — a misplaced `v-slot`/`#slot`, or a `v-else`/`v-else-if` with no adjacent `v-if` — has its structural transform report a proper compiler error and bail, but the element node is left in the tree without a `codegenNode`. The default `onError` throws, so this never surfaces; but `onError` is a public option and tooling commonly supplies a collecting (non-throwing) handler. In that case the orphaned node reaches codegen, and `genNode` throws `Error: Codegen node is missing for element/if/for node` (a `TypeError` in production builds where the assert is stripped) instead of degrading after the already-reported error.

Minimal repro:

```js
import { baseCompile } from '@vue/compiler-core'
baseCompile('<template v-else>x</template>', { onError: () => {} }) // throws "Codegen node is missing..."
```

Other triggers: `<template v-else-if="a">x</template>`, `<template #slot>x</template>`, `<div><template #slot>x</template></div>`.

The fix is in `genNode`: when an `element`/`if`/`for` node has no `codegenNode` (which only happens after such an error was reported and swallowed), emit a `null` placeholder rather than throwing. The underlying compiler error is still reported through `onError`.

Added integration tests in `compile.spec.ts` covering the trigger cases and asserting the underlying error is still reported. Full `compiler-core` + `compiler-dom` suites, typecheck and lint pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in template compilation. The compiler now gracefully reports errors for invalid structural directives instead of crashing during code generation.

* **Tests**
  * Added integration tests verifying proper error reporting for invalid template directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->