### PR TITLE
feat(runtime-dom): support data checkbox true values

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -596,6 +596,44 @@ describe('vModel', () => {
     expect(data.value).toEqual('yes')
   })
 
+  it('should work with checkbox and data-true-value/data-false-value', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: 'yes' }
+      },
+      render() {
+        return [
+          withVModel(
+            h('input', {
+              type: 'checkbox',
+              'data-true-value': 'yes',
+              'data-false-value': 'no',
+              'onUpdate:modelValue': setValue.bind(this),
+            }),
+            this.value,
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const input = root.querySelector('input')
+    const data = root._vnode.component.data
+
+    expect(input.checked).toEqual(true)
+    expect(input.getAttribute('data-true-value')).toBe('yes')
+    expect(input.getAttribute('data-false-value')).toBe('no')
+
+    input.checked = false
+    triggerEvent('change', input)
+    await nextTick()
+    expect(data.value).toEqual('no')
+
+    data.value = 'yes'
+    await nextTick()
+    expect(input.checked).toEqual(true)
+  })
+
   it('should work with checkbox and true-value/false-value with object values', async () => {
     const component = defineComponent({
       data() {

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -285,13 +285,32 @@ function getValue(el: HTMLOptionElement | HTMLInputElement) {
   return '_value' in el ? (el as any)._value : el.value
 }
 
-// retrieve raw value for true-value and false-value set via :true-value or :false-value bindings
+// retrieve raw value for true-value and false-value set via :true-value,
+// :false-value, data-true-value or data-false-value bindings
 function getCheckboxValue(
   el: HTMLInputElement & { _trueValue?: any; _falseValue?: any },
   checked: boolean,
 ) {
   const key = checked ? '_trueValue' : '_falseValue'
-  return key in el ? el[key] : checked
+  if (key in el) {
+    return el[key]
+  }
+  const dataKey = checked ? 'data-true-value' : 'data-false-value'
+  return el.hasAttribute(dataKey) ? el.getAttribute(dataKey) : checked
+}
+
+function getSSRCheckboxValue(vnode: VNode): unknown {
+  const props = vnode.props
+  if (!props) {
+    return true
+  }
+  if ('true-value' in props) {
+    return props['true-value']
+  }
+  if ('data-true-value' in props) {
+    return props['data-true-value']
+  }
+  return true
 }
 
 export const vModelDynamic: ObjectDirective<
@@ -364,7 +383,7 @@ export function initVModelForSSR(): void {
       if (vnode.props && value.has(vnode.props.value)) {
         return { checked: true }
       }
-    } else if (value) {
+    } else if (looseEqual(value, getSSRCheckboxValue(vnode))) {
       return { checked: true }
     }
   }

--- a/packages/server-renderer/__tests__/ssrDirectives.spec.ts
+++ b/packages/server-renderer/__tests__/ssrDirectives.spec.ts
@@ -432,6 +432,44 @@ describe('ssr: directives', () => {
           }),
         ),
       ).toBe(`<input type="checkbox" value="foo">`)
+
+      expect(
+        await renderToString(
+          createApp({
+            render() {
+              return withDirectives(
+                h('input', {
+                  type: 'checkbox',
+                  'data-true-value': 'yes',
+                  'data-false-value': 'no',
+                }),
+                [[vModelCheckbox, 'yes']],
+              )
+            },
+          }),
+        ),
+      ).toBe(
+        `<input type="checkbox" data-true-value="yes" data-false-value="no" checked>`,
+      )
+
+      expect(
+        await renderToString(
+          createApp({
+            render() {
+              return withDirectives(
+                h('input', {
+                  type: 'checkbox',
+                  'data-true-value': 'yes',
+                  'data-false-value': 'no',
+                }),
+                [[vModelCheckbox, 'no']],
+              )
+            },
+          }),
+        ),
+      ).toBe(
+        `<input type="checkbox" data-true-value="yes" data-false-value="no">`,
+      )
     })
   })
 


### PR DESCRIPTION
Fixes #13010.

## Summary
- support `data-true-value` and `data-false-value` as checkbox `v-model` value aliases
- keep existing `true-value` / `false-value` behavior intact
- align SSR checked rendering with the configured true value

## Validation
- pnpm vitest run packages/runtime-dom/__tests__/directives/vModel.spec.ts --project unit-jsdom
- pnpm vitest run packages/server-renderer/__tests__/ssrDirectives.spec.ts --project unit
- pnpm eslint packages/runtime-dom/src/directives/vModel.ts packages/runtime-dom/__tests__/directives/vModel.spec.ts packages/server-renderer/__tests__/ssrDirectives.spec.ts
- pnpm prettier --check packages/runtime-dom/src/directives/vModel.ts packages/runtime-dom/__tests__/directives/vModel.spec.ts packages/server-renderer/__tests__/ssrDirectives.spec.ts
- pnpm check