### PR TITLE
fix(runtime-dom): re-sync select when v-model is overridden in change handler (fix #10505)

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1009,6 +1009,52 @@ describe('vModel', () => {
     expect(bar.selected).toEqual(true)
   })
 
+  // #10505
+  it('should sync DOM when the model is overridden in the change handler', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: null as string | null }
+      },
+      render() {
+        return [
+          withVModel(
+            h(
+              'select',
+              {
+                value: null,
+                // a select that always forces its value back to 'foo'
+                'onUpdate:modelValue': () => {
+                  this.value = 'foo'
+                },
+              },
+              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
+            ),
+            this.value,
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const input = root.querySelector('select')
+    const foo = root.querySelector('option[value=foo]')
+    const bar = root.querySelector('option[value=bar]')
+    const data = root._vnode.component.data
+
+    // user picks 'bar', but the handler overrides the model back to 'foo'
+    foo.selected = false
+    bar.selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    // the DOM should reflect the overridden model value ('foo'), not the
+    // value the user just selected ('bar')
+    expect(data.value).toEqual('foo')
+    expect(input.selectedIndex).toEqual(0)
+    expect(foo.selected).toEqual(true)
+    expect(bar.selected).toEqual(false)
+  })
+
   it('multiple select (model is Array)', async () => {
     const component = defineComponent({
       data() {

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -40,7 +40,7 @@ function onCompositionEnd(e: Event) {
 const assignKey: unique symbol = Symbol('_assign')
 
 type ModelDirective<T, Modifiers extends string = string> = ObjectDirective<
-  T & { [assignKey]: AssignerFn; _assigning?: boolean },
+  T & { [assignKey]: AssignerFn; _assigning?: boolean; _assignedValue?: any },
   any,
   Modifiers
 >
@@ -214,13 +214,16 @@ export const vModelSelect: ModelDirective<HTMLSelectElement, 'number'> = {
         .map((o: HTMLOptionElement) =>
           number ? looseToNumber(getValue(o)) : getValue(o),
         )
-      el[assignKey](
-        el.multiple
-          ? isSetModel
-            ? new Set(selectedVal)
-            : selectedVal
-          : selectedVal[0],
-      )
+      const assignedValue = el.multiple
+        ? isSetModel
+          ? new Set(selectedVal)
+          : selectedVal
+        : selectedVal[0]
+      el[assignKey](assignedValue)
+      // remember the value just assigned by the user interaction so that the
+      // `updated` hook can detect when the model is later changed to a
+      // different value (e.g. reset) inside the update handler. #10505
+      el._assignedValue = assignedValue
       el._assigning = true
       nextTick(() => {
         el._assigning = false
@@ -237,7 +240,10 @@ export const vModelSelect: ModelDirective<HTMLSelectElement, 'number'> = {
     el[assignKey] = getModelAssigner(vnode)
   },
   updated(el, { value }) {
-    if (!el._assigning) {
+    // Skip the redundant DOM sync only when the model still holds the value
+    // produced by the user's selection. If it was changed to a different value
+    // during the update (e.g. reset to null), the DOM must be re-synced. #10505
+    if (!el._assigning || !looseEqual(value, el._assignedValue)) {
       setSelected(el, value)
     }
   },


### PR DESCRIPTION
### Summary

Fixes #10505.

When a `<select v-model>` has a change handler (or watcher) that reassigns
the model to a value **different** from the option the user just selected
(e.g. resetting it to `null`), the select's DOM state is left out of sync
with the model.

### Reproduction

From the issue: https://play.vuejs.org/#eNp9Uk1P4zAQ/SuzvtBKkO5q91SllXYRh+VAEXACc4iSSWtwbMsfoVLIf2ds00IRkEMSz3sz8+Z5BvbXmKIPyOas9NgZWXlccgVQOpRYe+hPOt2gXHCWA0IrziJh9/QnWs3rTaXWSCT6NhJX6jQFOEu1qJo2MRP6SoZI+0nILVpdzjLwBe0X0VYKD1jlLAvJB0P9W22jPBAKMoQN5Q0DOBjHcmaIWc7eDUdHV1thPEgSSanecUapPkSq6Iy2Hgaw2MIIrdUdHJFDRzGx1sr51y5R6CKySuetUGt4BhWkXE7ie3rIxeaAene/nNzdE4erNqhc6tA5mEzn0GvRwBDnFC1M9l2LZA/8WCxSw2mmwL5VxgsT3OZjErUEGOPrY7VciysCyeFkz5IdkzU0RivWxYPTipYkteKs1p0REu0q3QvZN9+J4KySUj+dp5i3AY938XqD9eMn8Qe3jTHOLi06tD1tzR7zlV2jz/DZ9QVu6X8P0mIGSexvwCt0Woa8tJH2L0ST7TteUvs/3TldzI0723pUbjdUFJosS3zOaA9Ovxn9Te7v4s+r1SMbXwCvMCS3

A select whose value is cleared/overridden inside the update handler keeps
showing the option the user picked instead of reflecting the new model value.

### Root cause

`2ffb956` (perf: optimize v-model multiple select w/ large lists) introduced
an `_assigning` flag so the `updated` hook can skip the redundant `setSelected`
call right after a user-initiated change. However, the flag is checked
unconditionally:

```ts
updated(el, { value }) {
  if (!el._assigning) {
    setSelected(el, value)
  }
}
```

If the model is changed to a value other than the one the user selected during
the same flush, `_assigning` is still `true`, so `setSelected` is skipped and
the DOM never gets re-synced.

### Fix

Remember the value produced by the user interaction (`_assignedValue`) and only
skip the DOM sync while the model still matches it. When the model has been
overridden, fall back to `setSelected`, keeping the original perf optimization
for the common case (the `looseEqual` check short-circuits on reference
equality, which is the case for unchanged large lists).

### Tests

Added a regression test under `vModel.spec.ts` that fails without the fix
(`selectedIndex` stays `-1` instead of pointing to the overridden option) and
passes with it. All existing `runtime-dom` unit tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed v-model synchronization with select elements when update handlers modify the bound model value, ensuring the DOM's selected option state correctly matches the final component value and remains synchronized throughout the update cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->