### PR TITLE
fix(runtime-core): clarify transition root warning

### DIFF
--- a/packages/runtime-core/__tests__/components/BaseTransition.spec.ts
+++ b/packages/runtime-core/__tests__/components/BaseTransition.spec.ts
@@ -183,6 +183,20 @@ describe('BaseTransition', () => {
     expect(props.onAfterEnter).toHaveBeenCalledTimes(1)
   })
 
+  test('warns when component root cannot be transitioned', () => {
+    const Child = {
+      render: () => [h('div'), h('div')],
+    }
+
+    mount({}, () => h(Child))
+
+    expect(
+      `Component inside <Transition> renders a non-element root node ` +
+        `that cannot be animated. Make sure the component renders a single ` +
+        `element root.`,
+    ).toHaveBeenWarned()
+  })
+
   describe('persisted: true', () => {
     // this is pretty much how v-show is implemented
     // (but using the directive API instead)

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -257,8 +257,9 @@ export function renderComponentRoot(
   if (vnode.transition) {
     if (__DEV__ && !isElementRoot(root)) {
       warn(
-        `Component inside <Transition> renders non-element root node ` +
-          `that cannot be animated.`,
+        `Component inside <Transition> renders a non-element root node ` +
+          `that cannot be animated. Make sure the component renders a single ` +
+          `element root.`,
       )
     }
     setTransitionHooks(root, vnode.transition)


### PR DESCRIPTION
## Summary

Clarify the warning shown when a component inside `<Transition>` renders a non-element root.

The new wording explains that the root cannot be animated and tells users to render a single element root, which addresses the confusion in #3338 without changing transition behavior.

Fixes #3338

## Validation

- `pnpm vitest run packages/runtime-core/__tests__/components/BaseTransition.spec.ts --project unit`
- `pnpm eslint packages/runtime-core/src/componentRenderUtils.ts packages/runtime-core/__tests__/components/BaseTransition.spec.ts`
- `pnpm prettier --check packages/runtime-core/src/componentRenderUtils.ts packages/runtime-core/__tests__/components/BaseTransition.spec.ts`
- `pnpm check`
