### PR TITLE
feat(runtime-core): merge refs in mergeProps

### DIFF
--- a/packages-private/dts-test/h.test-d.ts
+++ b/packages-private/dts-test/h.test-d.ts
@@ -25,7 +25,6 @@ describe('h inference w/ element', () => {
   h('div', { ref: 'foo' })
   h('div', { ref: ref(null) })
   h('div', { ref: _el => {} })
-  //  @ts-expect-error
   h('div', { ref: [] })
   //  @ts-expect-error
   h('div', { ref: {} })

--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -485,6 +485,35 @@ describe('vnode', () => {
       )
     })
 
+    test('ref', () => {
+      const ref1 = ref()
+      const ref2 = ref()
+      const fn = vi.fn()
+
+      expect(mergeProps({ ref: ref1 }, { ref: ref2 })).toMatchObject({
+        ref: [ref1, ref2],
+      })
+      expect(
+        mergeProps({ ref: ref1 }, { ref: undefined }, { ref: fn }),
+      ).toMatchObject({
+        ref: [ref1, fn],
+      })
+    })
+
+    test('ref normalization', () => {
+      const mockInstance = { type: {} } as any
+      const ref1 = ref()
+      const ref2 = ref()
+
+      setCurrentRenderingInstance(mockInstance)
+      const vnode = createVNode('div', mergeProps({ ref: ref1 }, { ref: ref2 }))
+      expect(vnode.ref).toMatchObject([
+        { i: mockInstance, r: ref1, f: false },
+        { i: mockInstance, r: ref2, f: false },
+      ])
+      setCurrentRenderingInstance(null)
+    })
+
     test('default', () => {
       let props1: Data = { foo: 'c' }
       let props2: Data = { foo: {}, bar: ['cc'] }

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -91,6 +91,7 @@ export type VNodeRef =
       ref: Element | ComponentPublicInstance | null,
       refs: Record<string, any>,
     ) => void)
+  | VNodeRef[]
 
 export type VNodeNormalizedRefAtom = {
   /**
@@ -436,11 +437,11 @@ const createVNodeWithArgsTransform = (
 const normalizeKey = ({ key }: VNodeProps): VNode['key'] =>
   key != null ? key : null
 
-const normalizeRef = ({
-  ref,
-  ref_key,
-  ref_for,
-}: VNodeProps): VNodeNormalizedRefAtom | null => {
+const normalizeSingleRef = (
+  ref: VNodeRef | undefined,
+  ref_key: VNodeProps['ref_key'],
+  ref_for: VNodeProps['ref_for'],
+): VNodeNormalizedRefAtom | null => {
   if (typeof ref === 'number') {
     ref = '' + ref
   }
@@ -452,6 +453,25 @@ const normalizeRef = ({
       : null
   ) as any
 }
+
+const normalizeRef = ({
+  ref,
+  ref_key,
+  ref_for,
+}: VNodeProps): VNodeNormalizedRefAtom | VNodeNormalizedRefAtom[] | null => {
+  if (isArray(ref)) {
+    return ref
+      .map(r => normalizeSingleRef(r, ref_key, ref_for))
+      .filter((r): r is VNodeNormalizedRefAtom => !!r)
+  }
+  return normalizeSingleRef(ref, ref_key, ref_for)
+}
+
+const mergeNormalizedRefs = (
+  ref: VNodeNormalizedRef,
+  extraRef: VNodeNormalizedRef,
+): VNodeNormalizedRefAtom[] =>
+  (isArray(ref) ? ref : [ref]).concat(isArray(extraRef) ? extraRef : [extraRef])
 
 function createBaseVNode(
   type: VNodeTypes | ClassComponent | typeof NULL_DYNAMIC_COMPONENT,
@@ -673,9 +693,7 @@ export function cloneVNode<T, U>(
           // if the vnode itself already has a ref, cloneVNode will need to merge
           // the refs so the single vnode can be set on multiple refs
           mergeRef && ref
-          ? isArray(ref)
-            ? ref.concat(normalizeRef(extraProps)!)
-            : [ref, normalizeRef(extraProps)!]
+          ? mergeNormalizedRefs(ref, normalizeRef(extraProps)!)
           : normalizeRef(extraProps)
         : ref,
     scopeId: vnode.scopeId,
@@ -881,6 +899,16 @@ export function mergeProps(...args: (Data & VNodeProps)[]): Data {
         }
       } else if (key === 'style') {
         ret.style = normalizeStyle([ret.style, toMerge.style])
+      } else if (key === 'ref') {
+        const existing = ret.ref
+        const incoming = toMerge.ref
+        if (incoming != null) {
+          ret.ref = existing
+            ? isArray(existing)
+              ? existing.concat(incoming)
+              : [existing, incoming]
+            : incoming
+        }
       } else if (isOn(key)) {
         const existing = ret[key]
         const incoming = toMerge[key]

--- a/packages/vue/__tests__/e2e/Transition.spec.ts
+++ b/packages/vue/__tests__/e2e/Transition.spec.ts
@@ -1703,6 +1703,7 @@ describe('e2e: Transition', () => {
         await click('#switchToA')
         await transitionFinish()
         await transitionFinish()
+        await transitionFinish()
         expect(await html('#container')).toBe('<div class="">CompA</div>')
 
         expect(onUnmountedSpyB).toBeCalledTimes(1)


### PR DESCRIPTION
## Summary

Allow `mergeProps()` to preserve multiple `ref` values instead of letting later props overwrite earlier refs.

When `mergeProps()` receives more than one non-null `ref`, it now keeps them as an array. `normalizeRef()` then normalizes each entry so the existing renderer ref-setting path can assign the same vnode to all merged refs.

Fixes #7473

## Validation

- `pnpm vitest run packages/runtime-core/__tests__/vnode.spec.ts --project unit`
- `pnpm eslint packages/runtime-core/src/vnode.ts packages/runtime-core/__tests__/vnode.spec.ts`
- `pnpm prettier --check packages/runtime-core/src/vnode.ts packages/runtime-core/__tests__/vnode.spec.ts`
- `pnpm check`
