### PR TITLE
feat(types): add directive name field

### DIFF
--- a/packages-private/dts-test/directives.test-d.ts
+++ b/packages-private/dts-test/directives.test-d.ts
@@ -25,6 +25,11 @@ describe('vmodel', () => {
 })
 
 describe('custom', () => {
+  expectType<ObjectDirective>({
+    name: 'focus',
+    mounted() {},
+  })
+
   expectType<{
     value: number
     oldValue: number | null

--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -66,6 +66,7 @@ export interface ObjectDirective<
   Modifiers extends string = string,
   Arg = any,
 > {
+  name?: string
   /**
    * @internal without this, ts-expect-error in directives.test-d.ts somehow
    * fails when running tsc, but passes in IDE and when testing against built

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -819,7 +819,6 @@ function propHasMismatch(
     // If `v-show=false`, `display: 'none'` should be added to expected
     if (vnode.dirs) {
       for (const { dir, value } of vnode.dirs) {
-        // @ts-expect-error only vShow has this internal name
         if (dir.name === 'show' && !value) {
           expectedMap.set('display', 'none')
         }


### PR DESCRIPTION
## Summary

Add an optional `name` field to `ObjectDirective`.

This lets object directives carry a stable name in the same way function directives already can through their function name, which helps external tooling such as test utilities identify and stub directives by name.

The existing hydration code already reads `dir.name` for `v-show`, so the obsolete `@ts-expect-error` there is removed.

Fixes #6887

## Validation

- `pnpm test-dts`
- `pnpm test-dts-only`
- `pnpm check`
- `pnpm eslint packages/runtime-core/src/directives.ts packages/runtime-core/src/hydration.ts packages-private/dts-test/directives.test-d.ts`
- `pnpm prettier --check packages/runtime-core/src/directives.ts packages/runtime-core/src/hydration.ts packages-private/dts-test/directives.test-d.ts`
