### PR TITLE
feat(reactivity): warn for computed created in computed getter

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -102,6 +102,17 @@ describe('reactivity/computed', () => {
     expect(c1.value).toBe(1)
   })
 
+  it('should warn when creating computed in computed getter', () => {
+    const c1 = computed(() => {
+      computed(() => 1)
+      return 1
+    })
+    c1.value
+    expect(
+      `computed() should not be called inside a computed getter.`,
+    ).toHaveBeenWarned()
+  })
+
   it('should trigger effect when chained', () => {
     const value = reactive({ foo: 0 })
     const getter1 = vi.fn(() => value.foo)

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -7,6 +7,7 @@ import {
   activeSub,
   batch,
   refreshComputed,
+  warnIfComputedCreatedInComputed,
 } from './effect'
 import type { Ref } from './ref'
 import { warn } from './warning'
@@ -209,6 +210,8 @@ export function computed<T>(
     getter = getterOrOptions.get
     setter = getterOrOptions.set
   }
+
+  warnIfComputedCreatedInComputed()
 
   const cRef = new ComputedRefImpl(getter, setter, isSSR)
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -38,6 +38,17 @@ export interface ReactiveEffectRunner<T = any> {
 
 export let activeSub: Subscriber | undefined
 
+export function warnIfComputedCreatedInComputed(): void {
+  if (
+    __DEV__ &&
+    activeSub &&
+    (activeSub as any).__v_isRef === true &&
+    (activeSub as any).effect === activeSub
+  ) {
+    warn(`computed() should not be called inside a computed getter.`)
+  }
+}
+
 export enum EffectFlags {
   /**
    * ReactiveEffect only


### PR DESCRIPTION
Fixes #7873.

## Summary
- warn in dev when `computed()` is called while another computed getter is active
- add computed coverage for the warning

## Notes
This keeps the warning scoped to nested `computed()` creation to avoid warning for existing `ref()` usage patterns in computed tests.

## Validation
- pnpm vitest run packages/reactivity/__tests__/computed.spec.ts --project unit
- pnpm eslint packages/reactivity/src/effect.ts packages/reactivity/src/computed.ts packages/reactivity/__tests__/computed.spec.ts
- pnpm prettier --check packages/reactivity/src/effect.ts packages/reactivity/src/computed.ts packages/reactivity/__tests__/computed.spec.ts
- pnpm check