### PR TITLE
feat(vue): add browser export condition

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -21,6 +21,7 @@
       "import": {
         "types": "./dist/vue.d.mts",
         "node": "./index.mjs",
+        "browser": "./dist/vue.esm-browser.js",
         "default": "./dist/vue.runtime.esm-bundler.js"
       },
       "require": {


### PR DESCRIPTION
Fixes #7179.

## Summary
- add a `browser` condition to the `vue` package import export map
- point browser-aware ESM resolution at the full browser build

## Validation
- pnpm prettier --check packages/vue/package.json
- pnpm check