### PR TITLE
fix(runtime-vapor): pause tracking when invoking function refs

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -392,6 +392,32 @@ describe('api: template ref', () => {
     expect(fn2.mock.calls[0][0]).toBe(host.children[0])
   })
 
+  it('function ref binding should not track dependencies read by callback', async () => {
+    const visible = ref(new Set<number>())
+    const fn = vi.fn((el: any) => {
+      if (!el || visible.value.has(0)) {
+        return
+      }
+      visible.value = new Set([0])
+    })
+
+    const t0 = template('<div></div>')
+    const { render } = define({
+      render() {
+        const n0 = t0()
+        setTemplateRefBinding(n0 as Element, () => fn)
+        return n0
+      },
+    })
+
+    render()
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(visible.value.has(0)).toBe(true)
+
+    await nextTick()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
   it('function ref unmount', async () => {
     const fn = vi.fn()
     const toggle = ref(true)

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -1,4 +1,10 @@
-import { type Ref, isRef, onScopeDispose } from '@vue/reactivity'
+import {
+  type Ref,
+  isRef,
+  onScopeDispose,
+  pauseTracking,
+  resetTracking,
+} from '@vue/reactivity'
 import {
   type VaporComponentInstance,
   currentInstance,
@@ -250,17 +256,11 @@ function setRef(
       if (canSetRef(oldRef, oldRefKey)) oldRef.value = null
       if (oldRefKey) refs[oldRefKey] = null
     } else if (isFunction(oldRef) && isDynamicFragment(el)) {
-      callWithErrorHandling(oldRef, instance, ErrorCodes.FUNCTION_REF, [
-        null,
-        refs,
-      ])
+      callFunctionRef(oldRef, instance, null, refs)
     }
   } else if (oldRef != null && isDynamicFragment(el)) {
     if (isFunction(oldRef)) {
-      callWithErrorHandling(oldRef, instance, ErrorCodes.FUNCTION_REF, [
-        null,
-        refs,
-      ])
+      callFunctionRef(oldRef, instance, null, refs)
     } else if (refFor) {
       // For dynamic ref-for branches, remove only this branch's previous value.
       unsetRef(el)
@@ -272,10 +272,7 @@ function setRef(
 
   if (isFunction(ref)) {
     const invokeRefSetter = (value?: Element | Record<string, any> | null) => {
-      callWithErrorHandling(ref, instance, ErrorCodes.FUNCTION_REF, [
-        value,
-        refs,
-      ])
+      callFunctionRef(ref, instance, value, refs)
     }
 
     invokeRefSetter(refValue)
@@ -364,6 +361,20 @@ function setRef(
     }
   }
   return ref
+}
+
+function callFunctionRef(
+  ref: Exclude<NodeRef, string | Ref>,
+  instance: VaporComponentInstance,
+  value: Element | Record<string, any> | null | undefined,
+  refs: Record<string, any>,
+): void {
+  pauseTracking()
+  try {
+    callWithErrorHandling(ref, instance, ErrorCodes.FUNCTION_REF, [value, refs])
+  } finally {
+    resetTracking()
+  }
 }
 
 const getRefValue = (el: RefEl) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template reference function callbacks to prevent unintended tracking of reactive dependencies during execution, ensuring callbacks don't re-trigger when underlying reactive state changes occur.

* **Tests**
  * Added test case validating that function reference callbacks do not track reactive dependencies and only execute once on initial mount, preventing unnecessary re-invocations in reactive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->