### PR TITLE
[codex] fix(ssr): preserve TransitionGroup fallthrough tag

### DIFF
--- a/packages/compiler-ssr/__tests__/ssrTransitionGroup.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrTransitionGroup.spec.ts
@@ -8,14 +8,28 @@ describe('transition-group', () => {
       compile(`<transition-group><div v-for="i in list"/></transition-group>`)
         .code,
     ).toMatchInlineSnapshot(`
-      "const { ssrRenderList: _ssrRenderList } = require("vue/server-renderer")
+      "const { TransitionGroup: _TransitionGroup, withCtx: _withCtx, renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock } = require("vue")
+      const { ssrRenderComponent: _ssrRenderComponent, ssrRenderList: _ssrRenderList } = require("vue/server-renderer")
 
       return function ssrRender(_ctx, _push, _parent, _attrs) {
-        _push(\`<!--[-->\`)
-        _ssrRenderList(_ctx.list, (i) => {
-          _push(\`<div></div>\`)
-        })
-        _push(\`<!--]-->\`)
+        _push(_ssrRenderComponent(_TransitionGroup, _attrs, {
+          default: _withCtx((_, _push, _parent, _scopeId) => {
+            if (_push) {
+              _push(\`<!--[-->\`)
+              _ssrRenderList(_ctx.list, (i) => {
+                _push(\`<div\${_scopeId}></div>\`)
+              })
+              _push(\`<!--]-->\`)
+            } else {
+              return [
+                (_openBlock(true), _createBlock(_Fragment, null, _renderList(_ctx.list, (i) => {
+                  return (_openBlock(), _createBlock("div"))
+                }), 256 /* UNKEYED_FRAGMENT */))
+              ]
+            }
+          }),
+          _: 1 /* STABLE */
+        }, _parent))
       }"
     `)
   })
@@ -133,20 +147,43 @@ describe('transition-group', () => {
             </transition-group>`,
       ).code,
     ).toMatchInlineSnapshot(`
-      "const { ssrRenderList: _ssrRenderList } = require("vue/server-renderer")
+      "const { TransitionGroup: _TransitionGroup, withCtx: _withCtx, renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode, createCommentVNode: _createCommentVNode } = require("vue")
+      const { ssrRenderComponent: _ssrRenderComponent, ssrRenderList: _ssrRenderList } = require("vue/server-renderer")
 
       return function ssrRender(_ctx, _push, _parent, _attrs) {
-        _push(\`<!--[-->\`)
-        _ssrRenderList(10, (i) => {
-          _push(\`<div></div>\`)
-        })
-        _ssrRenderList(10, (i) => {
-          _push(\`<div></div>\`)
-        })
-        if (_ctx.ok) {
-          _push(\`<div>ok</div>\`)
-        }
-        _push(\`<!--]-->\`)
+        _push(_ssrRenderComponent(_TransitionGroup, _attrs, {
+          default: _withCtx((_, _push, _parent, _scopeId) => {
+            if (_push) {
+              _push(\`<!--[-->\`)
+              _ssrRenderList(10, (i) => {
+                _push(\`<div\${_scopeId}></div>\`)
+              })
+              _push(\`<!--]--><!--[-->\`)
+              _ssrRenderList(10, (i) => {
+                _push(\`<div\${_scopeId}></div>\`)
+              })
+              _push(\`<!--]-->\`)
+              if (_ctx.ok) {
+                _push(\`<div\${_scopeId}>ok</div>\`)
+              } else {
+                _push(\`<!---->\`)
+              }
+            } else {
+              return [
+                (_openBlock(), _createBlock(_Fragment, null, _renderList(10, (i) => {
+                  return _createVNode("div")
+                }), 64 /* STABLE_FRAGMENT */)),
+                (_openBlock(), _createBlock(_Fragment, null, _renderList(10, (i) => {
+                  return _createVNode("div")
+                }), 64 /* STABLE_FRAGMENT */)),
+                (_ctx.ok)
+                  ? (_openBlock(), _createBlock("div", { key: 0 }, "ok"))
+                  : _createCommentVNode("v-if", true)
+              ]
+            }
+          }),
+          _: 1 /* STABLE */
+        }, _parent))
       }"
     `)
   })

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -34,6 +34,7 @@ import {
   createRoot,
   createSimpleExpression,
   createTransformContext,
+  findProp,
   getBaseTransformPreset,
   locStub,
   resolveComponentType,
@@ -96,21 +97,33 @@ export const ssrTransformComponent: NodeTransform = (node, context) => {
     return
   }
 
-  const component = resolveComponentType(node, context, true /* ssr */)
+  let component = resolveComponentType(node, context, true /* ssr */)
   const isDynamicComponent =
     isObject(component) && component.callee === RESOLVE_DYNAMIC_COMPONENT
-  componentTypeMap.set(node, component)
 
   if (isSymbol(component)) {
     if (component === SUSPENSE) {
+      componentTypeMap.set(node, component)
       return ssrTransformSuspense(node, context)
     } else if (component === TRANSITION_GROUP) {
-      return ssrTransformTransitionGroup(node, context)
+      if (!findProp(node, 'tag')) {
+        // No explicit tag: let the runtime component receive fallthrough attrs
+        // so a parent-provided `tag` can still become the rendered root.
+        component = context.helperString(TRANSITION_GROUP)
+      } else {
+        componentTypeMap.set(node, component)
+        return ssrTransformTransitionGroup(node, context)
+      }
     } else if (component === TRANSITION) {
+      componentTypeMap.set(node, component)
       return ssrTransformTransition(node, context)
+    } else {
+      componentTypeMap.set(node, component)
+      return // other built-in components: fallthrough
     }
-    return // other built-in components: fallthrough
   }
+
+  componentTypeMap.set(node, component)
 
   // Build the fallback vnode-based branch for the component's slots.
   // We need to clone the node into a fresh copy and use the buildSlots' logic

--- a/packages/server-renderer/__tests__/ssrSlot.spec.ts
+++ b/packages/server-renderer/__tests__/ssrSlot.spec.ts
@@ -234,6 +234,21 @@ describe('ssr: slot', () => {
     ).toBe(`<div><p>1</p><p>2</p></div>`)
   })
 
+  test('transition-group tag fallthrough from parent component', async () => {
+    expect(
+      await renderToString(
+        createApp({
+          components: {
+            one: {
+              template: `<TransitionGroup><slot/></TransitionGroup>`,
+            },
+          },
+          template: `<one tag="div"><p v-for="i in 2">{{ i }}</p></one>`,
+        }),
+      ),
+    ).toBe(`<div><p>1</p><p>2</p></div>`)
+  })
+
   // #12438
   test('async component slot with v-if true', async () => {
     const Layout = defineAsyncComponent(() =>


### PR DESCRIPTION
Fixes #12827.

When a `TransitionGroup` in SSR has no explicit `tag`, fallthrough attrs from a parent component can still carry `tag`. The SSR compiler previously flattened that branch to a fragment too early, so the parent-provided tag was lost during hydration.

This change keeps the no-explicit-tag case on the runtime component path, which lets fallthrough attrs reach `TransitionGroup` normally while preserving the existing fast path for explicit `tag` usage.

Tests:
- `pnpm exec vitest packages/compiler-ssr/__tests__/ssrTransitionGroup.spec.ts packages/server-renderer/__tests__/ssrSlot.spec.ts --run`