### PR TITLE
feat(runtime-core): support prepending teleports

### DIFF
--- a/packages-private/dts-test/tsx.test-d.tsx
+++ b/packages-private/dts-test/tsx.test-d.tsx
@@ -108,6 +108,7 @@ expectType<JSX.Element>(<Fragment key="1" />)
 
 expectType<JSX.Element>(<Teleport to="#foo" />)
 expectType<JSX.Element>(<Teleport to="#foo" key="1" />)
+expectType<JSX.Element>(<Teleport to="#foo" prepend />)
 
 // @ts-expect-error
 ;<Teleport />

--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -799,6 +799,22 @@ describe('renderer: teleport', () => {
       expect(serializeInner(target)).toBe(`<div>one</div><div>two</div>`)
     })
 
+    test('multiple teleport with same target and prepend', () => {
+      const target = nodeOps.createElement('div')
+      const root = nodeOps.createElement('div')
+
+      render(
+        h('div', [
+          h(Teleport, { to: target }, h('div', 'one')),
+          h(Teleport, { to: target, prepend: true }, 'two'),
+          h(Teleport, { to: target, prepend: true }, h('span', 'three')),
+        ]),
+        root,
+      )
+
+      expect(serializeInner(target)).toBe(`<span>three</span>two<div>one</div>`)
+    })
+
     test('should work when using template ref as target', async () => {
       const root = nodeOps.createElement('div')
       const target = ref(null)

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -22,6 +22,7 @@ export interface TeleportProps {
   to: string | RendererElement | null | undefined
   disabled?: boolean
   defer?: boolean
+  prepend?: boolean
 }
 
 const pendingMounts = new WeakMap<VNode, SchedulerJob>()
@@ -35,6 +36,14 @@ const isTeleportDisabled = (props: VNode['props']): boolean =>
 
 const isTeleportDeferred = (props: VNode['props']): boolean =>
   props && (props.defer || props.defer === '')
+
+const isTeleportPrepended = (props: VNode['props']): boolean =>
+  props && (props.prepend || props.prepend === '')
+
+const getTargetFirstChild = (target: RendererElement): RendererNode | null => {
+  const children = target.children
+  return target.firstChild || (children && children[0]) || null
+}
 
 const isTargetSVG = (target: RendererElement): boolean =>
   typeof SVGElement !== 'undefined' && target instanceof SVGElement
@@ -131,7 +140,15 @@ export const TeleportImpl = {
     const mountToTarget = (vnode: TeleportVNode = n2) => {
       const disabled = isTeleportDisabled(vnode.props)
       const target = (vnode.target = resolveTarget(vnode.props, querySelector))
-      const targetAnchor = prepareAnchor(target, vnode, createText, insert)
+      const targetAnchor = prepareAnchor(
+        target,
+        vnode,
+        createText,
+        insert,
+        target && isTeleportPrepended(vnode.props)
+          ? getTargetFirstChild(target)
+          : null,
+      )
       if (target) {
         // #2652 we could be teleporting from a non-SVG tree into an SVG tree
         if (namespace !== 'svg' && isTargetSVG(target)) {


### PR DESCRIPTION
Fixes #7595.

## Summary
- add a `prepend` prop to Teleport
- mount prepended Teleports before the current first child of the target
- add runtime and TSX type coverage

## Validation
- pnpm vitest run packages/runtime-core/__tests__/components/Teleport.spec.ts --project unit
- pnpm test-dts
- pnpm test-dts-only
- pnpm eslint packages/runtime-core/src/components/Teleport.ts packages/runtime-core/__tests__/components/Teleport.spec.ts packages-private/dts-test/tsx.test-d.tsx
- pnpm prettier --check packages/runtime-core/src/components/Teleport.ts packages/runtime-core/__tests__/components/Teleport.spec.ts packages-private/dts-test/tsx.test-d.tsx
- pnpm check