### PR TITLE
fix(compiler-sfc): include location for deep selector warnings

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -408,6 +408,7 @@ color: red
       expect(
         `::v-deep usage as a combinator has been deprecated.`,
       ).toHaveBeenWarned()
+      expect(`at test.css:1:1`).toHaveBeenWarned()
     })
 
     test('>>> (deprecated syntax)', () => {
@@ -419,6 +420,7 @@ color: red
       expect(
         `the >>> and /deep/ combinators have been deprecated.`,
       ).toHaveBeenWarned()
+      expect(`at test.css:1:1`).toHaveBeenWarned()
     })
 
     test('/deep/ (deprecated syntax)', () => {
@@ -430,6 +432,12 @@ color: red
       expect(
         `the >>> and /deep/ combinators have been deprecated.`,
       ).toHaveBeenWarned()
+      expect(`at test.css:1:1`).toHaveBeenWarned()
+    })
+
+    test('deprecated syntax warning includes line location', () => {
+      compileScoped(`.bar { color: red; }\n>>> .foo { color: red; }`)
+      expect(`at test.css:2:1`).toHaveBeenWarned()
     })
   })
 })

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -114,7 +114,7 @@ function rewriteSelector(
       n.spaces.before = n.spaces.after = ''
       warn(
         `the >>> and /deep/ combinators have been deprecated. ` +
-          `Use :deep() instead.`,
+          `Use :deep() instead.${formatRuleLocation(rule)}`,
       )
       return false
     }
@@ -207,7 +207,8 @@ function rewriteSelector(
           // .foo ::v-deep .bar -> .foo[xxxxxxx] .bar
           warn(
             `${value} usage as a combinator has been deprecated. ` +
-              `Use :deep(<inner-selector>) instead of ${value} <inner-selector>.`,
+              `Use :deep(<inner-selector>) instead of ${value} <inner-selector>.` +
+              formatRuleLocation(rule),
           )
 
           const prev = selector.at(selector.index(n) - 1)
@@ -342,6 +343,16 @@ function rewriteSelector(
 
 function isSpaceCombinator(node: selectorParser.Node) {
   return node.type === 'combinator' && /^\s+$/.test(node.value)
+}
+
+function formatRuleLocation(rule: Rule): string {
+  const start = rule.source?.start
+  if (!start) {
+    return ''
+  }
+  const file = rule.source?.input.file
+  const filename = file?.split(/[\\/]/).pop()
+  return `\n  at ${filename ? `${filename}:` : ''}${start.line}:${start.column}`
 }
 
 function isDeepSelector(node: selectorParser.Node): boolean {


### PR DESCRIPTION
Fixes #6404.

## Summary
- include the style rule location in deprecated `>>>`, `/deep/`, and combinator-style `::v-deep` warnings
- add coverage for same-line and multi-line warning locations

## Validation
- pnpm vitest run packages/compiler-sfc/__tests__/compileStyle.spec.ts --project unit
- pnpm eslint packages/compiler-sfc/src/style/pluginScoped.ts packages/compiler-sfc/__tests__/compileStyle.spec.ts
- pnpm prettier --check packages/compiler-sfc/src/style/pluginScoped.ts packages/compiler-sfc/__tests__/compileStyle.spec.ts
- pnpm check