### PR TITLE
fix(runtime-vapor): parse dynamic v-bind event options like vdom

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/staticTemplate.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/staticTemplate.spec.ts.snap
@@ -13,6 +13,17 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`static template marker > does not fold unsafe static attr names into template 1`] = `
+"import { setAttr as _setAttr, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _setAttr(n0, "foo-\\u0001bar", "")
+  return n0
+}"
+`;
+
 exports[`static template marker > does not mark custom element createElement path as static 1`] = `
 "import { createPlainElement as _createPlainElement } from 'vue';
 

--- a/packages/compiler-vapor/__tests__/staticTemplate.spec.ts
+++ b/packages/compiler-vapor/__tests__/staticTemplate.spec.ts
@@ -102,6 +102,17 @@ describe('static template marker', () => {
     expect(result.code).toMatchSnapshot()
   })
 
+  test('does not fold unsafe static attr names into template', () => {
+    const unsafeName = 'foo-\u0001bar'
+    const result = compileForStaticTemplateSnapshot(`<div ${unsafeName} />`)
+    expect(result.code).toContain('const t0 = _template("<div>", 1)')
+    expect(result.code).toContain('_setAttr(n0, "foo-\\u0001bar", "")')
+    expect(result.templates).toMatchObject([
+      { content: '<div>', root: true, static: false },
+    ])
+    expect(result.code).toMatchSnapshot()
+  })
+
   test('does not mark single-root element with dynamic event handler', () => {
     const result = compileForStaticTemplateSnapshot(
       '<button @click="foo"></button>',

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -858,7 +858,7 @@ export function render(_ctx) {
 exports[`compiler: element transform > empty template 1`] = `
 "
 export function render(_ctx) {
-  return null
+  return []
 }"
 `;
 

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vBind.spec.ts.snap
@@ -193,7 +193,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => _setDynamicProps(n0, [{ ["." + _ctx.foo(_ctx.bar)]: _ctx.id }]))
+  _renderEffect(() => _setDynamicProps(n0, [{ ["." + (_ctx.foo(_ctx.bar) || "")]: _ctx.id }]))
   return n0
 }"
 `;
@@ -204,7 +204,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _renderEffect(() => _setDynamicProps(n0, [{ ["." + _ctx.fooBar]: _ctx.id }]))
+  _renderEffect(() => _setDynamicProps(n0, [{ ["." + (_ctx.fooBar || "")]: _ctx.id }]))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vHtml.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vHtml.spec.ts.snap
@@ -11,6 +11,17 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 }"
 `;
 
+exports[`v-html > should ignore interpolation children when v-html is present 1`] = `
+"import { setHtml as _setHtml, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _setHtml(n0, _ctx.test))
+  return n0
+}"
+`;
+
 exports[`v-html > should raise error and ignore children when v-html is present 1`] = `
 "import { setHtml as _setHtml, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
@@ -310,6 +310,18 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`v-on > should handle setup-let assignment w/ inline: true 1`] = `
+"
+  const n0 = t0()
+  const n1 = t0()
+  const n2 = t0()
+  n0.$evtclick = _createInvoker(() => (_isRef(x) ? x.value = _unref(y) : x=_unref(y)))
+  n1.$evtclick = _createInvoker(() => (_isRef(x) ? x.value++ : x++))
+  n2.$evtclick = _createInvoker(() => ({ x } = _unref(y)))
+  return [n0, n1, n2]
+"
+`;
+
 exports[`v-on > should not delegate .stop when have multiple events of same name 1`] = `
 "import { on as _on, withModifiers as _withModifiers, template as _template } from 'vue';
 const t0 = _template("<div>", 1)

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -31,7 +31,7 @@ export function render(_ctx) {
         ? {
           name: "default",
           fn: () => {
-            return null
+            return []
           }
         }
         : void 0)
@@ -252,7 +252,7 @@ export function render(_ctx) {
   const _component_Bar = _resolveComponent("Bar")
   const n2 = _createAssetComponent("Foo", null, {
     "header": _extend(() => {
-      return null
+      return []
     }, { _: 8 }),
     "default": () => {
       const n1 = _createComponentWithFallback(_component_Bar)
@@ -340,7 +340,7 @@ exports[`compiler: transform slot > quote slot name 1`] = `
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, {
     "nav-bar-title-before": _extend(() => {
-      return null
+      return []
     }, { _: 8 })
   }, true)
   return n1

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -1610,7 +1610,7 @@ describe('compiler: element transform', () => {
   test('empty template', () => {
     const { code } = compileWithElementTransform('')
     expect(code).toMatchSnapshot()
-    expect(code).contain('return null')
+    expect(code).contain('return []')
   })
 
   test('custom element', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -451,7 +451,7 @@ describe('compiler v-bind', () => {
     })
     expect(code).contains('renderEffect')
     expect(code).contains(
-      `_setDynamicProps(n0, [{ ["." + _ctx.fooBar]: _ctx.id }])`,
+      `_setDynamicProps(n0, [{ ["." + (_ctx.fooBar || "")]: _ctx.id }])`,
     )
   })
 
@@ -627,6 +627,36 @@ describe('compiler v-bind', () => {
 
     expect(code).contains('renderEffect')
     expect(code).contains('_setAttr(n0, "foo-bar", _ctx.fooBar)')
+  })
+
+  test('.attr modifier w/ dynamic arg', () => {
+    const { ir, code } = compileWithVBind(`<div v-bind:[fooBar].attr="id"/>`)
+
+    expect(ir.block.effect[0].operations[0]).toMatchObject({
+      type: IRNodeTypes.SET_DYNAMIC_PROPS,
+      props: [
+        [
+          {
+            key: {
+              content: `fooBar`,
+              isStatic: false,
+            },
+            values: [
+              {
+                content: `id`,
+                isStatic: false,
+              },
+            ],
+            runtimeCamelize: false,
+            modifier: '^',
+          },
+        ],
+      ],
+    })
+    expect(code).contains('renderEffect')
+    expect(code).contains(
+      `_setDynamicProps(n0, [{ ["^" + (_ctx.fooBar || "")]: _ctx.id }])`,
+    )
   })
 
   test('.attr modifier w/ innerHTML', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vHtml.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vHtml.spec.ts
@@ -1,6 +1,7 @@
 import { BindingTypes, DOMErrorCodes, NodeTypes } from '@vue/compiler-dom'
 import {
   IRNodeTypes,
+  compile,
   transformChildren,
   transformElement,
   transformVHtml,
@@ -111,6 +112,20 @@ describe('v-html', () => {
     expect(code).matchSnapshot()
     // children should have been removed
     expect(code).contains('template("<div>", 1)')
+  })
+
+  test('should ignore interpolation children when v-html is present', () => {
+    const onError = vi.fn()
+    const { code } = compile(`<div v-html="test">{{ msg }}</div>`, {
+      prefixIdentifiers: true,
+      onError,
+    })
+
+    expect(onError.mock.calls).toMatchObject([
+      [{ code: DOMErrorCodes.X_V_HTML_WITH_CHILDREN }],
+    ])
+    expect(code).matchSnapshot()
+    expect(code).contains(`_setHtml(n0, _ctx.test)`)
   })
 
   test('should raise error if has no expression', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
@@ -365,6 +365,18 @@ describe('compiler: vModel transform', () => {
       })
     })
 
+    test('v-model with kebab-case argument for component should quote modelModifiers key', () => {
+      const cases = [
+        '<Comp v-model:foo-bar.trim="foo" />',
+        '<Comp v-bind="obj" v-model:foo-bar.trim="foo" />',
+      ]
+
+      for (const source of cases) {
+        const { code } = compileWithVModel(source)
+        expect(code).contain(`"foo-barModifiers": { trim: true }`)
+      }
+    })
+
     test('v-model:model with arguments for component should generate modelModifiers$', () => {
       const { code, ir } = compileWithVModel(
         '<Comp v-model:model.trim="foo" />',

--- a/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
@@ -166,6 +166,13 @@ describe('compiler: vModel transform', () => {
 
       expect(code).toMatchSnapshot()
     })
+
+    test('non-identifier modifiers should be quoted', () => {
+      const { code } = compileWithVModel('<input v-model.foo-bar="model" />')
+
+      expect(code).contains(`{ "foo-bar": true }`)
+      expect(code).not.contains(`{ foo-bar: true }`)
+    })
   })
 
   test('should support member expression', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -208,6 +208,33 @@ describe('v-on', () => {
     )
   })
 
+  test('should handle setup-let assignment w/ inline: true', () => {
+    const { code, helpers } = compileWithVOn(
+      `<div @click="x=y"/><div @click="x++"/><div @click="{ x } = y"/>`,
+      {
+        mode: 'module',
+        inline: true,
+        bindingMetadata: {
+          x: BindingTypes.SETUP_LET,
+          y: BindingTypes.SETUP_MAYBE_REF,
+        },
+      },
+    )
+
+    expect(code).matchSnapshot()
+    expect(helpers).contains('isRef')
+    expect(helpers).contains('unref')
+    expect(code).contains(
+      `n0.$evtclick = _createInvoker(() => (_isRef(x) ? x.value = _unref(y) : x=_unref(y)))`,
+    )
+    expect(code).contains(
+      `n1.$evtclick = _createInvoker(() => (_isRef(x) ? x.value++ : x++))`,
+    )
+    expect(code).contains(
+      `n2.$evtclick = _createInvoker(() => ({ x } = _unref(y)))`,
+    )
+  })
+
   test('should handle multiple inline statement', () => {
     const { ir, code } = compileWithVOn(`<div @click="foo();bar()"/>`)
 

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -549,6 +549,22 @@ describe('compiler: transform slot', () => {
     })
   })
 
+  test('slot v-else missing adjacent v-if should report compiler error', () => {
+    const cases = [
+      `<Comp><template #foo v-else>foo</template></Comp>`,
+      `<Comp><template #foo v-else-if="ok">foo</template></Comp>`,
+    ]
+
+    for (const source of cases) {
+      const onError = vi.fn()
+      expect(() => compileWithSlots(source, { onError })).not.toThrow()
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError.mock.calls[0][0]).toMatchObject({
+        code: ErrorCodes.X_V_ELSE_NO_ADJACENT_IF,
+      })
+    }
+  })
+
   test('slot + v-if / v-else[-if] should not cause error', () => {
     const { code } = compileWithSlots(
       `<div>

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -165,7 +165,7 @@ export function genBlockContent(
   const returnsCode: CodeFragment[] =
     returnNodes.length > 1
       ? genMulti(DELIMITERS_ARRAY, ...returnNodes)
-      : [returnNodes[0] || 'null']
+      : [returnNodes[0] || '[]']
   push(...returnsCode)
 
   resetBlock()

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -46,8 +46,8 @@ import {
   isSimpleIdentifier,
   toValidAssetId,
 } from '@vue/compiler-dom'
+import { genDirectivesForElement } from './directive'
 import { genEventHandler } from './event'
-import { genDirectiveModifiers, genDirectivesForElement } from './directive'
 import { findReturnedDynamic, genBlock, markSlotRootOperations } from './block'
 import {
   type DestructureMap,
@@ -56,6 +56,7 @@ import {
   parseValueDestructure,
 } from './for'
 import { genModelHandler } from './vModel'
+import { genDirectiveModifiers } from './modifier'
 import { isBuiltInComponent } from '../utils'
 import type { Expression } from '@babel/types'
 

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -43,6 +43,7 @@ import {
   type SimpleExpressionNode,
   createSimpleExpression,
   isMemberExpression,
+  isSimpleIdentifier,
   toValidAssetId,
 } from '@vue/compiler-dom'
 import { genEventHandler } from './event'
@@ -57,6 +58,11 @@ import {
 import { genModelHandler } from './vModel'
 import { isBuiltInComponent } from '../utils'
 import type { Expression } from '@babel/types'
+
+function genStaticModifierPropKey(name: string): CodeFragment[] {
+  const key = getModifierPropName(name)
+  return [isSimpleIdentifier(key) ? key : JSON.stringify(key)]
+}
 
 export function genCreateComponent(
   operation: CreateComponentIRNode,
@@ -356,7 +362,7 @@ function genStaticProps(
       const { key, modelModifiers } = prop
       if (modelModifiers && modelModifiers.length) {
         const modifiersKey = key.isStatic
-          ? [getModifierPropName(key.content)]
+          ? genStaticModifierPropKey(key.content)
           : ['[', ...genExpression(key, context), ' + "Modifiers"]']
         const modifiersVal = genDirectiveModifiers(modelModifiers)
         args.push([
@@ -428,7 +434,7 @@ function genDynamicProps(
           const { modelModifiers } = p
           if (modelModifiers && modelModifiers.length) {
             const modifiersKey = p.key.isStatic
-              ? ([getModifierPropName(p.key.content)] as CodeFragment[])
+              ? genStaticModifierPropKey(p.key.content)
               : ([
                   '[',
                   ...genExpression(p.key, context),

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -1,8 +1,4 @@
-import {
-  createSimpleExpression,
-  isSimpleIdentifier,
-  toValidAssetId,
-} from '@vue/compiler-dom'
+import { createSimpleExpression, toValidAssetId } from '@vue/compiler-dom'
 import { extend } from '@vue/shared'
 import { genExpression } from './expression'
 import type { CodegenContext } from '../generate'
@@ -17,6 +13,7 @@ import {
 import { type DirectiveIRNode, IRNodeTypes, type OperationNode } from '../ir'
 import { genVShow } from './vShow'
 import { genVModel } from './vModel'
+import { genDirectiveModifiers } from './modifier'
 
 export function genBuiltinDirective(
   oper: DirectiveIRNode,
@@ -85,15 +82,6 @@ function genCustomDirectives(
       modifiers,
     )
   }
-}
-
-export function genDirectiveModifiers(modifiers: string[]): string {
-  return modifiers
-    .map(
-      value =>
-        `${isSimpleIdentifier(value) ? value : JSON.stringify(value)}: true`,
-    )
-    .join(', ')
 }
 
 function filterCustomDirectives(

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -16,7 +16,12 @@ import {
   isStaticProperty,
   walkIdentifiers,
 } from '@vue/compiler-dom'
-import type { Identifier, Node } from '@babel/types'
+import type {
+  AssignmentExpression,
+  Identifier,
+  Node,
+  UpdateExpression,
+} from '@babel/types'
 import type { CodegenContext } from '../generate'
 import { isConstantExpression } from '../utils'
 import {
@@ -34,6 +39,8 @@ export function genExpression(
 ): CodeFragment[] {
   node = context.getExpressionReplacement(node)
   const { content, ast, isStatic, loc } = node
+  const { options } = context
+  const { inline } = options
 
   if (isStatic) {
     return [[JSON.stringify(content), NewlineType.None, loc]]
@@ -69,19 +76,35 @@ export function genExpression(
   let hasMemberExpression = false
   if (ids.length) {
     const [frag, push] = buildCodeFragment()
+    let lastEnd = 0
     ids
       .sort((a, b) => a.start! - b.start!)
-      .forEach((id, i) => {
+      .forEach(id => {
         // range is offset by -1 due to the wrapping parens when parsed
-        const start = id.start! - 1
-        const end = id.end! - 1
-        const last = ids[i - 1]
-
-        const leadingText = content.slice(last ? last.end! - 1 : 0, start)
-        if (leadingText.length) push([leadingText, NewlineType.Unknown])
-        const source = content.slice(start, end)
+        const idStart = id.start! - 1
+        const idEnd = id.end! - 1
+        const source = content.slice(idStart, idEnd)
         const parentStack = parentStackMap.get(id)!
         const parent = parentStack[parentStack.length - 1]
+        let start = idStart
+        let end = idEnd
+
+        if (
+          inline &&
+          options.bindingMetadata &&
+          options.bindingMetadata[source] === BindingTypes.SETUP_LET &&
+          parent &&
+          parent.type === 'UpdateExpression' &&
+          parent.argument === id
+        ) {
+          start = parent.start! - 1
+          end = parent.end! - 1
+        }
+
+        if (start < lastEnd) return
+
+        const leadingText = content.slice(lastEnd, start)
+        if (leadingText.length) push([leadingText, NewlineType.Unknown])
 
         hasMemberExpression ||=
           parent &&
@@ -101,14 +124,16 @@ export function genExpression(
             id,
             parent,
             parentStack,
+            node,
           ),
         )
 
-        if (i === ids.length - 1 && end < content.length) {
-          push([content.slice(end), NewlineType.Unknown])
-        }
+        lastEnd = end
       })
 
+    if (lastEnd < content.length) {
+      push([content.slice(lastEnd), NewlineType.Unknown])
+    }
     if (assignment && hasMemberExpression) {
       push(` = ${assignment}`)
     }
@@ -126,6 +151,7 @@ function genIdentifier(
   id?: Identifier,
   parent?: Node,
   parentStack?: Node[],
+  sourceNode?: SimpleExpressionNode,
 ): CodeFragment[] {
   const { options, helper, identifiers } = context
   const { inline, bindingMetadata } = options
@@ -147,33 +173,73 @@ function genIdentifier(
   }
 
   let prefix: string | undefined
-  if (isStaticProperty(parent) && parent.shorthand) {
+  const type = bindingMetadata && bindingMetadata[raw]
+  // ({ x } = y)
+  const isDestructureAssignment =
+    parent && isInDestructureAssignment(parent, parentStack || [])
+  // x = y
+  const isAssignmentLVal =
+    parent && parent.type === 'AssignmentExpression' && parent.left === id
+  // x++
+  const isUpdateArg =
+    parent && parent.type === 'UpdateExpression' && parent.argument === id
+
+  if (
+    isStaticProperty(parent) &&
+    parent.shorthand &&
+    !(inline && type === BindingTypes.SETUP_LET && isDestructureAssignment)
+  ) {
     // property shorthand like { foo }, we need to add the key since
     // we rewrite the value
     prefix = `${raw}: `
   }
 
-  const type = bindingMetadata && bindingMetadata[raw]
   if (inline) {
     switch (type) {
       case BindingTypes.SETUP_LET:
-        name = raw = assignment
-          ? `_isRef(${raw}) ? (${raw}.value = ${assignment}) : (${raw} = ${assignment})`
-          : unref()
+        if (isAssignmentLVal) {
+          const { right, operator } = parent as AssignmentExpression
+          const source = sourceNode!
+          const sourceContent = source.content
+          const rightStart = right.start! - 1
+          const rightEnd = right.end! - 1
+          const rightContent = sourceContent.slice(rightStart, rightEnd)
+          const rightExp = createSimpleExpression(rightContent, false, {
+            start: advancePositionWithClone(
+              source.loc.start,
+              sourceContent,
+              rightStart,
+            ),
+            end: advancePositionWithClone(
+              source.loc.start,
+              sourceContent,
+              rightEnd,
+            ),
+            source: rightContent,
+          })
+          rightExp.ast = parseExp(context, rightContent)
+          return [
+            prefix,
+            `${helper('isRef')}(${raw}) ? ${raw}.value ${operator} `,
+            ...genExpression(rightExp, context),
+            ` : `,
+            [raw, NewlineType.None, loc, name],
+          ]
+        } else if (isUpdateArg) {
+          const { prefix: isPrefix, operator } = parent as UpdateExpression
+          const updatePrefix = isPrefix ? operator : ``
+          const updatePostfix = isPrefix ? `` : operator
+          raw = `${helper('isRef')}(${raw}) ? ${updatePrefix}${raw}.value${updatePostfix} : ${updatePrefix}${raw}${updatePostfix}`
+        } else if (!isDestructureAssignment) {
+          name = raw = assignment
+            ? `${helper('isRef')}(${raw}) ? (${raw}.value = ${assignment}) : (${raw} = ${assignment})`
+            : unref()
+        }
         break
       case BindingTypes.SETUP_REF:
         name = raw = withAssignment(`${raw}.value`)
         break
       case BindingTypes.SETUP_MAYBE_REF:
-        // ({ x } = y)
-        const isDestructureAssignment =
-          parent && isInDestructureAssignment(parent, parentStack || [])
-        // x = y
-        const isAssignmentLVal =
-          parent && parent.type === 'AssignmentExpression' && parent.left === id
-        // x++
-        const isUpdateArg =
-          parent && parent.type === 'UpdateExpression' && parent.argument === id
         // const binding that may or may not be ref
         // if it's not a ref, then assignments don't make sense -
         // so we ignore the non-ref assignment case and generate code

--- a/packages/compiler-vapor/src/generators/modifier.ts
+++ b/packages/compiler-vapor/src/generators/modifier.ts
@@ -1,0 +1,10 @@
+import { isSimpleIdentifier } from '@vue/compiler-dom'
+
+export function genDirectiveModifiers(modifiers: string[]): string {
+  return modifiers
+    .map(
+      value =>
+        `${isSimpleIdentifier(value) ? value : JSON.stringify(value)}: true`,
+    )
+    .join(', ')
+}

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -400,6 +400,8 @@ export function genPropKey(
   if (runtimeCamelize) {
     key.push(' || ""')
     key = genCall(helper('camelize'), key)
+  } else if (modifier) {
+    key = ['(', ...key, ' || ""', ')']
   }
   if (handler) {
     key = genCall(helper('toHandlerKey'), key)

--- a/packages/compiler-vapor/src/generators/vModel.ts
+++ b/packages/compiler-vapor/src/generators/vModel.ts
@@ -3,6 +3,7 @@ import type { DirectiveIRNode } from '../ir'
 import { type CodeFragment, NEWLINE, genCall } from './utils'
 import { genExpression } from './expression'
 import type { SimpleExpressionNode } from '@vue/compiler-dom'
+import { genDirectiveModifiers } from './modifier'
 
 const helperMap = {
   text: 'applyTextModel',
@@ -34,7 +35,7 @@ export function genVModel(
       genModelHandler(exp!, context),
       // modifiers
       modifiers.length
-        ? `{ ${modifiers.map(e => e.content + ': true').join(',')} }`
+        ? `{ ${genDirectiveModifiers(modifiers.map(e => e.content))} }`
         : undefined,
     ),
   ]

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -470,9 +470,12 @@ function transformNativeElement(
 
     for (const prop of propsResult[1]) {
       const { key, values } = prop
+      const canStringifyAttrName =
+        key.isStatic && !UNSAFE_ATTR_NAME_RE.test(key.content)
       let foldedValue: string | boolean | undefined
       // handling asset imports
       if (
+        canStringifyAttrName &&
         context.imports.some(imported =>
           values[0].content.includes(imported.exp.content),
         )
@@ -483,7 +486,7 @@ function transformNativeElement(
         template += `${key.content}="${IMPORT_EXP_START}${values[0].content}${IMPORT_EXP_END}"`
         prevWasQuoted = true
       } else if (
-        key.isStatic &&
+        canStringifyAttrName &&
         values.length === 1 &&
         (values[0].isStatic || values[0].content === "''") &&
         !dynamicKeys.includes(key.content)
@@ -491,7 +494,7 @@ function transformNativeElement(
         const value = values[0].content === "''" ? '' : values[0].content
         appendTemplateProp(key.content, value)
       } else if (
-        key.isStatic &&
+        canStringifyAttrName &&
         !prop.modifier &&
         isBooleanAttr(key.content) &&
         (foldedValue = foldBooleanAttrValue(values)) != null
@@ -500,7 +503,7 @@ function transformNativeElement(
           appendTemplateProp(key.content)
         }
       } else if (
-        key.isStatic &&
+        canStringifyAttrName &&
         !prop.modifier &&
         hasBoundValue(values) &&
         (foldedValue =

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -69,6 +69,7 @@ import {
   getParserOptions,
 } from '../generators/utils'
 import { normalizeBindShorthand } from './vBind'
+import { ignoreVHtmlChildren } from './vHtml'
 import type { Expression, ObjectExpression, ObjectProperty } from '@babel/types'
 import { parseExpression } from '@babel/parser'
 
@@ -80,6 +81,10 @@ export const isReservedProp: (key: string) => boolean = /*#__PURE__*/ makeMap(
 export const transformElement: NodeTransform = (node, context) => {
   let effectIndex = context.block.effect.length
   const getEffectIndex = () => effectIndex++
+
+  if (node.type === NodeTypes.ELEMENT && node.children.length) {
+    ignoreVHtmlChildren(node, context as TransformContext<ElementNode>, 'node')
+  }
 
   // If the element is a component, we need to isolate its slots context.
   // This ensures that slots defined for this component are not accidentally

--- a/packages/compiler-vapor/src/transforms/vHtml.ts
+++ b/packages/compiler-vapor/src/transforms/vHtml.ts
@@ -1,7 +1,31 @@
 import { IRNodeTypes } from '../ir'
-import type { DirectiveTransform } from '../transform'
-import { DOMErrorCodes, createDOMCompilerError } from '@vue/compiler-dom'
+import type { DirectiveTransform, TransformContext } from '../transform'
+import {
+  DOMErrorCodes,
+  type ElementNode,
+  createDOMCompilerError,
+  findDir,
+} from '@vue/compiler-dom'
 import { EMPTY_EXPRESSION } from './utils'
+
+export function ignoreVHtmlChildren(
+  node: ElementNode,
+  context: TransformContext<ElementNode>,
+  clear: 'node' | 'template',
+): void {
+  if (!node.children.length) return
+  const dir = findDir(node, 'html')
+  if (!dir) return
+
+  context.options.onError(
+    createDOMCompilerError(DOMErrorCodes.X_V_HTML_WITH_CHILDREN, dir.loc),
+  )
+  if (clear === 'node') {
+    node.children.length = 0
+  } else {
+    context.childrenTemplate.length = 0
+  }
+}
 
 export const transformVHtml: DirectiveTransform = (dir, node, context) => {
   let { exp, loc } = dir
@@ -11,12 +35,7 @@ export const transformVHtml: DirectiveTransform = (dir, node, context) => {
     )
     exp = EMPTY_EXPRESSION
   }
-  if (node.children.length) {
-    context.options.onError(
-      createDOMCompilerError(DOMErrorCodes.X_V_HTML_WITH_CHILDREN, loc),
-    )
-    context.childrenTemplate.length = 0
-  }
+  ignoreVHtmlChildren(node, context, 'template')
 
   context.registerEffect([exp], {
     type: IRNodeTypes.SET_HTML,

--- a/packages/compiler-vapor/src/transforms/vSlot.ts
+++ b/packages/compiler-vapor/src/transforms/vSlot.ts
@@ -166,8 +166,8 @@ function transformTemplateSlot(
       },
     })
   } else if (vElse) {
-    const vIfSlot = slots[slots.length - 1] as IRSlotDynamic
-    if (vIfSlot.slotType === IRSlotType.CONDITIONAL) {
+    const vIfSlot = slots[slots.length - 1]
+    if (vIfSlot && vIfSlot.slotType === IRSlotType.CONDITIONAL) {
       let ifNode = vIfSlot
       while (
         ifNode.negative &&

--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -336,6 +336,10 @@ export { patchStyle } from './modules/style'
 /**
  * @internal
  */
+export { parseEventName } from './modules/events'
+/**
+ * @internal
+ */
 export { shouldSetAsProp, shouldSetAsPropForVueCE } from './patchProp'
 /**
  * @internal

--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -49,7 +49,7 @@ export function patchEvent(
       ? sanitizeEventValue(nextValue, rawName)
       : (nextValue as EventValue)
   } else {
-    const [name, options] = parseName(rawName)
+    const [name, options] = parseEventName(rawName)
     if (nextValue) {
       // add
       const invoker = (invokers[rawName] = createInvoker(
@@ -69,7 +69,9 @@ export function patchEvent(
 
 const optionsModifierRE = /(?:Once|Passive|Capture)$/
 
-function parseName(name: string): [string, EventListenerOptions | undefined] {
+export function parseEventName(
+  name: string,
+): [string, EventListenerOptions | undefined] {
   let options: EventListenerOptions | undefined
   if (optionsModifierRE.test(name)) {
     options = {}

--- a/packages/runtime-vapor/__tests__/apiCreateVaporApp.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateVaporApp.spec.ts
@@ -100,6 +100,30 @@ describe('api: createVaporApp', () => {
     expect(root.innerHTML).toBe(``)
   })
 
+  test('unmount in non-dev mode', () => {
+    __DEV__ = false
+    try {
+      const Comp = defineVaporComponent({
+        setup() {
+          return createTextNode('ok')
+        },
+      })
+
+      const root = document.createElement('div')
+      const app = createVaporApp(Comp)
+
+      app.mount(root)
+      expect(root.innerHTML).toBe(`ok`)
+      expect(app._instance).toBeNull()
+
+      expect(() => app.unmount()).not.toThrow()
+      expect(root.innerHTML).toBe(``)
+      expect(app._instance).toBeNull()
+    } finally {
+      __DEV__ = true
+    }
+  })
+
   test('provide', () => {
     const Root = define({
       setup() {

--- a/packages/runtime-vapor/__tests__/apiCreateVaporApp.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateVaporApp.spec.ts
@@ -3,6 +3,7 @@ import {
   createComponent,
   createTextNode,
   createVaporApp,
+  createVaporSSRApp,
   defineVaporComponent,
   template,
   withVaporDirectives,
@@ -122,6 +123,23 @@ describe('api: createVaporApp', () => {
     } finally {
       __DEV__ = true
     }
+  })
+
+  test('ssr mount should fall back to full mount when container is empty', () => {
+    const Comp = defineVaporComponent({
+      setup() {
+        return createTextNode('hello')
+      },
+    })
+
+    const root = document.createElement('div')
+    const app = createVaporSSRApp(Comp)
+
+    expect(() => app.mount(root)).not.toThrow()
+    expect(root.innerHTML).toBe(`hello`)
+    expect(
+      `Attempting to hydrate existing markup but container is empty. Performing full mount instead.`,
+    ).toHaveBeenWarned()
   })
 
   test('provide', () => {

--- a/packages/runtime-vapor/__tests__/apiCreateVaporApp.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateVaporApp.spec.ts
@@ -57,6 +57,26 @@ describe('api: createVaporApp', () => {
     expect(`already been mounted`).toHaveBeenWarned()
   })
 
+  test('mount should no-op when selector returns null', () => {
+    const Comp = defineVaporComponent({
+      setup() {
+        return createTextNode('hello')
+      },
+    })
+    const app = createVaporApp(Comp)
+    let proxy: any
+
+    expect(() => {
+      proxy = app.mount('#not-exist-id')
+    }).not.toThrow()
+
+    expect(proxy).toBeUndefined()
+    expect(
+      'Failed to mount app: mount target selector "#not-exist-id" returned null.',
+    ).toHaveBeenWarned()
+    expect(app._container).toBeNull()
+  })
+
   test('unmount', () => {
     const Comp = defineVaporComponent({
       props: {

--- a/packages/runtime-vapor/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentEmits.spec.ts
@@ -16,7 +16,7 @@ import {
   defineVaporComponent,
   template,
 } from '../src'
-import { makeRender } from './_utils'
+import { compile, makeRender } from './_utils'
 
 const define = makeRender()
 
@@ -65,6 +65,23 @@ describe('component: emit', () => {
     expect(onFoo).not.toHaveBeenCalled()
     expect(onBar).toHaveBeenCalled()
     expect(onBaz).toHaveBeenCalled()
+  })
+
+  test('should ignore nullish object v-bind sources when emitting', () => {
+    const Child = defineVaporComponent({
+      emits: ['ready'],
+      setup(_, { emit }) {
+        emit('ready')
+        return []
+      },
+    })
+    const Parent = compile(
+      `<template><components.Child v-bind="data.attrs" /></template>`,
+      ref({ attrs: null }),
+      { Child },
+    )
+
+    expect(() => define(Parent).render()).not.toThrow()
   })
 
   test('trigger camelCase handler', () => {

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -390,6 +390,13 @@ describe('patchProp', () => {
       setAttr(el, 'disabled', false)
       expect(el.getAttribute('disabled')).toBe('false')
     })
+
+    test('should set symbol attribute values', () => {
+      const el = document.createElement('div')
+      const symbol = Symbol('foo')
+      setAttr(el, 'data-foo', symbol)
+      expect(el.getAttribute('data-foo')).toBe(symbol.toString())
+    })
   })
 
   describe('setValue', () => {
@@ -530,6 +537,12 @@ describe('patchProp', () => {
       let res = setDynamicProp('^foo', 'bar')
       expect(res.getAttribute('foo')).toBe('bar')
       expect((res as any)['foo']).toBeUndefined()
+    })
+
+    test('should be able to set ^attr to symbol values', () => {
+      const symbol = Symbol('foo')
+      const res = setDynamicProp('^foo', symbol)
+      expect(res.getAttribute('foo')).toBe(symbol.toString())
     })
 
     test('should be able to set boolean prop', () => {

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -627,6 +627,25 @@ describe('patchProp', () => {
       expect(el.getAttribute('foo')).toBeNull()
     })
 
+    test('should treat nullish dynamic props as empty props', () => {
+      const el = document.createElement('div')
+
+      setDynamicProps(el, [null])
+      setDynamicProps(el, [undefined])
+
+      setDynamicProps(el, [{ foo: 'val' }])
+      expect(el.getAttribute('foo')).toBe('val')
+
+      setDynamicProps(el, [null])
+      expect(el.getAttribute('foo')).toBeNull()
+
+      setDynamicProps(el, [{ bar: 'val' }])
+      expect(el.getAttribute('bar')).toBe('val')
+
+      setDynamicProps(el, [undefined])
+      expect(el.getAttribute('bar')).toBeNull()
+    })
+
     test('should reset old modifier props', () => {
       const el = document.createElement('div')
 

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -694,6 +694,40 @@ describe('patchProp', () => {
       expect(handler).toHaveBeenCalledTimes(2)
     })
 
+    test('should parse dynamic event option modifiers like vdom', () => {
+      const el = document.createElement('button')
+      const handler = vi.fn()
+      const scope = effectScope()
+      scope.run(() => {
+        renderEffect(() => {
+          setDynamicProps(el, [{ onClickOnceCapture: handler }])
+        })
+      })
+
+      el.dispatchEvent(new Event('click'))
+      el.dispatchEvent(new Event('click'))
+
+      expect(handler).toHaveBeenCalledTimes(1)
+      scope.stop()
+    })
+
+    test('should parse dynamic event names like vdom', () => {
+      const el = document.createElement('button')
+      const handler = vi.fn()
+      const scope = effectScope()
+      scope.run(() => {
+        renderEffect(() => {
+          setDynamicProps(el, [{ onMyEventOnce: handler }])
+        })
+      })
+
+      el.dispatchEvent(new Event('my-event'))
+      el.dispatchEvent(new Event('my-event'))
+
+      expect(handler).toHaveBeenCalledTimes(1)
+      scope.stop()
+    })
+
     test('should restore fallthrough state when dynamic props throw', () => {
       const el = document.createElement('div')
       const attrs: Record<string, any> = {}

--- a/packages/runtime-vapor/src/apiCreateApp.ts
+++ b/packages/runtime-vapor/src/apiCreateApp.ts
@@ -97,8 +97,10 @@ function prepareApp() {
 function postPrepareApp(app: App) {
   app.vapor = true
   const mount = app.mount
-  app.mount = (container, ...args: any[]) => {
+  app.mount = (container, ...args: any[]): any => {
     container = normalizeContainer(container) as ParentNode
+    if (!container) return
+
     const proxy = mount(container, ...args)
     if (container instanceof Element) {
       container.removeAttribute('v-cloak')

--- a/packages/runtime-vapor/src/apiCreateApp.ts
+++ b/packages/runtime-vapor/src/apiCreateApp.ts
@@ -57,8 +57,16 @@ const mountApp: AppMountFn<ParentNode> = (app, container) => {
 let _hydrateApp: CreateAppFunction<ParentNode, VaporComponent>
 
 const hydrateApp: AppMountFn<ParentNode> = (app, container) => {
-  optimizePropertyLookup()
+  if (!container.hasChildNodes()) {
+    ;(__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
+      warn(
+        `Attempting to hydrate existing markup but container is empty. ` +
+          `Performing full mount instead.`,
+      )
+    return mountApp(app, container)
+  }
 
+  optimizePropertyLookup()
   let instance: VaporComponentInstance
   withHydration(container, () => {
     instance =

--- a/packages/runtime-vapor/src/apiCreateApp.ts
+++ b/packages/runtime-vapor/src/apiCreateApp.ts
@@ -24,6 +24,7 @@ import { optimizePropertyLookup } from './dom/prop'
 import { setIsHydratingEnabled, withHydration } from './dom/hydration'
 
 let _createApp: CreateAppFunction<ParentNode, VaporComponent>
+const rootInstances = new WeakMap<App, VaporComponentInstance>()
 
 const mountApp: AppMountFn<ParentNode> = (app, container) => {
   optimizePropertyLookup()
@@ -48,6 +49,7 @@ const mountApp: AppMountFn<ParentNode> = (app, container) => {
     )
   mountComponent(instance, container)
   flushOnAppMount()
+  rootInstances.set(app, instance)
 
   return instance!
 }
@@ -73,12 +75,16 @@ const hydrateApp: AppMountFn<ParentNode> = (app, container) => {
     mountComponent(instance, container)
     flushOnAppMount()
   })
+  rootInstances.set(app, instance!)
 
   return instance!
 }
 
 const unmountApp: AppUnmountFn = app => {
-  unmountComponent(app._instance as VaporComponentInstance, app._container)
+  const instance = ((__DEV__ && app._instance) ||
+    rootInstances.get(app)!) as VaporComponentInstance
+  unmountComponent(instance, app._container)
+  rootInstances.delete(app)
 }
 
 function prepareApp() {

--- a/packages/runtime-vapor/src/componentEmits.ts
+++ b/packages/runtime-vapor/src/componentEmits.ts
@@ -47,7 +47,7 @@ function propGetter(rawProps: RawProps, key: string) {
     let i = dynamicSources.length
     while (i--) {
       const source = resolveSource(dynamicSources[i])
-      if (hasOwn(source, key))
+      if (source && hasOwn(source, key))
         // for props passed from VDOM component, no need to resolve
         return (isInteropEnabled && dynamicSources[interopKey]) ||
           (isOn(key) && isFunction(dynamicSources[i]))

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -1,4 +1,5 @@
 import {
+  EMPTY_OBJ,
   type NormalizedStyle,
   camelize,
   canSetValueDirectly,
@@ -537,7 +538,7 @@ function setHtmlToBlock(block: Block, value: any): void {
 }
 
 export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
-  const props = args.length > 1 ? mergeProps(...args) : args[0]
+  const props = args.length > 1 ? mergeProps(...args) : args[0] || EMPTY_OBJ
   const cacheKey = `$dprops${isApplyingFallthroughProps ? '$' : ''}`
   const prevProps = el[cacheKey] as Record<string, any> | undefined
   const nextProps: Record<string, any> = Object.create(null)

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -7,6 +7,7 @@ import {
   isArray,
   isOn,
   isString,
+  isSymbol,
   normalizeClass,
   normalizeCssVarValue,
   normalizeStyle,
@@ -118,7 +119,7 @@ export function setAttr(
       }
     } else {
       if (value != null) {
-        el.setAttribute(key, value)
+        el.setAttribute(key, isSymbol(value) ? String(value) : value)
       } else {
         el.removeAttribute(key)
       }

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -26,6 +26,7 @@ import {
   isValidHtmlOrSvgAttribute,
   logMismatchError,
   mergeProps,
+  parseEventName,
   patchStyle,
   queuePostFlushCb,
   shouldSetAsProp,
@@ -586,7 +587,8 @@ export function setDynamicProp(
     if (shouldSkipFallthroughKey(el, key)) {
       return
     }
-    onBinding(el, key[2].toLowerCase() + key.slice(3), value)
+    const [event, options] = parseEventName(key)
+    onBinding(el, event, value, options)
   } else if (
     // force hydrate v-bind with .prop modifiers
     (forceHydrate = key[0] === '.')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed v-html directive behavior when child elements are present; now properly reports errors and clears conflicting content.
  * Improved dynamic property binding to handle nullish values with appropriate fallbacks.

* **Improvements**
  * Enhanced v-model modifier handling for non-identifier names (e.g., kebab-case).
  * Refined component lifecycle management during mounting and unmounting.
  * Better event parsing and handling for dynamic event listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->