### PR TITLE
fix(types): support exact optional public props

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-unit": "vitest --project unit*",
     "test-e2e": "node scripts/build.js vue -f global -d && vitest --project e2e",
     "test-dts": "run-s build-dts test-dts-only",
-    "test-dts-only": "tsc -p packages-private/dts-built-test/tsconfig.json && tsc -p ./packages-private/dts-test/tsconfig.test.json",
+    "test-dts-only": "tsc -p packages-private/dts-built-test/tsconfig.json && tsc -p ./packages-private/dts-test/tsconfig.test.json && tsc -p ./packages-private/dts-test/tsconfig.exactOptionalPropertyTypes.json",
     "test-coverage": "vitest run --project unit* --coverage",
     "prebench": "node scripts/build.js -pf esm-browser reactivity",
     "prebench-compare": "node scripts/build.js -pf esm-browser reactivity",

--- a/packages-private/dts-test/exactOptionalPropertyTypes.test-d.tsx
+++ b/packages-private/dts-test/exactOptionalPropertyTypes.test-d.tsx
@@ -9,10 +9,20 @@ describe('exactOptionalPropertyTypes', () => {
     },
   })
 
+  const WithDefault = defineComponent({
+    props: {
+      foo: {
+        type: String,
+        default: 'foo',
+      },
+    },
+  })
+
   const props = defineProps<{
     foo?: string
   }>()
 
   expectType<JSX.Element>(<Child {...props} />)
   expectType<JSX.Element>(<Child foo={undefined} />)
+  expectType<JSX.Element>(<WithDefault foo={undefined} />)
 })

--- a/packages-private/dts-test/exactOptionalPropertyTypes.test-d.tsx
+++ b/packages-private/dts-test/exactOptionalPropertyTypes.test-d.tsx
@@ -1,0 +1,18 @@
+import { defineComponent, defineProps } from 'vue'
+import { describe, expectType } from './utils'
+
+// #14366
+describe('exactOptionalPropertyTypes', () => {
+  const Child = defineComponent({
+    props: {
+      foo: String,
+    },
+  })
+
+  const props = defineProps<{
+    foo?: string
+  }>()
+
+  expectType<JSX.Element>(<Child {...props} />)
+  expectType<JSX.Element>(<Child foo={undefined} />)
+})

--- a/packages-private/dts-test/tsconfig.exactOptionalPropertyTypes.json
+++ b/packages-private/dts-test/tsconfig.exactOptionalPropertyTypes.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.test.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["./exactOptionalPropertyTypes.test-d.tsx"]
+}

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -316,7 +316,7 @@ export type ComponentPublicInstance<
   $: ComponentInternalInstance
   $data: D
   $props: MakeDefaultsOptional extends true
-    ? Partial<Defaults> &
+    ? LooseOptional<Partial<Defaults>> &
         Omit<Prettify<LooseOptional<P>> & PublicProps, keyof Defaults>
     : Prettify<LooseOptional<P>> & PublicProps
   $attrs: Attrs

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -132,6 +132,17 @@ export type UnwrapMixinsType<
 
 type EnsureNonVoid<T> = T extends void ? {} : T
 
+// preserve optional props for public consumers while still accepting undefined
+type LooseOptional<T> = IfAny<
+  T,
+  T,
+  T extends unknown
+    ? {
+        [K in keyof T]: {} extends Pick<T, K> ? T[K] | undefined : T[K]
+      }
+    : never
+>
+
 export type ComponentPublicInstanceConstructor<
   T extends ComponentPublicInstance<Props, RawBindings, D, C, M> =
     ComponentPublicInstance<any>,
@@ -305,8 +316,9 @@ export type ComponentPublicInstance<
   $: ComponentInternalInstance
   $data: D
   $props: MakeDefaultsOptional extends true
-    ? Partial<Defaults> & Omit<Prettify<P> & PublicProps, keyof Defaults>
-    : Prettify<P> & PublicProps
+    ? Partial<Defaults> &
+        Omit<Prettify<LooseOptional<P>> & PublicProps, keyof Defaults>
+    : Prettify<LooseOptional<P>> & PublicProps
   $attrs: Attrs
   $refs: Data & TypeRefs
   $slots: UnwrapSlotsType<S>


### PR DESCRIPTION
This PR fixes the exactOptionalPropertyTypes regression around defineProps spreads by widening the public $props surface for optional keys while keeping internal toRefs behavior intact. It adds a dedicated exact-optional dts fixture and tsconfig, and passes pnpm test-dts-only.

Fixes #14366.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new type-checking coverage for Vue component optional props when `exactOptionalPropertyTypes` is enabled.
  * Extended the DTS-only test run to include an additional strict TypeScript compilation pass.

* **Chores / Type Improvements**
  * Improved the public-facing component `$props` typing to better preserve optional-prop behavior under strict TypeScript settings, including components with default prop values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->