### PR TITLE
[codex] fix(compiler-sfc): resolve namespace type imports

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -990,6 +990,77 @@ describe('resolveType', () => {
       expect(deps && [...deps]).toStrictEqual(Object.keys(files))
     })
 
+    // #9187
+    test('namespace import', () => {
+      const files = {
+        '/foo.ts': 'export type P = { foo: number }',
+      }
+      const { props, deps } = resolve(
+        `
+        import * as Types from './foo'
+        defineProps<Types.P>()
+      `,
+        files,
+      )
+      expect(props).toStrictEqual({
+        foo: ['Number'],
+      })
+      expect(deps && [...deps]).toStrictEqual(Object.keys(files))
+    })
+
+    test('namespace import for emits', () => {
+      const files = {
+        '/foo.ts': `export type Emits = { (e: 'change'): void }`,
+      }
+      const { calls, deps } = resolve(
+        `
+        import * as Events from './foo'
+        defineEmits<Events.Emits>()
+      `,
+        files,
+      )
+      expect(calls).toHaveLength(1)
+      expect(calls![0].type).toBe('TSCallSignatureDeclaration')
+      expect(deps && [...deps]).toStrictEqual(Object.keys(files))
+    })
+
+    test('namespace re-export', () => {
+      const files = {
+        '/foo.ts': 'export type P = { foo: number }',
+        '/bar.ts': `export * as Types from './foo'`,
+      }
+      const { props, deps } = resolve(
+        `
+        import { Types } from './bar'
+        defineProps<Types.P>()
+      `,
+        files,
+      )
+      expect(props).toStrictEqual({
+        foo: ['Number'],
+      })
+      expect(deps && [...deps]).toStrictEqual(['/bar.ts', '/foo.ts'])
+    })
+
+    test('namespace re-export through export all', () => {
+      const files = {
+        '/foo.ts': 'export type P = { foo: number }',
+        '/bar.ts': `export * as Types from './foo'`,
+        '/baz.ts': `export * from './bar'`,
+      }
+      const { props, deps } = resolve(
+        `
+        import { Types } from './baz'
+        defineProps<Types.P>()
+      `,
+        files,
+      )
+      expect(props).toStrictEqual({
+        foo: ['Number'],
+      })
+      expect(deps && [...deps]).toStrictEqual(['/baz.ts', '/bar.ts', '/foo.ts'])
+    })
+
     // #10635
     test('relative tsx', () => {
       const files = {
@@ -2099,7 +2170,8 @@ function resolve(
     if (
       s.type === 'ExpressionStatement' &&
       s.expression.type === 'CallExpression' &&
-      (s.expression.callee as Identifier).name === 'defineProps'
+      ((s.expression.callee as Identifier).name === 'defineProps' ||
+        (s.expression.callee as Identifier).name === 'defineEmits')
     ) {
       target = s.expression.typeParameters!.params[0]
     }

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -111,7 +111,10 @@ interface WithScope {
 
 // scope types always has ownerScope attached
 type ScopeTypeNode = Node &
-  WithScope & { _ns?: TSModuleDeclaration & WithScope }
+  WithScope & {
+    _ns?: TSModuleDeclaration & WithScope
+    _namespaceScope?: TypeScope
+  }
 
 export class TypeScope {
   constructor(
@@ -830,8 +833,18 @@ function innerResolveTypeReference(
       }
     }
   } else {
-    let ns = innerResolveTypeReference(ctx, scope, name[0], node, onlyExported)
+    const [head, ...rest] = name
+    let ns = innerResolveTypeReference(ctx, scope, head, node, onlyExported)
     if (ns) {
+      if (ns._namespaceScope) {
+        return innerResolveTypeReference(
+          ctx,
+          ns._namespaceScope,
+          rest.length > 1 ? rest : rest[0],
+          node,
+          true,
+        )
+      }
       if (ns.type !== 'TSModuleDeclaration') {
         // namespace merged with other types, attached as _ns
         ns = ns._ns
@@ -954,7 +967,22 @@ function resolveTypeFromImport(
 ): ScopeTypeNode | undefined {
   const { source, imported } = scope.imports[name]
   const sourceScope = importSourceToScope(ctx, node, scope, source)
+  if (imported === '*') {
+    return createNamespaceReference(sourceScope)
+  }
   return resolveTypeReference(ctx, node, sourceScope, imported, true)
+}
+
+function createNamespaceReference(scope: TypeScope): ScopeTypeNode {
+  return {
+    type: 'TSTypeReference',
+    typeName: {
+      type: 'Identifier',
+      name: '*',
+    },
+    _ownerScope: scope,
+    _namespaceScope: scope,
+  }
 }
 
 function importSourceToScope(
@@ -1476,6 +1504,18 @@ function recordTypes(
                 // exporting local defined type
                 exportedTypes[exported] = types[local]
               }
+            } else if (
+              spec.type === 'ExportNamespaceSpecifier' &&
+              stmt.source
+            ) {
+              const exported = getId(spec.exported)
+              imports[exported] = {
+                source: stmt.source.value,
+                imported: '*',
+              }
+              exportedTypes[exported] = createNamespaceReference(
+                importSourceToScope(ctx, stmt.source, scope, stmt.source.value),
+              )
             }
           }
         }


### PR DESCRIPTION
Fixes #9187.

## Summary

Support namespace-qualified imported types in SFC macro type resolution, including:

- `import * as Types from './types'`
- `export * as Types from './types'`
- namespace re-exports forwarded through `export *`
- shared resolution for both `defineProps` and `defineEmits`

## Root cause

Namespace imports are recorded with `imported: '*'`, but the type resolver treated `'*'` as if it were a normal exported symbol name. As a result, resolution stopped at the namespace identifier in references such as `Types.Props`.

`ExportNamespaceSpecifier` nodes were also not recorded in the type scope, so `export * as Types` could not participate in imported type resolution.

## Change

- represent namespace imports internally with their source `TypeScope`
- continue qualified-name resolution inside that namespace scope using exported types only
- record namespace re-exports and preserve them through export-all chains
- add regression coverage for props, emits, direct namespace imports, and chained namespace re-exports

## Validation

- `pnpm exec vitest packages/compiler-sfc/__tests__ --run` (19 files, 474 tests)
- `pnpm exec eslint packages/compiler-sfc/src/script/resolveType.ts packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts`
- `pnpm exec prettier --check packages/compiler-sfc/src/script/resolveType.ts packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts`
- `pnpm exec tsc --incremental --noEmit`