### PR TITLE
fix(runtime-vapor): preserve render effect creation order when updating

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -95,11 +95,26 @@ function findInsertionIndex(
 /**
  * @internal for runtime-vapor only
  */
-export function queueJob(job: SchedulerJob, id?: number, isPre = false): void {
+export function queueJob(
+  job: SchedulerJob,
+  id?: number,
+  isPre = false,
+  order = 0,
+): void {
   if (
     queueJobWorker(
       job,
-      id === undefined ? (isPre ? -2 : Infinity) : isPre ? id * 2 : id * 2 + 1,
+      id === undefined
+        ? isPre
+          ? -2
+          : Infinity
+        : isPre
+          ? id * 2
+          : order
+            ? // `order / (order + 1)` is monotonic and always < 1, so it sorts
+              // same-component Vapor effects without changing component order.
+              id * 2 + 1 + order / (order + 1)
+            : id * 2 + 1,
       jobs,
       jobsLength,
       flushIndex,

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -93,6 +93,40 @@ describe('createFor', () => {
     expect(calls).toEqual(['render 1', 'render 2', 'render 3'])
   })
 
+  test('should not re-run stale item effect when parent if turns false same tick', async () => {
+    const show = ref(true)
+    const list = ref([{ text: 'foo' }])
+    const calls: string[] = []
+
+    const { host } = define(() => {
+      return createIf(
+        () => show.value,
+        () =>
+          createFor(
+            () => list.value,
+            item => {
+              const span = document.createElement('span')
+              renderEffect(() => {
+                calls.push(item.value.text)
+                span.textContent = item.value.text
+              })
+              return span
+            },
+          ),
+      )
+    }).render()
+
+    expect(calls).toEqual(['foo'])
+
+    calls.length = 0
+    list.value[0].text = 'bar'
+    show.value = false
+    await nextTick()
+
+    expect(host.innerHTML).toBe('<!--if-->')
+    expect(calls).toEqual([])
+  })
+
   test('should stop DOM item scopes when list is disposed by an outer v-for item', async () => {
     const groups = ref([
       { id: 1, items: [1, 2] },

--- a/packages/runtime-vapor/__tests__/if.spec.ts
+++ b/packages/runtime-vapor/__tests__/if.spec.ts
@@ -13,7 +13,7 @@ import {
 import { nextTick, ref } from '@vue/runtime-dom'
 import { VaporBlockShape, VaporIfFlags } from '@vue/shared'
 import type { Mock } from 'vitest'
-import { ifFlags, makeRender } from './_utils'
+import { compile, ifFlags, makeRender } from './_utils'
 import { setElementText } from '../src/dom/prop'
 import type { DynamicFragment } from '../src/fragment'
 
@@ -142,6 +142,53 @@ describe('createIf', () => {
     ok1.value = false
     await nextTick()
     expect(host.innerHTML).toBe('<!--if-->')
+  })
+
+  test('should not mount stale nested branch when parent if becomes false', async () => {
+    const data = ref<{
+      nodes: string[] | null
+      plainText: string | null
+    }>({
+      nodes: ['foo'],
+      plainText: 'foo',
+    })
+    const childSetup = vi.fn()
+    const Child = defineVaporComponent({
+      props: {
+        nodes: { type: Array, required: true },
+      },
+      setup() {
+        childSetup()
+        return template('<div>child</div>')()
+      },
+    })
+    const App = compile(
+      `<script setup vapor>
+        const data = _data
+        const Child = _components.Child
+      </script>
+      <template>
+        <template v-if="data.nodes">
+          <span v-if="data.plainText !== null">{{ data.plainText }}</span>
+          <Child v-else :nodes="data.nodes" />
+        </template>
+      </template>`,
+      data,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+
+    expect(host.innerHTML).toBe('<span>foo</span><!--if--><!--if-->')
+    expect(childSetup).not.toHaveBeenCalled()
+
+    data.value.plainText = null
+    data.value.nodes = null
+    await nextTick()
+
+    expect(host.innerHTML).toBe('<!--if-->')
+    expect(childSetup).not.toHaveBeenCalled()
+    expect(`type check failed for prop "nodes"`).not.toHaveBeenWarned()
   })
 
   test('with v-once', async () => {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -738,6 +738,9 @@ export class VaporComponentInstance<
   ec?: LifecycleHook // LifecycleHooks.ERROR_CAPTURED
   sp?: LifecycleHook<() => Promise<unknown>> // LifecycleHooks.SERVER_PREFETCH
 
+  // renderEffect creation counter for scheduler ordering.
+  effectCount = 0
+
   // dev only
   setupState?: Exposed extends Block ? undefined : ShallowUnwrapRef<Exposed>
   devtoolsRawSetupState?: any

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -19,11 +19,14 @@ export class RenderEffect extends ReactiveEffect {
   job: SchedulerJob
   updateJob?: SchedulerJob
   render: () => void
+  // Creation order within the owning component.
+  order: number
 
   constructor(render: () => void, noLifecycle = false) {
     super(noLifecycle ? render : undefined)
     this.render = render
     const instance = currentInstance as VaporComponentInstance | null
+    this.order = instance ? instance.effectCount++ : 0
     if (__DEV__ && !__TEST__ && !this.subs && !isVaporComponent(instance)) {
       warn('renderEffect called without active EffectScope or Vapor instance.')
     }
@@ -103,7 +106,7 @@ export class RenderEffect extends ReactiveEffect {
   notify(): void {
     const flags = this.flags
     if (!(flags & EffectFlags.PAUSED)) {
-      queueJob(this.job, this.i ? this.i.uid : undefined)
+      queueJob(this.job, this.i ? this.i.uid : undefined, false, this.order)
     }
   }
 }


### PR DESCRIPTION
Vapor components can create multiple render effects within the same component. When nested effects are queued in the same tick, trigger order may let a stale inner effect run before the outer control-flow effect that should tear it down.

Track each render effect's creation order per component and use it as a scheduler tiebreaker, while keeping component ids as the primary sort key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed render effect scheduling to prevent stale effects from re-running when parent conditional states change within the same update tick.
  * Improved nested component rendering to prevent unnecessary mounting when parent conditional branches become inactive.

* **Tests**
  * Added test coverage for conditional rendering scenarios with nested components and item effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->