### PR TITLE
fix(compiler-core): correct filter rewrite recursion

### DIFF
--- a/packages/compiler-core/src/compat/transformFilter.ts
+++ b/packages/compiler-core/src/compat/transformFilter.ts
@@ -48,7 +48,7 @@ function rewriteFilter(node: ExpressionNode, context: TransformContext) {
       if (child.type === NodeTypes.SIMPLE_EXPRESSION) {
         parseFilter(child, context)
       } else if (child.type === NodeTypes.COMPOUND_EXPRESSION) {
-        rewriteFilter(node, context)
+        rewriteFilter(child, context)
       } else if (child.type === NodeTypes.INTERPOLATION) {
         rewriteFilter(child.content, context)
       }


### PR DESCRIPTION
In rewriteFilter, the branch handling COMPOUND_EXPRESSION children recursively calls rewriteFilter(node...) instead of rewriteFilter(child...), so the function would never make progress if that branch were reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compiler bug where filters were not correctly processed in nested expressions. Filters will now be properly applied to complex nested expression structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->