### PR TITLE
fix(shared): exclude NaN and Infinity from stringifyStyle output

### DIFF
--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -198,6 +198,15 @@ describe('stringifyStyle', () => {
 
     expect(stringifyStyle(style)).toBe('color:blue;font-size:14px;')
   })
+
+  test('should preserve CSS custom properties even when value is NaN', () => {
+    const style: any = {
+      width: NaN,
+      '--x': NaN,
+    }
+
+    expect(stringifyStyle(style)).toBe('--x:NaN;')
+  })
 })
 
 describe('normalizeProps', () => {

--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -186,6 +186,18 @@ describe('stringifyStyle', () => {
     const expected = 'color:blue;font-size:14px;'
     expect(stringifyStyle(style)).toBe(expected)
   })
+
+  test('should ignore NaN and Infinity number values in style object', () => {
+    const style: any = {
+      color: 'blue',
+      width: NaN,
+      height: Infinity,
+      opacity: -Infinity,
+      fontSize: '14px',
+    }
+
+    expect(stringifyStyle(style)).toBe('color:blue;font-size:14px;')
+  })
 })
 
 describe('normalizeProps', () => {

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -51,7 +51,7 @@ export function stringifyStyle(
   let ret = ''
   for (const key in styles) {
     const value = styles[key]
-    if (isString(value) || typeof value === 'number') {
+    if (isString(value) || (typeof value === 'number' && isFinite(value))) {
       const normalizedKey = key.startsWith(`--`) ? key : hyphenate(key)
       // only render valid values
       ret += `${normalizedKey}:${value};`

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -51,7 +51,11 @@ export function stringifyStyle(
   let ret = ''
   for (const key in styles) {
     const value = styles[key]
-    if (isString(value) || (typeof value === 'number' && isFinite(value))) {
+    if (
+      key.startsWith('--') ||
+      isString(value) ||
+      (typeof value === 'number' && isFinite(value))
+    ) {
       const normalizedKey = key.startsWith(`--`) ? key : hyphenate(key)
       // only render valid values
       ret += `${normalizedKey}:${value};`


### PR DESCRIPTION
## Bug

`stringifyStyle` in `@vue/shared` uses `typeof value === 'number'` to determine whether a style value should be rendered. This passes for `NaN` and `Infinity` (both of which satisfy `typeof x === 'number'`), causing them to be emitted as literal CSS property values — which are invalid CSS and silently ignored by browsers.

**Example:**
```js
stringifyStyle({ width: NaN, height: Infinity, color: 'blue' })
// Before: 'width:NaN;height:Infinity;color:blue;'   ← invalid
// After:  'color:blue;'                              ← correct
```

## Fix

Replace `typeof value === 'number'` with `typeof value === 'number' && isFinite(value)`. This rejects `NaN`, `Infinity`, and `-Infinity` while preserving all valid numeric values (integers, floats, `0`, negative numbers).

## Verification

```
pnpm test packages/shared
```

All 60 tests pass (6 test files). New test added to `normalizeProp.spec.ts` covers `NaN`, `Infinity`, and `-Infinity`.

> AI-assisted contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented non-finite numeric values (NaN, Infinity, -Infinity) from being included in generated CSS styles, avoiding invalid output and improving stylesheet reliability.
  * Added test coverage to ensure numeric edge cases are handled correctly and that CSS custom properties continue to render as expected when values are NaN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->