### PR TITLE
[codex] fix(ssr): resolve teleports with suspense

### DIFF
--- a/packages/server-renderer/__tests__/ssrTeleport.spec.ts
+++ b/packages/server-renderer/__tests__/ssrTeleport.spec.ts
@@ -1,4 +1,4 @@
-import { Teleport, createApp, h } from 'vue'
+import { Teleport, createApp, defineAsyncComponent, h } from 'vue'
 import { renderToString } from '../src/renderToString'
 import { renderToSimpleStream } from '../src/renderToStream'
 import type { SSRContext } from '../src/render'
@@ -175,6 +175,54 @@ describe('ssrRenderTeleport', () => {
     expect(html).toBe('<!--teleport start--><!--teleport end-->')
     expect(ctx.teleports!['#target']).toBe(
       `<!--teleport start anchor--><div>content</div><!--teleport anchor-->`,
+    )
+  })
+
+  test('teleport work w/ suspense', async () => {
+    const ctx: SSRContext = {}
+
+    const AsyncComp = defineAsyncComponent(() =>
+      Promise.resolve({
+        render: () => h('div', 'content'),
+      }),
+    )
+
+    const Comp = {
+      template:
+        '<teleport to="#target"><Suspense><AsyncComp /></Suspense></teleport>',
+      components: { AsyncComp },
+    }
+
+    let html = ''
+    let resolve: () => void
+    const done = new Promise<void>(r => {
+      resolve = r
+    })
+
+    renderToSimpleStream(
+      h({
+        template: '<Comp />',
+        components: { Comp },
+      }),
+      ctx,
+      {
+        push(chunk) {
+          if (chunk === null) {
+            resolve()
+          } else {
+            html += chunk
+          }
+        },
+        destroy(err) {
+          throw err
+        },
+      },
+    )
+
+    await done
+    expect(html).toBe('<!--teleport start--><!--teleport end-->')
+    expect(ctx.teleports!['#target']).toBe(
+      '<!--teleport start anchor--><div>content</div><!--teleport anchor-->',
     )
   })
 })

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -103,7 +103,7 @@ export async function resolveTeleports(context: SSRContext): Promise<void> {
       // note: it's OK to await sequentially here because the Promises were
       // created eagerly in parallel.
       context.teleports[key] = await unrollBuffer(
-        await Promise.all([context.__teleportBuffers[key]]),
+        await Promise.all(context.__teleportBuffers[key].flat()),
       )
     }
   }


### PR DESCRIPTION
## Summary

Fix SSR teleports when the teleported subtree contains `<Suspense>`.

## Root cause

`resolveTeleports()` treated each teleport buffer as a single nested buffer entry. When the teleport content itself came from Suspense/async rendering, the buffer could be nested one level deeper, so the stream resolution never unwrapped the actual teleport payload correctly.

## Change

- flatten the collected teleport buffers before unrolling them into final teleport HTML
- add a regression test for `Teleport + Suspense`

## Validation

- `pnpm exec vitest packages/server-renderer/__tests__/ssrTeleport.spec.ts --run`