### PR TITLE
feat(compiler-dom): allow customizable select nesting

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/validateHtmlNesting.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/validateHtmlNesting.spec.ts
@@ -19,6 +19,18 @@ describe('validate html nesting', () => {
     expect(err).toBeUndefined()
   })
 
+  // #13158
+  it('should not warn with customizable select elements', () => {
+    let err: CompilerError | undefined
+    compile(
+      `<select><button><selectedcontent></selectedcontent></button><option><span>Option</span></option></select>`,
+      {
+        onWarn: e => (err = e),
+      },
+    )
+    expect(err).toBeUndefined()
+  })
+
   // #13318
   it('should not warn when parent tag is template', () => {
     let err: CompilerError | undefined
@@ -96,6 +108,18 @@ describe('isValidHTMLNesting', () => {
     expect(isValidHTMLNesting('table', 'tfoot')).toBe(true)
     expect(isValidHTMLNesting('table', 'caption')).toBe(true)
     expect(isValidHTMLNesting('table', 'colgroup')).toBe(true)
+  })
+
+  test('customizable select', () => {
+    // valid
+    expect(isValidHTMLNesting('select', 'button')).toBe(true)
+    expect(isValidHTMLNesting('button', 'selectedcontent')).toBe(true)
+    expect(isValidHTMLNesting('option', 'span')).toBe(true)
+
+    // invalid
+    expect(isValidHTMLNesting('select', 'span')).toBe(false)
+    expect(isValidHTMLNesting('select', 'selectedcontent')).toBe(false)
+    expect(isValidHTMLNesting('div', 'selectedcontent')).toBe(false)
   })
 
   test('td', () => {

--- a/packages/compiler-dom/src/htmlNesting.ts
+++ b/packages/compiler-dom/src/htmlNesting.ts
@@ -63,7 +63,7 @@ const onlyValidChildren: Record<string, Set<string>> = {
     'template',
   ]),
   optgroup: new Set(['option']),
-  select: new Set(['optgroup', 'option', 'hr']),
+  select: new Set(['button', 'optgroup', 'option', 'hr']),
   // table
   table: new Set(['caption', 'colgroup', 'tbody', 'tfoot', 'thead']),
   tr: new Set(['td', 'th']),
@@ -74,7 +74,6 @@ const onlyValidChildren: Record<string, Set<string>> = {
   // these elements can not have any children elements
   script: emptySet,
   iframe: emptySet,
-  option: emptySet,
   textarea: emptySet,
   style: emptySet,
   title: emptySet,
@@ -104,6 +103,7 @@ const onlyValidParents: Record<string, Set<string>> = {
   // li: new Set(["ul", "ol"]),
   summary: new Set(['details']),
   area: new Set(['map']),
+  selectedcontent: new Set(['button']),
 } as const
 
 /** maps element to set of elements that can not be it's children, others can */

--- a/packages/shared/src/domTagConfig.ts
+++ b/packages/shared/src/domTagConfig.ts
@@ -12,7 +12,7 @@ const HTML_TAGS =
   'canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,' +
   'th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,' +
   'option,output,progress,select,textarea,details,dialog,menu,' +
-  'summary,template,blockquote,iframe,tfoot'
+  'summary,template,blockquote,iframe,tfoot,selectedcontent'
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element
 const SVG_TAGS =


### PR DESCRIPTION
## Summary

Add compiler support for customizable select element nesting.

This recognizes `<selectedcontent>` as a native HTML tag and updates HTML nesting validation so Vue does not warn for the customizable select structure:

```html
<select>
  <button><selectedcontent></selectedcontent></button>
  <option><span>Option</span></option>
</select>
```

Fixes #13158

## Validation

- `pnpm vitest run packages/compiler-dom/__tests__/transforms/validateHtmlNesting.spec.ts --project unit`
- `pnpm eslint packages/shared/src/domTagConfig.ts packages/compiler-dom/src/htmlNesting.ts packages/compiler-dom/__tests__/transforms/validateHtmlNesting.spec.ts`
- `pnpm prettier --check packages/shared/src/domTagConfig.ts packages/compiler-dom/src/htmlNesting.ts packages/compiler-dom/__tests__/transforms/validateHtmlNesting.spec.ts`
- `pnpm check`
