### PR TITLE
perf(compiler-vapor): cache child context analysis

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/expression.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/expression.spec.ts.snap
@@ -25,6 +25,22 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: expression > cache expressions > absorbed member expression declaration skips string literals 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  const n1 = t0()
+  _renderEffect(() => {
+    const __foo_bar_foo_bar_baz = 'foo_bar' + _ctx.foo[_ctx.bar] + _ctx.baz
+    _setProp(n0, "id", __foo_bar_foo_bar_baz)
+    _setProp(n1, "id", __foo_bar_foo_bar_baz)
+  })
+  return [n0, n1]
+}"
+`;
+
 exports[`compiler: expression > cache expressions > cache variable used in both property shorthand and normal binding 1`] = `
 "import { setStyle as _setStyle, setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
@@ -182,6 +198,29 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: expression > cache expressions > overlapping repeated expressions avoid stale declarations 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  const n1 = t0()
+  const n2 = t0()
+  const n3 = t0()
+  _renderEffect(() => {
+    const _foo = _ctx.foo
+    const _bar = _ctx.bar
+    const _foo_bar_baz = _foo + _bar + _ctx.baz
+    const _foo_bar = _foo + _bar
+    _setProp(n0, "id", _foo_bar)
+    _setProp(n1, "id", _foo_bar)
+    _setProp(n2, "title", _foo_bar_baz)
+    _setProp(n3, "title", _foo_bar_baz)
+  })
+  return [n0, n1, n2, n3]
+}"
+`;
+
 exports[`compiler: expression > cache expressions > repeated expression in expressions 1`] = `
 "import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>")
@@ -196,6 +235,43 @@ export function render(_ctx) {
     _setProp(n0, "id", _foo_bar)
     _setProp(n1, "id", _foo_bar)
     _setProp(n2, "id", _foo + _foo_bar)
+  })
+  return [n0, n1, n2]
+}"
+`;
+
+exports[`compiler: expression > cache expressions > repeated expression replacement respects identifier boundaries 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  const n1 = t0()
+  const n2 = t0()
+  _renderEffect(() => {
+    const _foo = _ctx.foo
+    const _foo_bar = _foo + _ctx.bar
+    _setProp(n0, "id", _foo_bar)
+    _setProp(n1, "id", _foo_bar)
+    _setProp(n2, "title", _foo + _ctx.barbaz)
+  })
+  return [n0, n1, n2]
+}"
+`;
+
+exports[`compiler: expression > cache expressions > repeated expression replacement skips string literals 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  const n1 = t0()
+  const n2 = t0()
+  _renderEffect(() => {
+    const _foo_bar = _ctx.foo + _ctx.bar
+    _setProp(n0, "id", _foo_bar)
+    _setProp(n1, "id", _foo_bar)
+    _setProp(n2, "title", 'foo + bar' + _ctx.baz)
   })
   return [n0, n1, n2]
 }"

--- a/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
@@ -115,6 +115,55 @@ describe('compiler: expression', () => {
       expect(code).contains('_setProp(n2, "id", _foo + _foo_bar)')
     })
 
+    test('repeated expression replacement skips string literals', () => {
+      const { code } = compileWithExpression(`
+        <div :id="foo + bar"></div>
+        <div :id="foo + bar"></div>
+        <div :title="'foo + bar' + baz"></div>
+      `)
+      expect(code).matchSnapshot()
+      expect(code).contains('const _foo_bar = _ctx.foo + _ctx.bar')
+      expect(code).contains(`_setProp(n2, "title", 'foo + bar' + _ctx.baz)`)
+      expect(code).not.contains(`'_foo_bar'`)
+    })
+
+    test('repeated expression replacement respects identifier boundaries', () => {
+      const { code } = compileWithExpression(`
+        <div :id="foo + bar"></div>
+        <div :id="foo + bar"></div>
+        <div :title="foo + barbaz"></div>
+      `)
+      expect(code).matchSnapshot()
+      expect(code).contains('_setProp(n2, "title", _foo + _ctx.barbaz)')
+      expect(code).not.contains('_ctx.foo_barbaz')
+    })
+
+    test('overlapping repeated expressions avoid stale declarations', () => {
+      const { code } = compileWithExpression(`
+        <div :id="foo + bar"></div>
+        <div :id="foo + bar"></div>
+        <div :title="foo + bar + baz"></div>
+        <div :title="foo + bar + baz"></div>
+      `)
+      expect(code).matchSnapshot()
+      expect(code).contains('const _foo_bar = _foo + _bar')
+      expect(code).contains('const _foo_bar_baz = _foo + _bar + _ctx.baz')
+      expect(code).contains('_setProp(n2, "title", _foo_bar_baz)')
+      expect(code).contains('_setProp(n3, "title", _foo_bar_baz)')
+    })
+
+    test('absorbed member expression declaration skips string literals', () => {
+      const { code } = compileWithExpression(`
+        <div :id="'foo_bar' + foo[bar] + baz"></div>
+        <div :id="'foo_bar' + foo[bar] + baz"></div>
+      `)
+      expect(code).matchSnapshot()
+      expect(code).contains(
+        `const __foo_bar_foo_bar_baz = 'foo_bar' + _ctx.foo[_ctx.bar] + _ctx.baz`,
+      )
+      expect(code).not.contains(`'foo[bar]'`)
+    })
+
     test('repeated simple function calls', () => {
       const { code } = compileWithExpression(`
         <div :id="foo()"></div>

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -56,6 +56,7 @@ export function genBlockContent(
   context: CodegenContext,
   root?: boolean,
   genEffectsExtraFrag?: () => CodeFragment[],
+  skippedEffectIndexes?: Set<number>,
 ): CodeFragment[] {
   const [frag, push] = buildCodeFragment()
   const { dynamic, effect, operation, returns } = block
@@ -109,7 +110,7 @@ export function genBlockContent(
     }
 
     if (effectIndex < effectEnd) {
-      push(...genEffects(effect.slice(effectIndex, effectEnd), context))
+      push(...genEffectRange(effectIndex, effectEnd))
       effectIndex = effectEnd
     }
   }
@@ -154,7 +155,7 @@ export function genBlockContent(
     push(...genOperations(operation.slice(operationIndex), context))
   }
   if (effectIndex < effect.length) {
-    push(...genEffects(effect.slice(effectIndex), context, genEffectsExtraFrag))
+    push(...genEffectRange(effectIndex, effect.length, genEffectsExtraFrag))
   } else if (genEffectsExtraFrag) {
     push(...genEffects([], context, genEffectsExtraFrag))
   }
@@ -171,6 +172,28 @@ export function genBlockContent(
   resetBlock()
   context.singleUseAssetComponentNames = prevSingleUseAssetComponentNames
   return frag
+
+  function genEffectRange(
+    start: number,
+    end: number,
+    genExtraFrag?: () => CodeFragment[],
+  ): CodeFragment[] {
+    if (!skippedEffectIndexes) {
+      return genEffects(effect.slice(start, end), context, genExtraFrag)
+    }
+
+    const effects: typeof effect = []
+    for (let i = start; i < end; i++) {
+      if (!skippedEffectIndexes.has(i)) {
+        effects.push(effect[i])
+      }
+    }
+
+    if (effects.length || genExtraFrag) {
+      return genEffects(effects, context, genExtraFrag)
+    }
+    return []
+  }
 
   function genResolveAssets(
     kind: 'component' | 'directive',

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -311,6 +311,34 @@ type DeclarationValue = {
   exps?: Set<SimpleExpressionNode>
   seenCount?: number
 }
+type SourceRange = {
+  start: number
+  end: number
+}
+type VariableUse = {
+  name: string
+  loc?: SourceRange
+}
+type ExpressionRecord = {
+  variables: VariableUse[]
+}
+type ExpressionAnalysis = {
+  seenVariable: Record<string, number>
+  variableToExpMap: Map<string, Set<SimpleExpressionNode>>
+  expressionRecords: Map<SimpleExpressionNode, ExpressionRecord>
+  seenIdentifier: Set<string>
+  updatedVariable: Set<string>
+}
+type SeenExpression = {
+  count: number
+  first: SimpleExpressionNode
+}
+type ContentReplacement = {
+  start: number
+  end: number
+  content: string
+}
+type ReplacementPlan = Map<SimpleExpressionNode, ContentReplacement[]>
 
 export function processExpressions(
   context: CodegenContext,
@@ -325,7 +353,7 @@ export function processExpressions(
   const {
     seenVariable,
     variableToExpMap,
-    expToVariableMap,
+    expressionRecords,
     seenIdentifier,
     updatedVariable,
   } = analyzeExpressions(expressions)
@@ -337,7 +365,7 @@ export function processExpressions(
     context,
     seenVariable,
     variableToExpMap,
-    expToVariableMap,
+    expressionRecords,
     seenIdentifier,
     updatedVariable,
     reservedNames,
@@ -351,7 +379,7 @@ export function processExpressions(
     expressions,
     varDeclarations,
     updatedVariable,
-    expToVariableMap,
+    expressionRecords,
     reservedNames,
     expressionReplacements,
   )
@@ -366,24 +394,28 @@ export function processExpressions(
   }
 }
 
-function analyzeExpressions(expressions: SimpleExpressionNode[]) {
+function analyzeExpressions(
+  expressions: SimpleExpressionNode[],
+): ExpressionAnalysis {
   const seenVariable: Record<string, number> = Object.create(null)
   const variableToExpMap = new Map<string, Set<SimpleExpressionNode>>()
-  const expToVariableMap = new Map<
-    SimpleExpressionNode,
-    Array<{
-      name: string
-      loc?: { start: number; end: number }
-    }>
-  >()
+  const expressionRecords = new Map<SimpleExpressionNode, ExpressionRecord>()
   const seenIdentifier = new Set<string>()
   const updatedVariable = new Set<string>()
+
+  const getRecord = (exp: SimpleExpressionNode): ExpressionRecord => {
+    let record = expressionRecords.get(exp)
+    if (!record) {
+      expressionRecords.set(exp, (record = { variables: [] }))
+    }
+    return record
+  }
 
   const registerVariable = (
     name: string,
     exp: SimpleExpressionNode,
     isIdentifier: boolean,
-    loc?: { start: number; end: number },
+    loc?: SourceRange,
     parentStack: Node[] = [],
   ) => {
     if (isIdentifier) seenIdentifier.add(name)
@@ -393,9 +425,7 @@ function analyzeExpressions(expressions: SimpleExpressionNode[]) {
       (variableToExpMap.get(name) || new Set()).add(exp),
     )
 
-    const variables = expToVariableMap.get(exp) || []
-    variables.push({ name, loc })
-    expToVariableMap.set(exp, variables)
+    getRecord(exp).variables.push({ name, loc })
 
     if (
       parentStack.some(
@@ -457,7 +487,7 @@ function analyzeExpressions(expressions: SimpleExpressionNode[]) {
     seenVariable,
     seenIdentifier,
     variableToExpMap,
-    expToVariableMap,
+    expressionRecords,
     updatedVariable,
   }
 }
@@ -488,23 +518,15 @@ function processRepeatedVariables(
   context: CodegenContext,
   seenVariable: Record<string, number>,
   variableToExpMap: Map<string, Set<SimpleExpressionNode>>,
-  expToVariableMap: Map<
-    SimpleExpressionNode,
-    Array<{ name: string; loc?: { start: number; end: number } }>
-  >,
+  expressionRecords: Map<SimpleExpressionNode, ExpressionRecord>,
   seenIdentifier: Set<string>,
   updatedVariable: Set<string>,
   reservedNames: Set<string>,
   expressionReplacements: Map<SimpleExpressionNode, SimpleExpressionNode>,
 ): DeclarationValue[] {
   const declarations: DeclarationValue[] = []
-  const expToReplacementMap = new Map<
-    SimpleExpressionNode,
-    Array<{
-      name: string
-      locs: { start: number; end: number }[]
-    }>
-  >()
+  const declaredNames = new Set<string>()
+  const replacementPlan: ReplacementPlan = new Map()
 
   for (const [name, exps] of variableToExpMap) {
     if (updatedVariable.has(name)) continue
@@ -524,25 +546,26 @@ function processRepeatedVariables(
       // replaced during context.withId(..., ids)
       exps.forEach(node => {
         if (node.ast && varName !== name) {
-          const replacements = expToReplacementMap.get(node) || []
-          replacements.push({
-            name: varName,
-            locs: expToVariableMap.get(node)!.reduce(
-              (locs, v) => {
-                if (v.name === name && v.loc) locs.push(v.loc)
-                return locs
-              },
-              [] as { start: number; end: number }[],
-            ),
-          })
-          expToReplacementMap.set(node, replacements)
+          for (const variable of getExpressionVariables(
+            expressionRecords,
+            node,
+          )) {
+            if (variable.name === name && variable.loc) {
+              queueContentReplacement(replacementPlan, node, {
+                start: variable.loc.start - 1,
+                end: variable.loc.end - 1,
+                content: varName,
+              })
+            }
+          }
         }
       })
 
       if (
-        !declarations.some(d => d.name === varName) &&
-        (!isIdentifier || shouldDeclareVariable(name, expToVariableMap, exps))
+        !declaredNames.has(varName) &&
+        (!isIdentifier || shouldDeclareVariable(name, expressionRecords, exps))
       ) {
+        declaredNames.add(varName)
         declarations.push({
           name: varName,
           isIdentifier,
@@ -558,78 +581,105 @@ function processRepeatedVariables(
     }
   }
 
-  for (const [exp, replacements] of expToReplacementMap) {
-    let content = getProcessedExpression(exp, expressionReplacements).content
-    replacements
-      .flatMap(({ name, locs }) =>
-        locs.map(({ start, end }) => ({ start, end, name })),
-      )
-      .sort((a, b) => b.end - a.end)
-      .forEach(({ start, end, name }) => {
-        content = content.slice(0, start - 1) + name + content.slice(end - 1)
-      })
-
-    setExpressionReplacement(
-      expressionReplacements,
-      exp,
-      content,
-      parseExp(context, content),
-    )
-  }
+  applyReplacementPlan(context, expressionReplacements, replacementPlan)
 
   return declarations
 }
 
 function shouldDeclareVariable(
   name: string,
-  expToVariableMap: Map<
-    SimpleExpressionNode,
-    Array<{ name: string; loc?: { start: number; end: number } }>
-  >,
+  expressionRecords: Map<SimpleExpressionNode, ExpressionRecord>,
   exps: Set<SimpleExpressionNode>,
 ): boolean {
-  const vars = Array.from(exps, exp =>
-    expToVariableMap.get(exp)!.map(v => v.name),
-  )
+  const variableUsages: VariableUse[][] = []
+  let allSingleVariable = true
+  let hasRepeatedName = false
+  let hasDifferentLength = false
+
+  outer: for (const exp of exps) {
+    const variables = getExpressionVariables(expressionRecords, exp)
+
+    if (allSingleVariable && variables.length !== 1) {
+      allSingleVariable = false
+    }
+
+    if (
+      !hasDifferentLength &&
+      variableUsages.length > 0 &&
+      variables.length !== variableUsages[0].length
+    ) {
+      hasDifferentLength = true
+    }
+
+    let nameCount = 0
+    for (const variable of variables) {
+      if (variable.name === name && ++nameCount > 1) {
+        hasRepeatedName = true
+        break outer
+      }
+    }
+
+    variableUsages.push(variables)
+  }
+
   // assume name equals to `foo`
   // if each expression only references `foo`, declaration is needed
   // to avoid reactivity tracking
   // e.g., [[foo],[foo]]
-  if (vars.every(v => v.length === 1)) {
+  if (allSingleVariable) {
     return true
   }
 
   // if `foo` appears multiple times in one array, declaration is needed
   // e.g., [[foo,foo]]
-  if (vars.some(v => v.filter(e => e === name).length > 1)) {
+  if (hasRepeatedName) {
     return true
   }
 
-  const first = vars[0]
+  const first = variableUsages[0]
   // if arrays have different lengths, declaration is needed
   // e.g., [[foo],[foo,bar]]
-  if (vars.some(v => v.length !== first.length)) {
+  if (hasDifferentLength) {
     // special case, no declaration needed if one array is a subset of the other
     // because they will be treated as repeated expressions
     // e.g., [[foo,bar],[foo,foo,bar]] -> const foo_bar = _ctx.foo + _ctx.bar
-    if (
-      vars.some(
-        v => v.length > first.length && v.every(e => first.includes(e)),
-      ) ||
-      vars.some(v => first.length > v.length && first.every(e => v.includes(e)))
-    ) {
-      return false
+    for (const variables of variableUsages) {
+      if (variables.length === first.length) {
+        continue
+      }
+
+      const longer = variables.length > first.length ? variables : first
+      const shorter = variables.length > first.length ? first : variables
+      const shorterNames = new Set<string>()
+      for (const variable of shorter) {
+        shorterNames.add(variable.name)
+      }
+
+      let isSubset = true
+      for (const variable of longer) {
+        if (!shorterNames.has(variable.name)) {
+          isSubset = false
+          break
+        }
+      }
+      if (isSubset) {
+        return false
+      }
     }
     return true
   }
   // if arrays are identical, no declaration needed
   // because they will be treated as repeated expressions
   // e.g., [[foo,bar],[foo,bar]] -> const foo_bar = _ctx.foo + _ctx.bar
-  if (vars.every(v => v.every((e, idx) => e === first[idx]))) {
-    return false
+  for (const variables of variableUsages) {
+    for (let i = 0; i < variables.length; i++) {
+      if (variables[i].name !== first[i].name) {
+        return true
+      }
+    }
   }
 
-  return true
+  return false
 }
 
 function processRepeatedExpressions(
@@ -637,39 +687,32 @@ function processRepeatedExpressions(
   expressions: SimpleExpressionNode[],
   varDeclarations: DeclarationValue[],
   updatedVariable: Set<string>,
-  expToVariableMap: Map<
-    SimpleExpressionNode,
-    Array<{ name: string; loc?: { start: number; end: number } }>
-  >,
+  expressionRecords: Map<SimpleExpressionNode, ExpressionRecord>,
   reservedNames: Set<string>,
   expressionReplacements: Map<SimpleExpressionNode, SimpleExpressionNode>,
 ): DeclarationValue[] {
   const declarations: DeclarationValue[] = []
-  const seenExp = expressions.reduce(
-    (acc, exp) => {
-      const vars = expToVariableMap.get(exp)
-      if (!vars) return acc
+  const seenExp = new Map<string, SeenExpression>()
 
-      const processed = getProcessedExpression(exp, expressionReplacements)
-      const variables = vars.map(v => v.name)
-      // only handle expressions that are not identifiers
-      if (
-        processed.ast &&
-        processed.ast.type !== 'Identifier' &&
-        !(variables && variables.some(v => updatedVariable.has(v))) &&
-        // skip expressions containing globally allowed identifiers
-        // (e.g. Math.random(), Date.now() + foo) - they are not reactive
-        // and may involve impure calls with side effects
-        !variables.some(v => isGloballyAllowed(v))
-      ) {
-        acc[processed.content] = (acc[processed.content] || 0) + 1
+  for (const exp of expressions) {
+    const vars = expressionRecords.get(exp)?.variables
+    if (!vars) continue
+
+    const processed = getProcessedExpression(exp, expressionReplacements)
+    if (canCacheExpression(processed, vars, updatedVariable)) {
+      const seen = seenExp.get(processed.content)
+      if (seen) {
+        seen.count++
+      } else {
+        seenExp.set(processed.content, { count: 1, first: exp })
       }
-      return acc
-    },
-    Object.create(null) as Record<string, number>,
-  )
+    }
+  }
 
-  Object.entries(seenExp).forEach(([content, count]) => {
+  const repeatedExpressions = [...seenExp].sort(
+    ([contentA], [contentB]) => contentB.length - contentA.length,
+  )
+  for (const [content, { count, first }] of repeatedExpressions) {
     if (count > 1) {
       // foo + baz -> foo_baz
       // if foo and baz have no other references, we don't need to declare separate variables
@@ -679,7 +722,7 @@ function processRepeatedExpressions(
       // const foo_baz = foo + baz
       // we can generate:
       // const foo_baz = _ctx.foo + _ctx.baz
-      const delVars: Record<string, string> = {}
+      const removedDeclarations: Array<{ name: string; rawName: string }> = []
       for (let i = varDeclarations.length - 1; i >= 0; i--) {
         const item = varDeclarations[i]
         if (!item.exps || !item.seenCount) continue
@@ -690,24 +733,26 @@ function processRepeatedExpressions(
               content && item.seenCount === count,
         )
         if (shouldRemove) {
-          delVars[item.name] = item.rawName!
+          removedDeclarations.push({
+            name: item.name,
+            rawName: item.rawName!,
+          })
           reservedNames.delete(item.name)
           varDeclarations.splice(i, 1)
         }
       }
-      const matchedExpression = expressions.find(
-        exp =>
-          getProcessedExpression(exp, expressionReplacements).content ===
-          content,
-      )!
       const value = extend(
         {},
-        getProcessedExpression(matchedExpression, expressionReplacements),
+        getProcessedExpression(first, expressionReplacements),
       )
-      Object.keys(delVars).forEach(name => {
-        value.content = value.content.replace(name, delVars[name])
+      const restorePlan: ContentReplacement[] = []
+      for (const { name, rawName } of removedDeclarations) {
+        restorePlan.push(...findIdentifierReplacements(value, name, rawName))
+      }
+      if (restorePlan.length) {
+        value.content = applyContentReplacements(value.content, restorePlan)
         if (value.ast) value.ast = parseExp(context, value.content)
-      })
+      }
       const varName = getUniqueDeclarationName(
         genVarName(content),
         reservedNames,
@@ -718,7 +763,7 @@ function processRepeatedExpressions(
       })
 
       // assume content equals to `foo + baz`
-      expressions.forEach(exp => {
+      for (const exp of expressions) {
         const processed = getProcessedExpression(exp, expressionReplacements)
         // foo + baz -> foo_baz
         if (processed.content === content) {
@@ -726,22 +771,164 @@ function processRepeatedExpressions(
         }
         // foo + foo + baz -> foo + foo_baz
         else if (processed.content.includes(content)) {
-          const replacedContent = processed.content.replace(
-            new RegExp(escapeRegExp(content), 'g'),
+          const replacements = findContentReplacements(
+            processed,
+            content,
             varName,
           )
-          setExpressionReplacement(
-            expressionReplacements,
-            exp,
-            replacedContent,
-            parseExp(context, replacedContent),
-          )
+          if (replacements.length) {
+            const replacedContent = applyContentReplacements(
+              processed.content,
+              replacements,
+            )
+            setExpressionReplacement(
+              expressionReplacements,
+              exp,
+              replacedContent,
+              parseExp(context, replacedContent),
+            )
+          }
         }
-      })
+      }
     }
-  })
+  }
 
   return declarations
+}
+
+function canCacheExpression(
+  processed: SimpleExpressionNode,
+  vars: VariableUse[],
+  updatedVariable: Set<string>,
+): boolean {
+  if (!processed.ast || processed.ast.type === 'Identifier') {
+    return false
+  }
+
+  for (const { name } of vars) {
+    if (updatedVariable.has(name) || isGloballyAllowed(name)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function getExpressionVariables(
+  expressionRecords: Map<SimpleExpressionNode, ExpressionRecord>,
+  exp: SimpleExpressionNode,
+): VariableUse[] {
+  return expressionRecords.get(exp)?.variables || []
+}
+
+function queueContentReplacement(
+  replacementPlan: ReplacementPlan,
+  exp: SimpleExpressionNode,
+  replacement: ContentReplacement,
+): void {
+  const replacements = replacementPlan.get(exp)
+  if (replacements) {
+    replacements.push(replacement)
+  } else {
+    replacementPlan.set(exp, [replacement])
+  }
+}
+
+function applyReplacementPlan(
+  context: CodegenContext,
+  expressionReplacements: Map<SimpleExpressionNode, SimpleExpressionNode>,
+  replacementPlan: ReplacementPlan,
+): void {
+  for (const [exp, replacements] of replacementPlan) {
+    if (!replacements.length) continue
+
+    const content = applyContentReplacements(
+      getProcessedExpression(exp, expressionReplacements).content,
+      replacements,
+    )
+    setExpressionReplacement(
+      expressionReplacements,
+      exp,
+      content,
+      parseExp(context, content),
+    )
+  }
+}
+
+function findContentReplacements(
+  exp: SimpleExpressionNode,
+  content: string,
+  replacement: string,
+): ContentReplacement[] {
+  const identifiers = getIdentifierRanges(exp)
+  if (!identifiers.length) return []
+
+  const replacements: ContentReplacement[] = []
+  let searchStart = 0
+  let start = exp.content.indexOf(content, searchStart)
+  while (start !== -1) {
+    const end = start + content.length
+    let canReplace = false
+    for (const identifier of identifiers) {
+      if (start >= identifier.end || end <= identifier.start) {
+        continue
+      }
+      if (start > identifier.start || end < identifier.end) {
+        canReplace = false
+        break
+      }
+      canReplace = true
+    }
+    if (canReplace) {
+      replacements.push({ start, end, content: replacement })
+      searchStart = end
+    } else {
+      searchStart = start + 1
+    }
+    start = exp.content.indexOf(content, searchStart)
+  }
+
+  return replacements
+}
+
+function findIdentifierReplacements(
+  exp: SimpleExpressionNode,
+  name: string,
+  replacement: string,
+): ContentReplacement[] {
+  const replacements: ContentReplacement[] = []
+  for (const { start, end } of getIdentifierRanges(exp)) {
+    if (exp.content.slice(start, end) === name) {
+      replacements.push({ start, end, content: replacement })
+    }
+  }
+  return replacements
+}
+
+function getIdentifierRanges(exp: SimpleExpressionNode): SourceRange[] {
+  if (!exp.ast || typeof exp.ast !== 'object') return []
+
+  const identifiers: SourceRange[] = []
+  walkIdentifiers(
+    exp.ast,
+    id => {
+      identifiers.push({ start: id.start! - 1, end: id.end! - 1 })
+    },
+    false,
+  )
+  return identifiers
+}
+
+function applyContentReplacements(
+  content: string,
+  replacements: ContentReplacement[],
+): string {
+  replacements
+    .sort((a, b) => b.start - a.start)
+    .forEach(({ start, end, content: replacement }) => {
+      content = content.slice(0, start) + replacement + content.slice(end)
+    })
+  return content
 }
 
 function genDeclarations(
@@ -783,10 +970,6 @@ function genDeclarations(
   })
 
   return { ids, frag, varNames: [...varNames] }
-}
-
-function escapeRegExp(string: string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function parseExp(context: CodegenContext, content: string): Node {

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -12,7 +12,6 @@ import {
   type IRDynamicInfo,
   type IREffect,
   IRNodeTypes,
-  isBlockOperation,
 } from '../ir'
 import {
   type CodeFragment,
@@ -78,12 +77,8 @@ export function genFor(
     idMap[indexVar] = null
   }
 
-  const { selectorPatterns, keyOnlyBindingPatterns } = matchPatterns(
-    render,
-    keyProp,
-    idMap,
-    context,
-  )
+  const { selectorPatterns, keyOnlyBindingPatterns, skippedEffectIndexes } =
+    matchPatterns(render, keyProp, idMap, context)
   const selectorDeclarations: CodeFragment[] = []
   const selectorName = (i: number) =>
     selectorPatterns.length > 1 ? `_selector${id}_${i}` : `_selector${id}`
@@ -105,32 +100,38 @@ export function genFor(
     frag.push('(', ...args, ') => {', INDENT_START)
     if (selectorPatterns.length || keyOnlyBindingPatterns.length) {
       frag.push(
-        ...genBlockContent(render, context, false, () => {
-          const patternFrag: CodeFragment[] = []
+        ...genBlockContent(
+          render,
+          context,
+          false,
+          () => {
+            const patternFrag: CodeFragment[] = []
 
-          for (let i = 0; i < selectorPatterns.length; i++) {
-            const { effect } = selectorPatterns[i]
-            patternFrag.push(
-              NEWLINE,
-              `${selectorName(i)}(`,
-              ...genExpression(keyProp!, context),
-              `, () => {`,
-              INDENT_START,
-            )
-            for (const oper of effect.operations) {
-              patternFrag.push(...genOperation(oper, context))
+            for (let i = 0; i < selectorPatterns.length; i++) {
+              const { effect } = selectorPatterns[i]
+              patternFrag.push(
+                NEWLINE,
+                `${selectorName(i)}(`,
+                ...genExpression(keyProp!, context),
+                `, () => {`,
+                INDENT_START,
+              )
+              for (const oper of effect.operations) {
+                patternFrag.push(...genOperation(oper, context))
+              }
+              patternFrag.push(INDENT_END, NEWLINE, `})`)
             }
-            patternFrag.push(INDENT_END, NEWLINE, `})`)
-          }
 
-          for (const { effect } of keyOnlyBindingPatterns) {
-            for (const oper of effect.operations) {
-              patternFrag.push(...genOperation(oper, context))
+            for (const { effect } of keyOnlyBindingPatterns) {
+              for (const oper of effect.operations) {
+                patternFrag.push(...genOperation(oper, context))
+              }
             }
-          }
 
-          return patternFrag
-        }),
+            return patternFrag
+          },
+          skippedEffectIndexes,
+        ),
       )
     } else {
       frag.push(...genBlockContent(render, context))
@@ -383,65 +384,47 @@ function matchPatterns(
   const keyOnlyBindingPatterns: NonNullable<
     ReturnType<typeof matchKeyOnlyBindingPattern>
   >[] = []
-  const removedEffectIndexes: number[] = []
+  let skippedEffectIndexes: Set<number> | undefined
 
-  render.effect = render.effect.filter((effect, index) => {
-    if (keyProp !== undefined) {
-      const selector = matchSelectorPattern(
-        effect,
-        keyProp.content,
-        idMap,
-        context,
-      )
-      if (selector) {
-        selectorPatterns.push(selector)
-        removedEffectIndexes.push(index)
-        return false
-      }
-      const keyOnly = matchKeyOnlyBindingPattern(effect, keyProp.content)
-      if (keyOnly) {
-        keyOnlyBindingPatterns.push(keyOnly)
-        removedEffectIndexes.push(index)
-        return false
-      }
+  if (keyProp === undefined) {
+    return {
+      keyOnlyBindingPatterns,
+      selectorPatterns,
+      skippedEffectIndexes,
     }
+  }
 
-    return true
-  })
-
-  if (removedEffectIndexes.length) {
-    shiftEffectBoundaries(render.dynamic, removedEffectIndexes)
+  for (let index = 0; index < render.effect.length; index++) {
+    const effect = render.effect[index]
+    const selector = matchSelectorPattern(
+      effect,
+      keyProp.content,
+      idMap,
+      context,
+    )
+    if (selector) {
+      selectorPatterns.push(selector)
+      skipEffect(index)
+      continue
+    }
+    const keyOnly = matchKeyOnlyBindingPattern(effect, keyProp.content)
+    if (keyOnly) {
+      keyOnlyBindingPatterns.push(keyOnly)
+      skipEffect(index)
+    }
   }
 
   return {
     keyOnlyBindingPatterns,
     selectorPatterns,
+    skippedEffectIndexes,
   }
-}
 
-function shiftEffectBoundaries(
-  dynamic: IRDynamicInfo,
-  removedEffectIndexes: number[],
-): void {
-  const operation = dynamic.operation
-  if (
-    operation &&
-    isBlockOperation(operation) &&
-    operation.effectIndex !== undefined
-  ) {
-    let offset = 0
-    for (const removedIndex of removedEffectIndexes) {
-      if (removedIndex < operation.effectIndex) {
-        offset++
-      } else {
-        break
-      }
+  function skipEffect(index: number): void {
+    if (!skippedEffectIndexes) {
+      skippedEffectIndexes = new Set()
     }
-    operation.effectIndex -= offset
-  }
-
-  for (const child of dynamic.children) {
-    shiftEffectBoundaries(child, removedEffectIndexes)
+    skippedEffectIndexes.add(index)
   }
 }
 

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -11,7 +11,9 @@ import {
   type TemplateChildNode,
   defaultOnError,
   defaultOnWarn,
+  findDir,
   getSelfName,
+  isCommentOrWhitespace,
   isVSlot,
 } from '@vue/compiler-dom'
 import { EMPTY_OBJ, NOOP, extend, isArray, isString } from '@vue/shared'
@@ -67,6 +69,14 @@ export type TransformOptions = HackOptions<BaseTransformOptions>
 
 const generatedVarRE = /^[nxr](\d+)$/
 
+interface ChildContextInfo {
+  node: AllNode
+  hasSingleRootChild: boolean
+  isLastEffectiveChild: boolean[]
+}
+
+const childContextInfoCache = new WeakMap<TransformContext, ChildContextInfo>()
+
 export class TransformContext<T extends AllNode = AllNode> {
   selfName: string | null = null
   parent: TransformContext<RootNode | ElementNode> | null = null
@@ -104,6 +114,8 @@ export class TransformContext<T extends AllNode = AllNode> {
   // whether this node is on the rightmost path of the tree
   // (all ancestors are also last effective children)
   isOnRightmostPath: boolean = true
+  // whether this node is the component/template root
+  isSingleRoot: boolean = false
   // If an ancestor in the same template must close explicitly, descendants
   // with matching tags must also close so the browser doesn't consume the
   // ancestor close tag for the descendant.
@@ -318,9 +330,11 @@ export class TransformContext<T extends AllNode = AllNode> {
       effectiveParent = effectiveParent.parent
     }
 
+    const childInfo = this.getChildContextInfo()
     // compute whether this node is effectively the last child
-    const isLastEffectiveChild = this.isEffectivelyLastChild(index)
+    const isLastEffectiveChild = childInfo.isLastEffectiveChild[index]
     const isOnRightmostPath = this.isOnRightmostPath && isLastEffectiveChild
+    const isSingleRoot = this.isSingleRootChild(childInfo)
 
     return Object.assign(Object.create(TransformContext.prototype), this, {
       node,
@@ -337,6 +351,7 @@ export class TransformContext<T extends AllNode = AllNode> {
       effectiveParent,
       isLastEffectiveChild,
       isOnRightmostPath,
+      isSingleRoot,
       templateCloseTags: this.templateCloseTags,
       templateCloseBlocks: this.templateCloseBlocks,
     } satisfies Partial<TransformContext<T>>)
@@ -361,16 +376,99 @@ export class TransformContext<T extends AllNode = AllNode> {
     }
   }
 
-  private isEffectivelyLastChild(index: number): boolean {
-    const children = (this.node as ElementNode).children
-    if (!children) return true
+  private getChildContextInfo(): ChildContextInfo {
+    const node = this.node
+    if (node.type !== NodeTypes.ROOT && node.type !== NodeTypes.ELEMENT) {
+      return {
+        node,
+        hasSingleRootChild: true,
+        isLastEffectiveChild: [],
+      }
+    }
 
-    return children.every(
-      (c, i) =>
-        i <= index ||
-        (c.type === NodeTypes.ELEMENT && c.tagType === ElementTypes.COMPONENT),
+    const cached = childContextInfoCache.get(this)
+    if (cached && cached.node === node) {
+      return cached
+    }
+
+    const { children } = node
+    const isLastEffectiveChild = new Array<boolean>(children.length)
+    let hasFollowingEffectiveChild = false
+    for (let i = children.length - 1; i >= 0; i--) {
+      isLastEffectiveChild[i] = !hasFollowingEffectiveChild
+      if (!isComponentChild(children[i])) {
+        hasFollowingEffectiveChild = true
+      }
+    }
+
+    const childInfo = {
+      node,
+      hasSingleRootChild: hasSingleRootChild(children),
+      isLastEffectiveChild,
+    }
+    childContextInfoCache.set(this, childInfo)
+    return childInfo
+  }
+
+  private isSingleRootChild(childInfo: ChildContextInfo): boolean {
+    if (this.inVFor || !childInfo.hasSingleRootChild) {
+      return false
+    }
+
+    if (this.node.type === NodeTypes.ROOT) {
+      return true
+    }
+
+    return (
+      this.node.type === NodeTypes.ELEMENT &&
+      this.node.tagType === ElementTypes.TEMPLATE &&
+      !!this.parent &&
+      this.isSingleRoot
     )
   }
+}
+
+function hasSingleRootChild(children: TemplateChildNode[]): boolean {
+  let nonCommentChildren = 0
+  let hasEncounteredIf = false
+  let isSingleIfBlock = true
+
+  for (const child of children) {
+    if (isCommentOrWhitespace(child)) {
+      continue
+    }
+
+    nonCommentChildren++
+    if (isIfChild(child)) {
+      if (hasEncounteredIf) {
+        isSingleIfBlock = false
+      }
+      hasEncounteredIf = true
+    } else if (!hasEncounteredIf || !isElseChild(child)) {
+      isSingleIfBlock = false
+    }
+  }
+
+  return nonCommentChildren === 1 || isSingleIfBlock
+}
+
+function isComponentChild(child: TemplateChildNode): boolean {
+  return (
+    child.type === NodeTypes.ELEMENT && child.tagType === ElementTypes.COMPONENT
+  )
+}
+
+function isIfChild(child: TemplateChildNode): boolean {
+  return (
+    child.type === NodeTypes.IF ||
+    (child.type === NodeTypes.ELEMENT && !!findDir(child, 'if'))
+  )
+}
+
+function isElseChild(child: TemplateChildNode): boolean {
+  return (
+    child.type === NodeTypes.ELEMENT && !!findDir(child, /^else(-if)?$/, true)
+  )
 }
 
 const defaultOptions = {

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -6,15 +6,11 @@ import {
   ErrorCodes,
   NodeTypes,
   type PlainElementNode,
-  type RootNode,
   type SimpleExpressionNode,
-  type TemplateChildNode,
   advancePositionWithClone,
   createCompilerError,
   createSimpleExpression,
-  hasSingleChild,
   isSimpleIdentifier,
-  isSingleIfBlock,
   isStaticArgOf,
   isValidHTMLNesting,
   resolveModifiers,
@@ -136,7 +132,7 @@ export const transformElement: NodeTransform = (node, context) => {
       getEffectIndex,
     )
 
-    const singleRoot = isSingleRoot(context)
+    const singleRoot = context.isSingleRoot
 
     if (isComponent) {
       transformComponentElement(
@@ -275,35 +271,6 @@ export function isInSameTemplateAsParent(
       parent as TransformContext<ElementNode>,
     ) && isValidHTMLNesting(parentNode.tag, node.tag)
   )
-}
-
-function isSingleRoot(
-  context: TransformContext<RootNode | TemplateChildNode>,
-): boolean {
-  if (context.inVFor) {
-    return false
-  }
-
-  let { parent } = context
-  if (
-    parent &&
-    !(hasSingleChild(parent.node) || isSingleIfBlock(parent.node))
-  ) {
-    return false
-  }
-  while (
-    parent &&
-    parent.parent &&
-    parent.node.type === NodeTypes.ELEMENT &&
-    parent.node.tagType === ElementTypes.TEMPLATE
-  ) {
-    parent = parent.parent
-    if (!(hasSingleChild(parent.node) || isSingleIfBlock(parent.node))) {
-      return false
-    }
-  }
-
-  return context.root === parent
 }
 
 function transformComponentElement(

--- a/packages/compiler-vapor/src/transforms/transformText.ts
+++ b/packages/compiler-vapor/src/transforms/transformText.ts
@@ -121,17 +121,7 @@ export const transformText: NodeTransform = (node, context) => {
 
 function processInterpolation(context: TransformContext<InterpolationNode>) {
   const parentNode = context.parent!.node
-  const children = parentNode.children
-  const nexts = children.slice(context.index)
-  const idx = nexts.findIndex(n => !isTextLike(n))
-  const nodes = (idx > -1 ? nexts.slice(0, idx) : nexts) as Array<TextLike>
-
-  // merge leading text
-  const prev = children[context.index - 1]
-  if (prev && prev.type === NodeTypes.TEXT) {
-    nodes.unshift(prev)
-  }
-  const values = processTextLikeChildren(nodes, context)
+  const values = processTextLikeChildren(collectAdjacentText(context), context)
 
   if (values.length === 0 && parentNode.type !== NodeTypes.ROOT) {
     return
@@ -174,6 +164,25 @@ function processInterpolation(context: TransformContext<InterpolationNode>) {
     element: id,
     values,
   })
+}
+
+function collectAdjacentText(
+  context: TransformContext<InterpolationNode>,
+): TextLike[] {
+  const children = context.parent!.node.children
+  const nodes: TextLike[] = []
+  // Include leading text that belongs to the same text run.
+  const prev = children[context.index - 1]
+  let index =
+    prev && prev.type === NodeTypes.TEXT ? context.index - 1 : context.index
+
+  for (; index < children.length; index++) {
+    const child = children[index]
+    if (!isTextLike(child)) break
+    nodes.push(child)
+  }
+
+  return nodes
 }
 
 function processTextContainer(


### PR DESCRIPTION
Compute child-level structural facts once per parent transform context, including
the last effective child state and single-root eligibility.

This avoids repeatedly scanning sibling/root structure from transformElement
while preserving the existing template root and rightmost-path semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for expression-caching code generation behavior, including repeated expressions, identifier boundary handling, and overlapping cached declarations.

* **Refactor**
  * Refactored expression processing pipeline with improved analysis structure and targeted replacement strategies for enhanced reliability.
  * Optimized transform context calculations through caching to reduce redundant analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->