### PR TITLE
feat(server-renderer): export buffer helpers

### DIFF
--- a/packages-private/dts-test/serverRenderer.test-d.ts
+++ b/packages-private/dts-test/serverRenderer.test-d.ts
@@ -1,0 +1,17 @@
+import {
+  type SSRBuffer,
+  type SSRBufferItem,
+  createBuffer,
+  unrollBuffer,
+} from 'vue/server-renderer'
+import { expectType } from './utils'
+
+const { getBuffer, push } = createBuffer()
+
+push('hello')
+push(Promise.resolve([' world']))
+
+const buffer = getBuffer()
+expectType<SSRBuffer>(buffer)
+expectType<SSRBufferItem>(buffer)
+expectType<string | Promise<string>>(unrollBuffer(buffer))

--- a/packages/server-renderer/__tests__/buffer.spec.ts
+++ b/packages/server-renderer/__tests__/buffer.spec.ts
@@ -1,0 +1,20 @@
+import { createBuffer, unrollBuffer } from '../src'
+
+describe('SSR buffer helpers', () => {
+  test('creates and unrolls nested buffers', async () => {
+    const parent = createBuffer()
+    const child = createBuffer()
+
+    parent.push('<div>')
+    child.push('<span>')
+    child.push('hello')
+    child.push('</span>')
+    parent.push(child.getBuffer())
+    parent.push(Promise.resolve(['async']))
+    parent.push('</div>')
+
+    expect(await unrollBuffer(parent.getBuffer())).toBe(
+      '<div><span>hello</span>async</div>',
+    )
+  })
+})

--- a/packages/server-renderer/src/index.ts
+++ b/packages/server-renderer/src/index.ts
@@ -2,8 +2,9 @@ import { initDirectivesForSSR } from 'vue'
 initDirectivesForSSR()
 
 // public
-export type { SSRContext } from './render'
-export { renderToString } from './renderToString'
+export type { SSRBuffer, SSRBufferItem, SSRContext } from './render'
+export { createBuffer } from './render'
+export { renderToString, unrollBuffer } from './renderToString'
 export {
   renderToSimpleStream,
   renderToNodeStream,


### PR DESCRIPTION
Fixes #7414.

## Summary
- export `createBuffer`, `unrollBuffer`, `SSRBuffer`, and `SSRBufferItem` from the server renderer public entry
- add runtime coverage for nested/async buffer unrolling
- add dts coverage through `vue/server-renderer`

## Validation
- pnpm vitest run packages/server-renderer/__tests__/buffer.spec.ts --project unit
- pnpm test-dts
- pnpm eslint packages/server-renderer/src/index.ts packages/server-renderer/__tests__/buffer.spec.ts packages-private/dts-test/serverRenderer.test-d.ts
- pnpm prettier --check packages/server-renderer/src/index.ts packages/server-renderer/__tests__/buffer.spec.ts packages-private/dts-test/serverRenderer.test-d.ts
- pnpm check