### PR TITLE
perf(vapor): skip SlotFragment for stable slot fallback

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -26,14 +26,14 @@ export function render(_ctx) {
 `;
 
 exports[`compile > custom directive > component 1`] = `
-"import { resolveComponent as _resolveComponent, resolveDirective as _resolveDirective, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, withVaporDirectives as _withVaporDirectives, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, resolveDirective as _resolveDirective, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, withVaporDirectives as _withVaporDirectives, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
   const _component_Bar = _resolveComponent("Bar")
   const _directive_hello = _resolveDirective("hello")
   const _directive_test = _resolveDirective("test")
-  const n4 = _createAssetComponent("Comp", null, () => {
+  const n4 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (true), () => {
       const n3 = t0()
       _setInsertionState(n3, null, 0)
@@ -42,7 +42,7 @@ export function render(_ctx) {
       return n3
     }, null, 17 /* BLOCK_SHAPE, ONCE */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   _withVaporDirectives(n4, [[_directive_test]])
   return n4
 }"

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
@@ -29,14 +29,14 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transition > the v-if/else-if/else branches in Transition should ignore comments 1`] = `
-"import { VaporTransition as _VaporTransition, setInsertionState as _setInsertionState, createIf as _createIf, createComponent as _createComponent, template as _template } from 'vue';
+"import { VaporTransition as _VaporTransition, setInsertionState as _setInsertionState, createIf as _createIf, extend as _extend, createComponent as _createComponent, template as _template } from 'vue';
 const t0 = _template("<div>hey", 2)
 const t1 = _template("<p>", 2)
 const t2 = _template("<!-- this should not be ignored -->", 2)
 const t3 = _template("<div>")
 
 export function render(_ctx) {
-  const n17 = _createComponent(_VaporTransition, null, () => {
+  const n17 = _createComponent(_VaporTransition, null, _extend(() => {
     const n0 = _createIf(() => (_ctx.a), () => {
       const n2 = t0()
       return n2
@@ -57,7 +57,7 @@ export function render(_ctx) {
       return n15
     }, 645 /* BLOCK_SHAPE, SLOT_ROOT, INDEX_SHIFT */), 389 /* BLOCK_SHAPE, SLOT_ROOT, INDEX_SHIFT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n17
 }"
 `;
@@ -96,17 +96,17 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transition > work with v-if 1`] = `
-"import { VaporTransition as _VaporTransition, createIf as _createIf, createComponent as _createComponent, template as _template } from 'vue';
+"import { VaporTransition as _VaporTransition, createIf as _createIf, extend as _extend, createComponent as _createComponent, template as _template } from 'vue';
 const t0 = _template("<h1>foo", 2)
 
 export function render(_ctx) {
-  const n3 = _createComponent(_VaporTransition, null, () => {
+  const n3 = _createComponent(_VaporTransition, null, _extend(() => {
     const n0 = _createIf(() => (_ctx.show), () => {
       const n2 = t0()
       return n2
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n3
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -140,18 +140,18 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: element transform > component > hoist asset component also used in conditional component slot 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, createAssetComponent as _createAssetComponent } from 'vue';
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
   const _component_Child = _resolveComponent("Child")
   const n0 = _createComponentWithFallback(_component_Child)
-  const n5 = _createAssetComponent("Parent", null, () => {
+  const n5 = _createAssetComponent("Parent", null, _extend(() => {
     const n1 = _createIf(() => (_ctx.ok), () => {
       const n3 = _createComponentWithFallback(_component_Child)
       return n3
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n1
-  })
+  }, { _: 8 }))
   return [n0, n5]
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -41,25 +41,6 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > does not mark non-root v-if slot content as slot root 1`] = `
-"import { setInsertionState as _setInsertionState, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<span>", 2)
-const t1 = _template("<div>")
-
-export function render(_ctx) {
-  const n4 = _createAssetComponent("Comp", null, () => {
-    const n3 = t1()
-    _setInsertionState(n3, null, 0)
-    const n0 = _createIf(() => (_ctx.show), () => {
-      const n2 = t0()
-      return n2
-    })
-    return n3
-  }, true)
-  return n4
-}"
-`;
-
 exports[`compiler: transform slot > dynamic slots name 1`] = `
 "import { createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("foo", 2)
@@ -242,41 +223,6 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > marks root slot outlet fallback as slot root 1`] = `
-"import { createIf as _createIf, createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<span>", 2)
-
-export function render(_ctx) {
-  const n5 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, () => {
-      const n2 = _createIf(() => (_ctx.show), () => {
-        const n4 = t0()
-        return n4
-      }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
-      return n2
-    }, 4)
-    return n0
-  }, { _: 8 }), true)
-  return n5
-}"
-`;
-
-exports[`compiler: transform slot > marks root v-if slot content as slot root 1`] = `
-"import { createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<span>", 2)
-
-export function render(_ctx) {
-  const n3 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createIf(() => (_ctx.show), () => {
-      const n2 = t0()
-      return n2
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
-    return n0
-  }, { _: 8 }), true)
-  return n3
-}"
-`;
-
 exports[`compiler: transform slot > named slots w/ implicit default slot 1`] = `
 "import { createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("foo", 2)
@@ -314,19 +260,6 @@ export function render(_ctx) {
     }
   }, true)
   return n2
-}"
-`;
-
-exports[`compiler: transform slot > nested component slot 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
-
-export function render(_ctx) {
-  const _component_B = _resolveComponent("B")
-  const n1 = _createAssetComponent("A", null, () => {
-    const n0 = _createComponentWithFallback(_component_B)
-    return n0
-  }, true)
-  return n1
 }"
 `;
 
@@ -414,18 +347,6 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > runtime dynamic component slot content should be non-stable 1`] = `
-"import { createDynamicComponent as _createDynamicComponent, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
-
-export function render(_ctx) {
-  const n1 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 4)
-    return n0
-  }, { _: 8 }), true)
-  return n1
-}"
-`;
-
 exports[`compiler: transform slot > slot + v-if / v-else[-if] should not cause error 1`] = `
 "import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createSlot as _createSlot, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
@@ -445,6 +366,101 @@ export function render(_ctx) {
     return n5
   }, 21 /* BLOCK_SHAPE, ONCE */)
   return n6
+}"
+`;
+
+exports[`compiler: transform slot > slot fast path > component root is stable 1`] = `
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const _component_B = _resolveComponent("B")
+  const n1 = _createAssetComponent("A", null, () => {
+    const n0 = _createComponentWithFallback(_component_B)
+    return n0
+  }, true)
+  return n1
+}"
+`;
+
+exports[`compiler: transform slot > slot fast path > non-root v-if under stable template root is stable 1`] = `
+"import { setInsertionState as _setInsertionState, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<span>", 2)
+const t1 = _template("<div>")
+
+export function render(_ctx) {
+  const n4 = _createAssetComponent("Comp", null, () => {
+    const n3 = t1()
+    _setInsertionState(n3, null, 0)
+    const n0 = _createIf(() => (_ctx.show), () => {
+      const n2 = t0()
+      return n2
+    })
+    return n3
+  }, true)
+  return n4
+}"
+`;
+
+exports[`compiler: transform slot > slot fast path > root slot outlet fallback is non-stable 1`] = `
+"import { createIf as _createIf, createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<span>", 2)
+
+export function render(_ctx) {
+  const n5 = _createAssetComponent("Comp", null, _extend(() => {
+    const n0 = _createSlot("default", null, () => {
+      const n2 = _createIf(() => (_ctx.show), () => {
+        const n4 = t0()
+        return n4
+      }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+      return n2
+    }, 4)
+    return n0
+  }, { _: 8 }), true)
+  return n5
+}"
+`;
+
+exports[`compiler: transform slot > slot fast path > root v-for slot content is non-stable 1`] = `
+"import { createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<span>")
+
+export function render(_ctx) {
+  const n3 = _createAssetComponent("Comp", null, _extend(() => {
+    const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
+      const n2 = t0()
+      return n2
+    }, undefined, 40)
+    return n0
+  }, { _: 8 }), true)
+  return n3
+}"
+`;
+
+exports[`compiler: transform slot > slot fast path > root v-if slot content is non-stable 1`] = `
+"import { createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<span>", 2)
+
+export function render(_ctx) {
+  const n3 = _createAssetComponent("Comp", null, _extend(() => {
+    const n0 = _createIf(() => (_ctx.show), () => {
+      const n2 = t0()
+      return n2
+    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    return n0
+  }, { _: 8 }), true)
+  return n3
+}"
+`;
+
+exports[`compiler: transform slot > slot fast path > runtime dynamic component root is non-stable 1`] = `
+"import { createDynamicComponent as _createDynamicComponent, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n1 = _createAssetComponent("Comp", null, _extend(() => {
+    const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 4)
+    return n0
+  }, { _: 8 }), true)
+  return n1
 }"
 `;
 

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -160,15 +160,15 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot w/ nested component> 1`] = `
-"import { resolveComponent as _resolveComponent, createSlot as _createSlot, createComponentWithFallback as _createComponentWithFallback } from 'vue';
+"import { resolveComponent as _resolveComponent, createSlot as _createSlot, extend as _extend, createComponentWithFallback as _createComponentWithFallback } from 'vue';
 
 export function render(_ctx) {
   const _component_Comp = _resolveComponent("Comp")
   const n2 = _createComponentWithFallback(_component_Comp, null, () => {
-    const n1 = _createComponentWithFallback(_component_Comp, null, () => {
+    const n1 = _createComponentWithFallback(_component_Comp, null, _extend(() => {
       const n0 = _createSlot("default", null, null, 4)
       return n0
-    })
+    }, { _: 8 }))
     return n1
   }, true)
   return n2
@@ -176,55 +176,55 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag only 1`] = `
-"import { createSlot as _createSlot, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n1 = _createAssetComponent("Comp", null, () => {
+  const n1 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot("default", null, null, 4)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n1
 }"
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag w/ template 1`] = `
-"import { createSlot as _createSlot, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, () => {
+  const n2 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot("default", null, null, 4)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n2
 }"
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-for 1`] = `
-"import { createSlot as _createSlot, createFor as _createFor, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n3 = _createAssetComponent("Comp", null, () => {
+  const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
       const n2 = _createSlot("default", null, null, 4)
       return n2
     }, undefined, 48)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n3
 }"
 `;
 
 exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-if 1`] = `
-"import { createSlot as _createSlot, createIf as _createIf, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n3 = _createAssetComponent("Comp", null, () => {
+  const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.ok), () => {
       const n2 = _createSlot("default", null, null, 4)
       return n2
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n3
 }"
 `;
@@ -243,11 +243,11 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > marks root slot outlet fallback as slot root 1`] = `
-"import { createIf as _createIf, createSlot as _createSlot, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { createIf as _createIf, createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<span>", 2)
 
 export function render(_ctx) {
-  const n5 = _createAssetComponent("Comp", null, () => {
+  const n5 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot("default", null, () => {
       const n2 = _createIf(() => (_ctx.show), () => {
         const n4 = t0()
@@ -256,23 +256,23 @@ export function render(_ctx) {
       return n2
     }, 4)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n5
 }"
 `;
 
 exports[`compiler: transform slot > marks root v-if slot content as slot root 1`] = `
-"import { createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<span>", 2)
 
 export function render(_ctx) {
-  const n3 = _createAssetComponent("Comp", null, () => {
+  const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.show), () => {
       const n2 = t0()
       return n2
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n3
 }"
 `;
@@ -300,14 +300,14 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > nested component should not inherit parent slots 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
+"import { resolveComponent as _resolveComponent, extend as _extend, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
   const _component_Bar = _resolveComponent("Bar")
   const n2 = _createAssetComponent("Foo", null, {
-    "header": () => {
+    "header": _extend(() => {
       return null
-    },
+    }, { _: 8 }),
     "default": () => {
       const n1 = _createComponentWithFallback(_component_Bar)
       return n1
@@ -402,14 +402,26 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > quote slot name 1`] = `
-"import { createAssetComponent as _createAssetComponent } from 'vue';
+"import { extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, {
-    "nav-bar-title-before": () => {
+    "nav-bar-title-before": _extend(() => {
       return null
-    }
+    }, { _: 8 })
   }, true)
+  return n1
+}"
+`;
+
+exports[`compiler: transform slot > runtime dynamic component slot content should be non-stable 1`] = `
+"import { createDynamicComponent as _createDynamicComponent, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n1 = _createAssetComponent("Comp", null, _extend(() => {
+    const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 4)
+    return n0
+  }, { _: 8 }), true)
   return n1
 }"
 `;
@@ -456,12 +468,12 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > slot owner context > slot with component inside v-for should not need withVaporCtx 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createFor as _createFor, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
   const _component_ChildComp = _resolveComponent("ChildComp")
-  const n5 = _createAssetComponent("Comp", null, () => {
+  const n5 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
       const n3 = t0()
       _setInsertionState(n3, null, 0)
@@ -469,18 +481,18 @@ export function render(_ctx) {
       return n3
     }, undefined, 40)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n5
 }"
 `;
 
 exports[`compiler: transform slot > slot owner context > slot with component inside v-if should not need withVaporCtx 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
   const _component_ChildComp = _resolveComponent("ChildComp")
-  const n5 = _createAssetComponent("Comp", null, () => {
+  const n5 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.show), () => {
       const n3 = t0()
       _setInsertionState(n3, null, 0)
@@ -488,7 +500,7 @@ export function render(_ctx) {
       return n3
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n5
 }"
 `;
@@ -507,11 +519,11 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > slot owner context > slot with custom element inside v-if should not need withVaporCtx 1`] = `
-"import { setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
-  const n5 = _createAssetComponent("Comp", null, () => {
+  const n5 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.show), () => {
       const n3 = t0()
       _setInsertionState(n3, null, 0)
@@ -519,7 +531,7 @@ export function render(_ctx) {
       return n3
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n5
 }"
 `;
@@ -536,14 +548,36 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: transform slot > slot owner context > slot with dynamic root and stable sibling should be non-stable 1`] = `
+"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<span> ")
+const t1 = _template("<i>tail", 2)
+
+export function render(_ctx) {
+  const n5 = _createAssetComponent("Comp", null, _extend(() => {
+    const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
+      const n2 = t0()
+      const x2 = _txt(n2)
+      _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value)))
+      return n2
+    }, undefined, 40)
+    const n3 = t1()
+    const x0 = _txt(n0)
+    _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
+    return [n0, n3]
+  }, { _: 8 }), true)
+  return n5
+}"
+`;
+
 exports[`compiler: transform slot > slot owner context > slot with nested v-if containing component should not need withVaporCtx 1`] = `
-"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<span>")
 const t1 = _template("<div>")
 
 export function render(_ctx) {
   const _component_ChildComp = _resolveComponent("ChildComp")
-  const n8 = _createAssetComponent("Comp", null, () => {
+  const n8 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.a), () => {
       const n6 = t1()
       _setInsertionState(n6, null, 0)
@@ -556,7 +590,7 @@ export function render(_ctx) {
       return n6
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n8
 }"
 `;
@@ -589,23 +623,23 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform slot > slot owner context > slot with slot outlet should not need withVaporCtx 1`] = `
-"import { createSlot as _createSlot, createAssetComponent as _createAssetComponent } from 'vue';
+"import { createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
-  const n2 = _createAssetComponent("Comp", null, () => {
+  const n2 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot("default", null, null, 4)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n2
 }"
 `;
 
 exports[`compiler: transform slot > slot owner context > slot with v-for but no component should not need withVaporCtx 1`] = `
-"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div> ")
 
 export function render(_ctx) {
-  const n4 = _createAssetComponent("Comp", null, () => {
+  const n4 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
       const n2 = t0()
       const x2 = _txt(n2)
@@ -615,18 +649,18 @@ export function render(_ctx) {
     const x0 = _txt(n0)
     _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n4
 }"
 `;
 
 exports[`compiler: transform slot > slot owner context > slot with v-if but no component should not need withVaporCtx 1`] = `
-"import { createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+"import { createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>content", 2)
 const t1 = _template("<span>fallback", 2)
 
 export function render(_ctx) {
-  const n7 = _createAssetComponent("Comp", null, () => {
+  const n7 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.show), () => {
       const n2 = t0()
       return n2
@@ -635,7 +669,7 @@ export function render(_ctx) {
       return n4
     }, 389 /* BLOCK_SHAPE, SLOT_ROOT, INDEX_SHIFT */)
     return n0
-  }, true)
+  }, { _: 8 }), true)
   return n7
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -126,14 +126,6 @@ describe('compiler: transform slot', () => {
     expect(code).contains(`name: "default",`)
   })
 
-  test('empty default slot should be non-stable', () => {
-    const { code } = compileWithSlots(
-      `<Comp><template #default></template></Comp>`,
-    )
-
-    expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-  })
-
   test('on-component default slot', () => {
     const { ir, code } = compileWithSlots(
       `<Comp v-slot="{ foo }">{{ foo + bar }}</Comp>`,
@@ -576,65 +568,65 @@ describe('compiler: transform slot', () => {
     expect(code).contains(`"nav-bar-title-before"`)
   })
 
-  test('nested component slot', () => {
-    const { ir, code } = compileWithSlots(`<A><B/></A>`)
-    expect(code).toMatchSnapshot()
-    expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-    expect(ir.block.dynamic.children[0].operation).toMatchObject({
-      type: IRNodeTypes.CREATE_COMPONENT_NODE,
-      tag: 'A',
-      slots: [
-        {
-          slotType: IRSlotType.STATIC,
-          slots: {
-            default: {
-              type: IRNodeTypes.BLOCK,
-              dynamic: {
-                children: [
-                  {
-                    operation: {
-                      type: IRNodeTypes.CREATE_COMPONENT_NODE,
-                      tag: 'B',
-                      slots: [],
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        },
-      ],
+  describe('slot fast path', () => {
+    test('comment-only default slot is non-stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><template #default><!--foo--></template></Comp>`,
+      )
+
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
     })
-  })
 
-  test('marks root v-if slot content as slot root', () => {
-    const { code } = compileWithSlots(`<Comp><span v-if="show"/></Comp>`)
+    test('component root is stable', () => {
+      const { code } = compileWithSlots(`<A><B/></A>`)
 
-    expect(code).toMatchSnapshot()
-    expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-  })
+      expect(code).toMatchSnapshot()
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
 
-  test('runtime dynamic component slot content should be non-stable', () => {
-    const { code } = compileWithSlots(`<Comp><component :is="view"/></Comp>`)
+    test('root v-if slot content is non-stable', () => {
+      const { code } = compileWithSlots(`<Comp><span v-if="show"/></Comp>`)
 
-    expect(code).toMatchSnapshot()
-    expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-  })
+      expect(code).toMatchSnapshot()
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
 
-  test('does not mark non-root v-if slot content as slot root', () => {
-    const { code } = compileWithSlots(
-      `<Comp><div><span v-if="show"/></div></Comp>`,
-    )
+    test('root v-for slot content is non-stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><span v-for="item in list"/></Comp>`,
+      )
 
-    expect(code).toMatchSnapshot()
-  })
+      expect(code).toMatchSnapshot()
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
 
-  test('marks root slot outlet fallback as slot root', () => {
-    const { code } = compileWithSlots(
-      `<Comp><slot><span v-if="show"/></slot></Comp>`,
-    )
+    test('runtime dynamic component root is non-stable', () => {
+      // Keep VDOM parity for <Comp><component :is="view" /></Comp>:
+      // fallback renders when view is null, unlike <Comp><Foo /></Comp> where
+      // the static component vnode is valid even if Foo renders empty output.
+      const { code } = compileWithSlots(`<Comp><component :is="view"/></Comp>`)
 
-    expect(code).toMatchSnapshot()
+      expect(code).toMatchSnapshot()
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
+
+    test('non-root v-if under stable template root is stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><div><span v-if="show"/></div></Comp>`,
+      )
+
+      expect(code).toMatchSnapshot()
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
+
+    test('root slot outlet fallback is non-stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><slot><span v-if="show"/></slot></Comp>`,
+      )
+
+      expect(code).toMatchSnapshot()
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
   })
 
   describe('forwarded slots', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -1,4 +1,5 @@
 import { ErrorCodes, NodeTypes } from '@vue/compiler-dom'
+import { VaporSlotFlags } from '@vue/shared'
 import {
   IRNodeTypes,
   IRSlotType,
@@ -36,6 +37,7 @@ describe('compiler: transform slot', () => {
   test('implicit default slot', () => {
     const { ir, code } = compileWithSlots(`<Comp><div/></Comp>`)
     expect(code).toMatchSnapshot()
+    expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
 
     expect([...ir.template.keys()]).toEqual(['<div>'])
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
@@ -68,6 +70,7 @@ describe('compiler: transform slot', () => {
       `<Comp><template # v-if="show"></template></Comp>`,
     )
     expect(code).toMatchSnapshot()
+    expect(code).toContain(`$: [`)
 
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.CREATE_COMPONENT_NODE,
@@ -92,6 +95,7 @@ describe('compiler: transform slot', () => {
       `<Comp><template # v-for="item in list">{{ item }}</template></Comp>`,
     )
     expect(code).toMatchSnapshot()
+    expect(code).toContain(`$: [`)
 
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.CREATE_COMPONENT_NODE,
@@ -120,6 +124,14 @@ describe('compiler: transform slot', () => {
       children: [{ id: 2 }],
     })
     expect(code).contains(`name: "default",`)
+  })
+
+  test('empty default slot should be non-stable', () => {
+    const { code } = compileWithSlots(
+      `<Comp><template #default></template></Comp>`,
+    )
+
+    expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
   })
 
   test('on-component default slot', () => {
@@ -567,6 +579,7 @@ describe('compiler: transform slot', () => {
   test('nested component slot', () => {
     const { ir, code } = compileWithSlots(`<A><B/></A>`)
     expect(code).toMatchSnapshot()
+    expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.CREATE_COMPONENT_NODE,
       tag: 'A',
@@ -598,6 +611,14 @@ describe('compiler: transform slot', () => {
     const { code } = compileWithSlots(`<Comp><span v-if="show"/></Comp>`)
 
     expect(code).toMatchSnapshot()
+    expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+  })
+
+  test('runtime dynamic component slot content should be non-stable', () => {
+    const { code } = compileWithSlots(`<Comp><component :is="view"/></Comp>`)
+
+    expect(code).toMatchSnapshot()
+    expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
   })
 
   test('does not mark non-root v-if slot content as slot root', () => {
@@ -619,6 +640,7 @@ describe('compiler: transform slot', () => {
   describe('forwarded slots', () => {
     test('<slot> tag only', () => {
       const { code } = compileWithSlots(`<Comp><slot/></Comp>`)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).toMatchSnapshot()
     })
 
@@ -679,6 +701,7 @@ describe('compiler: transform slot', () => {
       const { ir, code } = compileWithSlots(`<Comp><!--foo--></Comp>`)
 
       expect(code).toContain(`<!--foo-->`)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(ir.block.dynamic.children[0].operation).toMatchObject({
         type: IRNodeTypes.CREATE_COMPONENT_NODE,
         slots: [
@@ -834,6 +857,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -846,6 +870,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -858,6 +883,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -887,6 +913,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -901,6 +928,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -917,6 +945,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -929,6 +958,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -942,6 +972,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -954,6 +985,21 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain('withVaporCtx')
+      expect(code).toMatchSnapshot()
+    })
+
+    test('slot with dynamic root and stable sibling should be non-stable', () => {
+      const { code } = compileWithSlots(`
+        <Comp>
+          <template #default>
+            <span v-for="item in items">{{ item }}</span>
+            <i>tail</i>
+          </template>
+        </Comp>
+      `)
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -971,6 +1017,7 @@ describe('compiler: transform slot', () => {
           isCustomElement: tag => tag.startsWith('my-'),
         },
       )
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
@@ -990,6 +1037,7 @@ describe('compiler: transform slot', () => {
           isCustomElement: tag => tag.startsWith('my-'),
         },
       )
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -241,7 +241,7 @@ function markSlotRootComponent(operation: CreateComponentIRNode): void {
   }
 }
 
-function findReturnedDynamic(
+export function findReturnedDynamic(
   block: BlockIRNode,
   id: number,
 ): IRDynamicInfo | undefined {

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -802,6 +802,11 @@ function hasStableSlotRoot(
           hasValidRoot = true
           continue
         }
+        // Align with VDOM fallback semantics:
+        // <component :is="view" /> renders fallback when view is null because
+        // the dynamic component root becomes a comment vnode. This differs from
+        // <Foo />, whose component vnode is valid slot content even if Foo
+        // renders null/comment.
         return false
       case IRNodeTypes.KEY:
         if (hasStableSlotRoot(operation.block, context)) {

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -1,5 +1,6 @@
 import {
   VaporDynamicComponentFlags,
+  VaporSlotFlags,
   camelize,
   extend,
   getModifierPropName,
@@ -8,8 +9,11 @@ import {
 } from '@vue/shared'
 import type { CodegenContext } from '../generate'
 import {
+  type BlockIRNode,
   type CreateComponentIRNode,
+  type IRDynamicInfo,
   IRDynamicPropsKind,
+  IRNodeTypes,
   type IRProp,
   type IRProps,
   type IRPropsStatic,
@@ -43,7 +47,7 @@ import {
 } from '@vue/compiler-dom'
 import { genEventHandler } from './event'
 import { genDirectiveModifiers, genDirectivesForElement } from './directive'
-import { genBlock, markSlotRootOperations } from './block'
+import { findReturnedDynamic, genBlock, markSlotRootOperations } from './block'
 import {
   type DestructureMap,
   type DestructureMapValue,
@@ -655,7 +659,7 @@ function genBasicDynamicSlot(
   return genMulti(
     DELIMITERS_OBJECT_NEWLINE,
     ['name: ', ...genExpression(name, context)],
-    ['fn: ', ...genSlotBlockWithProps(fn, context)],
+    ['fn: ', ...genSlotBlockWithProps(fn, context, false)],
   )
 }
 
@@ -678,7 +682,7 @@ function genLoopSlot(
     ['name: ', ...context.withId(() => genExpression(name, context), idMap)],
     [
       'fn: ',
-      ...context.withId(() => genSlotBlockWithProps(fn, context), idMap),
+      ...context.withId(() => genSlotBlockWithProps(fn, context, false), idMap),
     ],
   )
   return [
@@ -718,7 +722,11 @@ function genConditionalSlot(
   ]
 }
 
-function genSlotBlockWithProps(oper: SlotBlockIRNode, context: CodegenContext) {
+function genSlotBlockWithProps(
+  oper: SlotBlockIRNode,
+  context: CodegenContext,
+  emitNonStableFlag = true,
+) {
   let propsName: string | undefined
   let exitScope: (() => void) | undefined
   let depth: number | undefined
@@ -754,8 +762,66 @@ function genSlotBlockWithProps(oper: SlotBlockIRNode, context: CodegenContext) {
     () => genBlock(oper, context, propsName ? [propsName] : []),
     idMap,
   )
+  // Dynamic slot sources keep rawSlots.$, so runtime stays conservative.
+  if (emitNonStableFlag && !hasStableSlotRoot(oper, context)) {
+    blockFn = genCall(
+      context.helper('extend'),
+      blockFn,
+      `{ _: ${VaporSlotFlags.NON_STABLE} }`,
+    )
+  }
   exitSlotBlock()
   exitScope && exitScope()
 
   return blockFn
+}
+
+const commentOnlyTemplateRE = /^(?:<!--[\s\S]*?-->)+$/
+
+// A slot can skip fallback/boundary tracking only when its root shape is stable.
+// Components count as valid even if their own render result is a comment.
+function hasStableSlotRoot(
+  block: BlockIRNode,
+  context: CodegenContext,
+): boolean {
+  let hasValidRoot = false
+  for (let i = 0; i < block.returns.length; i++) {
+    const id = block.returns[i]
+    const child = findReturnedDynamic(block, id)
+    const operation = child && child.operation
+    if (!operation) {
+      if (child && isStableTemplateSlotRoot(child, context)) {
+        hasValidRoot = true
+      }
+      continue
+    }
+
+    switch (operation.type) {
+      case IRNodeTypes.CREATE_COMPONENT_NODE:
+        if (!operation.dynamic || operation.dynamic.isStatic) {
+          hasValidRoot = true
+          continue
+        }
+        return false
+      case IRNodeTypes.KEY:
+        if (hasStableSlotRoot(operation.block, context)) {
+          hasValidRoot = true
+          continue
+        }
+        return false
+      default:
+        return false
+    }
+  }
+  return hasValidRoot
+}
+
+function isStableTemplateSlotRoot(
+  child: IRDynamicInfo,
+  context: CodegenContext,
+): boolean {
+  if (child.template == null) return false
+  const content = context.ir.template.entries[child.template].content
+  // Preserved whitespace is a real text root; trim only for comment detection.
+  return content !== '' && !commentOnlyTemplateRE.test(content.trim())
 }

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -10,6 +10,7 @@ import {
   createIf,
   createSlot,
   createVaporApp,
+  createVaporSSRApp,
   defineVaporAsyncComponent,
   defineVaporComponent,
   insert,
@@ -41,6 +42,7 @@ import {
   VaporIfFlags,
   VaporSlotFlags,
   VaporVForFlags,
+  extend,
 } from '@vue/shared'
 import { compile, makeRender } from './_utils'
 import type { DynamicSlot } from '../src/componentSlots'
@@ -78,6 +80,7 @@ const keyedIfShape =
 const slotRootIfShape = VaporBlockShape.SINGLE_ROOT | VaporIfFlags.SLOT_ROOT
 const keyedSlotRootIfShape = keyedIfShape | VaporIfFlags.SLOT_ROOT
 const slotRootForFlags = VaporVForFlags.SLOT_ROOT
+const nonStableSlot = { _: VaporSlotFlags.NON_STABLE } as const
 
 function renderWithSlots(slots: any): any {
   let instance: any
@@ -364,13 +367,16 @@ describe('component: slots', () => {
       )
       const { host } = define(() =>
         createComponent(Child, null, {
-          default: () =>
-            createIf(
-              () => show.value,
-              () => document.createTextNode('content'),
-              undefined,
-              keyedSlotRootIfShape,
-            ),
+          default: extend(
+            () =>
+              createIf(
+                () => show.value,
+                () => document.createTextNode('content'),
+                undefined,
+                keyedSlotRootIfShape,
+              ),
+            nonStableSlot,
+          ),
         }),
       ).render()
 
@@ -389,13 +395,16 @@ describe('component: slots', () => {
       )
       const { host } = define(() =>
         createComponent(Child, null, {
-          default: () =>
-            createFor(
-              () => items.value,
-              item => document.createTextNode(item.value),
-              undefined,
-              slotRootForFlags,
-            ),
+          default: extend(
+            () =>
+              createFor(
+                () => items.value,
+                item => document.createTextNode(item.value),
+                undefined,
+                slotRootForFlags,
+              ),
+            nonStableSlot,
+          ),
         }),
       ).render()
 
@@ -414,14 +423,17 @@ describe('component: slots', () => {
       )
       const { host } = define(() =>
         createComponent(Child, null, {
-          default: () =>
-            createDynamicComponent(
-              () => current.value,
-              null,
-              null,
-              VaporDynamicComponentFlags.SINGLE_ROOT |
-                VaporDynamicComponentFlags.SLOT_ROOT,
-            ),
+          default: extend(
+            () =>
+              createDynamicComponent(
+                () => current.value,
+                null,
+                null,
+                VaporDynamicComponentFlags.SINGLE_ROOT |
+                  VaporDynamicComponentFlags.SLOT_ROOT,
+              ),
+            nonStableSlot,
+          ),
         }),
       ).render()
 
@@ -1280,7 +1292,28 @@ describe('component: slots', () => {
       expect(observedBoundary).toBe(null)
     })
 
-    test('slot with fallback uses slot fragment', () => {
+    test('hydrated plain slot without fallback uses dynamic fragment', () => {
+      let slotBlock!: Block
+      const container = document.createElement('div')
+      container.innerHTML = '<!--[-->content<!--]-->'
+      const Comp = defineVaporComponent(() => {
+        return (slotBlock = createSlot('default'))
+      })
+
+      createVaporSSRApp(
+        defineVaporComponent(() =>
+          createComponent(Comp, null, {
+            default: () => template('content')(),
+          }),
+        ),
+      ).mount(container)
+
+      expect(slotBlock).toBeInstanceOf(DynamicFragment)
+      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+      expect(container.innerHTML).toBe('<!--[-->content<!--]-->')
+    })
+
+    test('slot with fallback and explicit empty slots uses dynamic fragment', () => {
       let slotBlock!: Block
       const Comp = defineVaporComponent(() => {
         return (slotBlock = createSlot('default', null, () =>
@@ -1290,7 +1323,126 @@ describe('component: slots', () => {
 
       define(() => createComponent(Comp, null, {})).render()
 
+      expect(slotBlock).toBeInstanceOf(DynamicFragment)
+      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+    })
+
+    test('slot with fallback and no slots uses dynamic fragment', () => {
+      let slotBlock!: Block
+      const Comp = defineVaporComponent(() => {
+        return (slotBlock = createSlot('default', null, () =>
+          template('fallback')(),
+        ))
+      })
+
+      const { host } = define(() => createComponent(Comp)).render()
+
+      expect(slotBlock).toBeInstanceOf(DynamicFragment)
+      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+      expect(host.innerHTML).toBe('fallback<!--slot-->')
+    })
+
+    test('hydrated slot with fallback and no slots uses dynamic fragment', () => {
+      let slotBlock!: Block
+      const container = document.createElement('div')
+      container.innerHTML = '<!--[-->fallback<!--]-->'
+      const Comp = defineVaporComponent(() => {
+        return (slotBlock = createSlot('default', null, () =>
+          template('fallback')(),
+        ))
+      })
+
+      createVaporSSRApp(
+        defineVaporComponent(() => createComponent(Comp)),
+      ).mount(container)
+
+      expect(slotBlock).toBeInstanceOf(DynamicFragment)
+      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+      expect(container.innerHTML).toBe('<!--[-->fallback<!--]-->')
+    })
+
+    test('stable slot with fallback uses dynamic fragment', () => {
+      let slotBlock!: Block
+      const slot = (() => template('<p>A</p>')()) as BlockFn
+      const Comp = defineVaporComponent(() => {
+        return (slotBlock = createSlot('default', null, () =>
+          template('fallback')(),
+        ))
+      })
+
+      const { host } = define(() =>
+        createComponent(Comp, null, {
+          default: slot,
+        }),
+      ).render()
+
+      expect(slotBlock).toBeInstanceOf(DynamicFragment)
+      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+      expect(host.innerHTML).toBe('<p>A</p><!--slot-->')
+    })
+
+    test('hydrated stable slot with fallback uses dynamic fragment', () => {
+      let slotBlock!: Block
+      const container = document.createElement('div')
+      container.innerHTML = '<!--[--><p>A</p><!--]-->'
+      const slot = (() => template('<p>A</p>')()) as BlockFn
+      const Comp = defineVaporComponent(() => {
+        return (slotBlock = createSlot('default', null, () =>
+          template('fallback')(),
+        ))
+      })
+
+      createVaporSSRApp(
+        defineVaporComponent(() =>
+          createComponent(Comp, null, {
+            default: slot,
+          }),
+        ),
+      ).mount(container)
+
+      expect(slotBlock).toBeInstanceOf(DynamicFragment)
+      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+      expect(container.innerHTML).toBe('<!--[--><p>A</p><!--]-->')
+    })
+
+    test('non-stable slot with fallback uses slot fragment', () => {
+      let slotBlock!: Block
+      const slot = (() => template('<p>A</p>')()) as BlockFn
+      ;(slot as any)._ = VaporSlotFlags.NON_STABLE
+      const Comp = defineVaporComponent(() => {
+        return (slotBlock = createSlot('default', null, () =>
+          template('fallback')(),
+        ))
+      })
+
+      define(() =>
+        createComponent(Comp, null, {
+          default: slot,
+        }),
+      ).render()
+
       expect(slotBlock).toBeInstanceOf(SlotFragment)
+    })
+
+    test('stable component slot with fallback does not render fallback when component output is empty', () => {
+      let slotBlock!: Block
+      const Empty = defineVaporComponent(() => document.createComment('empty'))
+      const slot = (() => createComponent(Empty)) as BlockFn
+      const Comp = defineVaporComponent(() => {
+        return (slotBlock = createSlot('default', null, () =>
+          template('fallback')(),
+        ))
+      })
+
+      const { host } = define(() =>
+        createComponent(Comp, null, {
+          default: slot,
+        }),
+      ).render()
+
+      expect(slotBlock).toBeInstanceOf(DynamicFragment)
+      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+      expect(host.innerHTML).not.toContain('fallback')
     })
 
     test('slot props should be isolated per fragment in v-for', async () => {
@@ -1630,7 +1782,7 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               return createIf(
                 () => toggle.value,
                 () => {
@@ -1639,7 +1791,7 @@ describe('component: slots', () => {
                 undefined,
                 keyedSlotRootIfShape,
               )
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -1669,7 +1821,7 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               return createIf(
                 () => toggle.value,
                 () => {
@@ -1678,7 +1830,7 @@ describe('component: slots', () => {
                 undefined,
                 keyedSlotRootIfShape,
               )
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -1780,9 +1932,9 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               return template('<!--comment-->')()
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -1804,7 +1956,7 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               return createIf(
                 () => toggle.value,
                 () => {
@@ -1813,7 +1965,7 @@ describe('component: slots', () => {
                 undefined,
                 keyedSlotRootIfShape,
               )
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -1844,7 +1996,7 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               return createIf(
                 () => outerShow.value,
                 () => {
@@ -1860,7 +2012,7 @@ describe('component: slots', () => {
                 undefined,
                 keyedSlotRootIfShape,
               )
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -1905,7 +2057,7 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               const n2 = createFor(
                 () => items.value,
                 for_item0 => {
@@ -1920,7 +2072,7 @@ describe('component: slots', () => {
                 slotRootForFlags,
               )
               return n2
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -1953,7 +2105,7 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               const n2 = createFor(
                 () => items.value,
                 for_item0 => {
@@ -1968,7 +2120,7 @@ describe('component: slots', () => {
                 slotRootForFlags,
               )
               return n2
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -2005,7 +2157,7 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               return createFor(
                 () => items.value,
                 for_item0 => {
@@ -2026,7 +2178,7 @@ describe('component: slots', () => {
                 item => item.text,
                 slotRootForFlags,
               )
-            },
+            }, nonStableSlot),
           })
         },
       }).render()
@@ -2694,12 +2846,12 @@ describe('component: slots', () => {
       const Parent = defineVaporComponent({
         setup() {
           const n2 = createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               const n0 = createSlot('default', null, () => {
                 return template('<!-- <div></div> -->')()
               })
               return n0
-            },
+            }, nonStableSlot),
           })
           return n2
         },
@@ -2708,7 +2860,10 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Parent, null, {
-            default: () => template('<!-- <div>App</div> -->')(),
+            default: extend(
+              () => template('<!-- <div>App</div> -->')(),
+              nonStableSlot,
+            ),
           })
         },
       }).render()
@@ -2795,7 +2950,7 @@ describe('component: slots', () => {
       const Parent = defineVaporComponent({
         setup() {
           const n2 = createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               const n0 = createSlot('default', null, () => {
                 const n2 = createIf(
                   () => show.value,
@@ -2809,7 +2964,7 @@ describe('component: slots', () => {
                 return n2
               })
               return n0
-            },
+            }, nonStableSlot),
           })
           return n2
         },
@@ -2818,7 +2973,10 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Parent, null, {
-            default: () => template('<!-- <div>App</div> -->')(),
+            default: extend(
+              () => template('<!-- <div>App</div> -->')(),
+              nonStableSlot,
+            ),
           })
         },
       }).render()
@@ -2843,7 +3001,7 @@ describe('component: slots', () => {
       const Parent = defineVaporComponent({
         setup() {
           const n2 = createComponent(Child, null, {
-            default: () => {
+            default: extend(() => {
               const n0 = createSlot('default', null, () => {
                 const n2 = createFor(
                   () => items.value,
@@ -2861,7 +3019,7 @@ describe('component: slots', () => {
                 return n2
               })
               return n0
-            },
+            }, nonStableSlot),
           })
           return n2
         },
@@ -2870,7 +3028,10 @@ describe('component: slots', () => {
       const { html } = define({
         setup() {
           return createComponent(Parent, null, {
-            default: () => template('<!-- <div>App</div> -->')(),
+            default: extend(
+              () => template('<!-- <div>App</div> -->')(),
+              nonStableSlot,
+            ),
           })
         },
       }).render()
@@ -2950,14 +3111,14 @@ describe('component: slots', () => {
               targetComponent,
               null,
               {
-                foo: () => {
+                foo: extend(() => {
                   return fallbackText
                     ? createSlot('foo', null, () => {
                         const n2 = template(`<div>${fallbackText}</div>`)()
                         return n2
                       })
                     : createSlot('foo', null)
-                },
+                }, nonStableSlot),
               },
               true,
             )

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1266,185 +1266,6 @@ describe('component: slots', () => {
       )
     })
 
-    test('plain slot without fallback uses dynamic fragment', () => {
-      let slotBlock!: Block
-      let observedBoundary: SlotBoundaryContext | null | undefined
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot(
-          'default',
-          null,
-          undefined,
-          VaporSlotFlags.SLOT_ROOT,
-        ))
-      })
-
-      define(() =>
-        createComponent(Comp, null, {
-          default: () => {
-            observedBoundary = getCurrentSlotBoundary()
-            return template('content')()
-          },
-        }),
-      ).render()
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-      expect(observedBoundary).toBe(null)
-    })
-
-    test('hydrated plain slot without fallback uses dynamic fragment', () => {
-      let slotBlock!: Block
-      const container = document.createElement('div')
-      container.innerHTML = '<!--[-->content<!--]-->'
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default'))
-      })
-
-      createVaporSSRApp(
-        defineVaporComponent(() =>
-          createComponent(Comp, null, {
-            default: () => template('content')(),
-          }),
-        ),
-      ).mount(container)
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-      expect(container.innerHTML).toBe('<!--[-->content<!--]-->')
-    })
-
-    test('slot with fallback and explicit empty slots uses dynamic fragment', () => {
-      let slotBlock!: Block
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default', null, () =>
-          template('fallback')(),
-        ))
-      })
-
-      define(() => createComponent(Comp, null, {})).render()
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-    })
-
-    test('slot with fallback and no slots uses dynamic fragment', () => {
-      let slotBlock!: Block
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default', null, () =>
-          template('fallback')(),
-        ))
-      })
-
-      const { host } = define(() => createComponent(Comp)).render()
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-      expect(host.innerHTML).toBe('fallback<!--slot-->')
-    })
-
-    test('hydrated slot with fallback and no slots uses dynamic fragment', () => {
-      let slotBlock!: Block
-      const container = document.createElement('div')
-      container.innerHTML = '<!--[-->fallback<!--]-->'
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default', null, () =>
-          template('fallback')(),
-        ))
-      })
-
-      createVaporSSRApp(
-        defineVaporComponent(() => createComponent(Comp)),
-      ).mount(container)
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-      expect(container.innerHTML).toBe('<!--[-->fallback<!--]-->')
-    })
-
-    test('stable slot with fallback uses dynamic fragment', () => {
-      let slotBlock!: Block
-      const slot = (() => template('<p>A</p>')()) as BlockFn
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default', null, () =>
-          template('fallback')(),
-        ))
-      })
-
-      const { host } = define(() =>
-        createComponent(Comp, null, {
-          default: slot,
-        }),
-      ).render()
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-      expect(host.innerHTML).toBe('<p>A</p><!--slot-->')
-    })
-
-    test('hydrated stable slot with fallback uses dynamic fragment', () => {
-      let slotBlock!: Block
-      const container = document.createElement('div')
-      container.innerHTML = '<!--[--><p>A</p><!--]-->'
-      const slot = (() => template('<p>A</p>')()) as BlockFn
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default', null, () =>
-          template('fallback')(),
-        ))
-      })
-
-      createVaporSSRApp(
-        defineVaporComponent(() =>
-          createComponent(Comp, null, {
-            default: slot,
-          }),
-        ),
-      ).mount(container)
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-      expect(container.innerHTML).toBe('<!--[--><p>A</p><!--]-->')
-    })
-
-    test('non-stable slot with fallback uses slot fragment', () => {
-      let slotBlock!: Block
-      const slot = (() => template('<p>A</p>')()) as BlockFn
-      ;(slot as any)._ = VaporSlotFlags.NON_STABLE
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default', null, () =>
-          template('fallback')(),
-        ))
-      })
-
-      define(() =>
-        createComponent(Comp, null, {
-          default: slot,
-        }),
-      ).render()
-
-      expect(slotBlock).toBeInstanceOf(SlotFragment)
-    })
-
-    test('stable component slot with fallback does not render fallback when component output is empty', () => {
-      let slotBlock!: Block
-      const Empty = defineVaporComponent(() => document.createComment('empty'))
-      const slot = (() => createComponent(Empty)) as BlockFn
-      const Comp = defineVaporComponent(() => {
-        return (slotBlock = createSlot('default', null, () =>
-          template('fallback')(),
-        ))
-      })
-
-      const { host } = define(() =>
-        createComponent(Comp, null, {
-          default: slot,
-        }),
-      ).render()
-
-      expect(slotBlock).toBeInstanceOf(DynamicFragment)
-      expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-      expect(host.innerHTML).not.toContain('fallback')
-    })
-
     test('slot props should be isolated per fragment in v-for', async () => {
       const items = ref([0, 1, 2])
 
@@ -2734,6 +2555,230 @@ describe('component: slots', () => {
       increment()
       await nextTick()
       expect(html()).toBe('<span>initial:1</span><!--slot-->')
+    })
+
+    describe('slot fast path', () => {
+      describe('runtime', () => {
+        test('plain slot without fallback', () => {
+          let slotBlock!: Block
+          let observedBoundary: SlotBoundaryContext | null | undefined
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot(
+              'default',
+              null,
+              undefined,
+              VaporSlotFlags.SLOT_ROOT,
+            ))
+          })
+
+          define(() =>
+            createComponent(Comp, null, {
+              default: () => {
+                observedBoundary = getCurrentSlotBoundary()
+                return template('content')()
+              },
+            }),
+          ).render()
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(observedBoundary).toBe(null)
+        })
+
+        test('slot with fallback and explicit empty slots', () => {
+          let slotBlock!: Block
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default', null, () =>
+              template('fallback')(),
+            ))
+          })
+
+          define(() => createComponent(Comp, null, {})).render()
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+        })
+
+        test('slot with fallback and no slots', () => {
+          let slotBlock!: Block
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default', null, () =>
+              template('fallback')(),
+            ))
+          })
+
+          const { host } = define(() => createComponent(Comp)).render()
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(host.innerHTML).toBe('fallback<!--slot-->')
+        })
+
+        test('stable slot with fallback', () => {
+          let slotBlock!: Block
+          const slot = (() => template('<p>A</p>')()) as BlockFn
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default', null, () =>
+              template('fallback')(),
+            ))
+          })
+
+          const { host } = define(() =>
+            createComponent(Comp, null, {
+              default: slot,
+            }),
+          ).render()
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(host.innerHTML).toBe('<p>A</p><!--slot-->')
+        })
+
+        test('non-stable slot with fallback uses slot fragment', () => {
+          let slotBlock!: Block
+          const slot = (() => template('<p>A</p>')()) as BlockFn
+          ;(slot as any)._ = VaporSlotFlags.NON_STABLE
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default', null, () =>
+              template('fallback')(),
+            ))
+          })
+
+          define(() =>
+            createComponent(Comp, null, {
+              default: slot,
+            }),
+          ).render()
+
+          expect(slotBlock).toBeInstanceOf(SlotFragment)
+        })
+
+        test('stable component slot with fallback does not render fallback when component output is empty', () => {
+          let slotBlock!: Block
+          // Component slot content counts as provided even when it renders
+          // invalid output, matching VDOM slot fallback semantics.
+          const Empty = defineVaporComponent(() =>
+            document.createComment('empty'),
+          )
+          const slot = (() => createComponent(Empty)) as BlockFn
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default', null, () =>
+              template('fallback')(),
+            ))
+          })
+
+          const { host } = define(() =>
+            createComponent(Comp, null, {
+              default: slot,
+            }),
+          ).render()
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(host.innerHTML).not.toContain('fallback')
+        })
+      })
+
+      describe('hydration', () => {
+        test('plain slot without fallback', () => {
+          let slotBlock!: Block
+          const container = document.createElement('div')
+          container.innerHTML = '<!--[-->content<!--]-->'
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default'))
+          })
+
+          createVaporSSRApp(
+            defineVaporComponent(() =>
+              createComponent(Comp, null, {
+                default: () => template('content')(),
+              }),
+            ),
+          ).mount(container)
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(container.innerHTML).toBe('<!--[-->content<!--]-->')
+        })
+
+        test('slot with fallback and no slots', () => {
+          let slotBlock!: Block
+          const container = document.createElement('div')
+          container.innerHTML = '<!--[-->fallback<!--]-->'
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default', null, () =>
+              template('fallback')(),
+            ))
+          })
+
+          createVaporSSRApp(
+            defineVaporComponent(() => createComponent(Comp)),
+          ).mount(container)
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(container.innerHTML).toBe('<!--[-->fallback<!--]-->')
+        })
+
+        test('stable slot with fallback', () => {
+          let slotBlock!: Block
+          const container = document.createElement('div')
+          container.innerHTML = '<!--[--><p>A</p><!--]-->'
+          const slot = (() => template('<p>A</p>')()) as BlockFn
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = createSlot('default', null, () =>
+              template('fallback')(),
+            ))
+          })
+
+          createVaporSSRApp(
+            defineVaporComponent(() =>
+              createComponent(Comp, null, {
+                default: slot,
+              }),
+            ),
+          ).mount(container)
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(container.innerHTML).toBe('<!--[--><p>A</p><!--]-->')
+        })
+
+        test('forwarded empty slot without consuming following sibling', () => {
+          let slotBlock!: Block
+          const Child = defineVaporComponent({
+            setup() {
+              return [
+                template('<main>content</main>')(),
+                (slotBlock = createSlot('footer')),
+                template('<p>after</p>')(),
+              ]
+            },
+          })
+          const Parent = defineVaporComponent({
+            setup() {
+              return createComponent(Child, null, {
+                footer: () => createSlot('footer'),
+              })
+            },
+          })
+          const container = document.createElement('div')
+          container.innerHTML =
+            '<!--[--><main>content</main><!--[--><!--]--><p>after</p><!--]-->'
+
+          createVaporSSRApp(
+            defineVaporComponent(() => createComponent(Parent)),
+          ).mount(container)
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(container.innerHTML).toBe(
+            '<!--[--><main>content</main><!--[--><!--]--><!--slot--><p>after</p><!--]-->',
+          )
+          expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+          expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+        })
+      })
     })
   })
 

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -14,7 +14,12 @@ import {
   vModelText,
   withDirectives,
 } from 'vue'
-import { VaporBlockShape, VaporVForFlags } from '@vue/shared'
+import {
+  VaporBlockShape,
+  VaporSlotFlags,
+  VaporVForFlags,
+  extend,
+} from '@vue/shared'
 import type { LooseRawProps, VaporComponent } from '../../src/component'
 import { ifFlags, makeRender } from '../_utils'
 import { VaporKeepAlive } from '../../src/components/KeepAlive'
@@ -41,6 +46,7 @@ const define = makeRender()
 const timeout = (n: number = 0) => new Promise(r => setTimeout(r, n))
 const singleRootIfElse =
   VaporBlockShape.SINGLE_ROOT | (VaporBlockShape.SINGLE_ROOT << 2)
+const nonStableSlot = { _: VaporSlotFlags.NON_STABLE } as const
 
 describe('VaporKeepAlive', () => {
   let one: VaporComponent
@@ -421,18 +427,21 @@ describe('VaporKeepAlive', () => {
 
     const renderItems = (items: typeof itemsA) =>
       createComponent(SlotConsumer, null, {
-        default: () =>
-          createFor(
-            () => items.value,
-            item => {
-              const n0 = template('<span> </span>')() as any
-              const x0 = child(n0) as any
-              renderEffect(() => setText(x0, String(item.value)))
-              return n0
-            },
-            item => item,
-            VaporVForFlags.SLOT_ROOT,
-          ),
+        default: extend(
+          () =>
+            createFor(
+              () => items.value,
+              item => {
+                const n0 = template('<span> </span>')() as any
+                const x0 = child(n0) as any
+                renderEffect(() => setText(x0, String(item.value)))
+                return n0
+              },
+              item => item,
+              VaporVForFlags.SLOT_ROOT,
+            ),
+          nonStableSlot,
+        ),
       })
 
     const { html } = define({

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -47,6 +47,7 @@ import {
   isInteropEnabled,
 } from './vdomInteropState'
 import { setScopeId, trackScopeIdFragment } from './scopeId'
+import { withHydratingSlotBoundary } from './dom/hydrateFragment'
 
 /**
  * Flag to indicate if we are executing a once slot.
@@ -89,7 +90,9 @@ export type LooseRawSlots =
 
 export type StaticSlots = Record<string, VaporSlot>
 
-export type VaporSlot = BlockFn
+export type VaporSlot = BlockFn & {
+  _?: VaporSlotFlags.NON_STABLE
+}
 export type DynamicSlot = { name: string; fn: VaporSlot }
 export type DynamicSlotFn = () => DynamicSlot | DynamicSlot[]
 export type DynamicSlotSource = StaticSlots | DynamicSlotFn
@@ -149,6 +152,7 @@ function getOwnedSlot(
   }
   const wrapped = ((...args: any[]) =>
     withSlotOwner(slots, () => slot(...args))) as VaporSlot
+  wrapped._ = slot._
   wrappers.set(key, { slot, wrapped })
   return wrapped
 }
@@ -305,31 +309,33 @@ export function createSlot(
       (instance as GenericComponentInstance).ce ||
       (instance.parent && isAsyncWrapper(instance.parent) && instance.parent.ce)
     )
-    const needsSlotFragment =
-      isHydrating ||
-      !!fallback ||
-      !!getCurrentSlotBoundary() ||
-      isCustomElementSlot
+    const needsSlotFragment = shouldUseSlotFragment(
+      rawSlots,
+      name,
+      fallback,
+      isCustomElementSlot,
+    )
     const slotFragment = needsSlotFragment
       ? new SlotFragment(slotRoot)
       : undefined
     let dynamicFragment: DynamicFragment | undefined
+    const isForwardedHydrationSlot =
+      isHydrating &&
+      currentSlotOwner != null &&
+      currentSlotOwner !== currentInstance
     if (slotFragment) {
       fragment = slotFragment
-      if (isHydrating) {
-        // Hydration uses forwarded slots to decide close marker ownership.
-        slotFragment.forwarded =
-          currentSlotOwner != null && currentSlotOwner !== currentInstance
-      }
+      slotFragment.forwarded = isForwardedHydrationSlot
     } else {
-      // Fast path: plain slots without fallback/boundary semantics only need a
-      // DynamicFragment. SlotFragment is reserved for fallback owners.
+      // Fast path: DynamicFragment is enough, but hydration still enters the
+      // slot boundary so it can own the SSR close marker.
       dynamicFragment = new DynamicFragment(
         __DEV__ ? 'slot' : undefined,
         false,
         false,
       )
       dynamicFragment.isSlot = true
+      dynamicFragment.forwarded = isForwardedHydrationSlot
       fragment = dynamicFragment
     }
     const isDynamicName = isFunction(name)
@@ -367,16 +373,20 @@ export function createSlot(
       }
 
       const slot = getSlot(rawSlots, slotName)
-      if (slot) {
-        if (slotFragment) {
-          slotFragment.updateSlot(getBoundSlot(slot), fallback)
-        } else {
-          dynamicFragment!.update(getBoundSlot(slot))
-        }
-      } else if (slotFragment) {
-        slotFragment.updateSlot(undefined, fallback)
+      const render = slot ? getBoundSlot(slot) : undefined
+      if (slotFragment) {
+        slotFragment.updateSlot(render, fallback)
       } else {
-        dynamicFragment!.update()
+        // When no slot render exists, the fast path hands fallback to the
+        // DynamicFragment; during hydration it owns the slot SSR range, so
+        // empty dynamic roots get its close marker.
+        if (isHydrating) {
+          withHydratingSlotBoundary(() =>
+            dynamicFragment!.update(render || fallback),
+          )
+        } else {
+          dynamicFragment!.update(render || fallback)
+        }
       }
     }
 
@@ -424,4 +434,37 @@ export function createSlot(
   }
 
   return fragment
+}
+
+function isNonStableSlot(slot: VaporSlot | undefined): boolean {
+  return !!slot && slot._ === VaporSlotFlags.NON_STABLE
+}
+
+function shouldUseSlotFragment(
+  rawSlots: RawSlots,
+  name: string | (() => string),
+  fallback: VaporSlot | undefined,
+  isCustomElementSlot: boolean,
+): boolean {
+  // Native CE slots render a real <slot>, so SlotFragment owns fallback.
+  if (isCustomElementSlot) return true
+
+  // Nested fallback resolution must preserve the boundary chain.
+  if (getCurrentSlotBoundary()) return true
+
+  // Without fallback, there is no fallback branch to track.
+  if (!fallback) return false
+
+  // No slots means fallback is the only possible branch.
+  if (rawSlots === EMPTY_OBJ) return false
+
+  // Dynamic names and dynamic slot sources still need runtime resolution.
+  if (isFunction(name) || rawSlots.$) return true
+
+  const slot = getSlot(rawSlots, name)
+  // No matching static slot means fallback is the only possible branch.
+  if (!slot) return false
+
+  // Non-stable slot content can become invalid, making fallback reachable.
+  return isNonStableSlot(slot)
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -229,6 +229,7 @@ export class DynamicFragment extends RenderContextFragment {
   // pure marker consumed by the isSlotFragment predicate; the core update
   // pipeline never reads it.
   isSlot?: boolean
+  forwarded?: boolean
   inTransition?: boolean
   // Fallthrough attrs hooks register branch-owned effects on insert.
   hasFallthroughAttrs?: true

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -19,6 +19,7 @@ export {
 } from './apiDefineCustomElement'
 
 // compiler-use only
+export { extend } from '@vue/shared'
 export { insert, prepend, remove, type Block } from './block'
 export { setInsertionState } from './insertionState'
 export {

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -105,6 +105,9 @@ export enum VaporSlotFlags {
   NO_SLOTTED = 1,
   ONCE = 1 << 1,
   SLOT_ROOT = 1 << 2,
+  // Per-slot function metadata. The slot root can start invalid or become
+  // invalid, so fallback may be reachable and needs SlotFragment tracking.
+  NON_STABLE = 1 << 3,
 }
 
 export enum VaporDynamicComponentFlags {


### PR DESCRIPTION
Mark slot functions with non-stable root content in compiler-vapor so runtime-vapor can keep SlotFragment only when fallback/boundary tracking is needed. Stable slot content and no-slot fallback cases can use the lighter DynamicFragment fast path while preserving hydration slot anchors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced slot compilation and runtime rendering with improved stability detection, ensuring more accurate slot behavior in dynamic, conditional, and forwarded slot scenarios.

* **Tests**
  * Updated and expanded slot-related test coverage to validate the new stability-tracking system and improve test accuracy across various slot configurations and hydration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->