### PR TITLE
fix(reactivity): avoid triggering effects when set fails

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -138,6 +138,28 @@ describe('reactivity/reactive', () => {
     expect('foo' in original).toBe(false)
   })
 
+  test('failed set operation should not trigger effects', () => {
+    const original: any = {}
+    Object.defineProperty(original, 'foo', {
+      value: 1,
+      writable: false,
+      configurable: true,
+    })
+    const observed = reactive(original)
+    let dummy
+    let run = 0
+    effect(() => {
+      run++
+      dummy = observed.foo
+    })
+
+    expect(() => {
+      observed.foo = 2
+    }).toThrow(TypeError)
+    expect(dummy).toBe(1)
+    expect(run).toBe(1)
+  })
+
   test('original value change should reflect in observed value (Object)', () => {
     const original: any = { foo: 1 }
     const observed = reactive(original)

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -181,7 +181,7 @@ class MutableReactiveHandler extends BaseReactiveHandler {
       isRef(target) ? target : receiver,
     )
     // don't trigger if target is something up in the prototype chain of original
-    if (target === toRaw(receiver)) {
+    if (target === toRaw(receiver) && result) {
       if (!hadKey) {
         trigger(target, TriggerOpTypes.ADD, key, value)
       } else if (hasChanged(value, oldValue)) {


### PR DESCRIPTION
This fixes a small reactivity edge case where `MutableReactiveHandler.set` triggered effects even when the underlying `Reflect.set` operation failed.

For example, assigning to a non-writable property through a reactive proxy throws and leaves the value unchanged, but the dependent effect was still re-run.

The handler now only triggers `ADD` / `SET` notifications when `Reflect.set` succeeds.

Tests added:
- failed set operation should not trigger effects

Validation:
- `pnpm exec vitest run packages/reactivity/__tests__/reactive.spec.ts -t "failed set operation should not trigger effects"`
- `pnpm exec vitest run packages/reactivity`
- `pnpm exec prettier --check packages/reactivity/src/baseHandlers.ts packages/reactivity/__tests__/reactive.spec.ts`
- `pnpm exec eslint packages/reactivity/src/baseHandlers.ts packages/reactivity/__tests__/reactive.spec.ts`
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the reactivity system to prevent triggering updates when property assignments fail on protected or read-only properties, ensuring correct state management.

* **Tests**
  * Added test coverage to verify that failed property assignments do not trigger dependent updates and that cached values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->