### PR TITLE
fix(runtime-vapor): pair vdom interop update hooks

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -40,9 +40,9 @@ export function render(_ctx) {
       const n2 = _createComponentWithFallback(_component_Bar)
       _withVaporDirectives(n2, [[_directive_hello, void 0, void 0, { world: true }]])
       return n3
-    }, null, 17 /* BLOCK_SHAPE, ONCE */)
+    }, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   _withVaporDirectives(n4, [[_directive_test]])
   return n4
 }"
@@ -227,7 +227,7 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
       _setText(x2, _toDisplayString(_ctx.selected === _for_item0.value.id ? 'danger' : ''))
     })
     return n6
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   n0.onReset(_selector0.reset)
   return n0
 }"
@@ -275,7 +275,7 @@ export function render(_ctx) {
   const n1 = _createIf(() => (true), () => {
     const n3 = t0()
     return n3
-  }, null, 49 /* BLOCK_SHAPE, TRUE_NO_SCOPE, ONCE */)
+  }, null, 49 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE, ONCE */)
   _renderEffect(() => _setProp(n4, "disabled", _ctx.foo))
   return n6
 }"
@@ -335,7 +335,7 @@ export function render(_ctx) {
       _setClassName(n2, (_for_item0.value.id === _ctx.state.selected ? 1 : 0), "danger")
     })
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   n0.onReset(_selector0.reset)
   return n0
 }"
@@ -360,7 +360,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.a.b), (_for_item0, _for_key0, _for_index0) => {
     const n2 = t0()
     return n2
-  }, undefined, 8)
+  }, undefined, 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/__snapshots__/staticTemplate.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/staticTemplate.spec.ts.snap
@@ -143,7 +143,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
     const n2 = t0()
     return n2
-  }, (item) => (item), 8)
+  }, (item) => (item), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
@@ -53,11 +53,11 @@ export function render(_ctx) {
         const n13 = t2()
         const n14 = t1()
         return [n13, n14]
-      }, 777 /* BLOCK_SHAPE, INDEX_SHIFT */)
+      }, 777 /* TRUE_SINGLE_ROOT, FALSE_MULTI_ROOT, KEYED_INDEX_2 */)
       return n15
-    }, 645 /* BLOCK_SHAPE, SLOT_ROOT, INDEX_SHIFT */), 389 /* BLOCK_SHAPE, SLOT_ROOT, INDEX_SHIFT */)
+    }, 645 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, SLOT_ROOT, KEYED_INDEX_1 */), 389 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, SLOT_ROOT, KEYED_INDEX_0 */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n17
 }"
 `;
@@ -104,9 +104,9 @@ export function render(_ctx) {
     const n0 = _createIf(() => (_ctx.show), () => {
       const n2 = t0()
       return n2
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n3
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/logicalIndex.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/logicalIndex.spec.ts.snap
@@ -61,7 +61,7 @@ export function render(_ctx) {
   const n1 = _createIf(() => (true), () => {
     const n3 = t0()
     return n3
-  }, null, 49 /* BLOCK_SHAPE, TRUE_NO_SCOPE, ONCE */)
+  }, null, 49 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE, ONCE */)
   return n5
 }"
 `;
@@ -80,7 +80,7 @@ export function render(_ctx) {
   const n1 = _createIf(() => (true), () => {
     const n3 = t0()
     return n3
-  }, null, 49 /* BLOCK_SHAPE, TRUE_NO_SCOPE, ONCE */)
+  }, null, 49 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE, ONCE */)
   return n4
 }"
 `;
@@ -100,7 +100,7 @@ export function render(_ctx) {
   const n1 = _createIf(() => (true), () => {
     const n3 = t0()
     return n3
-  }, null, 49 /* BLOCK_SHAPE, TRUE_NO_SCOPE, ONCE */)
+  }, null, 49 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE, ONCE */)
   return n5
 }"
 `;
@@ -312,7 +312,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = t0()
     return n2
-  }, (i) => (i), 8)
+  }, (i) => (i), 8 /* IS_SINGLE_NODE */)
   return n3
 }"
 `;
@@ -328,7 +328,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = t0()
     return n2
-  }, (i) => (i), 8)
+  }, (i) => (i), 8 /* IS_SINGLE_NODE */)
   return n3
 }"
 `;
@@ -344,7 +344,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.show), () => {
     const n2 = t0()
     return n2
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   return n3
 }"
 `;
@@ -361,7 +361,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.show), () => {
     const n2 = t0()
     return n2
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   return n4
 }"
 `;
@@ -377,7 +377,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.show), () => {
     const n2 = t0()
     return n2
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   return n3
 }"
 `;
@@ -399,7 +399,7 @@ export function render(_ctx) {
   }, () => {
     const n5 = t1()
     return n5
-  }, 357 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 357 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   _setInsertionState(n7, null, 2)
   const n6 = _createAssetComponent("Comp2")
   return n7
@@ -423,7 +423,7 @@ export function render(_ctx) {
   }, () => {
     const n5 = t1()
     return n5
-  }, 357 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 357 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   return n6
 }"
 `;
@@ -444,7 +444,7 @@ export function render(_ctx) {
   }, () => {
     const n4 = t1()
     return n4
-  }, 357 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 357 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   return n6
 }"
 `;
@@ -469,7 +469,7 @@ export function render(_ctx) {
   }, () => {
     const n6 = t2()
     return n6
-  }, 613 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */), 293 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */)
+  }, 613 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_1 */), 293 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_0 */)
   return n8
 }"
 `;
@@ -489,7 +489,7 @@ export function render(_ctx) {
   }, () => {
     const n4 = t1()
     return n4
-  }, 357 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 357 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   return n5
 }"
 `;
@@ -509,7 +509,7 @@ export function render(_ctx) {
   }, () => {
     const n4 = t1()
     return n4
-  }, 357 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 357 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   _setInsertionState(n6, null, 2)
   const n5 = _createAssetComponent("Comp")
   return n6
@@ -531,7 +531,7 @@ export function render(_ctx) {
   }, () => {
     const n4 = t1()
     return n4
-  }, 357 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 357 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   return n5
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformChildren.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformChildren.spec.ts.snap
@@ -12,7 +12,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (1), () => {
     const n2 = t0()
     return n2
-  }, null, 49 /* BLOCK_SHAPE, TRUE_NO_SCOPE, ONCE */)
+  }, null, 49 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE, ONCE */)
   return n4
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -149,9 +149,9 @@ export function render(_ctx) {
     const n1 = _createIf(() => (_ctx.ok), () => {
       const n3 = _createComponentWithFallback(_component_Child)
       return n3
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n1
-  }, { _: 8 }))
+  }, { _: 8 /* NON_STABLE */ }))
   return [n0, n5]
 }"
 `;
@@ -628,7 +628,7 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
     const n2 = _createComponent(_ctx.Comp)
     return n2
-  }, (item) => (item), 2)
+  }, (item) => (item), 2 /* IS_COMPONENT */)
   return n0
 }"
 `;
@@ -814,7 +814,7 @@ exports[`compiler: element transform > dynamic component > dynamic binding 1`] =
 "import { createDynamicComponent as _createDynamicComponent } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.foo), null, null, 1)
+  const n0 = _createDynamicComponent(() => (_ctx.foo), null, null, 1 /* SINGLE_ROOT */)
   return n0
 }"
 `;
@@ -823,7 +823,7 @@ exports[`compiler: element transform > dynamic component > dynamic binding short
 "import { createDynamicComponent as _createDynamicComponent } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.is), null, null, 1)
+  const n0 = _createDynamicComponent(() => (_ctx.is), null, null, 1 /* SINGLE_ROOT */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformKey.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformKey.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`compiler: key > with dynamic key > <component is/> + key 1`] = `
 
 export function render(_ctx) {
   const n0 = _createKeyedFragment(() => (_ctx.id), () => {
-    const n1 = _createDynamicComponent(() => (_ctx.view), null, null, 1)
+    const n1 = _createDynamicComponent(() => (_ctx.view), null, null, 1 /* SINGLE_ROOT */)
     return n1
   })
   return n0
@@ -125,7 +125,7 @@ export function render(_ctx) {
       return n5
     })
     return n4
-  }), 293 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */)
+  }), 293 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_0 */)
   return n0
 }"
 `;
@@ -138,7 +138,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = t0()
     return n2
-  }, (i) => (i), 8)
+  }, (i) => (i), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -163,7 +163,7 @@ exports[`compiler: key > with static key > <component is literal/> + key 1`] = `
 "import { createDynamicComponent as _createDynamicComponent, setBlockKey as _setBlockKey } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => ('div'), null, null, 1)
+  const n0 = _createDynamicComponent(() => ('div'), null, null, 1 /* SINGLE_ROOT */)
   _setBlockKey(n0, "1")
   return n0
 }"
@@ -173,7 +173,7 @@ exports[`compiler: key > with static key > <component is/> + key 1`] = `
 "import { createDynamicComponent as _createDynamicComponent, setBlockKey as _setBlockKey } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 1)
+  const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 1 /* SINGLE_ROOT */)
   _setBlockKey(n0, "1")
   return n0
 }"

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
@@ -142,11 +142,11 @@ export function render(_ctx) {
         const x6 = _txt(n6)
         _renderEffect(() => _setText(x6, _toDisplayString(_for_item0.value)))
         return n6
-      }, undefined, 40)
+      }, undefined, 8)
       const x4 = _txt(n4)
       _renderEffect(() => _setText(x4, _toDisplayString(_ctx.item)))
       return n4
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    })
     return n2
   })
   return n0
@@ -158,7 +158,7 @@ exports[`compiler: transform <slot> outlets > root dynamic component fallback 1`
 
 export function render(_ctx) {
   const n0 = _createSlot("default", null, () => {
-    const n2 = _createDynamicComponent(() => (_ctx.view), null, null, 5)
+    const n2 = _createDynamicComponent(() => (_ctx.view), null, null, 1)
     return n2
   })
   return n0
@@ -174,7 +174,7 @@ export function render(_ctx) {
     const n2 = _createIf(() => (_ctx.ok), () => {
       const n4 = t0()
       return n4
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    })
     return n2
   })
   return n0

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
@@ -142,7 +142,7 @@ export function render(_ctx) {
         const x6 = _txt(n6)
         _renderEffect(() => _setText(x6, _toDisplayString(_for_item0.value)))
         return n6
-      }, undefined, 8)
+      }, undefined, 8 /* IS_SINGLE_NODE */)
       const x4 = _txt(n4)
       _renderEffect(() => _setText(x4, _toDisplayString(_ctx.item)))
       return n4
@@ -158,7 +158,7 @@ exports[`compiler: transform <slot> outlets > root dynamic component fallback 1`
 
 export function render(_ctx) {
   const n0 = _createSlot("default", null, () => {
-    const n2 = _createDynamicComponent(() => (_ctx.view), null, null, 1)
+    const n2 = _createDynamicComponent(() => (_ctx.view), null, null, 1 /* SINGLE_ROOT */)
     return n2
   })
   return n0
@@ -185,7 +185,7 @@ exports[`compiler: transform <slot> outlets > slot outlet with scopeId and slott
 "import { createSlot as _createSlot } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createSlot("default", null, null, 1)
+  const n0 = _createSlot("default", null, null, 1 /* NO_SLOTTED */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformTemplateRef.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformTemplateRef.spec.ts.snap
@@ -44,7 +44,7 @@ exports[`compiler: template ref transform > dynamic component static ref 1`] = `
 "import { createDynamicComponent as _createDynamicComponent, setStaticTemplateRef as _setStaticTemplateRef } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 1)
+  const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 1 /* SINGLE_ROOT */)
   _setStaticTemplateRef(n0, "foo")
   return n0
 }"
@@ -68,7 +68,7 @@ export function render(_ctx) {
     const n2 = t0()
     _renderEffect(() => _setTemplateRef(n2, _ctx.foo, true))
     return n2
-  }, undefined, 12)
+  }, undefined, 12 /* IS_SINGLE_NODE, ONCE */)
   return n0
 }"
 `;
@@ -158,7 +158,7 @@ export function render(_ctx) {
     const n2 = t0()
     _setTemplateRef(n2, "foo", true)
     return n2
-  }, undefined, 12)
+  }, undefined, 12 /* IS_SINGLE_NODE, ONCE */)
   return n0
 }"
 `;
@@ -173,7 +173,7 @@ export function render(_ctx) {
     const n2 = t0()
     _setTemplateRef(n2, "foo")
     return n2
-  }, null, 17 /* BLOCK_SHAPE, ONCE */)
+  }, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -10,7 +10,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value[0] + _for_item0.value.slice(1) + _for_key0.value)))
     return n2
-  }, ([id, ...other], index) => (id), 8)
+  }, ([id, ...other], index) => (id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -25,7 +25,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value[0] + _for_item0.value[1] + _for_key0.value)))
     return n2
-  }, ([id, other], index) => (id), 8)
+  }, ([id, other], index) => (id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -42,7 +42,7 @@ export function render(_ctx) {
     n2.$evtclick = _createInvoker(() => (_ctx.remove(_for_item0.value)))
     _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value)))
     return n2
-  }, (item) => (item.id), 8)
+  }, (item) => (item.id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -57,7 +57,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _setText(x2, _toDisplayString(_for_item0.value.id + _for_item0.value.id))
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -74,7 +74,7 @@ export function render(_ctx) {
       _setClassName(n2, (_for_item0.value.id === _ctx.state.selected ? 1 : 0), "danger")
     })
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   n0.onReset(_selector0.reset)
   return n0
 }"
@@ -92,7 +92,7 @@ export function render(_ctx) {
       _setClassName(n2, (_todo.completed ? 1 : 0) | (_todo === _ctx.editedTodo ? 2 : 0), [" completed", " editing"])
     })
     return n2
-  }, (todo) => (todo.id), 8)
+  }, (todo) => (todo.id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -109,7 +109,7 @@ export function render(_ctx) {
       _setProp(n2, "index", _for_key0.value)
     })
     return n2
-  }, undefined, 8)
+  }, undefined, 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -130,7 +130,7 @@ export function render(_ctx) {
       _setProp(n2, "title", _ctx.active === _for_item0.value.id ? 'b' : '')
     })
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   n0.onReset(_selector0_0.reset)
   n0.onReset(_selector0_1.reset)
   return n0
@@ -151,9 +151,9 @@ export function render(_ctx) {
       const x4 = _txt(n4)
       _renderEffect(() => _setText(x4, _toDisplayString(_for_item1.value+_for_item0.value)))
       return n4
-    }, undefined, 9)
+    }, undefined, 9 /* FAST_REMOVE, IS_SINGLE_NODE */)
     return n5
-  }, undefined, 8)
+  }, undefined, 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -168,7 +168,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value.id + _getRestElement(_for_item0.value, ["id"]) + _for_key0.value)))
     return n2
-  }, ({ id, ...other }, index) => (id), 8)
+  }, ({ id, ...other }, index) => (id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -183,7 +183,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value.id) + _toDisplayString(_for_item0.value.value)))
     return n2
-  }, ({ id, value }) => (id), 8)
+  }, ({ id, value }) => (id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -198,7 +198,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value + _for_key0.value + _for_index0.value)))
     return n2
-  }, (value, key, index) => (key), 8)
+  }, (value, key, index) => (key), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -216,7 +216,7 @@ export function render(_ctx) {
       _setText(x2, _toDisplayString(_ctx.selected === _for_item0.value.id ? 'danger' : ''))
     })
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   n0.onReset(_selector0.reset)
   return n0
 }"
@@ -234,7 +234,7 @@ export function render(_ctx) {
       _setClassName(n2, (_ctx.selected === _for_item0.value.id ? 1 : 0), "danger")
     })
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   n0.onReset(_selector0.reset)
   return n0
 }"
@@ -252,7 +252,7 @@ export function render(_ctx) {
       _setClassName(n2, (_row.label === _row.id ? 1 : 0), "danger")
     })
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -269,7 +269,7 @@ export function render(_ctx) {
       _setClassName(n2, (_for_item0.value.id === _ctx.selected ? 1 : 0), "danger")
     })
     return n2
-  }, (row) => (row.id), 8)
+  }, (row) => (row.id), 8 /* IS_SINGLE_NODE */)
   n0.onReset(_selector0.reset)
   return n0
 }"
@@ -285,7 +285,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _renderEffect(() => _setText(x2, _toDisplayString(_getDefaultValue(_for_item0.value.foo, () => (_ctx.bar)) + _ctx.bar + _ctx.baz + _getDefaultValue(_for_item0.value.baz[0], () => (_ctx.quux)) + _ctx.quux)))
     return n2
-  }, undefined, 8)
+  }, undefined, 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;
@@ -301,7 +301,7 @@ export function render(_ctx) {
     const n2 = _child(n3)
     _renderEffect(() => _setText(n2, _toDisplayString(_for_item0.value)))
     return [n2, n3]
-  }, undefined, 2)
+  }, undefined, 2 /* IS_COMPONENT */)
   return n0
 }"
 `;
@@ -313,7 +313,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = _createDynamicComponent(() => (_ctx.view))
     return n2
-  }, (item) => (item.id), 18)
+  }, (item) => (item.id), 18 /* IS_COMPONENT, IS_FRAGMENT */)
   return n0
 }"
 `;
@@ -325,7 +325,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = _createSlot(() => (_for_item0.value.name))
     return n2
-  }, (item) => (item.id), 16)
+  }, (item) => (item.id), 16 /* IS_FRAGMENT */)
   return n0
 }"
 `;
@@ -337,7 +337,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = _createComponentWithFallback(_resolveDynamicComponent("view"))
     return n2
-  }, (item) => (item.id), 2)
+  }, (item) => (item.id), 2 /* IS_COMPONENT */)
   return n0
 }"
 `;
@@ -355,9 +355,9 @@ export function render(_ctx) {
     }, () => {
       const n6 = _createComponentWithFallback(_component_Comp)
       return n6
-    }, 266 /* BLOCK_SHAPE, INDEX_SHIFT */)
+    }, 266 /* TRUE_MULTI_ROOT, FALSE_MULTI_ROOT, KEYED_INDEX_0 */)
     return n2
-  }, undefined, 16)
+  }, undefined, 16 /* IS_FRAGMENT */)
   return n0
 }"
 `;
@@ -375,7 +375,7 @@ export function render(_ctx) {
       return n3
     })
     return n2
-  }, undefined, 16)
+  }, undefined, 16 /* IS_FRAGMENT */)
   return n0
 }"
 `;
@@ -391,9 +391,9 @@ export function render(_ctx) {
       const x4 = _txt(n4)
       _renderEffect(() => _setText(x4, _toDisplayString(_for_item1.value)))
       return n4
-    }, undefined, 8)
+    }, undefined, 8 /* IS_SINGLE_NODE */)
     return n2
-  }, undefined, 16)
+  }, undefined, 16 /* IS_FRAGMENT */)
   return n0
 }"
 `;
@@ -409,7 +409,7 @@ export function render(_ctx) {
     const n2 = _child(n3)
     _renderEffect(() => _setText(n2, _toDisplayString(_for_item0.value)))
     return [n2, n3]
-  }, undefined, 2)
+  }, undefined, 2 /* IS_COMPONENT */)
   return n0
 }"
 `;
@@ -444,7 +444,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
     const n2 = t0()
     return n2
-  }, undefined, 8)
+  }, undefined, 8 /* IS_SINGLE_NODE */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vHtml.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vHtml.spec.ts.snap
@@ -58,7 +58,7 @@ exports[`v-html > work with dynamic component 1`] = `
 "import { createDynamicComponent as _createDynamicComponent, setBlockHtml as _setBlockHtml, renderEffect as _renderEffect } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.Comp), null, null, 1)
+  const n0 = _createDynamicComponent(() => (_ctx.Comp), null, null, 1 /* SINGLE_ROOT */)
   _renderEffect(() => _setBlockHtml(n0, _ctx.foo))
   return n0
 }"

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vIf.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vIf.spec.ts.snap
@@ -36,7 +36,7 @@ export function render(_ctx) {
     const n10 = t3()
     const n11 = t4()
     return [n10, n11]
-  }, 618 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */), 293 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */)
+  }, 618 /* TRUE_MULTI_ROOT, FALSE_MULTI_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_1 */), 293 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_0 */)
   const n13 = t5()
   const x13 = _txt(n13)
   _renderEffect(() => _setText(x13, _toDisplayString(_ctx.text)))
@@ -65,11 +65,11 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.ok), () => {
     const n2 = t0()
     return n2
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   const n3 = _createIf(() => (_ctx.ok), () => {
     const n5 = t0()
     return n5
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   return [n0, n3]
 }"
 `;
@@ -87,11 +87,11 @@ export function render(_ctx) {
   }, () => _createIf(() => (_ctx.bar), () => {
     const n4 = t1()
     return n4
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */), 293 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */), 293 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_0 */)
   const n6 = _createIf(() => (_ctx.baz), () => {
     const n8 = t2()
     return n8
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   return [n0, n6]
 }"
 `;
@@ -106,7 +106,7 @@ export function render(_ctx) {
     const n2 = t0()
     const n3 = t1()
     return [n2, n3]
-  }, null, 34 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 34 /* TRUE_MULTI_ROOT, TRUE_NO_SCOPE */)
   return n0
 }"
 `;
@@ -119,7 +119,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.foo), () => {
     const n2 = t0()
     return n2
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   return n0
 }"
 `;
@@ -132,7 +132,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.foo), () => {
     const n2 = t0()
     return n2
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   return n0
 }"
 `;
@@ -146,7 +146,7 @@ export function render(_ctx) {
     const n2 = _createFor(() => (_ctx.list), (_for_item0) => {
       const n4 = t0()
       return n4
-    }, undefined, 8)
+    }, undefined, 8 /* IS_SINGLE_NODE */)
     return n2
   })
   return n0
@@ -164,7 +164,7 @@ export function render(_ctx) {
       const x4 = _txt(n4)
       _renderEffect(() => _setText(x4, "item: " + _toDisplayString(_for_item0.value)))
       return n4
-    }, (item, index) => (index), 8)
+    }, (item, index) => (index), 8 /* IS_SINGLE_NODE */)
     return n2
   })
   return n0
@@ -185,7 +185,7 @@ export function render(_ctx) {
   }, () => {
     const n5 = t2()
     return n5
-  }, 358 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 358 /* TRUE_MULTI_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   return n0
 }"
 `;
@@ -204,7 +204,7 @@ export function render(_ctx) {
     const x4 = _txt(n4)
     _renderEffect(() => _setText(x4, _toDisplayString(_ctx.msg)))
     return [n2, n3, n4]
-  }, null, 2 /* BLOCK_SHAPE */)
+  }, null, 2 /* TRUE_MULTI_ROOT */)
   return n0
 }"
 `;
@@ -221,7 +221,7 @@ export function render(_ctx) {
   }, () => {
     const n4 = t1()
     return n4
-  }, 357 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 357 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)
   return n0
 }"
 `;
@@ -245,7 +245,7 @@ export function render(_ctx) {
   }, () => {
     const n10 = t2()
     return n10
-  }, 117 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, ONCE */), 549 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */), 293 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */)
+  }, 117 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, ONCE */), 549 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_1 */), 293 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_0 */)
   return n0
 }"
 `;
@@ -262,7 +262,7 @@ export function render(_ctx) {
   }, () => _createIf(() => (_ctx.orNot), () => {
     const n4 = t1()
     return n4
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */), 293 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */), 293 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_0 */)
   return n0
 }"
 `;
@@ -280,7 +280,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.foo), () => {
     const n2 = t0()
     return n2
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
   _setInsertionState(n8, null, 1)
   const n3 = _createIf(() => (_ctx.bar), () => {
     const n5 = t1()
@@ -288,7 +288,7 @@ export function render(_ctx) {
   }, () => {
     const n7 = t2()
     return n7
-  }, 613 /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)
+  }, 613 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_1 */)
   return n8
 }"
 `;
@@ -306,7 +306,7 @@ export function render(_ctx) {
   }, () => _createIf(() => (_ctx.bar), () => {
     const n4 = t1()
     return n4
-  }, null, 33 /* BLOCK_SHAPE, TRUE_NO_SCOPE */), 293 /* BLOCK_SHAPE, TRUE_NO_SCOPE, INDEX_SHIFT */)
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */), 293 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, KEYED_INDEX_0 */)
   const n6 = t2()
   return [n0, n6]
 }"
@@ -322,7 +322,7 @@ export function render(_ctx) {
     const x2 = _txt(n2)
     _setText(x2, _toDisplayString(_ctx.msg))
     return n2
-  }, null, 17 /* BLOCK_SHAPE, ONCE */)
+  }, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)
   return n0
 }"
 `;
@@ -336,7 +336,7 @@ export function render(_ctx) {
     const n2 = t0()
     _renderEffect(() => _setDynamicEvents(n2, { click: _ctx.clickEvent }))
     return n2
-  }, null, 17 /* BLOCK_SHAPE, ONCE */)
+  }, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
@@ -66,7 +66,7 @@ const t0 = _template("<div>", 1)
 export function render(_ctx) {
   const n1 = t0()
   _setInsertionState(n1, null, 0)
-  const n0 = _createSlot("default", null, null, 2)
+  const n0 = _createSlot("default", null, null, 2 /* ONCE */)
   return n1
 }"
 `;
@@ -89,7 +89,7 @@ export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
     const n2 = t0()
     return n2
-  }, undefined, 12)
+  }, undefined, 12 /* IS_SINGLE_NODE, ONCE */)
   return n0
 }"
 `;
@@ -102,7 +102,7 @@ export function render(_ctx) {
   const n0 = _createIf(() => (_ctx.expr), () => {
     const n2 = t0()
     return n2
-  }, null, 17 /* BLOCK_SHAPE, ONCE */)
+  }, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)
   return n0
 }"
 `;
@@ -119,7 +119,7 @@ export function render(_ctx) {
   }, () => {
     const n4 = t1()
     return n4
-  }, 85 /* BLOCK_SHAPE, FALSE_NO_SCOPE, ONCE */)
+  }, 85 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, FALSE_NO_SCOPE, ONCE */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -147,7 +147,7 @@ export function render(_ctx) {
   const _component_Comp = _resolveComponent("Comp")
   const n2 = _createComponentWithFallback(_component_Comp, null, () => {
     const n1 = _createComponentWithFallback(_component_Comp, null, _extend(() => {
-      const n0 = _createSlot("default", null, null, 4)
+      const n0 = _createSlot()
       return n0
     }, { _: 8 }))
     return n1
@@ -161,7 +161,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag only 1`] = `
 
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 4)
+    const n0 = _createSlot()
     return n0
   }, { _: 8 }), true)
   return n1
@@ -173,7 +173,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ template 1`]
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 4)
+    const n0 = _createSlot()
     return n0
   }, { _: 8 }), true)
   return n2
@@ -186,7 +186,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-for 1`] = 
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
-      const n2 = _createSlot("default", null, null, 4)
+      const n2 = _createSlot()
       return n2
     }, undefined, 48)
     return n0
@@ -201,7 +201,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-if 1`] = `
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.ok), () => {
-      const n2 = _createSlot("default", null, null, 4)
+      const n2 = _createSlot()
       return n2
     }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
     return n0
@@ -411,9 +411,9 @@ export function render(_ctx) {
       const n2 = _createIf(() => (_ctx.show), () => {
         const n4 = t0()
         return n4
-      }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+      })
       return n2
-    }, 4)
+    })
     return n0
   }, { _: 8 }), true)
   return n5
@@ -473,7 +473,7 @@ export function render(_ctx) {
       () => (_createForSlots(_ctx.slots, (_, name) => ({
         name: name,
         fn: () => {
-          const n0 = _createSlot(() => (name), null, null, 4)
+          const n0 = _createSlot(() => (name))
           return n0
         }
       })))
@@ -643,7 +643,7 @@ exports[`compiler: transform slot > slot owner context > slot with slot outlet i
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 4)
+    const n0 = _createSlot()
     return n0
   }, { _: 8 }), true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -149,7 +149,7 @@ export function render(_ctx) {
     const n1 = _createComponentWithFallback(_component_Comp, null, _extend(() => {
       const n0 = _createSlot()
       return n0
-    }, { _: 8 }))
+    }, { _: 8 /* NON_STABLE */ }))
     return n1
   }, true)
   return n2
@@ -163,7 +163,7 @@ export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot()
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n1
 }"
 `;
@@ -175,7 +175,7 @@ export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot()
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n2
 }"
 `;
@@ -188,9 +188,9 @@ export function render(_ctx) {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
       const n2 = _createSlot()
       return n2
-    }, undefined, 48)
+    }, undefined, 48 /* IS_FRAGMENT, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -203,9 +203,9 @@ export function render(_ctx) {
     const n0 = _createIf(() => (_ctx.ok), () => {
       const n2 = _createSlot()
       return n2
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -253,7 +253,7 @@ export function render(_ctx) {
   const n2 = _createAssetComponent("Foo", null, {
     "header": _extend(() => {
       return []
-    }, { _: 8 }),
+    }, { _: 8 /* NON_STABLE */ }),
     "default": () => {
       const n1 = _createComponentWithFallback(_component_Bar)
       return n1
@@ -341,7 +341,7 @@ export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, {
     "nav-bar-title-before": _extend(() => {
       return []
-    }, { _: 8 })
+    }, { _: 8 /* NON_STABLE */ })
   }, true)
   return n1
 }"
@@ -364,7 +364,7 @@ export function render(_ctx) {
   }, () => {
     const n5 = _createComponentWithFallback(_component_Bar)
     return n5
-  }, 21 /* BLOCK_SHAPE, ONCE */)
+  }, 21 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, ONCE */)
   return n6
 }"
 `;
@@ -392,11 +392,11 @@ export function render(_ctx) {
       const n2 = _createIf(() => (_ctx.show), () => {
         const n4 = t0()
         return n4
-      }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+      }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
       return n2
     })
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -429,9 +429,9 @@ export function render(_ctx) {
     const n0 = _createFor(() => (_ctx.list), (_for_item0) => {
       const n2 = t0()
       return n2
-    }, undefined, 40)
+    }, undefined, 40 /* IS_SINGLE_NODE, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -445,9 +445,9 @@ export function render(_ctx) {
     const n0 = _createIf(() => (_ctx.show), () => {
       const n2 = t0()
       return n2
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -457,9 +457,9 @@ exports[`compiler: transform slot > slot fast path > runtime dynamic component r
 
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 4)
+    const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 4 /* SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n1
 }"
 `;
@@ -495,9 +495,9 @@ export function render(_ctx) {
       _setInsertionState(n3, null, 0)
       const n2 = _createComponentWithFallback(_component_ChildComp)
       return n3
-    }, undefined, 40)
+    }, undefined, 40 /* IS_SINGLE_NODE, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -514,9 +514,9 @@ export function render(_ctx) {
       _setInsertionState(n3, null, 0)
       const n2 = _createComponentWithFallback(_component_ChildComp)
       return n3
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -545,9 +545,9 @@ export function render(_ctx) {
       _setInsertionState(n3, null, 0)
       const n2 = _createPlainElement("my-element")
       return n3
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -576,7 +576,7 @@ export function render(_ctx) {
       const x2 = _txt(n2)
       _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value)))
       return n2
-    }, undefined, 8)
+    }, undefined, 8 /* IS_SINGLE_NODE */)
     const n3 = t1()
     const x0 = _txt(n0)
     _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
@@ -604,9 +604,9 @@ export function render(_ctx) {
         return n5
       })
       return n6
-    }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+    }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n8
 }"
 `;
@@ -645,7 +645,7 @@ export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot()
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n2
 }"
 `;
@@ -661,11 +661,11 @@ export function render(_ctx) {
       const x2 = _txt(n2)
       _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value)))
       return n2
-    }, undefined, 40)
+    }, undefined, 40 /* IS_SINGLE_NODE, SLOT_ROOT */)
     const x0 = _txt(n0)
     _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n4
 }"
 `;
@@ -683,9 +683,9 @@ export function render(_ctx) {
     }, () => {
       const n4 = t1()
       return n4
-    }, 389 /* BLOCK_SHAPE, SLOT_ROOT, INDEX_SHIFT */)
+    }, 389 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, SLOT_ROOT, KEYED_INDEX_0 */)
     return n0
-  }, { _: 8 }), true)
+  }, { _: 8 /* NON_STABLE */ }), true)
   return n7
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -464,7 +464,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > dynamic slot source with slot outlet should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > dynamic slot source with slot outlet keeps dynamic slot function 1`] = `
 "import { createSlot as _createSlot, createForSlots as _createForSlots, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
@@ -483,7 +483,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with component inside v-for should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with component inside v-for is non-stable 1`] = `
 "import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
@@ -502,7 +502,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with component inside v-if should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with component inside v-if is non-stable 1`] = `
 "import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
@@ -521,7 +521,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with component should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with component is stable 1`] = `
 "import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
@@ -534,7 +534,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with custom element inside v-if should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with custom element inside v-if is non-stable 1`] = `
 "import { setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
@@ -552,7 +552,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with custom element should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with custom element is stable 1`] = `
 "import { createPlainElement as _createPlainElement, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
@@ -564,13 +564,13 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with dynamic root and stable sibling should be non-stable 1`] = `
-"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+exports[`compiler: transform slot > slot owner context > slot with dynamic root and stable sibling is stable 1`] = `
+"import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<span> ")
 const t1 = _template("<i>tail", 2)
 
 export function render(_ctx) {
-  const n5 = _createAssetComponent("Comp", null, _extend(() => {
+  const n5 = _createAssetComponent("Comp", null, () => {
     const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
       const n2 = t0()
       const x2 = _txt(n2)
@@ -581,12 +581,12 @@ export function render(_ctx) {
     const x0 = _txt(n0)
     _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
     return [n0, n3]
-  }, { _: 8 }), true)
+  }, true)
   return n5
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with nested v-if containing component should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with nested v-if containing component is non-stable 1`] = `
 "import { resolveComponent as _resolveComponent, setInsertionState as _setInsertionState, createComponentWithFallback as _createComponentWithFallback, createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<span>")
 const t1 = _template("<div>")
@@ -611,7 +611,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with only static elements should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with only static elements is stable 1`] = `
 "import { createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>static content", 2)
 
@@ -624,7 +624,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with only text interpolation should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with only text interpolation is stable 1`] = `
 "import { toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template(" ")
 
@@ -638,7 +638,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with slot outlet should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with slot outlet is non-stable 1`] = `
 "import { createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent } from 'vue';
 
 export function render(_ctx) {
@@ -650,7 +650,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with v-for but no component should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with v-for but no component is non-stable 1`] = `
 "import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div> ")
 
@@ -670,7 +670,7 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: transform slot > slot owner context > slot with v-if but no component should not need withVaporCtx 1`] = `
+exports[`compiler: transform slot > slot owner context > slot with v-if but no component is non-stable 1`] = `
 "import { createIf as _createIf, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>content", 2)
 const t1 = _template("<span>fallback", 2)

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -382,6 +382,25 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: transform slot > slot fast path > forwarded root slot outlet fallback tracks root validity 1`] = `
+"import { createIf as _createIf, createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template("<span>", 2)
+
+export function render(_ctx) {
+  const n5 = _createAssetComponent("Comp", null, _extend(() => {
+    const n0 = _createSlot("default", null, () => {
+      const n2 = _createIf(() => (_ctx.show), () => {
+        const n4 = t0()
+        return n4
+      }, null, 129 /* BLOCK_SHAPE, SLOT_ROOT */)
+      return n2
+    })
+    return n0
+  }, { _: 8 }), true)
+  return n5
+}"
+`;
+
 exports[`compiler: transform slot > slot fast path > non-root v-if under stable template root is stable 1`] = `
 "import { setInsertionState as _setInsertionState, createIf as _createIf, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<span>", 2)
@@ -398,25 +417,6 @@ export function render(_ctx) {
     return n3
   }, true)
   return n4
-}"
-`;
-
-exports[`compiler: transform slot > slot fast path > root slot outlet fallback is non-stable 1`] = `
-"import { createIf as _createIf, createSlot as _createSlot, extend as _extend, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
-const t0 = _template("<span>", 2)
-
-export function render(_ctx) {
-  const n5 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, () => {
-      const n2 = _createIf(() => (_ctx.show), () => {
-        const n4 = t0()
-        return n4
-      })
-      return n2
-    })
-    return n0
-  }, { _: 8 }), true)
-  return n5
 }"
 `;
 

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -576,7 +576,7 @@ export function render(_ctx) {
       const x2 = _txt(n2)
       _renderEffect(() => _setText(x2, _toDisplayString(_for_item0.value)))
       return n2
-    }, undefined, 40)
+    }, undefined, 8)
     const n3 = t1()
     const x0 = _txt(n0)
     _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vText.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vText.spec.ts.snap
@@ -48,7 +48,7 @@ exports[`v-text > work with dynamic component 1`] = `
 "import { createDynamicComponent as _createDynamicComponent, toDisplayString as _toDisplayString, setBlockText as _setBlockText, renderEffect as _renderEffect } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.Comp), null, null, 1)
+  const n0 = _createDynamicComponent(() => (_ctx.Comp), null, null, 1 /* SINGLE_ROOT */)
   _renderEffect(() => _setBlockText(n0, _toDisplayString(_ctx.foo)))
   return n0
 }"

--- a/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformSlotOutlet.spec.ts
@@ -14,6 +14,8 @@ import {
 } from '../../src'
 import { makeCompile } from './_utils'
 
+const slotNoSlottedFlag = `${VaporSlotFlags.NO_SLOTTED} /* NO_SLOTTED */`
+
 const compileWithSlotsOutlet = makeCompile({
   nodeTransforms: [
     transformText,
@@ -325,7 +327,7 @@ describe('compiler: transform <slot> outlets', () => {
       slotted: false,
     })
     expect(code).toMatchSnapshot()
-    expect(code).toContain(String(VaporSlotFlags.NO_SLOTTED))
+    expect(code).toContain(slotNoSlottedFlag)
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.SLOT_OUTLET_NODE,
       id: 0,

--- a/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
@@ -40,7 +40,7 @@ describe('compiler: v-for', () => {
     expect(code).matchSnapshot()
     expect(helpers).contains('createFor')
     expect(code).toContain(
-      `}, (item) => (item.id), ${VaporVForFlags.IS_SINGLE_NODE})`,
+      `}, (item) => (item.id), ${VaporVForFlags.IS_SINGLE_NODE} /* IS_SINGLE_NODE */)`,
     )
     expect([...ir.template.keys()]).toEqual(['<div> '])
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
@@ -435,7 +435,9 @@ describe('compiler: v-for', () => {
       `<Comp v-for="item in list">{{item}}</Comp>`,
     )
     expect(code).matchSnapshot()
-    expect(code).toContain(`}, undefined, ${VaporVForFlags.IS_COMPONENT})`)
+    expect(code).toContain(
+      `}, undefined, ${VaporVForFlags.IS_COMPONENT} /* IS_COMPONENT */)`,
+    )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).component,
     ).toBe(true)
@@ -449,7 +451,7 @@ describe('compiler: v-for', () => {
     expect(code).toContain(
       `}, (item) => (item.id), ${
         VaporVForFlags.IS_COMPONENT | VaporVForFlags.IS_FRAGMENT
-      })`,
+      } /* IS_COMPONENT, IS_FRAGMENT */)`,
     )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).component,
@@ -469,7 +471,7 @@ describe('compiler: v-for', () => {
     )
     expect(code).matchSnapshot()
     expect(code).toContain(
-      `}, (item) => (item.id), ${VaporVForFlags.IS_COMPONENT})`,
+      `}, (item) => (item.id), ${VaporVForFlags.IS_COMPONENT} /* IS_COMPONENT */)`,
     )
   })
 
@@ -479,7 +481,7 @@ describe('compiler: v-for', () => {
     )
     expect(code).matchSnapshot()
     expect(code).toContain(
-      `}, (item) => (item.id), ${VaporVForFlags.IS_FRAGMENT})`,
+      `}, (item) => (item.id), ${VaporVForFlags.IS_FRAGMENT} /* IS_FRAGMENT */)`,
     )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).render.dynamic
@@ -494,9 +496,7 @@ describe('compiler: v-for', () => {
       `<template v-for="item in list"><div>{{ item }}</div><span>{{ item }}</span></template>`,
     )
     expect(code).matchSnapshot()
-    expect(code).not.toContain(
-      `}, undefined, ${VaporVForFlags.IS_SINGLE_NODE})`,
-    )
+    expect(code).not.toContain('IS_SINGLE_NODE')
   })
 
   test('v-for on template with single component child', () => {
@@ -504,7 +504,9 @@ describe('compiler: v-for', () => {
       `<template v-for="item in list"><Comp>{{item}}</Comp></template>`,
     )
     expect(code).matchSnapshot()
-    expect(code).toContain(`}, undefined, ${VaporVForFlags.IS_COMPONENT})`)
+    expect(code).toContain(
+      `}, undefined, ${VaporVForFlags.IS_COMPONENT} /* IS_COMPONENT */)`,
+    )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).component,
     ).toBe(true)
@@ -518,7 +520,9 @@ describe('compiler: v-for', () => {
       </template>`,
     )
     expect(code).matchSnapshot()
-    expect(code).toContain(`}, undefined, ${VaporVForFlags.IS_FRAGMENT})`)
+    expect(code).toContain(
+      `}, undefined, ${VaporVForFlags.IS_FRAGMENT} /* IS_FRAGMENT */)`,
+    )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).component,
     ).toBe(false)
@@ -535,7 +539,9 @@ describe('compiler: v-for', () => {
       `<template v-for="row in rows"><div v-for="item in row">{{ item }}</div></template>`,
     )
     expect(code).matchSnapshot()
-    expect(code).toContain(`}, undefined, ${VaporVForFlags.IS_FRAGMENT})`)
+    expect(code).toContain(
+      `}, undefined, ${VaporVForFlags.IS_FRAGMENT} /* IS_FRAGMENT */)`,
+    )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).render.dynamic
         .children[0].operation,
@@ -549,7 +555,9 @@ describe('compiler: v-for', () => {
       `<template v-for="item in items"><div :key="item.id">{{ item.text }}</div></template>`,
     )
     expect(code).matchSnapshot()
-    expect(code).toContain(`}, undefined, ${VaporVForFlags.IS_FRAGMENT})`)
+    expect(code).toContain(
+      `}, undefined, ${VaporVForFlags.IS_FRAGMENT} /* IS_FRAGMENT */)`,
+    )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).render.dynamic
         .children[0].operation,

--- a/packages/compiler-vapor/__tests__/transforms/vIf.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vIf.spec.ts
@@ -87,7 +87,7 @@ describe('compiler: v-if', () => {
     const { code } = compileWithVIf(`<div v-if="ok">static</div>`)
 
     expect(code).contains(
-      `}, null, ${singleRootNoScope} /* BLOCK_SHAPE, TRUE_NO_SCOPE */)`,
+      `}, null, ${singleRootNoScope} /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)`,
     )
   })
 
@@ -97,14 +97,14 @@ describe('compiler: v-if', () => {
     )
 
     expect(code).contains(
-      `}, null, ${VaporBlockShape.MULTI_ROOT | VaporIfFlags.TRUE_NO_SCOPE} /* BLOCK_SHAPE, TRUE_NO_SCOPE */)`,
+      `}, null, ${VaporBlockShape.MULTI_ROOT | VaporIfFlags.TRUE_NO_SCOPE} /* TRUE_MULTI_ROOT, TRUE_NO_SCOPE */)`,
     )
   })
 
   test('packs once flag', () => {
     const { code } = compileWithVIf(`<div v-if="ok" v-once />`)
 
-    expect(code).contains(`}, null, 17 /* BLOCK_SHAPE, ONCE */)`)
+    expect(code).contains(`}, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)`)
     expect(code).not.contains(`}, null, 1, true)`)
   })
 
@@ -114,7 +114,7 @@ describe('compiler: v-if', () => {
     )
 
     expect(code).contains(
-      `}, ${singleRootIfElseNoScope | (1 << VaporIfFlags.INDEX_SHIFT)} /* BLOCK_SHAPE, TRUE_NO_SCOPE, FALSE_NO_SCOPE, INDEX_SHIFT */)`,
+      `}, ${singleRootIfElseNoScope | (1 << VaporIfFlags.INDEX_SHIFT)} /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, TRUE_NO_SCOPE, FALSE_NO_SCOPE, KEYED_INDEX_0 */)`,
     )
     expect(code).not.contains(`}, 5, null, 0)`)
   })
@@ -210,7 +210,7 @@ describe('compiler: v-if', () => {
 
     expect(code).toMatchSnapshot()
     expect(code).contains(
-      `}, null, ${singleRootNoScope} /* BLOCK_SHAPE, TRUE_NO_SCOPE */)`,
+      `}, null, ${singleRootNoScope} /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)`,
     )
     expect(code).toContain('_template("hello", 2)')
     expect([...ir.template.keys()]).toMatchObject(['hello'])

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -600,6 +600,22 @@ describe('compiler: transform slot', () => {
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
     })
 
+    test('stable root sibling keeps slot content stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><span/><div v-if="show"/></Comp>`,
+      )
+
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
+
+    test('static component root sibling keeps slot content stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><Foo/><component :is="view"/></Comp>`,
+      )
+
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
+
     test('root v-if slot content is non-stable', () => {
       const { code } = compileWithSlots(`<Comp><span v-if="show"/></Comp>`)
 
@@ -613,6 +629,30 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toMatchSnapshot()
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
+
+    test('all dynamic root slot content is non-stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><div v-if="a"/><p v-if="b"/></Comp>`,
+      )
+
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
+
+    test('root v-for with root v-if slot content is non-stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><div v-for="item in list"/><p v-if="ok"/></Comp>`,
+      )
+
+      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    })
+
+    test('comment with dynamic root slot content is non-stable', () => {
+      const { code } = compileWithSlots(
+        `<Comp><!--foo--><div v-if="show"/></Comp>`,
+      )
+
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
     })
 
@@ -857,7 +897,7 @@ describe('compiler: transform slot', () => {
   })
 
   describe('slot owner context', () => {
-    test('slot with only static elements should not need withVaporCtx', () => {
+    test('slot with only static elements is stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -866,11 +906,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with component should not need withVaporCtx', () => {
+    test('slot with component is stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -879,11 +918,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with slot outlet should not need withVaporCtx', () => {
+    test('slot with slot outlet is non-stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -892,11 +930,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('dynamic slot source with slot outlet should not need withVaporCtx', () => {
+    test('dynamic slot source with slot outlet keeps dynamic slot function', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template v-for="(_, name) in slots" #[name]>
@@ -907,11 +944,10 @@ describe('compiler: transform slot', () => {
       expect(code).toContain(`$: [
       () => (_createForSlots`)
       expect(code).toContain(`fn: () =>`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with component inside v-if should not need withVaporCtx', () => {
+    test('slot with component inside v-if is non-stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -922,11 +958,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with component inside v-for should not need withVaporCtx', () => {
+    test('slot with component inside v-for is non-stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -937,11 +972,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with nested v-if containing component should not need withVaporCtx', () => {
+    test('slot with nested v-if containing component is non-stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -954,11 +988,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with only text interpolation should not need withVaporCtx', () => {
+    test('slot with only text interpolation is stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -967,11 +1000,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with v-if but no component should not need withVaporCtx', () => {
+    test('slot with v-if but no component is non-stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -981,11 +1013,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with v-for but no component should not need withVaporCtx', () => {
+    test('slot with v-for but no component is non-stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -994,11 +1025,10 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with dynamic root and stable sibling should be non-stable', () => {
+    test('slot with dynamic root and stable sibling is stable', () => {
       const { code } = compileWithSlots(`
         <Comp>
           <template #default>
@@ -1007,12 +1037,11 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
+      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with custom element should not need withVaporCtx', () => {
+    test('slot with custom element is stable', () => {
       const { code } = compileWithSlots(
         `
         <Comp>
@@ -1026,11 +1055,10 @@ describe('compiler: transform slot', () => {
         },
       )
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
 
-    test('slot with custom element inside v-if should not need withVaporCtx', () => {
+    test('slot with custom element inside v-if is non-stable', () => {
       const { code } = compileWithSlots(
         `
         <Comp>
@@ -1046,7 +1074,6 @@ describe('compiler: transform slot', () => {
         },
       )
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('withVaporCtx')
       expect(code).toMatchSnapshot()
     })
   })

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -1,5 +1,9 @@
 import { ErrorCodes, NodeTypes } from '@vue/compiler-dom'
-import { VaporSlotFlags } from '@vue/shared'
+import {
+  VaporDynamicComponentFlags,
+  VaporSlotFlags,
+  VaporVForFlags,
+} from '@vue/shared'
 import {
   IRNodeTypes,
   IRSlotType,
@@ -606,6 +610,7 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain('SLOT_ROOT')
     })
 
     test('static component root sibling keeps slot content stable', () => {
@@ -614,6 +619,9 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(
+        `null, null, ${VaporDynamicComponentFlags.SLOT_ROOT})`,
+      )
     })
 
     test('root v-if slot content is non-stable', () => {
@@ -638,6 +646,7 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain('SLOT_ROOT')
     })
 
     test('root v-for with root v-if slot content is non-stable', () => {
@@ -646,6 +655,10 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(
+        `, undefined, ${VaporVForFlags.IS_SINGLE_NODE | VaporVForFlags.SLOT_ROOT})`,
+      )
+      expect(code).toContain('SLOT_ROOT')
     })
 
     test('comment with dynamic root slot content is non-stable', () => {
@@ -654,6 +667,7 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain('SLOT_ROOT')
     })
 
     test('runtime dynamic component root is non-stable', () => {
@@ -1038,6 +1052,9 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(
+        `, undefined, ${VaporVForFlags.IS_SINGLE_NODE | VaporVForFlags.SLOT_ROOT})`,
+      )
       expect(code).toMatchSnapshot()
     })
 

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -20,6 +20,10 @@ import {
 } from '../../src'
 import { makeCompile } from './_utils'
 
+const dynamicSlotRootFlag = `${VaporDynamicComponentFlags.SLOT_ROOT} /* SLOT_ROOT */`
+const slotNonStableFlag = `_: ${VaporSlotFlags.NON_STABLE} /* NON_STABLE */`
+const slotRootFlag = `${VaporSlotFlags.SLOT_ROOT} /* SLOT_ROOT */`
+
 const compileWithSlots = makeCompile({
   nodeTransforms: [
     transformText,
@@ -41,7 +45,7 @@ describe('compiler: transform slot', () => {
   test('implicit default slot', () => {
     const { ir, code } = compileWithSlots(`<Comp><div/></Comp>`)
     expect(code).toMatchSnapshot()
-    expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+    expect(code).not.toContain(slotNonStableFlag)
 
     expect([...ir.template.keys()]).toEqual(['<div>'])
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
@@ -594,14 +598,14 @@ describe('compiler: transform slot', () => {
         `<Comp><template #default><!--foo--></template></Comp>`,
       )
 
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
     })
 
     test('component root is stable', () => {
       const { code } = compileWithSlots(`<A><B/></A>`)
 
       expect(code).toMatchSnapshot()
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
     })
 
     test('stable root sibling keeps slot content stable', () => {
@@ -609,7 +613,7 @@ describe('compiler: transform slot', () => {
         `<Comp><span/><div v-if="show"/></Comp>`,
       )
 
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
       expect(code).not.toContain('SLOT_ROOT')
     })
 
@@ -618,17 +622,15 @@ describe('compiler: transform slot', () => {
         `<Comp><Foo/><component :is="view"/></Comp>`,
       )
 
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain(
-        `null, null, ${VaporDynamicComponentFlags.SLOT_ROOT})`,
-      )
+      expect(code).not.toContain(slotNonStableFlag)
+      expect(code).not.toContain(`null, null, ${dynamicSlotRootFlag})`)
     })
 
     test('root v-if slot content is non-stable', () => {
       const { code } = compileWithSlots(`<Comp><span v-if="show"/></Comp>`)
 
       expect(code).toMatchSnapshot()
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
     })
 
     test('root v-for slot content is non-stable', () => {
@@ -637,7 +639,7 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toMatchSnapshot()
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
     })
 
     test('all dynamic root slot content is non-stable', () => {
@@ -645,7 +647,7 @@ describe('compiler: transform slot', () => {
         `<Comp><div v-if="a"/><p v-if="b"/></Comp>`,
       )
 
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toContain('SLOT_ROOT')
     })
 
@@ -654,9 +656,11 @@ describe('compiler: transform slot', () => {
         `<Comp><div v-for="item in list"/><p v-if="ok"/></Comp>`,
       )
 
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toContain(
-        `, undefined, ${VaporVForFlags.IS_SINGLE_NODE | VaporVForFlags.SLOT_ROOT})`,
+        `, undefined, ${
+          VaporVForFlags.IS_SINGLE_NODE | VaporVForFlags.SLOT_ROOT
+        } /* IS_SINGLE_NODE, SLOT_ROOT */)`,
       )
       expect(code).toContain('SLOT_ROOT')
     })
@@ -666,7 +670,7 @@ describe('compiler: transform slot', () => {
         `<Comp><!--foo--><div v-if="show"/></Comp>`,
       )
 
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toContain('SLOT_ROOT')
     })
 
@@ -677,7 +681,8 @@ describe('compiler: transform slot', () => {
       const { code } = compileWithSlots(`<Comp><component :is="view"/></Comp>`)
 
       expect(code).toMatchSnapshot()
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
+      expect(code).toContain(`null, null, ${dynamicSlotRootFlag})`)
     })
 
     test('non-root v-if under stable template root is stable', () => {
@@ -686,7 +691,7 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toMatchSnapshot()
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
     })
 
     test('ordinary slot outlet fallback does not track parent content', () => {
@@ -701,7 +706,7 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toMatchSnapshot()
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toContain('SLOT_ROOT')
     })
   })
@@ -709,9 +714,9 @@ describe('compiler: transform slot', () => {
   describe('forwarded slots', () => {
     test('<slot> tag only', () => {
       const { code } = compileWithSlots(`<Comp><slot/></Comp>`)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).not.toContain(
-        `_createSlot("default", null, null, ${VaporSlotFlags.SLOT_ROOT})`,
+        `_createSlot("default", null, null, ${slotRootFlag})`,
       )
       expect(code).toMatchSnapshot()
     })
@@ -773,7 +778,7 @@ describe('compiler: transform slot', () => {
       const { ir, code } = compileWithSlots(`<Comp><!--foo--></Comp>`)
 
       expect(code).toContain(`<!--foo-->`)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(ir.block.dynamic.children[0].operation).toMatchObject({
         type: IRNodeTypes.CREATE_COMPONENT_NODE,
         slots: [
@@ -929,7 +934,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -941,7 +946,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -953,7 +958,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -981,7 +986,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -995,7 +1000,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -1011,7 +1016,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -1023,7 +1028,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -1036,7 +1041,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -1048,7 +1053,7 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -1061,9 +1066,11 @@ describe('compiler: transform slot', () => {
           </template>
         </Comp>
       `)
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
       expect(code).not.toContain(
-        `, undefined, ${VaporVForFlags.IS_SINGLE_NODE | VaporVForFlags.SLOT_ROOT})`,
+        `, undefined, ${
+          VaporVForFlags.IS_SINGLE_NODE | VaporVForFlags.SLOT_ROOT
+        } /* IS_SINGLE_NODE, SLOT_ROOT */)`,
       )
       expect(code).toMatchSnapshot()
     })
@@ -1081,7 +1088,7 @@ describe('compiler: transform slot', () => {
           isCustomElement: tag => tag.startsWith('my-'),
         },
       )
-      expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
 
@@ -1100,7 +1107,7 @@ describe('compiler: transform slot', () => {
           isCustomElement: tag => tag.startsWith('my-'),
         },
       )
-      expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).toContain(slotNonStableFlag)
       expect(code).toMatchSnapshot()
     })
   })

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -696,6 +696,7 @@ describe('compiler: transform slot', () => {
 
       expect(code).toMatchSnapshot()
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain('SLOT_ROOT')
     })
   })
 
@@ -703,6 +704,9 @@ describe('compiler: transform slot', () => {
     test('<slot> tag only', () => {
       const { code } = compileWithSlots(`<Comp><slot/></Comp>`)
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
+      expect(code).not.toContain(
+        `_createSlot("default", null, null, ${VaporSlotFlags.SLOT_ROOT})`,
+      )
       expect(code).toMatchSnapshot()
     })
 

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -689,14 +689,20 @@ describe('compiler: transform slot', () => {
       expect(code).not.toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
     })
 
-    test('root slot outlet fallback is non-stable', () => {
+    test('ordinary slot outlet fallback does not track parent content', () => {
+      const { code } = compileWithSlots(`<slot><span v-if="show"/></slot>`)
+
+      expect(code).not.toContain('SLOT_ROOT')
+    })
+
+    test('forwarded root slot outlet fallback tracks root validity', () => {
       const { code } = compileWithSlots(
         `<Comp><slot><span v-if="show"/></slot></Comp>`,
       )
 
       expect(code).toMatchSnapshot()
       expect(code).toContain(`_: ${VaporSlotFlags.NON_STABLE}`)
-      expect(code).not.toContain('SLOT_ROOT')
+      expect(code).toContain('SLOT_ROOT')
     })
   })
 

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -6,13 +6,9 @@ import type {
   IRDynamicInfo,
   IRSlots,
   IfIRNode,
+  OperationNode,
 } from '../ir'
-import {
-  IRNodeTypes,
-  IRSlotType,
-  type OperationNode,
-  isBlockOperation,
-} from '../ir'
+import { IRNodeTypes, IRSlotType, isBlockOperation } from '../ir'
 import {
   type CodeFragment,
   DELIMITERS_ARRAY,
@@ -31,7 +27,6 @@ import {
 } from './operation'
 import { genChildren, genSelf } from './template'
 import { toValidAssetId } from '@vue/compiler-dom'
-import { VaporSlotFlags } from '@vue/shared'
 
 export function genBlock(
   oper: BlockIRNode,
@@ -219,8 +214,6 @@ export function markSlotRootOperations(block: BlockIRNode): void {
       markSlotRootIf(operation)
     } else if (operation.type === IRNodeTypes.FOR) {
       markSlotRootFor(operation)
-    } else if (operation.type === IRNodeTypes.SLOT_OUTLET_NODE) {
-      markSlotRootSlotOutlet(operation)
     } else if (operation.type === IRNodeTypes.CREATE_COMPONENT_NODE) {
       markSlotRootComponent(operation)
     }
@@ -247,15 +240,6 @@ function markSlotRootFor(operation: ForIRNode): void {
     operation.slotRoot = true
   }
   markSlotRootOperations(operation.render)
-}
-
-function markSlotRootSlotOutlet(
-  operation: Extract<OperationNode, { type: IRNodeTypes.SLOT_OUTLET_NODE }>,
-): void {
-  operation.flags |= VaporSlotFlags.SLOT_ROOT
-  if (operation.fallback) {
-    markSlotRootOperations(operation.fallback)
-  }
 }
 
 function markSlotRootComponent(operation: CreateComponentIRNode): void {

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -86,10 +86,8 @@ export function genCreateComponent(
     operation.dynamic && !operation.dynamic.isStatic
   )
   const dynamicComponentFlags = isRuntimeDynamicComponent
-    ? (root ? VaporDynamicComponentFlags.SINGLE_ROOT : 0) |
-      (once ? VaporDynamicComponentFlags.ONCE : 0) |
-      (slotRoot ? VaporDynamicComponentFlags.SLOT_ROOT : 0)
-    : 0
+    ? genDynamicComponentFlags(root, once, slotRoot)
+    : false
   const rawSlots = genRawSlots(slots, context)
   const [ids, handlers] = processInlineHandlers(props, context)
   const rawProps = context.withId(() => genRawProps(props, context, true), ids)
@@ -118,13 +116,7 @@ export function genCreateComponent(
       tag,
       rawProps,
       rawSlots,
-      isRuntimeDynamicComponent
-        ? dynamicComponentFlags
-          ? String(dynamicComponentFlags)
-          : false
-        : root
-          ? 'true'
-          : false,
+      isRuntimeDynamicComponent ? dynamicComponentFlags : root ? 'true' : false,
       isRuntimeDynamicComponent ? false : once && 'true',
       isRuntimeDynamicComponent ? false : maybeSelfReference && 'true',
     ),
@@ -164,6 +156,34 @@ export function genCreateComponent(
       )
     }
   }
+}
+
+function genDynamicComponentFlags(
+  root: boolean | undefined,
+  once: boolean | undefined,
+  slotRoot: boolean | undefined,
+): string | false {
+  let flags = 0
+  const names: string[] = []
+
+  if (root) {
+    flags |= VaporDynamicComponentFlags.SINGLE_ROOT
+    names.push('SINGLE_ROOT')
+  }
+  if (once) {
+    flags |= VaporDynamicComponentFlags.ONCE
+    names.push('ONCE')
+  }
+  if (slotRoot) {
+    flags |= VaporDynamicComponentFlags.SLOT_ROOT
+    names.push('SLOT_ROOT')
+  }
+
+  if (!flags) {
+    return false
+  }
+
+  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
 }
 
 function getUniqueHandlerName(context: CodegenContext, name: string): string {
@@ -774,16 +794,33 @@ function genSlotBlockWithProps(
   )
   // Dynamic slot sources keep rawSlots.$, so runtime stays conservative.
   if (emitNonStableFlag && !hasStableRoot) {
-    blockFn = genCall(
-      context.helper('extend'),
-      blockFn,
-      `{ _: ${VaporSlotFlags.NON_STABLE} }`,
-    )
+    blockFn = genCall(context.helper('extend'), blockFn, [
+      `{ _: ${genSlotFlags(VaporSlotFlags.NON_STABLE)} }`,
+    ])
   }
   exitSlotBlock()
   exitScope && exitScope()
 
   return blockFn
+}
+
+function genSlotFlags(flags: number): string {
+  const names: string[] = []
+
+  if (flags & VaporSlotFlags.NO_SLOTTED) {
+    names.push('NO_SLOTTED')
+  }
+  if (flags & VaporSlotFlags.ONCE) {
+    names.push('ONCE')
+  }
+  if (flags & VaporSlotFlags.SLOT_ROOT) {
+    names.push('SLOT_ROOT')
+  }
+  if (flags & VaporSlotFlags.NON_STABLE) {
+    names.push('NON_STABLE')
+  }
+
+  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
 }
 
 const commentOnlyTemplateRE = /^(?:<!--[\s\S]*?-->)+$/

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -785,7 +785,7 @@ function genSlotBlockWithProps(
 
 const commentOnlyTemplateRE = /^(?:<!--[\s\S]*?-->)+$/
 
-// A slot can skip fallback/boundary tracking only when its root shape is stable.
+// A slot can skip fallback/boundary tracking when at least one root is stable.
 // Components count as valid even if their own render result is a comment.
 function hasStableSlotRoot(
   block: BlockIRNode,
@@ -813,16 +813,17 @@ function hasStableSlotRoot(
         // <component :is="view" /> renders fallback when view is null because
         // the dynamic component root becomes a comment vnode. This differs from
         // <Foo />, whose component vnode is valid slot content even if Foo
-        // renders null/comment.
-        return false
+        // renders null/comment. Keep scanning because a stable sibling can
+        // still make the whole slot content valid.
+        continue
       case IRNodeTypes.KEY:
         if (hasStableSlotRoot(operation.block, context)) {
           hasValidRoot = true
           continue
         }
-        return false
+        continue
       default:
-        return false
+        continue
     }
   }
   return hasValidRoot

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -764,13 +764,16 @@ function genSlotBlockWithProps(
   }
 
   const exitSlotBlock = context.enterSlotBlock()
-  markSlotRootOperations(oper)
+  const hasStableRoot = hasStableSlotRoot(oper, context)
+  if (!hasStableRoot) {
+    markSlotRootOperations(oper)
+  }
   let blockFn = context.withId(
     () => genBlock(oper, context, propsName ? [propsName] : []),
     idMap,
   )
   // Dynamic slot sources keep rawSlots.$, so runtime stays conservative.
-  if (emitNonStableFlag && !hasStableSlotRoot(oper, context)) {
+  if (emitNonStableFlag && !hasStableRoot) {
     blockFn = genCall(
       context.helper('extend'),
       blockFn,

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -141,25 +141,14 @@ export function genFor(
   }, idMap)
   exitScope()
 
-  let flags = 0
-  if (onlyChild) {
-    flags |= VaporVForFlags.FAST_REMOVE
-  }
-  if (component) {
-    flags |= VaporVForFlags.IS_COMPONENT
-  }
-  if (isFragmentBlock(render)) {
-    flags |= VaporVForFlags.IS_FRAGMENT
-  }
-  if (!component && isSingleNodeBlock(render)) {
-    flags |= VaporVForFlags.IS_SINGLE_NODE
-  }
-  if (once) {
-    flags |= VaporVForFlags.ONCE
-  }
-  if (slotRoot) {
-    flags |= VaporVForFlags.SLOT_ROOT
-  }
+  const flags = genForFlags(
+    onlyChild,
+    component,
+    isFragmentBlock(render),
+    !component && isSingleNodeBlock(render),
+    once,
+    slotRoot,
+  )
 
   const onResetCalls: CodeFragment[] = []
   for (let i = 0; i < selectorPatterns.length; i++) {
@@ -175,7 +164,7 @@ export function genFor(
       sourceExpr,
       blockFn,
       genCallback(keyProp),
-      flags ? String(flags) : undefined,
+      flags,
     ),
     ...onResetCalls,
   ]
@@ -206,6 +195,49 @@ export function genFor(
     idToPathMap.forEach((_, id) => (idMap[id] = null))
     return idMap
   }
+}
+
+function genForFlags(
+  onlyChild: boolean | undefined,
+  component: boolean | undefined,
+  isFragment: boolean,
+  isSingleNode: boolean,
+  once: boolean | undefined,
+  slotRoot: boolean | undefined,
+): string | undefined {
+  let flags = 0
+  const names: string[] = []
+
+  if (onlyChild) {
+    flags |= VaporVForFlags.FAST_REMOVE
+    names.push('FAST_REMOVE')
+  }
+  if (component) {
+    flags |= VaporVForFlags.IS_COMPONENT
+    names.push('IS_COMPONENT')
+  }
+  if (isFragment) {
+    flags |= VaporVForFlags.IS_FRAGMENT
+    names.push('IS_FRAGMENT')
+  }
+  if (isSingleNode) {
+    flags |= VaporVForFlags.IS_SINGLE_NODE
+    names.push('IS_SINGLE_NODE')
+  }
+  if (once) {
+    flags |= VaporVForFlags.ONCE
+    names.push('ONCE')
+  }
+  if (slotRoot) {
+    flags |= VaporVForFlags.SLOT_ROOT
+    names.push('SLOT_ROOT')
+  }
+
+  if (!flags) {
+    return undefined
+  }
+
+  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
 }
 
 function isSingleNodeBlock(block: BlockIRNode): boolean {

--- a/packages/compiler-vapor/src/generators/if.ts
+++ b/packages/compiler-vapor/src/generators/if.ts
@@ -87,12 +87,18 @@ function genIfFlagNames(
   index: number | undefined,
   blockShape: number,
 ): string {
-  const names = ['BLOCK_SHAPE']
+  const names = [`TRUE_${genBlockShapeName(blockShape)}`]
+  const falseShape = blockShape >> 2
+  const hasFalseBranch = (falseShape & 0b11) !== VaporBlockShape.EMPTY
+
+  if (hasFalseBranch) {
+    names.push(`FALSE_${genBlockShapeName(falseShape)}`)
+  }
 
   if (blockShape & VaporIfFlags.TRUE_NO_SCOPE) {
     names.push('TRUE_NO_SCOPE')
   }
-  if (blockShape & VaporIfFlags.FALSE_NO_SCOPE) {
+  if (hasFalseBranch && blockShape & VaporIfFlags.FALSE_NO_SCOPE) {
     names.push('FALSE_NO_SCOPE')
   }
 
@@ -103,8 +109,20 @@ function genIfFlagNames(
     names.push('SLOT_ROOT')
   }
   if (!once && index !== undefined) {
-    names.push('INDEX_SHIFT')
+    names.push(`KEYED_INDEX_${index}`)
   }
 
   return names.join(', ')
+}
+
+function genBlockShapeName(flags: number): string {
+  switch (flags & 0b11) {
+    case VaporBlockShape.EMPTY:
+      return 'EMPTY'
+    case VaporBlockShape.SINGLE_ROOT:
+      return 'SINGLE_ROOT'
+    case VaporBlockShape.MULTI_ROOT:
+      return 'MULTI_ROOT'
+  }
+  return 'UNKNOWN'
 }

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -1,5 +1,6 @@
 import type { CodegenContext } from '../generate'
 import type { SlotOutletIRNode } from '../ir'
+import { VaporSlotFlags } from '@vue/shared'
 import { genBlock, markSlotRootOperations } from './block'
 import { genExpression } from './expression'
 import { type CodeFragment, NEWLINE, buildCodeFragment, genCall } from './utils'
@@ -43,9 +44,28 @@ export function genSlotOutlet(
       nameArg,
       rawPropsArg,
       fallbackArg,
-      flags ? String(flags) : undefined,
+      genSlotFlags(flags),
     ),
   )
 
   return frag
+}
+
+function genSlotFlags(flags: number): string | undefined {
+  if (!flags) {
+    return undefined
+  }
+
+  const names: string[] = []
+  if (flags & VaporSlotFlags.NO_SLOTTED) {
+    names.push('NO_SLOTTED')
+  }
+  if (flags & VaporSlotFlags.ONCE) {
+    names.push('ONCE')
+  }
+  if (flags & VaporSlotFlags.SLOT_ROOT) {
+    names.push('SLOT_ROOT')
+  }
+
+  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
 }

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -1,6 +1,6 @@
 import type { CodegenContext } from '../generate'
 import type { SlotOutletIRNode } from '../ir'
-import { genBlock } from './block'
+import { genBlock, markSlotRootOperations } from './block'
 import { genExpression } from './expression'
 import { type CodeFragment, NEWLINE, buildCodeFragment, genCall } from './utils'
 import { genRawProps } from './component'
@@ -15,6 +15,10 @@ export function genSlotOutlet(
 
   let fallbackArg: CodeFragment[] | undefined
   if (fallback) {
+    if (context.inSlotBlock) {
+      // Forwarded fallback validity affects the owning slot's exposed branch;
+      markSlotRootOperations(fallback)
+    }
     fallbackArg = genBlock(fallback, context)
   }
   const createSlot = helper('createSlot')

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -1,6 +1,6 @@
 import type { CodegenContext } from '../generate'
 import type { SlotOutletIRNode } from '../ir'
-import { genBlock, markSlotRootOperations } from './block'
+import { genBlock } from './block'
 import { genExpression } from './expression'
 import { type CodeFragment, NEWLINE, buildCodeFragment, genCall } from './utils'
 import { genRawProps } from './component'
@@ -15,7 +15,6 @@ export function genSlotOutlet(
 
   let fallbackArg: CodeFragment[] | undefined
   if (fallback) {
-    markSlotRootOperations(fallback)
     fallbackArg = genBlock(fallback, context)
   }
   const createSlot = helper('createSlot')

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1175,6 +1175,49 @@ describe('component: slots', () => {
       app.unmount()
     })
 
+    test('updates fallback body DOM without dirtying parent slot content', async () => {
+      const data = ref(false)
+      const Outer = compile(
+        `<template><slot><span>outer fallback</span></slot></template>`,
+        data,
+      )
+      const Child = compile(
+        `<template>
+          <slot>
+            <span>child fallback<i v-if="data"> detail</i></span>
+          </slot>
+        </template>`,
+        data,
+      )
+      const App = compile(
+        `<template>
+          <components.Outer>
+            <components.Child>
+              <span v-if="false">content</span>
+            </components.Child>
+          </components.Outer>
+        </template>`,
+        data,
+        { Outer, Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toContain('child fallback')
+      expect(root.innerHTML).not.toContain('outer fallback')
+      expect(root.innerHTML).not.toContain('<i>')
+
+      data.value = true
+      await nextTick()
+
+      expect(root.innerHTML).toContain('child fallback')
+      expect(root.innerHTML).toContain('<i> detail</i>')
+      expect(root.innerHTML).not.toContain('outer fallback')
+
+      app.unmount()
+    })
+
     test('vdom slot dirties parent boundary when content validity changes', async () => {
       const show = ref(true)
       const boundary = {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1133,6 +1133,48 @@ describe('component: slots', () => {
       app.unmount()
     })
 
+    test('propagates root forwarded slot exposed validity', async () => {
+      const data = ref(true)
+      const Outer = compile(
+        `<template><slot><span>outer fallback</span></slot></template>`,
+        data,
+      )
+      const Parent = compile(
+        `<template>
+          <components.Outer>
+            <slot>
+              <span v-if="data">forwarded fallback</span>
+            </slot>
+          </components.Outer>
+        </template>`,
+        data,
+        { Outer },
+      )
+      const App = compile(
+        `<template>
+          <components.Parent>
+            <span v-if="false">content</span>
+          </components.Parent>
+        </template>`,
+        data,
+        { Parent },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toContain('<span>forwarded fallback</span>')
+      expect(root.innerHTML).not.toContain('outer fallback')
+
+      data.value = false
+      await nextTick()
+
+      expect(root.innerHTML).toContain('<span>outer fallback</span>')
+      expect(root.innerHTML).not.toContain('forwarded fallback')
+
+      app.unmount()
+    })
+
     test('vdom slot dirties parent boundary when content validity changes', async () => {
       const show = ref(true)
       const boundary = {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1089,6 +1089,50 @@ describe('component: slots', () => {
       app.unmount()
     })
 
+    test('compiled forwarded slot fallback validity re-resolves inherited fallback', async () => {
+      const data = ref(false)
+      const Child = compile(
+        `<template><slot><span>child fallback</span></slot></template>`,
+        data,
+      )
+      const Parent = compile(
+        `<template>
+          <components.Child>
+            <slot>
+              <span v-if="data">parent fallback</span>
+            </slot>
+          </components.Child>
+        </template>`,
+        data,
+        { Child },
+      )
+      const App = compile(
+        `<template>
+          <components.Parent>
+            <span v-if="data && false">content</span>
+          </components.Parent>
+        </template>`,
+        data,
+        { Parent },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe(
+        '<span>child fallback</span><!--slot--><!--slot-->',
+      )
+
+      data.value = true
+      await nextTick()
+
+      expect(root.innerHTML).toBe(
+        '<span>parent fallback</span><!--if--><!--slot--><!--slot-->',
+      )
+
+      app.unmount()
+    })
+
     test('vdom slot dirties parent boundary when content validity changes', async () => {
       const show = ref(true)
       const boundary = {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -2674,6 +2674,72 @@ describe('component: slots', () => {
           expect(slotBlock).not.toBeInstanceOf(SlotFragment)
           expect(host.innerHTML).not.toContain('fallback')
         })
+
+        test('compiled stable sibling keeps fallback hidden when dynamic sibling becomes invalid', async () => {
+          const show = ref(true)
+          const Child = compile(
+            `<template><slot><span>fallback</span></slot></template>`,
+            show,
+          )
+          const Parent = compile(
+            `<template>
+              <components.Child>
+                <span>stable</span>
+                <div v-if="data">dynamic</div>
+              </components.Child>
+            </template>`,
+            show,
+            { Child },
+          )
+          const root = document.createElement('div')
+          const app = createVaporApp(Parent)
+          app.mount(root)
+
+          expect(root.innerHTML).toBe(
+            '<span>stable</span><div>dynamic</div><!--if--><!--slot-->',
+          )
+
+          show.value = false
+          await nextTick()
+
+          expect(root.innerHTML).toBe('<span>stable</span><!--if--><!--slot-->')
+        })
+
+        test('compiled component root keeps fallback hidden when component output becomes invalid', async () => {
+          const show = ref(true)
+          const Child = compile(
+            `<template><slot><span>fallback</span></slot></template>`,
+            show,
+          )
+          const Inner = compile(
+            `<script setup>
+              const props = defineProps(['show'])
+            </script>
+            <template>
+              <span v-if="props.show">inner</span>
+            </template>`,
+            show,
+          )
+          const Parent = compile(
+            `<template>
+              <components.Child>
+                <components.Inner :show="data" />
+              </components.Child>
+            </template>`,
+            show,
+            { Child, Inner },
+          )
+          const root = document.createElement('div')
+          const app = createVaporApp(Parent)
+          app.mount(root)
+
+          expect(root.innerHTML).toBe('<span>inner</span><!--if--><!--slot-->')
+
+          show.value = false
+          await nextTick()
+
+          expect(root.innerHTML).toBe('<!--if--><!--slot-->')
+        })
       })
 
       describe('hydration', () => {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -116,7 +116,7 @@ function createTestSlotResolutionState(options: {
   const boundary: SlotBoundaryContext = {
     parent: null,
     getFallback: () => options.fallback,
-    run: fn => fn(),
+    run: (fn, scope) => (scope ? scope.run(fn)! : fn()),
     markDirty: () => markSlotResolutionDirty(state),
   }
   state = {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -2784,6 +2784,92 @@ describe('component: slots', () => {
 
           expect(root.innerHTML).toBe('<!--if--><!--slot-->')
         })
+
+        test('recomputes validity for all-dynamic multi-root slot content', async () => {
+          const data = ref('both')
+          const Child = compile(
+            `<template><slot><span>fallback</span></slot></template>`,
+            data,
+          )
+          const Parent = compile(
+            `<template>
+              <components.Child>
+                <span v-if="data !== 'none' && data !== 'second'">first</span>
+                <div v-if="data !== 'none' && data !== 'first'">second</div>
+              </components.Child>
+            </template>`,
+            data,
+            { Child },
+          )
+          const root = document.createElement('div')
+          const app = createVaporApp(Parent)
+          app.mount(root)
+
+          expect(root.innerHTML).toContain('<span>first</span>')
+          expect(root.innerHTML).toContain('<div>second</div>')
+          expect(root.innerHTML).not.toContain('fallback')
+
+          data.value = 'first'
+          await nextTick()
+
+          expect(root.innerHTML).toContain('<span>first</span>')
+          expect(root.innerHTML).not.toContain('second')
+          expect(root.innerHTML).not.toContain('fallback')
+
+          data.value = 'none'
+          await nextTick()
+
+          expect(root.innerHTML).toBe('<span>fallback</span><!--slot-->')
+
+          data.value = 'second'
+          await nextTick()
+
+          expect(root.innerHTML).toContain('<div>second</div>')
+          expect(root.innerHTML).not.toContain('first')
+          expect(root.innerHTML).not.toContain('fallback')
+        })
+
+        test('recomputes validity for v-for and v-if slot roots', async () => {
+          const data = ref({ items: ['one'], show: true })
+          const Child = compile(
+            `<template><slot><span>fallback</span></slot></template>`,
+            data,
+          )
+          const Parent = compile(
+            `<template>
+              <components.Child>
+                <span v-for="item in data.items">{{ item }}</span>
+                <div v-if="data.show">tail</div>
+              </components.Child>
+            </template>`,
+            data,
+            { Child },
+          )
+          const root = document.createElement('div')
+          const app = createVaporApp(Parent)
+          app.mount(root)
+
+          expect(root.innerHTML).toContain('<span>one</span>')
+          expect(root.innerHTML).toContain('<div>tail</div>')
+          expect(root.innerHTML).not.toContain('fallback')
+
+          data.value = { items: [], show: true }
+          await nextTick()
+
+          expect(root.innerHTML).toContain('<div>tail</div>')
+          expect(root.innerHTML).not.toContain('fallback')
+
+          data.value = { items: [], show: false }
+          await nextTick()
+
+          expect(root.innerHTML).toBe('<span>fallback</span><!--slot-->')
+
+          data.value = { items: ['two'], show: false }
+          await nextTick()
+
+          expect(root.innerHTML).toContain('<span>two</span>')
+          expect(root.innerHTML).not.toContain('fallback')
+        })
       })
 
       describe('hydration', () => {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -62,9 +62,9 @@ import {
   withSlotBoundary,
 } from '../src/slotBoundary'
 import {
-  type SlotFallbackState,
-  markSlotFallbackDirty,
-  recheckSlotFallback,
+  type SlotResolutionState,
+  markSlotResolutionDirty,
+  recheckSlotResolution,
 } from '../src/slotFragment'
 import {
   getCurrentSlotEndAnchor,
@@ -103,7 +103,7 @@ function renderWithSlots(slots: any): any {
   return instance
 }
 
-function createTestSlotFallbackState(options: {
+function createTestSlotResolutionState(options: {
   fallback?: BlockFn
   content?: Block
   parentNode?: ParentNode | null
@@ -111,13 +111,13 @@ function createTestSlotFallbackState(options: {
   isBusy?: () => boolean
   isContentValid?: () => boolean
   isDisposed?: () => boolean
-}): SlotFallbackState {
-  let state!: SlotFallbackState
+}): SlotResolutionState {
+  let state!: SlotResolutionState
   const boundary: SlotBoundaryContext = {
     parent: null,
     getFallback: () => options.fallback,
     run: fn => fn(),
-    markDirty: () => markSlotFallbackDirty(state),
+    markDirty: () => markSlotResolutionDirty(state),
   }
   state = {
     boundary,
@@ -132,7 +132,7 @@ function createTestSlotFallbackState(options: {
     isContentValid:
       options.isContentValid || (() => isValidBlock(options.content || [])),
     syncNodes: () => {},
-    notifyFallbackValidityChange: vi.fn(),
+    notifyExposedValidityChange: vi.fn(),
   }
   return state
 }
@@ -446,7 +446,7 @@ describe('component: slots', () => {
       const container = document.createElement('div')
       const anchor = document.createComment('slot')
       const showLocal = ref(false)
-      let state!: SlotFallbackState
+      let state!: SlotResolutionState
       const parentBoundary: SlotBoundaryContext = {
         parent: null,
         getFallback: () => () => document.createTextNode('parent fallback'),
@@ -463,7 +463,7 @@ describe('component: slots', () => {
             keyedSlotRootIfShape,
           ),
         run: fn => fn(),
-        markDirty: () => markSlotFallbackDirty(state),
+        markDirty: () => markSlotResolutionDirty(state),
       }
       state = {
         boundary,
@@ -477,11 +477,11 @@ describe('component: slots', () => {
         isDisposed: () => false,
         isContentValid: () => false,
         syncNodes: () => {},
-        notifyFallbackValidityChange: vi.fn(),
+        notifyExposedValidityChange: vi.fn(),
       }
 
       container.append(anchor)
-      recheckSlotFallback(state)
+      recheckSlotResolution(state)
 
       expect(container.innerHTML).toBe('parent fallback<!--slot-->')
 
@@ -496,7 +496,7 @@ describe('component: slots', () => {
       const anchor = document.createComment('slot')
       let localFallback: BlockFn | undefined = () =>
         document.createTextNode('local fallback')
-      let state!: SlotFallbackState
+      let state!: SlotResolutionState
       const parentBoundary: SlotBoundaryContext = {
         parent: null,
         getFallback: () => () => document.createTextNode('parent fallback'),
@@ -507,7 +507,7 @@ describe('component: slots', () => {
         parent: parentBoundary,
         getFallback: () => localFallback,
         run: fn => fn(),
-        markDirty: () => markSlotFallbackDirty(state),
+        markDirty: () => markSlotResolutionDirty(state),
       }
       state = {
         boundary,
@@ -521,15 +521,15 @@ describe('component: slots', () => {
         isDisposed: () => false,
         isContentValid: () => false,
         syncNodes: () => {},
-        notifyFallbackValidityChange: vi.fn(),
+        notifyExposedValidityChange: vi.fn(),
       }
 
       container.append(anchor)
-      recheckSlotFallback(state)
+      recheckSlotResolution(state)
       expect(container.innerHTML).toBe('local fallback<!--slot-->')
 
       localFallback = undefined
-      recheckSlotFallback(state, true)
+      recheckSlotResolution(state, true)
       expect(container.innerHTML).toBe('parent fallback<!--slot-->')
     })
 
@@ -718,9 +718,9 @@ describe('component: slots', () => {
       expect(markDirty).toHaveBeenCalledTimes(2)
     })
 
-    test('slot fallback state ignores dirty notifications after dispose', () => {
+    test('slot resolution state ignores dirty notifications after dispose', () => {
       let disposed = false
-      const state = createTestSlotFallbackState({
+      const state = createTestSlotResolutionState({
         isDisposed: () => disposed,
       })
 
@@ -730,7 +730,7 @@ describe('component: slots', () => {
       expect(state.pendingRecheck).toBe(false)
     })
 
-    test('removed slot fragment ignores queued fallback dirty notifications', () => {
+    test('removed slot fragment ignores queued resolution dirty notifications', () => {
       const container = document.createElement('div')
       const fallbackRuns = vi.fn()
       const cleanup = vi.fn()
@@ -902,13 +902,13 @@ describe('component: slots', () => {
       expect(frag.anchor).toBe(end.previousSibling)
     })
 
-    test('slot fallback state stops fallback scope when fallback body throws', async () => {
+    test('slot resolution state stops fallback scope when fallback body throws', async () => {
       const source = ref(0)
       const effectRuns = vi.fn()
       const cleanup = vi.fn()
       const err = new Error('fallback boom')
 
-      const state = createTestSlotFallbackState({
+      const state = createTestSlotResolutionState({
         fallback: () => {
           onScopeDispose(cleanup)
           renderEffect(() => {
@@ -918,7 +918,7 @@ describe('component: slots', () => {
         },
       })
 
-      expect(() => recheckSlotFallback(state)).toThrow(err)
+      expect(() => recheckSlotResolution(state)).toThrow(err)
       expect(state.activeFallback).toBe(null)
       expect(cleanup).toHaveBeenCalledTimes(1)
       expect(effectRuns).toHaveBeenCalledTimes(1)
@@ -929,9 +929,9 @@ describe('component: slots', () => {
       expect(effectRuns).toHaveBeenCalledTimes(1)
     })
 
-    test('slot fallback state rechecks when idle', () => {
+    test('slot resolution state rechecks when idle', () => {
       const fallback = document.createTextNode('fallback')
-      const state = createTestSlotFallbackState({
+      const state = createTestSlotResolutionState({
         fallback: () => fallback,
       })
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -47,14 +47,19 @@ import {
 import { compile, makeRender } from './_utils'
 import type { DynamicSlot } from '../src/componentSlots'
 import { setElementText, setText } from '../src/dom/prop'
-import { type Block, type BlockFn, isValidBlock } from '../src/block'
+import {
+  type Block,
+  type BlockFn,
+  isValidBlock,
+  isValidSlot,
+} from '../src/block'
 import {
   hydrateNode,
   isHydrationAnchor,
   setCurrentHydrationNode,
   setIsHydratingEnabled,
 } from '../src/dom/hydration'
-import { DynamicFragment, SlotFragment, VaporFragment } from '../src/fragment'
+import { DynamicFragment, SlotFragment } from '../src/fragment'
 import {
   type SlotBoundaryContext,
   currentSlotBoundary,
@@ -130,7 +135,7 @@ function createTestSlotResolutionState(options: {
     isBusy: options.isBusy || (() => false),
     isDisposed: options.isDisposed || (() => false),
     isContentValid:
-      options.isContentValid || (() => isValidBlock(options.content || [])),
+      options.isContentValid || (() => isValidSlot(options.content || [])),
     syncNodes: () => {},
     notifyExposedValidityChange: vi.fn(),
   }
@@ -230,14 +235,6 @@ describe('component: slots', () => {
       const frag = new SlotFragment()
 
       frag.updateSlot(undefined, () => document.createTextNode('fallback'))
-
-      expect(isValidBlock(frag)).toBe(true)
-    })
-
-    test('slot fragment validityPending takes precedence over effective output', () => {
-      const frag = new SlotFragment()
-
-      frag.validityPending = true
 
       expect(isValidBlock(frag)).toBe(true)
     })
@@ -531,31 +528,6 @@ describe('component: slots', () => {
       localFallback = undefined
       recheckSlotResolution(state, true)
       expect(container.innerHTML).toBe('parent fallback<!--slot-->')
-    })
-
-    test('slot fragment delays fallback activation until pending child validity resolves', () => {
-      const container = document.createElement('div')
-      const frag = new SlotFragment()
-      let child!: VaporFragment
-
-      frag.updateSlot(
-        () => {
-          child = new VaporFragment([])
-          child.validityPending = true
-          trackSlotBoundaryDirtying(child)
-          return child
-        },
-        () => document.createTextNode('fallback'),
-      )
-      insert(frag, container)
-
-      expect(container.innerHTML).toBe('<!--slot-->')
-
-      child.validityPending = false
-      child.nodes = []
-      child.onUpdated!.forEach(hook => hook())
-
-      expect(container.innerHTML).toBe('fallback<!--slot-->')
     })
 
     test('slot boundary dirtying ignores non-root v-if updates', async () => {
@@ -2870,6 +2842,37 @@ describe('component: slots', () => {
           expect(root.innerHTML).toBe('<!--if--><!--slot-->')
         })
 
+        test('compiled root v-if component slot hides fallback when shown even if component output is empty', async () => {
+          const show = ref(false)
+          const Child = compile(
+            `<template><slot><span>fallback</span></slot></template>`,
+            show,
+          )
+          const Empty = compile(
+            `<template><span v-if="false">empty</span></template>`,
+            show,
+          )
+          const Parent = compile(
+            `<template>
+              <components.Child>
+                <components.Empty v-if="data" />
+              </components.Child>
+            </template>`,
+            show,
+            { Child, Empty },
+          )
+          const root = document.createElement('div')
+          const app = createVaporApp(Parent)
+          app.mount(root)
+
+          expect(root.innerHTML).toBe('<span>fallback</span><!--slot-->')
+
+          show.value = true
+          await nextTick()
+
+          expect(root.innerHTML).toBe('<!--if--><!--if--><!--slot-->')
+        })
+
         test('recomputes validity for all-dynamic multi-root slot content', async () => {
           const data = ref('both')
           const Child = compile(
@@ -4283,7 +4286,7 @@ describe('component: slots', () => {
         expect(mountSpy).toHaveBeenCalledTimes(1)
       })
 
-      test('vdom fallback added over valid forwarded vapor content should activate later when content becomes invalid', async () => {
+      test('vdom fallback added over forwarded vapor component content stays hidden when component output becomes invalid', async () => {
         const useFallback = ref(false)
         const showContent = ref(true)
         const mountSpy = vi.fn()
@@ -4336,7 +4339,7 @@ describe('component: slots', () => {
 
         showContent.value = false
         await nextTick()
-        expect(root.innerHTML).toBe('<div>fallback</div>')
+        expect(root.innerHTML).toBe('<!--if-->')
         expect(mountSpy).toHaveBeenCalledTimes(1)
       })
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -57,9 +57,9 @@ import {
 import { DynamicFragment, SlotFragment, VaporFragment } from '../src/fragment'
 import {
   type SlotBoundaryContext,
-  getCurrentSlotBoundary,
+  currentSlotBoundary,
   trackSlotBoundaryDirtying,
-  withOwnedSlotBoundary,
+  withSlotBoundary,
 } from '../src/slotBoundary'
 import {
   type SlotFallbackState,
@@ -264,58 +264,56 @@ describe('component: slots', () => {
       const inheritedFallback = vi.fn(() =>
         document.createTextNode('inherited fallback'),
       )
-      const frag = new SlotFragment()
-      frag.parentSlotBoundary = {
+      const parentBoundary: SlotBoundaryContext = {
         parent: null,
         getFallback: () => inheritedFallback,
         run: fn => fn(),
         markDirty: vi.fn(),
       }
+      const frag = withSlotBoundary(parentBoundary, () => new SlotFragment())
 
       frag.updateSlot(undefined, localFallback)
 
-      expect(frag.fallbackBlock).toBeInstanceOf(Text)
-      expect((frag.fallbackBlock as Text).textContent).toBe('local fallback')
+      expect(frag.activeFallback).toBeInstanceOf(Text)
+      expect((frag.activeFallback as Text).textContent).toBe('local fallback')
       expect(localFallback).toHaveBeenCalled()
       expect(inheritedFallback).not.toHaveBeenCalled()
     })
 
     test('slot fragment local fallback renders nested slots against the parent boundary', () => {
-      const parentBoundary = {
+      const parentBoundary: SlotBoundaryContext = {
         parent: null,
         getFallback: () => () => document.createTextNode('outer fallback'),
         run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
-      const frag = new SlotFragment()
-      frag.parentSlotBoundary = parentBoundary
+      const frag = withSlotBoundary(parentBoundary, () => new SlotFragment())
       let fallbackBoundary: any
 
       frag.updateSlot(undefined, () => {
-        fallbackBoundary = getCurrentSlotBoundary()
+        fallbackBoundary = currentSlotBoundary
         return []
       })
 
       // Fallback body renders under a redirected boundary whose `.parent` is
       // the owning boundary's parent — so nested slots inherit from the
       // grandparent, avoiding fallback -> <slot> -> same fallback recursion.
-      expect(fallbackBoundary).not.toBe(frag.slotFallbackBoundary)
+      expect(fallbackBoundary).not.toBe(frag.boundary)
       expect(fallbackBoundary.parent).toBe(parentBoundary)
     })
 
     test('slot fragment local fallback keeps itself as owner for nested fragments', () => {
       const container = document.createElement('div')
-      const parentBoundary = {
+      const parentBoundary: SlotBoundaryContext = {
         parent: null,
         getFallback: () => () => document.createTextNode('outer fallback'),
         run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
-      const frag = new SlotFragment()
+      const frag = withSlotBoundary(parentBoundary, () => new SlotFragment())
       const child = new DynamicFragment('if', false, false)
       let initialized = false
 
-      frag.parentSlotBoundary = parentBoundary
       frag.updateSlot(undefined, () => {
         if (!initialized) {
           initialized = true
@@ -339,14 +337,13 @@ describe('component: slots', () => {
         document.createTextNode('local fallback'),
       )
       const container = document.createElement('div')
-      const frag = new SlotFragment()
-      const parentBoundary = {
+      const parentBoundary: SlotBoundaryContext = {
         parent: null,
         getFallback: () => () => document.createTextNode(ancestorText.value),
         run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
-      frag.parentSlotBoundary = parentBoundary
+      const frag = withSlotBoundary(parentBoundary, () => new SlotFragment())
 
       frag.updateSlot(undefined, localFallback)
       insert(frag, container)
@@ -571,7 +568,7 @@ describe('component: slots', () => {
         markDirty,
       }
       const Child = defineVaporComponent(() =>
-        withOwnedSlotBoundary(boundary, () =>
+        withSlotBoundary(boundary, () =>
           createIf(
             () => show.value,
             () => document.createTextNode('content'),
@@ -598,7 +595,7 @@ describe('component: slots', () => {
         markDirty,
       }
       const Child = defineVaporComponent(() =>
-        withOwnedSlotBoundary(boundary, () =>
+        withSlotBoundary(boundary, () =>
           createFor(
             () => items.value,
             item => document.createTextNode(String(item.value)),
@@ -623,7 +620,7 @@ describe('component: slots', () => {
         markDirty,
       }
       const Child = defineVaporComponent(() =>
-        withOwnedSlotBoundary(boundary, () =>
+        withSlotBoundary(boundary, () =>
           createIf(
             () => show.value,
             () => document.createTextNode('content'),
@@ -655,7 +652,7 @@ describe('component: slots', () => {
         markDirty,
       }
       const Child = defineVaporComponent(() =>
-        withOwnedSlotBoundary(boundary, () =>
+        withSlotBoundary(boundary, () =>
           createFor(
             () => items.value,
             item => document.createTextNode(String(item.value)),
@@ -687,7 +684,7 @@ describe('component: slots', () => {
         markDirty,
       }
       const Child = defineVaporComponent(() =>
-        withOwnedSlotBoundary(boundary, () =>
+        withSlotBoundary(boundary, () =>
           createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT),
         ),
       )
@@ -754,7 +751,7 @@ describe('component: slots', () => {
       frag.boundary.markDirty()
 
       expect(fallbackRuns).toHaveBeenCalledTimes(1)
-      expect(frag.fallbackBlock).toBe(null)
+      expect(frag.activeFallback).toBe(null)
       expect(cleanup).toHaveBeenCalledTimes(1)
     })
 
@@ -958,7 +955,7 @@ describe('component: slots', () => {
       const slotsRef = shallowRef({
         default: () => [h('div', text.value)],
       })
-      const frag = withOwnedSlotBoundary(boundary, () =>
+      const frag = withSlotBoundary(boundary, () =>
         vapor.vdomSlot(
           slotsRef,
           'default',
@@ -996,7 +993,7 @@ describe('component: slots', () => {
       const slotsRef = shallowRef({
         default: () => [h('div', text.value)],
       })
-      const frag = withOwnedSlotBoundary(boundary, () =>
+      const frag = withSlotBoundary(boundary, () =>
         vapor.vdomSlot(slotsRef, 'default', {}, instance),
       )
       const host = document.createElement('div')
@@ -1026,7 +1023,7 @@ describe('component: slots', () => {
       const slotsRef = shallowRef({
         default: () => (show.value ? [h('div', 'content')] : []),
       })
-      const frag = withOwnedSlotBoundary(boundary, () =>
+      const frag = withSlotBoundary(boundary, () =>
         vapor.vdomSlot(
           slotsRef,
           'default',
@@ -1107,7 +1104,7 @@ describe('component: slots', () => {
       const slotsRef = shallowRef({
         default: () => (show.value ? [h('div', 'content')] : []),
       })
-      const frag = withOwnedSlotBoundary(boundary, () =>
+      const frag = withSlotBoundary(boundary, () =>
         vapor.vdomSlot(
           slotsRef,
           'default',
@@ -1162,7 +1159,7 @@ describe('component: slots', () => {
         })
         return child
       }
-      const frag = withOwnedSlotBoundary(boundary, () =>
+      const frag = withSlotBoundary(boundary, () =>
         vapor.vdomSlot(
           slotsRef,
           'default',
@@ -2574,7 +2571,7 @@ describe('component: slots', () => {
           define(() =>
             createComponent(Comp, null, {
               default: () => {
-                observedBoundary = getCurrentSlotBoundary()
+                observedBoundary = currentSlotBoundary
                 return template('content')()
               },
             }),

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -3690,7 +3690,7 @@ describe('Vapor Mode hydration', () => {
         "
         <!--[-->
         <!--[--><!--]-->
-        <!--for--><i>tail</i><!--]-->
+        <i>tail</i><!--]-->
         "
       `,
       )
@@ -3703,8 +3703,8 @@ describe('Vapor Mode hydration', () => {
         `
         "
         <!--[-->
-        <!--[--><!--]-->
-        <span>foo</span><span>bar</span><!--for--><i>tail</i><!--]-->
+        <!--[--><span>foo</span><span>bar</span><!--]-->
+        <i>tail</i><!--]-->
         "
       `,
       )
@@ -3715,8 +3715,8 @@ describe('Vapor Mode hydration', () => {
         `
         "
         <!--[-->
-        <!--[--><!--]-->
-        <span>foo</span><span>bar</span><!--for--><i>tail2</i><!--]-->
+        <!--[--><span>foo</span><span>bar</span><!--]-->
+        <i>tail2</i><!--]-->
         "
       `,
       )
@@ -3857,14 +3857,14 @@ describe('Vapor Mode hydration', () => {
 
       expect(`Hydration node mismatch`).not.toHaveBeenWarned()
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
-      	"
-      	<!--[-->
-      	<!--[-->
-      	<!--[--><!----><!--]-->
-      	<!--[--><!----><!--]-->
-      	<!--for--><!--]-->
-      	<i>tail</i><!--]-->
-      	"
+        "
+        <!--[-->
+        <!--[-->
+        <!--[--><!----><!--]-->
+        <!--[--><!----><!--]-->
+        <!--]-->
+        <i>tail</i><!--]-->
+        "
       `)
 
       data.items.push({ text: 'c', show: true })
@@ -3872,14 +3872,14 @@ describe('Vapor Mode hydration', () => {
 
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
-      	"
-      	<!--[-->
-      	<!--[-->
-      	<!--[--><!----><!--]-->
-      	<!--[--><!----><!--]-->
-      	<span>c</span><!--if--><!--for--><!--]-->
-      	<i>tail</i><!--]-->
-      	"
+        "
+        <!--[-->
+        <!--[-->
+        <!--[--><!----><!--]-->
+        <!--[--><!----><!--]-->
+        <span>c</span><!--if--><!--]-->
+        <i>tail</i><!--]-->
+        "
       `,
       )
 
@@ -3893,7 +3893,7 @@ describe('Vapor Mode hydration', () => {
         <!--[-->
         <!--[--><!----><!--]-->
         <!--[--><span>b</span><!----><!--]-->
-        <span>c</span><!--if--><!--for--><!--]-->
+        <span>c</span><!--if--><!--]-->
         <i>tail</i><!--]-->
         "
       `,

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -11009,6 +11009,61 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toBe('<div>content</div>')
   })
 
+  test('hydrate compiled VDOM slot child keeps owner root current after branch update', async () => {
+    const data = reactive({
+      child: 'span',
+      show: true,
+    })
+    const { container } = await testWithVDOMApp(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.VaporChild v-if="data.show">
+          <components.VdomChild />
+        </components.VaporChild>
+      </template>`,
+      {
+        VaporChild: {
+          code: `<template><slot /></template>`,
+          vapor: true,
+        },
+        VdomChild: {
+          code: `<script setup>const data = _data</script>
+            <template>
+              <span v-if="data.child === 'span'">span</span>
+              <div v-else>div</div>
+            </template>`,
+          vapor: false,
+        },
+      },
+      data,
+    )
+
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "
+      <!--[--><span>span</span><!--]-->
+      "
+    `)
+
+    data.child = 'div'
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "
+      <!--[--><div>div</div><!--]-->
+      "
+    `)
+
+    data.show = false
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toBe('<!--v-if-->')
+
+    data.show = true
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toBe('<div>div</div>')
+  })
+
   test('hydrate VDOM slot content can mount after hydrating as empty', async () => {
     const data = reactive({
       show: false,

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -204,8 +204,9 @@ describe('vdomInterop', () => {
       const host = document.createElement('div')
       app.mount(host)
 
-      const onUpdated = vi.fn()
-      frag.onUpdated = [onUpdated]
+      const calls: string[] = []
+      frag.onBeforeUpdate = [() => calls.push('beforeUpdate')]
+      frag.onUpdated = [() => calls.push('updated')]
 
       const getNodes = () =>
         (Array.isArray(frag.nodes) ? frag.nodes : [frag.nodes]).filter(Boolean)
@@ -222,7 +223,7 @@ describe('vdomInterop', () => {
       expect(getNodes().some((n: Node) => n instanceof HTMLDivElement)).toBe(
         true,
       )
-      expect(onUpdated).toHaveBeenCalled()
+      expect(calls).toEqual(['beforeUpdate', 'updated'])
     })
 
     test('mounts vnode slot content after active fallback without reusing invalid vnode content', async () => {

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -121,7 +121,6 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         frag.update(() => createInnerComp(resolvedComp!, instance))
         return frag
       }
-      frag.validityPending = true
 
       const onError = (err: Error) => {
         setPendingRequest(null)
@@ -137,7 +136,6 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         return load()
           .then(() => {
             resolvedComp = getResolvedComp()
-            frag.validityPending = false
             if (resolvedComp) {
               frag.update(() => createInnerComp(resolvedComp!, instance))
             }
@@ -145,7 +143,6 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
           })
           .catch(err => {
             onError(err)
-            frag.validityPending = false
             if (errorComponent) {
               frag.update(() => createErrorComp(errorComponent, instance, err))
             }
@@ -186,7 +183,6 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
           render = () => createInnerComp(loadingComponent, instance)
         }
 
-        frag.validityPending = !render && !error.value
         frag.update(render)
         // Manually trigger cacheBlock for KeepAlive
         if (isKeepAliveEnabled && frag.keepAliveCtx) {

--- a/packages/runtime-vapor/src/apiDefineCustomElement.ts
+++ b/packages/runtime-vapor/src/apiDefineCustomElement.ts
@@ -26,7 +26,7 @@ import type {
   VaporRenderResult,
 } from './apiDefineComponent'
 import type { StaticSlots } from './componentSlots'
-import { SlotFragment, isFragment } from './fragment'
+import { isFragment, isSlotFragment } from './fragment'
 
 export type VaporElementConstructor<P = {}> = {
   new (initialProps?: Record<string, any>): VaporElement & P
@@ -300,7 +300,7 @@ export class VaporElement extends VueElementBase<
       // current owner rather than a stale DOM snapshot.
       if (
         replacement.usedFallback &&
-        block instanceof SlotFragment &&
+        isSlotFragment(block) &&
         block.customElementFallback
       ) {
         this._updateFragmentNodes(block.customElementFallback, replacements)

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -72,24 +72,33 @@ export function isBlock(val: NonNullable<unknown>): val is Block {
   )
 }
 
-export function isValidBlock(block: Block | null | undefined): boolean {
+export function isValidBlock(
+  block: Block | null | undefined,
+  componentAsValid: boolean = false,
+): boolean {
   if (!block) {
     return false
   } else if (block instanceof Node) {
     return !(block instanceof Comment)
   } else if (isVaporComponent(block)) {
-    return isValidBlock(block.block)
+    return componentAsValid || isValidBlock(block.block, componentAsValid)
   } else if (isArray(block)) {
-    return block.length > 0 && block.some(isValidBlock)
+    return (
+      block.length > 0 &&
+      block.some(block => isValidBlock(block, componentAsValid))
+    )
   } else {
     if (isInteropEnabled && block.isBlockValid) {
       return block.isBlockValid()
     }
-    if (block.validityPending) {
-      return true
-    }
-    return isValidBlock(block.nodes)
+    return isValidBlock(block.nodes, componentAsValid)
   }
+}
+
+// Slot validity follows VDOM fallback semantics: a component root counts as
+// provided content even when its rendered block is empty.
+export function isValidSlot(block: Block | null | undefined): boolean {
+  return isValidBlock(block, true)
 }
 
 export function insert(

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -89,7 +89,7 @@ export function isValidBlock(
     )
   } else {
     if (isInteropEnabled && block.isBlockValid) {
-      return block.isBlockValid()
+      return block.isBlockValid(componentAsValid)
     }
     return isValidBlock(block.nodes, componentAsValid)
   }

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -319,13 +319,8 @@ export function createSlot(
       ? new SlotFragment(slotRoot)
       : undefined
     let dynamicFragment: DynamicFragment | undefined
-    const isForwardedHydrationSlot =
-      isHydrating &&
-      currentSlotOwner != null &&
-      currentSlotOwner !== currentInstance
     if (slotFragment) {
       fragment = slotFragment
-      slotFragment.forwarded = isForwardedHydrationSlot
     } else {
       // Fast path: DynamicFragment is enough, but hydration still enters the
       // slot boundary so it can own the SSR close marker.
@@ -335,9 +330,14 @@ export function createSlot(
         false,
       )
       dynamicFragment.isSlot = true
-      dynamicFragment.forwarded = isForwardedHydrationSlot
       fragment = dynamicFragment
     }
+
+    if (isHydrating) {
+      ;(fragment as DynamicFragment).forwarded =
+        currentSlotOwner != null && currentSlotOwner !== currentInstance
+    }
+
     const isDynamicName = isFunction(name)
 
     const renderSlot = () => {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -39,7 +39,7 @@ import {
   type VaporFragment,
   isInteropFragment,
 } from './fragment'
-import { getCurrentSlotBoundary, withOwnedSlotBoundary } from './slotBoundary'
+import { currentSlotBoundary, withSlotBoundary } from './slotBoundary'
 import { createElement } from './dom/node'
 import { setDynamicProps } from './dom/prop'
 import {
@@ -359,7 +359,7 @@ export function createSlot(
         if (once) setSlotProps()
         else renderEffect(setSlotProps)
         if (fallback) {
-          withOwnedSlotBoundary(slotFragment!.parentSlotBoundary, () => {
+          withSlotBoundary(slotFragment!.parentSlotBoundary, () => {
             const fallbackBlock = fallback()
             // Keep the live fallback block on the SlotFragment itself. The
             // native slot outlet is temporary and gets removed by CE slot
@@ -436,10 +436,6 @@ export function createSlot(
   return fragment
 }
 
-function isNonStableSlot(slot: VaporSlot | undefined): boolean {
-  return !!slot && slot._ === VaporSlotFlags.NON_STABLE
-}
-
 function shouldUseSlotFragment(
   rawSlots: RawSlots,
   name: string | (() => string),
@@ -450,7 +446,7 @@ function shouldUseSlotFragment(
   if (isCustomElementSlot) return true
 
   // Nested fallback resolution must preserve the boundary chain.
-  if (getCurrentSlotBoundary()) return true
+  if (currentSlotBoundary) return true
 
   // Without fallback, there is no fallback branch to track.
   if (!fallback) return false
@@ -466,5 +462,5 @@ function shouldUseSlotFragment(
   if (!slot) return false
 
   // Non-stable slot content can become invalid, making fallback reachable.
-  return isNonStableSlot(slot)
+  return slot._ === VaporSlotFlags.NON_STABLE
 }

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -359,7 +359,7 @@ export function createSlot(
         if (once) setSlotProps()
         else renderEffect(setSlotProps)
         if (fallback) {
-          withSlotBoundary(slotFragment!.parentSlotBoundary, () => {
+          withSlotBoundary(slotFragment!.slotBoundary, () => {
             const fallbackBlock = fallback()
             // Keep the live fallback block on the SlotFragment itself. The
             // native slot outlet is temporary and gets removed by CE slot

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -30,7 +30,7 @@ import { extend, isArray } from '@vue/shared'
 import {
   RenderContextFragment,
   isFragment,
-  runWithFragmentCtx,
+  runWithFragmentCtxOnly,
 } from '../fragment'
 import {
   advanceHydrationNode,
@@ -147,7 +147,7 @@ export class TeleportFragment extends RenderContextFragment {
       // init and slot re-runs, where new nodes capture the ambient context.
       // The equality fast path keeps the synchronous first run free.
       renderEffect(() =>
-        runWithFragmentCtx(this, () =>
+        runWithFragmentCtxOnly(this, () =>
           this.handleChildrenUpdate(
             this.rawSlots && this.rawSlots.default
               ? (this.rawSlots.default as BlockFn)()

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -113,8 +113,7 @@ export class RenderContextFragment<
   readonly renderInstance: GenericComponentInstance | null = currentInstance
   readonly slotOwner: VaporComponentInstance | null = currentSlotOwner
   readonly keepAliveCtx?: VaporKeepAliveContext | null
-  readonly inheritedSlotBoundary: SlotBoundaryContext | null =
-    currentSlotBoundary
+  readonly slotBoundary: SlotBoundaryContext | null = currentSlotBoundary
 
   constructor(nodes: T) {
     super(nodes)
@@ -142,7 +141,7 @@ export function runWithFragmentCtx<R>(
   // restoring. This keeps ordinary branch renders on the cheap path.
   if (
     currentSlotOwner === fragment.slotOwner &&
-    currentSlotBoundary === fragment.inheritedSlotBoundary &&
+    currentSlotBoundary === fragment.slotBoundary &&
     (!isKeepAliveEnabled || currentKeepAliveCtx === keepAliveCtx)
   ) {
     return fn()
@@ -153,7 +152,7 @@ export function runWithFragmentCtx<R>(
   if (isKeepAliveEnabled) {
     prevKeepAliveCtx = setCurrentKeepAliveCtx(keepAliveCtx)
   }
-  const prevBoundary = setCurrentSlotBoundary(fragment.inheritedSlotBoundary)
+  const prevBoundary = setCurrentSlotBoundary(fragment.slotBoundary)
   try {
     return fn()
   } finally {
@@ -441,7 +440,6 @@ export class SlotFragment
   isSlot = true
   private disposed = false
   forwarded = false
-  readonly parentSlotBoundary: SlotBoundaryContext | null = currentSlotBoundary
   // Custom elements with `shadowRoot: false` replace their native slot outlet
   // after mount. Keep the live fallback block on the fragment so CE slot sync
   // can preserve block ownership after the outlet node is gone.
@@ -469,11 +467,8 @@ export class SlotFragment
   }
 
   get boundary(): SlotBoundaryContext {
-    if (this.ownBoundary) {
-      return this.ownBoundary
-    }
-    return (this.ownBoundary = {
-      parent: this.parentSlotBoundary,
+    return (this.ownBoundary ||= {
+      parent: this.slotBoundary,
       getFallback: () => this.localFallback,
       run: (fn, scope) => this.runWithRenderCtx(fn, scope),
       markDirty: () => markSlotResolutionDirty(this),
@@ -595,8 +590,8 @@ export class SlotFragment
   }
 
   notifyExposedValidityChange(): void {
-    if (this.notifyParentBoundary && this.parentSlotBoundary) {
-      this.parentSlotBoundary.markDirty()
+    if (this.notifyParentBoundary && this.slotBoundary) {
+      this.slotBoundary.markDirty()
     }
   }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -229,6 +229,8 @@ export class DynamicFragment extends RenderContextFragment {
   // pure marker consumed by the isSlotFragment predicate; the core update
   // pipeline never reads it.
   isSlot?: boolean
+  // Hydration-only marker consumed by hydrateFragment: empty forwarded slots
+  // leave the SSR close marker to the parent slot boundary.
   forwarded?: boolean
   // Marks the generic dynamic fragment that createPlainElement creates for the
   // default-slot children of a dynamic element resolved to a native tag

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -8,6 +8,7 @@ import {
   type VaporTransitionHooks,
   insert,
   isValidBlock,
+  isValidSlot,
   remove,
 } from './block'
 import {
@@ -70,8 +71,6 @@ export class VaporFragment<
   nodes: T
   vnode?: VNode | null
   anchor?: Node
-  // Async component fragments are valid while waiting for resolved output.
-  validityPending?: boolean
   isBlockValid?: () => boolean
   insert?: (
     parent: ParentNode,
@@ -545,7 +544,7 @@ export class SlotFragment
               setCurrentHydratingSlotFallbackActive(true)
             }
             this.updateContent(slotRender, key)
-            const contentValid = isValidBlock(this.content)
+            const contentValid = isValidSlot(this.content)
             recheckSlotResolution(this, shouldForce)
             // Updates run under the temporary fallback-active marker so empty
             // inner branches can materialize their own anchors if fallback
@@ -592,7 +591,7 @@ export class SlotFragment
   }
 
   isContentValid(): boolean {
-    return isValidBlock(this.content)
+    return isValidSlot(this.content)
   }
 
   syncNodes(): void {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -71,7 +71,7 @@ export class VaporFragment<
   nodes: T
   vnode?: VNode | null
   anchor?: Node
-  isBlockValid?: () => boolean
+  isBlockValid?: (componentAsValid?: boolean) => boolean
   insert?: (
     parent: ParentNode,
     anchor: Node | null,

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -24,11 +24,10 @@ import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
 import {
   type SlotBoundaryContext,
   currentSlotBoundary,
-  getCurrentSlotBoundary,
   hasSlotFallback,
   setCurrentSlotBoundary,
   trackSlotBoundaryDirtying,
-  withOwnedSlotBoundary,
+  withSlotBoundary,
 } from './slotBoundary'
 import {
   hydrateDynamicFragmentAnchor,
@@ -243,18 +242,13 @@ export class DynamicFragment extends RenderContextFragment {
   inTransition?: boolean
   // Fallthrough attrs hooks register branch-owned effects on insert.
   hasFallthroughAttrs?: true
-  // Whether update() claims the SSR anchor itself during hydration.
-  // SlotFragment opts out: updateSlot owns its hydration timing.
-  readonly autoHydrate: boolean
   constructor(
     anchorLabel?: string,
     keyed: boolean = false,
     locate: boolean = true,
     trackSlotBoundary: boolean = false,
-    autoHydrate: boolean = true,
   ) {
     super(EMPTY_BLOCK)
-    this.autoHydrate = autoHydrate
     if (keyed) this.keyed = true
     if (
       isTransitionEnabled &&
@@ -272,6 +266,12 @@ export class DynamicFragment extends RenderContextFragment {
       if (__DEV__) this.anchorLabel = anchorLabel
     }
     if (trackSlotBoundary) trackSlotBoundaryDirtying(this)
+  }
+
+  // Whether update() claims the SSR anchor itself during hydration.
+  // SlotFragment opts out: updateSlot owns its hydration timing.
+  protected get autoHydrate(): boolean {
+    return true
   }
 
   update(render?: BlockFn, key: any = render, noScope: boolean = false): void {
@@ -438,7 +438,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
   isSlot = true
   private disposed = false
   forwarded = false
-  parentSlotBoundary: SlotBoundaryContext | null = getCurrentSlotBoundary()
+  readonly parentSlotBoundary: SlotBoundaryContext | null = currentSlotBoundary
   // Custom elements with `shadowRoot: false` replace their native slot outlet
   // after mount. Keep the live fallback block on the fragment so CE slot sync
   // can preserve block ownership after the outlet node is gone.
@@ -449,54 +449,32 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
   isRenderingFallback = false
   private content: Block = EMPTY_BLOCK
   private localFallback?: BlockFn
-  private isUpdatingSlot = false
-  private _slotFallbackBoundary?: SlotBoundaryContext
-  // Set for slot-root outlets (a <slot> that is itself the root of enclosing
-  // slot content): their exposed validity *is* that content's validity, so
-  // flips must dirty the enclosing boundary.
-  private notifyParent: boolean
-
-  constructor(notifyParent: boolean = false) {
-    // updateSlot owns hydration timing, so opt out of autoHydrate.
-    super(
-      isHydrating || __DEV__ ? 'slot' : undefined,
-      false,
-      false,
-      false,
-      false,
-    )
-    this.notifyParent = notifyParent
+  private isUpdating = false
+  private ownBoundary?: SlotBoundaryContext
+  // Slot-root outlets expose their content validity to the enclosing boundary.
+  constructor(private readonly notifyParentBoundary: boolean = false) {
+    super(isHydrating || __DEV__ ? 'slot' : undefined, false, false, false)
     if (!isHydrating) {
       this.insert = (parent, anchor) => this.insertSlot(parent, anchor)
     }
     this.remove = parent => this.removeSlot(parent)
   }
 
-  private ensureSlotFallbackBoundary(): SlotBoundaryContext {
-    if (this._slotFallbackBoundary) {
-      return this._slotFallbackBoundary
+  // updateSlot owns hydration timing, so opt out of autoHydrate.
+  protected get autoHydrate(): boolean {
+    return false
+  }
+
+  get boundary(): SlotBoundaryContext {
+    if (this.ownBoundary) {
+      return this.ownBoundary
     }
-    const owner = this
-    return (this._slotFallbackBoundary = {
-      get parent() {
-        return owner.parentSlotBoundary
-      },
+    return (this.ownBoundary = {
+      parent: this.parentSlotBoundary,
       getFallback: () => this.localFallback,
       run: (fn, scope) => this.runWithRenderCtx(fn, scope),
       markDirty: () => markSlotFallbackDirty(this),
     })
-  }
-
-  get fallbackBlock(): Block | null {
-    return this.activeFallback
-  }
-
-  get boundary(): SlotBoundaryContext {
-    return this.slotFallbackBoundary
-  }
-
-  get slotFallbackBoundary(): SlotBoundaryContext {
-    return this.ensureSlotFallbackBoundary()
   }
 
   private insertSlot(parent: ParentNode, anchor: Node | null): void {
@@ -541,20 +519,21 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
   ): void {
     const prevLocalFallback = this.localFallback
     this.localFallback = fallback
-    const boundary = this.slotFallbackBoundary
+    const boundary = this.boundary
     const slotRender = render
-      ? () => withOwnedSlotBoundary(boundary, render)
+      ? () => withSlotBoundary(boundary, render)
       : () => EMPTY_BLOCK
-    this.isUpdatingSlot = true
+    this.isUpdating = true
     this.pendingRecheck = false
 
     try {
       const shouldForce = prevLocalFallback !== fallback
       if (isHydrating) {
+        const boundaryHasFallback = hasSlotFallback(boundary)
         withHydratingSlotBoundary(() => {
           const prev = isHydratingSlotFallbackActive()
           try {
-            if (hasSlotFallback(boundary)) {
+            if (boundaryHasFallback) {
               setCurrentHydratingSlotFallbackActive(true)
             }
             this.updateContent(slotRender, key)
@@ -566,7 +545,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
             // outer state before hydrateDynamicFragmentAnchor(); the surrounding
             // finally still restores nested callers when we leave this
             // boundary.
-            if (!hasSlotFallback(boundary) || contentValid) {
+            if (!boundaryHasFallback || contentValid) {
               setCurrentHydratingSlotFallbackActive(prev)
             }
             hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
@@ -580,7 +559,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
       }
     } finally {
       this.pendingRecheck = false
-      this.isUpdatingSlot = false
+      this.isUpdating = false
     }
   }
 
@@ -597,7 +576,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
   }
 
   isBusy(): boolean {
-    return this.isUpdatingSlot
+    return this.isUpdating
   }
 
   isDisposed(): boolean {
@@ -613,7 +592,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
   }
 
   notifyFallbackValidityChange(): void {
-    if (this.notifyParent && this.parentSlotBoundary) {
+    if (this.notifyParentBoundary && this.parentSlotBoundary) {
       this.parentSlotBoundary.markDirty()
     }
   }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -37,10 +37,10 @@ import {
   withHydratingSlotBoundary,
 } from './dom/hydrateFragment'
 import {
-  type SlotFallbackState,
-  disposeSlotFallback,
-  markSlotFallbackDirty,
-  recheckSlotFallback,
+  type SlotResolutionState,
+  disposeSlotResolution,
+  markSlotResolutionDirty,
+  recheckSlotResolution,
 } from './slotFragment'
 import { setBlockKey } from './helpers/setKey'
 import {
@@ -434,7 +434,10 @@ export class DynamicFragment extends RenderContextFragment {
 // reads the base class binding at module evaluation time, and fragment.ts
 // sits inside a module cycle, so hoisting the class into another module can
 // hit the base class before it is initialized depending on entry order.
-export class SlotFragment extends DynamicFragment implements SlotFallbackState {
+export class SlotFragment
+  extends DynamicFragment
+  implements SlotResolutionState
+{
   isSlot = true
   private disposed = false
   forwarded = false
@@ -473,7 +476,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
       parent: this.parentSlotBoundary,
       getFallback: () => this.localFallback,
       run: (fn, scope) => this.runWithRenderCtx(fn, scope),
-      markDirty: () => markSlotFallbackDirty(this),
+      markDirty: () => markSlotResolutionDirty(this),
     })
   }
 
@@ -488,15 +491,15 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
     remove(nodes, parent)
     if (this.activeFallback === nodes) {
       // the exposed fallback was just torn down by remove() above; null it
-      // so disposeSlotFallback does not remove it a second time
+      // so disposeSlotResolution does not remove it a second time
       this.activeFallback = null
     }
-    disposeSlotFallback(this)
+    disposeSlotResolution(this)
   }
 
   protected getBranchParent(): ParentNode | null {
     // When fallback is active, recompute content without inserting it. The
-    // content may still be invalid, so recheckSlotFallback decides whether it
+    // content may still be invalid, so recheckSlotResolution decides whether it
     // can return to the DOM.
     return this.activeFallback ? null : super.getBranchParent()
   }
@@ -505,7 +508,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
     // update() operates on this.nodes, but while fallback is active `nodes`
     // points at the fallback block. Aim it at the content branch so the base
     // pipeline re-renders content, then capture the result back; the
-    // subsequent recheckSlotFallback decides what `nodes` exposes
+    // subsequent recheckSlotResolution decides what `nodes` exposes
     // (syncNodes).
     this.nodes = this.content
     this.update(render, key)
@@ -538,7 +541,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
             }
             this.updateContent(slotRender, key)
             const contentValid = isValidBlock(this.content)
-            recheckSlotFallback(this, shouldForce)
+            recheckSlotResolution(this, shouldForce)
             // Updates run under the temporary fallback-active marker so empty
             // inner branches can materialize their own anchors if fallback
             // takes over. If recheck resolves back to content, restore the
@@ -555,7 +558,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
         })
       } else {
         this.updateContent(slotRender, key)
-        recheckSlotFallback(this, shouldForce)
+        recheckSlotResolution(this, shouldForce)
       }
     } finally {
       this.pendingRecheck = false
@@ -591,7 +594,7 @@ export class SlotFragment extends DynamicFragment implements SlotFallbackState {
     this.nodes = this.activeFallback || this.content
   }
 
-  notifyFallbackValidityChange(): void {
+  notifyExposedValidityChange(): void {
     if (this.notifyParentBoundary && this.parentSlotBoundary) {
       this.parentSlotBoundary.markDirty()
     }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -123,16 +123,26 @@ export class RenderContextFragment<
   }
 
   protected runWithRenderCtx<R>(fn: () => R, scope?: EffectScope): R {
-    const prevInstance = setCurrentInstance(this.renderInstance, scope)
-    try {
-      return runWithFragmentCtx(this, fn)
-    } finally {
-      setCurrentInstance(...prevInstance)
-    }
+    return runWithRenderCtx(this, fn, scope)
   }
 }
 
-export function runWithFragmentCtx<R>(
+export function runWithRenderCtx<R>(
+  fragment: RenderContextFragment,
+  fn: () => R,
+  scope?: EffectScope,
+): R {
+  const prevInstance = setCurrentInstance(fragment.renderInstance, scope)
+  try {
+    return runWithFragmentCtxOnly(fragment, fn)
+  } finally {
+    setCurrentInstance(...prevInstance)
+  }
+}
+
+// Restores fragment-owned ambient state only. The caller must already have the
+// correct currentInstance / currentScope; use runWithRenderCtx for late renders.
+export function runWithFragmentCtxOnly<R>(
   fragment: RenderContextFragment,
   fn: () => R,
 ): R {

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -11,8 +11,8 @@ export interface SlotBoundaryContext {
   parent: SlotBoundaryContext | null
   getFallback: () => BlockFn | undefined
   // Re-establishes the owning slot's ambient slot / fragment context around
-  // late renders such as fallback bodies, which run long after the slot's own
-  // setup finished.
+  // late renders such as fallback bodies, and runs them in the provided effect
+  // scope when one is provided.
   run<R>(fn: () => R, scope?: EffectScope): R
   // Notifies the owning slot that the validity of a dynamic branch rendered
   // under this boundary may have changed; routes into the slot resolution

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -15,8 +15,8 @@ export interface SlotBoundaryContext {
   // setup finished.
   run<R>(fn: () => R, scope?: EffectScope): R
   // Notifies the owning slot that the validity of content rendered under
-  // this boundary may have changed; routes into the fallback state machine
-  // (markSlotFallbackDirty).
+  // this boundary may have changed; routes into the slot resolution state
+  // machine (markSlotResolutionDirty).
   markDirty: () => void
   // Cached fallback-masking view of this boundary, used while rendering its
   // own fallback (see getRedirectedBoundary in slotFragment.ts).

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -1,5 +1,5 @@
 import type { EffectScope } from '@vue/reactivity'
-import { type BlockFn, isValidBlock } from './block'
+import { type BlockFn, isValidSlot } from './block'
 import type { VaporFragment } from './fragment'
 
 // A slot boundary is one slot outlet's fallback-resolution point. Forwarded
@@ -52,10 +52,10 @@ export function trackSlotBoundaryDirtying(fragment: VaporFragment): void {
 
   let prevValid: boolean
   ;(fragment.onBeforeUpdate ||= []).push(() => {
-    prevValid = isValidBlock(fragment)
+    prevValid = isValidSlot(fragment)
   })
   ;(fragment.onUpdated ||= []).push(() => {
-    if (isValidBlock(fragment) !== prevValid) {
+    if (isValidSlot(fragment) !== prevValid) {
       boundary.markDirty()
     }
   })

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -25,10 +25,6 @@ export interface SlotBoundaryContext {
 
 export let currentSlotBoundary: SlotBoundaryContext | null = null
 
-export function getCurrentSlotBoundary(): SlotBoundaryContext | null {
-  return currentSlotBoundary
-}
-
 export function setCurrentSlotBoundary(
   b: SlotBoundaryContext | null,
 ): SlotBoundaryContext | null {
@@ -39,7 +35,7 @@ export function setCurrentSlotBoundary(
   }
 }
 
-export function withOwnedSlotBoundary<R>(
+export function withSlotBoundary<R>(
   boundary: SlotBoundaryContext | null,
   fn: () => R,
 ): R {

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -56,16 +56,15 @@ export function withOwnedSlotBoundary<R>(
 export function trackSlotBoundaryDirtying(fragment: VaporFragment): void {
   const boundary = currentSlotBoundary
   if (!boundary) return
-  let prevValid = isValidBlock(fragment)
+
+  let prevValid: boolean
   ;(fragment.onBeforeUpdate ||= []).push(() => {
     prevValid = isValidBlock(fragment)
   })
   ;(fragment.onUpdated ||= []).push(() => {
-    const valid = isValidBlock(fragment)
-    if (valid !== prevValid) {
+    if (isValidBlock(fragment) !== prevValid) {
       boundary.markDirty()
     }
-    prevValid = valid
   })
 }
 

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -18,9 +18,6 @@ export interface SlotBoundaryContext {
   // under this boundary may have changed; routes into the slot resolution
   // state machine (markSlotResolutionDirty).
   markDirty: () => void
-  // Cached fallback-masking view of this boundary, used while rendering its
-  // own fallback (see getRedirectedBoundary in slotFragment.ts).
-  redirected?: SlotBoundaryContext
 }
 
 export let currentSlotBoundary: SlotBoundaryContext | null = null

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -14,9 +14,9 @@ export interface SlotBoundaryContext {
   // late renders such as fallback bodies, which run long after the slot's own
   // setup finished.
   run<R>(fn: () => R, scope?: EffectScope): R
-  // Notifies the owning slot that the validity of content rendered under
-  // this boundary may have changed; routes into the slot resolution state
-  // machine (markSlotResolutionDirty).
+  // Notifies the owning slot that the validity of a dynamic branch rendered
+  // under this boundary may have changed; routes into the slot resolution
+  // state machine (markSlotResolutionDirty).
   markDirty: () => void
   // Cached fallback-masking view of this boundary, used while rendering its
   // own fallback (see getRedirectedBoundary in slotFragment.ts).

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -13,7 +13,7 @@ import { isHydrating } from './dom/hydration'
 import {
   type SlotBoundaryContext,
   hasSlotFallback,
-  withOwnedSlotBoundary,
+  withSlotBoundary,
 } from './slotBoundary'
 import { SlotFragment } from './fragment'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
@@ -46,9 +46,7 @@ function getRedirectedBoundary(
     return boundary.redirected
   }
   return (boundary.redirected = {
-    get parent() {
-      return boundary.parent
-    },
+    parent: boundary.parent,
     getFallback: () => undefined,
     run: (fn, scope) => boundary.run(fn, scope),
     markDirty: () => boundary.markDirty(),
@@ -78,9 +76,7 @@ function renderSlotFallback(
   }
 
   const renderFallback = () =>
-    withOwnedSlotBoundary(getRedirectedBoundary(boundary), () =>
-      localFallback(),
-    )
+    withSlotBoundary(getRedirectedBoundary(boundary), localFallback)
   const local = boundary.run(() => scope.run(renderFallback) || [], scope)
   if (isValidBlock(local)) {
     return local
@@ -99,7 +95,7 @@ export interface SlotFallbackState {
   // The committed fallback block, or null while content is exposed.
   activeFallback: Block | null
   // Detached scope owning the active fallback's effects (see
-  // renderSlotFallbackState); stopped by clearSlotFallback.
+  // renderFallbackInScope); stopped by clearSlotFallback.
   fallbackScope?: EffectScope
   // Validity of the exposed branch as of the last recheck; undefined before
   // the first recheck. Flips trigger notifyFallbackValidityChange.
@@ -167,11 +163,7 @@ export function markSlotFallbackDirty(state: SlotFallbackState): void {
   if (state.isDisposed()) {
     return
   }
-  if (state.isRenderingFallback) {
-    state.pendingRecheck = true
-    return
-  }
-  if (state.isBusy()) {
+  if (state.isRenderingFallback || state.isBusy()) {
     state.pendingRecheck = true
     return
   }
@@ -197,7 +189,7 @@ function clearSlotFallback(state: SlotFallbackState): void {
 // not die with whatever branch scope happens to be active when a recheck
 // fires, so its lifetime is managed manually (stopped by clearSlotFallback,
 // or right here when the render throws or yields nothing).
-function renderSlotFallbackState(
+function renderFallbackInScope(
   state: SlotFallbackState,
 ): { block: Block; scope: EffectScope } | undefined {
   const scope = new EffectScope(true)
@@ -269,7 +261,7 @@ function renderAndCommitSlotFallback(
   state: SlotFallbackState,
   hadFallback: boolean,
 ): void {
-  const result = renderSlotFallbackState(state)
+  const result = renderFallbackInScope(state)
   clearSlotFallback(state)
   if (result) {
     commitSlotFallback(state, result.block, result.scope, !hadFallback)
@@ -304,14 +296,9 @@ export function recheckSlotFallback(
   const fallback = state.activeFallback
   const fallbackValid = fallback ? isValidBlock(fallback) : false
   const contentValid = state.isContentValid()
-  // This tracks the validity of the currently exposed branch, whether it is
-  // slot content or fallback.
-  const prevNodesValid =
-    state.lastNodesValid === undefined
-      ? fallback
-        ? fallbackValid
-        : contentValid
-      : state.lastNodesValid
+  // Validity of the currently exposed branch (fallback if active, else content).
+  const exposedValid = fallback ? fallbackValid : contentValid
+  const prevNodesValid = state.lastNodesValid ?? exposedValid
   if (!force && contentValid && !fallback && prevNodesValid) {
     state.syncNodes()
     state.lastNodesValid = true

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -34,25 +34,6 @@ import { setBlockKey } from './helpers/setKey'
 // slot implementations in vdomInterop.ts, which keep their per-slot state in
 // closures.
 
-// View of a boundary used while rendering that boundary's own fallback. It
-// masks the local fallback (getFallback -> undefined) so slot outlets
-// *inside* the fallback body resolve against the parent chain instead of
-// recursively landing on the very fallback being rendered, while keeping the
-// owner's ambient slot / fragment context and local resolution dirty channel.
-function getRedirectedBoundary(
-  boundary: SlotBoundaryContext,
-): SlotBoundaryContext {
-  if (boundary.redirected) {
-    return boundary.redirected
-  }
-  return (boundary.redirected = {
-    parent: boundary.parent,
-    getFallback: () => undefined,
-    run: (fn, scope) => boundary.run(fn, scope),
-    markDirty: () => boundary.markDirty(),
-  })
-}
-
 // Walks the boundary chain outward and renders the nearest fallback into
 // `scope`. Returns:
 // - a valid block: the innermost fallback that rendered valid output;
@@ -76,7 +57,15 @@ function renderSlotFallback(
   }
 
   const renderFallback = () =>
-    withSlotBoundary(getRedirectedBoundary(boundary), localFallback)
+    withSlotBoundary(
+      {
+        ...boundary,
+        // Hide the local fallback while rendering it, so slot outlets inside
+        // the fallback don't resolve to the same fallback again.
+        getFallback: () => undefined,
+      },
+      localFallback,
+    )
   const local = boundary.run(() => scope.run(renderFallback) || [], scope)
   if (isValidBlock(local)) {
     return local

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -34,45 +34,45 @@ import { setBlockKey } from './helpers/setKey'
 // slot implementations in vdomInterop.ts, which keep their per-slot state in
 // closures.
 
-// Walks the boundary chain outward and renders the nearest fallback into
-// `scope`. Returns:
+// Walks the boundary chain outward and renders fallbacks into `scope`. Returns:
 // - a valid block: the innermost fallback that rendered valid output;
 // - an invalid block: every boundary providing a fallback rendered invalid
-//   output (e.g. a fallback whose root v-if is currently false). The inherited
-//   result wins when present; otherwise the local invalid block is kept. Their
-//   effects stay live in the shared scope, so the chosen fallback can become
-//   valid later;
+//   output (e.g. a fallback whose root v-if is currently false). The outermost
+//   invalid result is kept. Their effects stay live in the shared scope, so a
+//   fallback can become valid later;
 // - undefined: no boundary in the chain provides a fallback at all.
 function renderSlotFallback(
   boundary: SlotBoundaryContext | null,
   scope: EffectScope,
 ): Block | undefined {
-  if (!boundary) {
-    return undefined
+  let block: Block | undefined
+
+  while (boundary) {
+    const current = boundary
+    const localFallback = current.getFallback()
+
+    if (localFallback) {
+      const content = current.run(
+        () =>
+          withSlotBoundary(
+            {
+              ...current,
+              // Hide the local fallback while rendering it, so slot outlets inside
+              // the fallback don't resolve to the same fallback again.
+              getFallback: () => undefined,
+            },
+            localFallback,
+          ),
+        scope,
+      )
+      if (isValidBlock(content)) return content
+      block = content
+    }
+
+    boundary = current.parent
   }
 
-  const localFallback = boundary.getFallback()
-  if (!localFallback) {
-    return renderSlotFallback(boundary.parent, scope)
-  }
-
-  const renderFallback = () =>
-    withSlotBoundary(
-      {
-        ...boundary,
-        // Hide the local fallback while rendering it, so slot outlets inside
-        // the fallback don't resolve to the same fallback again.
-        getFallback: () => undefined,
-      },
-      localFallback,
-    )
-  const local = boundary.run(() => scope.run(renderFallback) || [], scope)
-  if (isValidBlock(local)) {
-    return local
-  }
-
-  const inherited = renderSlotFallback(boundary.parent, scope)
-  return inherited === undefined ? local : inherited
+  return block
 }
 
 // Per-slot state the slot resolution machine operates on. Implemented by

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -19,7 +19,7 @@ import { SlotFragment } from './fragment'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
 import { setBlockKey } from './helpers/setKey'
 
-// Slot fallback resolution.
+// Slot resolution.
 //
 // Vapor has no component-level re-render: once slot content is rendered, the
 // only signal that its *validity* changed (e.g. a root v-if inside the slot
@@ -29,7 +29,7 @@ import { setBlockKey } from './helpers/setKey'
 // the content while it is valid, otherwise the nearest valid fallback up the
 // boundary chain.
 //
-// The machine is written against the duck-typed SlotFallbackState interface
+// The machine is written against the duck-typed SlotResolutionState interface
 // because it has three hosts: SlotFragment (vapor slots) and the two interop
 // slot implementations in vdomInterop.ts, which keep their per-slot state in
 // closures.
@@ -86,9 +86,9 @@ function renderSlotFallback(
   return inherited === undefined ? local : inherited
 }
 
-// Per-slot state the fallback machine operates on. Implemented by
+// Per-slot state the slot resolution machine operates on. Implemented by
 // SlotFragment and by the two interop slots in vdomInterop.ts.
-export interface SlotFallbackState {
+export interface SlotResolutionState {
   // The slot's own resolution point; its parent chain supplies inherited
   // fallbacks for forwarded slots.
   boundary: SlotBoundaryContext
@@ -98,7 +98,7 @@ export interface SlotFallbackState {
   // renderFallbackInScope); stopped by clearSlotFallback.
   fallbackScope?: EffectScope
   // Validity of the exposed branch as of the last recheck; undefined before
-  // the first recheck. Flips trigger notifyFallbackValidityChange.
+  // the first recheck. Flips trigger notifyExposedValidityChange.
   lastNodesValid?: boolean
   // A dirty notification arrived while a fallback render or a host update
   // was in flight; folded into the recheck that completes that operation.
@@ -119,7 +119,7 @@ export interface SlotFallbackState {
   syncNodes(): void
   // Reports an exposed-branch validity flip so an enclosing boundary can
   // recheck its own fallback decision.
-  notifyFallbackValidityChange(): void
+  notifyExposedValidityChange(): void
 }
 
 // Takes a block's nodes out of the DOM without tearing the block down: no
@@ -159,7 +159,7 @@ function detachBlock(block: Block, parent: ParentNode): void {
 // user fallback code is rendering or the host is mid content update, the
 // notification is folded into pendingRecheck instead of recursing: the
 // in-flight operation ends with a recheck that subsumes it.
-export function markSlotFallbackDirty(state: SlotFallbackState): void {
+export function markSlotResolutionDirty(state: SlotResolutionState): void {
   if (state.isDisposed()) {
     return
   }
@@ -167,10 +167,10 @@ export function markSlotFallbackDirty(state: SlotFallbackState): void {
     state.pendingRecheck = true
     return
   }
-  recheckSlotFallback(state, true)
+  recheckSlotResolution(state, true)
 }
 
-function clearSlotFallback(state: SlotFallbackState): void {
+function clearSlotFallback(state: SlotResolutionState): void {
   const fallback = state.activeFallback
   if (fallback) {
     const parentNode = state.getParentNode()
@@ -190,7 +190,7 @@ function clearSlotFallback(state: SlotFallbackState): void {
 // fires, so its lifetime is managed manually (stopped by clearSlotFallback,
 // or right here when the render throws or yields nothing).
 function renderFallbackInScope(
-  state: SlotFallbackState,
+  state: SlotResolutionState,
 ): { block: Block; scope: EffectScope } | undefined {
   const scope = new EffectScope(true)
   let renderedFallback: Block | undefined
@@ -215,7 +215,7 @@ function renderFallbackInScope(
   }
 }
 
-export function insertActiveSlotFallback(state: SlotFallbackState): void {
+export function insertActiveSlotFallback(state: SlotResolutionState): void {
   const fallback = state.activeFallback
   if (isHydrating || !fallback || !isValidBlock(fallback)) {
     return
@@ -231,7 +231,7 @@ export function insertActiveSlotFallback(state: SlotFallbackState): void {
 // (invalid) content gets parked outside the DOM while staying alive. When
 // replacing an already active fallback, the content is parked already.
 function commitSlotFallback(
-  state: SlotFallbackState,
+  state: SlotResolutionState,
   block: Block,
   scope: EffectScope,
   detachContent: boolean,
@@ -243,7 +243,7 @@ function commitSlotFallback(
   state.activeFallback = block
   state.fallbackScope = scope
   if (isTransitionEnabled) {
-    const transitionState = state as SlotFallbackState & TransitionOptions
+    const transitionState = state as SlotResolutionState & TransitionOptions
     if (transitionState.$transition) {
       // Match VDOM slot fallback branch identity so fallback enter does not
       // early-remove the currently leaving slot content.
@@ -258,7 +258,7 @@ function commitSlotFallback(
 }
 
 function renderAndCommitSlotFallback(
-  state: SlotFallbackState,
+  state: SlotResolutionState,
   hadFallback: boolean,
 ): void {
   const result = renderFallbackInScope(state)
@@ -268,12 +268,12 @@ function renderAndCommitSlotFallback(
     // drain notifications folded into this fallback render/update window
     if (state.pendingRecheck) {
       state.pendingRecheck = false
-      recheckSlotFallback(state, true)
+      recheckSlotResolution(state, true)
     }
   }
 }
 
-export function disposeSlotFallback(state: SlotFallbackState): void {
+export function disposeSlotResolution(state: SlotResolutionState): void {
   clearSlotFallback(state)
   state.pendingRecheck = false
   state.lastNodesValid = undefined
@@ -284,8 +284,8 @@ export function disposeSlotFallback(state: SlotFallbackState): void {
 // was rendered from (a boundary was dirtied, or the fallback prop changed),
 // so a kept fallback must be re-rendered rather than merely re-inserted;
 // without `force` only the insertion state is reconciled.
-export function recheckSlotFallback(
-  state: SlotFallbackState,
+export function recheckSlotResolution(
+  state: SlotResolutionState,
   force: boolean = false,
 ): void {
   if (state.isRenderingFallback) {
@@ -351,6 +351,6 @@ export function recheckSlotFallback(
   state.syncNodes()
   state.lastNodesValid = nextNodesValid
   if (prevNodesValid !== nextNodesValid) {
-    state.notifyFallbackValidityChange()
+    state.notifyExposedValidityChange()
   }
 }

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -4,7 +4,7 @@ import {
   type Block,
   type TransitionOptions,
   insert,
-  isValidBlock,
+  isValidSlot,
   remove,
   removeNode,
 } from './block'
@@ -65,7 +65,7 @@ function renderSlotFallback(
           ),
         scope,
       )
-      if (isValidBlock(content)) return content
+      if (isValidSlot(content)) return content
       block = content
     }
 
@@ -206,7 +206,7 @@ function renderFallbackInScope(
 
 export function insertActiveSlotFallback(state: SlotResolutionState): void {
   const fallback = state.activeFallback
-  if (isHydrating || !fallback || !isValidBlock(fallback)) {
+  if (isHydrating || !fallback || !isValidSlot(fallback)) {
     return
   }
   const parentNode = state.getParentNode()
@@ -283,7 +283,7 @@ export function recheckSlotResolution(
   }
 
   const fallback = state.activeFallback
-  const fallbackValid = fallback ? isValidBlock(fallback) : false
+  const fallbackValid = fallback ? isValidSlot(fallback) : false
   const contentValid = state.isContentValid()
   // Validity of the currently exposed branch (fallback if active, else content).
   const exposedValid = fallback ? fallbackValid : contentValid
@@ -337,7 +337,7 @@ export function recheckSlotResolution(
       : nextFallback
         ? nextFallback === fallback
           ? fallbackValid
-          : isValidBlock(nextFallback)
+          : isValidSlot(nextFallback)
         : state.isContentValid()
   state.syncNodes()
   state.lastNodesValid = nextNodesValid

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -38,7 +38,7 @@ import { setBlockKey } from './helpers/setKey'
 // masks the local fallback (getFallback -> undefined) so slot outlets
 // *inside* the fallback body resolve against the parent chain instead of
 // recursively landing on the very fallback being rendered, while keeping the
-// owner's ambient slot / fragment context and dirty channel.
+// owner's ambient slot / fragment context and local resolution dirty channel.
 function getRedirectedBoundary(
   boundary: SlotBoundaryContext,
 ): SlotBoundaryContext {
@@ -346,7 +346,9 @@ export function recheckSlotResolution(
     contentValid && !nextFallback
       ? true
       : nextFallback
-        ? isValidBlock(nextFallback)
+        ? nextFallback === fallback
+          ? fallbackValid
+          : isValidBlock(nextFallback)
         : state.isContentValid()
   state.syncNodes()
   state.lastNodesValid = nextNodesValid

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -342,9 +342,12 @@ export function recheckSlotFallback(
   }
 
   const nextFallback = state.activeFallback
-  const nextNodesValid = nextFallback
-    ? isValidBlock(nextFallback)
-    : state.isContentValid()
+  const nextNodesValid =
+    contentValid && !nextFallback
+      ? true
+      : nextFallback
+        ? isValidBlock(nextFallback)
+        : state.isContentValid()
   state.syncNodes()
   state.lastNodesValid = nextNodesValid
   if (prevNodesValid !== nextNodesValid) {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1606,7 +1606,7 @@ function renderVDOMSlot(
                 trackSlotVNodeUpdatesWithRefresh(
                   hydratedContent,
                   refreshSlotVNode,
-                  slotRoot ? notifyBeforeUpdate : undefined,
+                  notifyBeforeUpdate,
                 )
                 // Forwarded slot fragments that resolve to an empty SSR range
                 // should stay on that range instead of re-entering it through
@@ -1658,7 +1658,7 @@ function renderVDOMSlot(
               trackSlotVNodeUpdatesWithRefresh(
                 slotContent,
                 refreshSlotVNode,
-                slotRoot ? notifyBeforeUpdate : undefined,
+                notifyBeforeUpdate,
               )
               const prevRendered = contentState.rendered
               const prevIsVNode = isVNode(prevRendered)
@@ -2256,6 +2256,11 @@ function createVNodeChildrenFragment(
       frag.onUpdated.forEach(hook => hook())
     }
   }
+  const notifyBeforeUpdate = (): void => {
+    if (isMounted && frag.onBeforeUpdate) {
+      frag.onBeforeUpdate.forEach(hook => hook())
+    }
+  }
 
   const renderContent = () => {
     const prev = currentInstance
@@ -2264,6 +2269,7 @@ function createVNodeChildrenFragment(
       renderEffect(() => {
         runWithFragmentCtx(frag, () => {
           const nextChildren = render()
+          notifyBeforeUpdate()
           if (isHydrating) {
             nextChildren.forEach(vnode => hydrateVNode(vnode, parentComponent))
             currentChildren = nextChildren
@@ -2295,9 +2301,13 @@ function createVNodeChildrenFragment(
           } else if (!currentVNode) {
             currentChildren = nextChildren
             currentVNode = createVNode(Fragment, null, nextChildren)
-            trackSlotVNodeUpdatesWithRefresh(currentVNode, () => {
-              notifyUpdated(syncResolvedNodes(nextChildren))
-            })
+            trackSlotVNodeUpdatesWithRefresh(
+              currentVNode,
+              () => {
+                notifyUpdated(syncResolvedNodes(nextChildren))
+              },
+              notifyBeforeUpdate,
+            )
             if (nextChildren.length) {
               internals.mc(
                 nextChildren,
@@ -2312,9 +2322,13 @@ function createVNodeChildrenFragment(
             }
           } else {
             const nextVNode = createVNode(Fragment, null, nextChildren)
-            trackSlotVNodeUpdatesWithRefresh(nextVNode, () => {
-              notifyUpdated(syncResolvedNodes(nextChildren))
-            })
+            trackSlotVNodeUpdatesWithRefresh(
+              nextVNode,
+              () => {
+                notifyUpdated(syncResolvedNodes(nextChildren))
+              },
+              notifyBeforeUpdate,
+            )
             internals.pc(
               currentVNode,
               nextVNode,
@@ -2364,9 +2378,13 @@ function createVNodeChildrenFragment(
     if (!isMounted) {
       startRenderEffect()
       if (currentVNode) {
-        trackSlotVNodeUpdatesWithRefresh(currentVNode, () => {
-          notifyUpdated(syncResolvedNodes(currentChildren))
-        })
+        trackSlotVNodeUpdatesWithRefresh(
+          currentVNode,
+          () => {
+            notifyUpdated(syncResolvedNodes(currentChildren))
+          },
+          notifyBeforeUpdate,
+        )
       }
       if (currentChildren.length) {
         internals.mc(

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -879,12 +879,19 @@ function createVNodeFragment(vnode: VNode): {
 } {
   const frag = createInteropFragment(EMPTY_BLOCK, vnode)
   frag.$key = vnode.key
-  let validityPending = !isHydrating
+  // Optimistic slot validity: `frag.nodes` stays EMPTY_BLOCK until `syncNodes`
+  // runs (on insert), so report valid to keep a host boundary from mounting its
+  // fallback before the content exists. This keeps the common (valid) case free —
+  // an empty result is corrected later when the resolve path notifies the
+  // boundary to recheck; starting invalid would instead mount-then-teardown the
+  // fallback on every interop mount. Hydration starts resolved (SSR nodes exist).
+  let contentResolved = isHydrating
   const syncNodes = () => {
     frag.nodes = resolveVNodeNodes(vnode)
-    validityPending = false
+    contentResolved = true
   }
-  frag.isBlockValid = () => (validityPending ? true : isValidBlock(frag.nodes))
+  frag.isBlockValid = componentAsValid =>
+    contentResolved ? isValidBlock(frag.nodes, componentAsValid) : true
   trackFragmentVNodeUpdates(frag, vnode, syncNodes)
   return { frag, syncNodes }
 }
@@ -1397,7 +1404,10 @@ function renderVDOMSlot(
 ): VaporFragment {
   const suspense = currentParentSuspense || parentComponent.suspense
   const frag = createInteropFragment()
-  let validityPending = !isHydrating
+  // `isBlockValid` below reports VDOM-side validity (`contentState.valid`), not
+  // `isValidBlock(frag.nodes)`: `frag.nodes` tracks the active fallback when one
+  // is shown. (Optimism rationale: see createVNodeFragment.)
+  let contentResolved = isHydrating
 
   let isMounted = false
   const contentState = {
@@ -1413,10 +1423,10 @@ function renderVDOMSlot(
   let isContentUpdateRecheck = false
   let localFallback: BlockFn | undefined
   let slotResolutionState!: SlotResolutionState
-  frag.isBlockValid = () => {
-    if (validityPending) return true
+  frag.isBlockValid = componentAsValid => {
+    if (!contentResolved) return true
     return slotResolutionState.activeFallback
-      ? isValidSlot(slotResolutionState.activeFallback)
+      ? isValidBlock(slotResolutionState.activeFallback, componentAsValid)
       : contentState.valid
   }
   const boundary: SlotBoundaryContext = {
@@ -1471,7 +1481,7 @@ function renderVDOMSlot(
       contentState.nodes = EMPTY_BLOCK
       contentState.valid = false
     }
-    validityPending = false
+    contentResolved = true
   }
 
   const notifyUpdated = (): void => {
@@ -1912,8 +1922,10 @@ function renderVaporSlot(
     // fallback lifecycle. Forcing the interop wrapper to own that branch breaks
     // fallback blocks that can later resolve to an empty vnode list.
     const frag = createInteropFragment()
-    let validityPending = !isHydrating
-    frag.isBlockValid = () => (validityPending ? true : isValidSlot(frag.nodes))
+    // Optimistic until content resolves into `frag.nodes`; see createVNodeFragment.
+    let contentResolved = isHydrating
+    frag.isBlockValid = componentAsValid =>
+      contentResolved ? isValidBlock(frag.nodes, componentAsValid) : true
     const slotBoundary = frag.slotBoundary
     let contentNodes: Block = EMPTY_BLOCK
     let isResolvingContent = false
@@ -1975,7 +1987,7 @@ function renderVaporSlot(
       isContentValid: () => isValidSlot(contentNodes),
       syncNodes: () => {
         frag.nodes = slotResolutionState.activeFallback || contentNodes
-        validityPending = false
+        contentResolved = true
       },
       notifyExposedValidityChange: () => {
         if (slotBoundary) {
@@ -2227,8 +2239,10 @@ function createVNodeChildrenFragment(
     currentParentSuspense || (parentComponent && parentComponent.suspense)
   const frag = createInteropFragment()
   let contentValid = false
-  let validityPending = !isHydrating
-  frag.isBlockValid = () => (validityPending ? true : contentValid)
+  // `isBlockValid` reports `contentValid` (VDOM-side `ensureValidVNode`), not
+  // `isValidBlock(frag.nodes)`. (Optimism rationale: see createVNodeFragment.)
+  let contentResolved = isHydrating
+  frag.isBlockValid = () => (contentResolved ? contentValid : true)
   let currentVNode: VNode | null = null
   let currentChildren: VNode[] = EMPTY_VNODES
   let currentParentNode: ParentNode | null = null
@@ -2238,7 +2252,7 @@ function createVNodeChildrenFragment(
   const scope = effectScope()
 
   const syncResolvedNodes = (children: VNode[] = currentChildren): boolean => {
-    const prevValid = validityPending ? true : contentValid
+    const prevValid = contentResolved ? contentValid : true
     contentValid = !!ensureValidVNode(children)
     if (children.length === 0) {
       frag.nodes = EMPTY_BLOCK
@@ -2247,7 +2261,7 @@ function createVNodeChildrenFragment(
     } else {
       frag.nodes = children.map(resolveVNodeNodes) as Block[]
     }
-    validityPending = false
+    contentResolved = true
     return prevValid !== contentValid
   }
 
@@ -2295,9 +2309,9 @@ function createVNodeChildrenFragment(
           } else if (!isMounted) {
             currentChildren = nextChildren
             currentVNode = createVNode(Fragment, null, nextChildren)
-            const wasPending = validityPending
+            const wasResolved = contentResolved
             const validityChanged = syncResolvedNodes(nextChildren)
-            if (!wasPending) {
+            if (wasResolved) {
               notifyUpdated(validityChanged)
             }
             return

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1601,7 +1601,7 @@ function renderVDOMSlot(
                 frag.$key = getVNodeKey(hydratedContent)
                 const refreshSlotVNode = () => {
                   frag.nodes = resolveVNodeNodes(hydratedContent)
-                  if (frag.onUpdated) frag.onUpdated.forEach(m => m())
+                  notifyUpdated()
                 }
                 trackSlotVNodeUpdatesWithRefresh(
                   hydratedContent,

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -130,11 +130,11 @@ import {
   withSlotBoundary,
 } from './slotBoundary'
 import {
-  type SlotFallbackState,
-  disposeSlotFallback,
+  type SlotResolutionState,
+  disposeSlotResolution,
   insertActiveSlotFallback,
-  markSlotFallbackDirty,
-  recheckSlotFallback,
+  markSlotResolutionDirty,
+  recheckSlotResolution,
 } from './slotFragment'
 import {
   getCurrentSlotEndAnchor,
@@ -1411,11 +1411,11 @@ function renderVDOMSlot(
   const inheritedBoundary = frag.inheritedSlotBoundary
   let isContentUpdateRecheck = false
   let localFallback: BlockFn | undefined
-  let fallbackState!: SlotFallbackState
+  let slotResolutionState!: SlotResolutionState
   frag.isBlockValid = () => {
     if (validityPending) return true
-    return fallbackState.activeFallback
-      ? isValidBlock(fallbackState.activeFallback)
+    return slotResolutionState.activeFallback
+      ? isValidBlock(slotResolutionState.activeFallback)
       : contentState.valid
   }
   const boundary: SlotBoundaryContext = {
@@ -1424,9 +1424,9 @@ function renderVDOMSlot(
     },
     getFallback: (): BlockFn | undefined => localFallback,
     run: fn => runWithFragmentCtx(frag, fn),
-    markDirty: () => markSlotFallbackDirty(fallbackState),
+    markDirty: () => markSlotResolutionDirty(slotResolutionState),
   }
-  fallbackState = {
+  slotResolutionState = {
     boundary,
     activeFallback: null,
     pendingRecheck: false,
@@ -1438,9 +1438,9 @@ function renderVDOMSlot(
     isDisposed: () => disposed,
     isContentValid: () => contentState.valid,
     syncNodes: () => {
-      frag.nodes = fallbackState.activeFallback || contentState.nodes
+      frag.nodes = slotResolutionState.activeFallback || contentState.nodes
     },
-    notifyFallbackValidityChange: () => {
+    notifyExposedValidityChange: () => {
       if (slotRoot && !isContentUpdateRecheck && inheritedBoundary) {
         inheritedBoundary.markDirty()
       }
@@ -1485,17 +1485,19 @@ function renderVDOMSlot(
     }
   }
 
-  const recheckAfterContentUpdate = (forceFallbackRecheck = false): void => {
+  const recheckResolutionAfterContentUpdate = (
+    forceResolutionRecheck = false,
+  ): void => {
     isContentUpdateRecheck = true
     try {
-      recheckSlotFallback(fallbackState, forceFallbackRecheck)
+      recheckSlotResolution(slotResolutionState, forceResolutionRecheck)
     } finally {
       isContentUpdateRecheck = false
     }
   }
 
-  const finishContentUpdate = (forceFallbackRecheck = false): void => {
-    recheckAfterContentUpdate(forceFallbackRecheck)
+  const finishContentUpdate = (forceResolutionRecheck = false): void => {
+    recheckResolutionAfterContentUpdate(forceResolutionRecheck)
     notifyUpdated()
   }
 
@@ -1522,7 +1524,7 @@ function renderVDOMSlot(
         insert(contentState.rendered, parentNode, anchor)
       }
 
-      insertActiveSlotFallback(fallbackState)
+      insertActiveSlotFallback(slotResolutionState)
     }
 
     notifyUpdated()
@@ -1546,7 +1548,7 @@ function renderVDOMSlot(
     } else if (contentState.rendered) {
       remove(contentState.rendered, parentNode)
     }
-    disposeSlotFallback(fallbackState)
+    disposeSlotResolution(slotResolutionState)
   }
 
   const render = () => {
@@ -1648,7 +1650,7 @@ function renderVDOMSlot(
                 const prevValid = contentState.valid
                 const prevOutput = frag.nodes
                 setRenderedContent(slotContent)
-                recheckAfterContentUpdate()
+                recheckResolutionAfterContentUpdate()
                 if (
                   contentState.valid !== prevValid ||
                   !isSameResolvedOutput(prevOutput, frag.nodes)
@@ -1665,7 +1667,7 @@ function renderVDOMSlot(
               const prevIsVNode = isVNode(prevRendered)
               const prevVNode =
                 prevIsVNode &&
-                (!fallbackState.activeFallback || contentState.valid)
+                (!slotResolutionState.activeFallback || contentState.valid)
                   ? prevRendered
                   : null
               if (prevRendered && !prevIsVNode) {
@@ -1921,13 +1923,13 @@ function renderVaporSlot(
     let currentAnchor: Node | null = null
     let slotScope: ReturnType<typeof effectScope> | undefined
     let disposed = false
-    let fallbackState!: SlotFallbackState
+    let slotResolutionState!: SlotResolutionState
     let ownedSlotFragment: SlotFragment | undefined
     let ownedSlotFragmentDirtyQueued = false
-    const markInteropFallbackDirty = (): void => {
+    const markInteropSlotResolutionDirty = (): void => {
       const target = ownedSlotFragment
       if (!target) {
-        markSlotFallbackDirty(fallbackState)
+        markSlotResolutionDirty(slotResolutionState)
         return
       }
       // When the inner SlotFragment owns the fallback, a single vdom flush
@@ -1939,7 +1941,7 @@ function renderVaporSlot(
       ownedSlotFragmentDirtyQueued = true
       queuePostFlushCb(() => {
         ownedSlotFragmentDirtyQueued = false
-        markSlotFallbackDirty(target)
+        markSlotResolutionDirty(target)
       })
     }
     const outletFallbackBoundary: SlotBoundaryContext = {
@@ -1949,7 +1951,7 @@ function renderVaporSlot(
       getFallback: () =>
         slotState.outletFallback.value ? outletFallback : undefined,
       run: fn => runWithFragmentCtx(frag, fn),
-      markDirty: markInteropFallbackDirty,
+      markDirty: markInteropSlotResolutionDirty,
     }
     const localFallbackBoundary: SlotBoundaryContext = {
       get parent() {
@@ -1958,9 +1960,9 @@ function renderVaporSlot(
       getFallback: () =>
         slotState.localFallback.value ? localFallback : undefined,
       run: fn => runWithFragmentCtx(frag, fn),
-      markDirty: markInteropFallbackDirty,
+      markDirty: markInteropSlotResolutionDirty,
     }
-    fallbackState = {
+    slotResolutionState = {
       boundary: localFallbackBoundary,
       activeFallback: null,
       pendingRecheck: false,
@@ -1972,18 +1974,18 @@ function renderVaporSlot(
       isDisposed: () => disposed,
       isContentValid: () => isValidBlock(contentNodes),
       syncNodes: () => {
-        frag.nodes = fallbackState.activeFallback || contentNodes
+        frag.nodes = slotResolutionState.activeFallback || contentNodes
         validityPending = false
       },
-      notifyFallbackValidityChange: () => {
+      notifyExposedValidityChange: () => {
         if (inheritedBoundary) {
           inheritedBoundary.markDirty()
         }
       },
     }
     const takePendingRecheck = (): boolean => {
-      const shouldRecheck = fallbackState.pendingRecheck
-      fallbackState.pendingRecheck = false
+      const shouldRecheck = slotResolutionState.pendingRecheck
+      slotResolutionState.pendingRecheck = false
       return shouldRecheck
     }
 
@@ -1993,7 +1995,7 @@ function renderVaporSlot(
         currentParentNode = parentNode
       }
       disposed = true
-      disposeSlotFallback(fallbackState)
+      disposeSlotResolution(slotResolutionState)
       slotScope = undefined
       currentParentNode = null
       currentAnchor = null
@@ -2016,7 +2018,7 @@ function renderVaporSlot(
       )
       const hasInteropFallback =
         !!slotState.localFallback.value || !!slotState.outletFallback.value
-      fallbackState.pendingRecheck = false
+      slotResolutionState.pendingRecheck = false
       const finalizeResolvedContent = (
         resolvedContent: Block | undefined,
       ): Block | undefined => {
@@ -2027,7 +2029,7 @@ function renderVaporSlot(
           return resolvedContent
         }
         contentNodes = resolvedContent || EMPTY_BLOCK
-        recheckSlotFallback(fallbackState, takePendingRecheck())
+        recheckSlotResolution(slotResolutionState, takePendingRecheck())
         return resolvedContent
       }
       let resolvedContent: Block | undefined
@@ -2069,30 +2071,30 @@ function renderVaporSlot(
       if (hasInteropFallback && isSlotFragment(resolvedContent)) {
         ownedSlotFragment = resolvedContent
         trackInteropFallbackChanges(vnode.vs!.scope, slotState, () =>
-          markInteropFallbackDirty(),
+          markInteropSlotResolutionDirty(),
         )
         dispose()
         return resolvedContent
       }
 
-      fallbackState.pendingRecheck = false
+      slotResolutionState.pendingRecheck = false
       frag.insert = (parentNode, anchor) => {
         currentParentNode = parentNode
         currentAnchor = anchor
-        if (fallbackState.activeFallback) {
-          insertActiveSlotFallback(fallbackState)
+        if (slotResolutionState.activeFallback) {
+          insertActiveSlotFallback(slotResolutionState)
         } else {
           insert(frag.nodes, parentNode, anchor)
         }
       }
       frag.remove = parentNode => {
-        if (!fallbackState.activeFallback) {
+        if (!slotResolutionState.activeFallback) {
           remove(frag.nodes, parentNode)
         }
         dispose(parentNode)
       }
       trackInteropFallbackChanges(vnode.vs!.scope, slotState, () => {
-        recheckSlotFallback(fallbackState, true)
+        recheckSlotResolution(slotResolutionState, true)
       })
 
       if (isHydrating && currentHydrationNode) {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -121,7 +121,8 @@ import {
   type VaporFragment,
   isFragment,
   isSlotFragment,
-  runWithFragmentCtx,
+  runWithFragmentCtxOnly,
+  runWithRenderCtx,
 } from './fragment'
 import {
   type SlotBoundaryContext,
@@ -1422,7 +1423,7 @@ function renderVDOMSlot(
       return slotBoundary
     },
     getFallback: (): BlockFn | undefined => localFallback,
-    run: fn => runWithFragmentCtx(frag, fn),
+    run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
     markDirty: () => markSlotResolutionDirty(slotResolutionState),
   }
   slotResolutionState = {
@@ -1556,7 +1557,7 @@ function renderVDOMSlot(
     try {
       const renderSlotContent = () => {
         notifyBeforeUpdate()
-        runWithFragmentCtx(frag, () =>
+        runWithFragmentCtxOnly(frag, () =>
           withSlotBoundary(boundary, () => {
             let slotContent: VNode | Block | undefined
             let slotContentValid = false
@@ -1949,7 +1950,7 @@ function renderVaporSlot(
       },
       getFallback: () =>
         slotState.outletFallback.value ? outletFallback : undefined,
-      run: fn => runWithFragmentCtx(frag, fn),
+      run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
       markDirty: markInteropSlotResolutionDirty,
     }
     const localFallbackBoundary: SlotBoundaryContext = {
@@ -1958,7 +1959,7 @@ function renderVaporSlot(
       },
       getFallback: () =>
         slotState.localFallback.value ? localFallback : undefined,
-      run: fn => runWithFragmentCtx(frag, fn),
+      run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
       markDirty: markInteropSlotResolutionDirty,
     }
     slotResolutionState = {
@@ -2037,7 +2038,7 @@ function renderVaporSlot(
         if (isHydrating) {
           resolvedContent = withHydratingSlotBoundary(() =>
             finalizeResolvedContent(
-              runWithFragmentCtx(frag, () => {
+              runWithFragmentCtxOnly(frag, () => {
                 const renderSlot = () =>
                   withSlotBoundary(localFallbackBoundary, () =>
                     invokeVaporSlot(vnode),
@@ -2050,7 +2051,7 @@ function renderVaporSlot(
           )
         } else {
           resolvedContent = finalizeResolvedContent(
-            runWithFragmentCtx(frag, () =>
+            runWithFragmentCtxOnly(frag, () =>
               withSlotBoundary(localFallbackBoundary, () =>
                 invokeVaporSlot(vnode),
               ),
@@ -2269,7 +2270,7 @@ function createVNodeChildrenFragment(
     simpleSetCurrentInstance(parentComponent)
     try {
       renderEffect(() => {
-        runWithFragmentCtx(frag, () => {
+        runWithFragmentCtxOnly(frag, () => {
           const nextChildren = render()
           notifyBeforeUpdate()
           if (isHydrating) {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1485,6 +1485,7 @@ function renderVDOMSlot(
   }
 
   const notifyUpdated = (): void => {
+    syncInteropRoot(parentComponent)
     if (isMounted && frag.onUpdated) {
       frag.onUpdated.forEach(u => u())
     }
@@ -2165,6 +2166,16 @@ function syncVNodeEl(vnode: VNode, instance: VaporComponentInstance): void {
   }
 }
 
+function syncInteropRoot(instance: VaporComponentInstance): void {
+  const state = vnodeHookStateMap.get(instance)
+  if (!state) return
+  syncVNodeEl(state.vnode, instance)
+  const hooks = state.postRootSyncHooks
+  for (let i = 0; i < hooks.length; i++) {
+    hooks[i](state.vnode)
+  }
+}
+
 interface VNodeHookState {
   vnode: VNode
   skipVnodeHooks: boolean
@@ -2185,7 +2196,7 @@ function ensureVNodeHookState(
       postRootSyncHooks: [],
     }
     vnodeHookStateMap.set(instance, state)
-    ;(instance.bu || (instance.bu = [])).push(() => {
+    ;(instance.bu ||= []).push(() => {
       if (state!.skipVnodeHooks) return
       const vnodeHook =
         state!.vnode.props && state!.vnode.props.onVnodeBeforeUpdate
@@ -2202,13 +2213,7 @@ function ensureVNodeHookState(
     // Sync the outer component vnode before running any updated hooks. Hooks
     // that depend on the latest root, like scoped CSS interop, run immediately
     // after the sync and before component updated hooks / onVnodeUpdated.
-    ;(instance.u || (instance.u = [])).unshift(() => {
-      syncVNodeEl(state!.vnode, instance)
-      const hooks = state!.postRootSyncHooks
-      for (let i = 0; i < hooks.length; i++) {
-        hooks[i](state!.vnode)
-      }
-    })
+    ;(instance.u ||= []).unshift(() => syncInteropRoot(instance))
     instance.u.push(() => {
       if (state!.skipVnodeHooks) {
         state!.skipVnodeHooks = false
@@ -2603,16 +2608,7 @@ function trackInteropScopeIdFragment(
 ): void {
   if (interopScopeIdFragmentMap.get(frag) === instance) return
   interopScopeIdFragmentMap.set(frag, instance)
-  ;(frag.onUpdated || (frag.onUpdated = [])).push(() => {
-    const state = vnodeHookStateMap.get(instance)
-    if (!state) return
-    syncVNodeEl(state.vnode, instance)
-    setInteropVnodeScopeId(
-      instance,
-      state.vnode,
-      instance.parent as ComponentInternalInstance | null,
-    )
-  })
+  ;(frag.onUpdated ||= []).push(() => syncInteropRoot(instance))
 }
 
 function setInteropVnodeScopeId(

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1396,7 +1396,6 @@ function renderVDOMSlot(
   const suspense = currentParentSuspense || parentComponent.suspense
   const frag = createInteropFragment()
   let validityPending = !isHydrating
-  const instance = currentInstance
 
   let isMounted = false
   const contentState = {
@@ -1408,7 +1407,7 @@ function renderVDOMSlot(
   let currentAnchor: Node | null = null
   let disposed = false
   const scope = effectScope()
-  const inheritedBoundary = frag.inheritedSlotBoundary
+  const slotBoundary = frag.slotBoundary
   let isContentUpdateRecheck = false
   let localFallback: BlockFn | undefined
   let slotResolutionState!: SlotResolutionState
@@ -1420,7 +1419,7 @@ function renderVDOMSlot(
   }
   const boundary: SlotBoundaryContext = {
     get parent() {
-      return inheritedBoundary
+      return slotBoundary
     },
     getFallback: (): BlockFn | undefined => localFallback,
     run: fn => runWithFragmentCtx(frag, fn),
@@ -1441,8 +1440,8 @@ function renderVDOMSlot(
       frag.nodes = slotResolutionState.activeFallback || contentState.nodes
     },
     notifyExposedValidityChange: () => {
-      if (slotRoot && !isContentUpdateRecheck && inheritedBoundary) {
-        inheritedBoundary.markDirty()
+      if (slotRoot && !isContentUpdateRecheck && slotBoundary) {
+        slotBoundary.markDirty()
       }
     },
   }
@@ -1553,7 +1552,7 @@ function renderVDOMSlot(
 
   const render = () => {
     const prev = currentInstance
-    simpleSetCurrentInstance(instance)
+    simpleSetCurrentInstance(frag.renderInstance)
     try {
       const renderSlotContent = () => {
         notifyBeforeUpdate()
@@ -1914,7 +1913,7 @@ function renderVaporSlot(
     let validityPending = !isHydrating
     frag.isBlockValid = () =>
       validityPending ? true : isValidBlock(frag.nodes)
-    const inheritedBoundary = frag.inheritedSlotBoundary
+    const slotBoundary = frag.slotBoundary
     let contentNodes: Block = EMPTY_BLOCK
     let isResolvingContent = false
     let localFallback!: BlockFn
@@ -1946,7 +1945,7 @@ function renderVaporSlot(
     }
     const outletFallbackBoundary: SlotBoundaryContext = {
       get parent() {
-        return inheritedBoundary
+        return slotBoundary
       },
       getFallback: () =>
         slotState.outletFallback.value ? outletFallback : undefined,
@@ -1978,8 +1977,8 @@ function renderVaporSlot(
         validityPending = false
       },
       notifyExposedValidityChange: () => {
-        if (inheritedBoundary) {
-          inheritedBoundary.markDirty()
+        if (slotBoundary) {
+          slotBoundary.markDirty()
         }
       },
     }
@@ -2252,8 +2251,8 @@ function createVNodeChildrenFragment(
   }
 
   const notifyUpdated = (validityChanged = false): void => {
-    if (validityChanged && frag.inheritedSlotBoundary) {
-      frag.inheritedSlotBoundary.markDirty()
+    if (validityChanged && frag.slotBoundary) {
+      frag.slotBoundary.markDirty()
     }
     if (isMounted && frag.onUpdated) {
       frag.onUpdated.forEach(hook => hook())
@@ -2284,7 +2283,7 @@ function createVNodeChildrenFragment(
             // patching needs the boundary insertion point after that local
             // anchor; otherwise later fallback siblings patch in front of it.
             if (
-              frag.inheritedSlotBoundary &&
+              frag.slotBoundary &&
               currentAnchor &&
               isHydrationAnchor(currentAnchor) &&
               currentAnchor !== getCurrentSlotEndAnchor() &&

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -117,16 +117,17 @@ import {
 import {
   type DynamicFragment,
   RenderContextFragment,
-  SlotFragment,
+  type SlotFragment,
   type VaporFragment,
   isFragment,
+  isSlotFragment,
   runWithFragmentCtx,
 } from './fragment'
 import {
   type SlotBoundaryContext,
   hasSlotFallback,
   trackSlotBoundaryDirtying,
-  withOwnedSlotBoundary,
+  withSlotBoundary,
 } from './slotBoundary'
 import {
   type SlotFallbackState,
@@ -1555,7 +1556,7 @@ function renderVDOMSlot(
       const renderSlotContent = () => {
         notifyBeforeUpdate()
         runWithFragmentCtx(frag, () =>
-          withOwnedSlotBoundary(boundary, () => {
+          withSlotBoundary(boundary, () => {
             let slotContent: VNode | Block | undefined
             let slotContentValid = false
 
@@ -2022,7 +2023,7 @@ function renderVaporSlot(
         if (resolvedContent && scopeIds) {
           setScopeId(resolvedContent, scopeIds)
         }
-        if (hasInteropFallback && resolvedContent instanceof SlotFragment) {
+        if (hasInteropFallback && isSlotFragment(resolvedContent)) {
           return resolvedContent
         }
         contentNodes = resolvedContent || EMPTY_BLOCK
@@ -2037,7 +2038,7 @@ function renderVaporSlot(
             finalizeResolvedContent(
               runWithFragmentCtx(frag, () => {
                 const renderSlot = () =>
-                  withOwnedSlotBoundary(localFallbackBoundary, () =>
+                  withSlotBoundary(localFallbackBoundary, () =>
                     invokeVaporSlot(vnode),
                   )
                 return hasSlotFallback(localFallbackBoundary)
@@ -2049,7 +2050,7 @@ function renderVaporSlot(
         } else {
           resolvedContent = finalizeResolvedContent(
             runWithFragmentCtx(frag, () =>
-              withOwnedSlotBoundary(localFallbackBoundary, () =>
+              withSlotBoundary(localFallbackBoundary, () =>
                 invokeVaporSlot(vnode),
               ),
             ),
@@ -2065,7 +2066,7 @@ function renderVaporSlot(
           onScopeDispose(() => dispose(), true)
         })
       }
-      if (hasInteropFallback && resolvedContent instanceof SlotFragment) {
+      if (hasInteropFallback && isSlotFragment(resolvedContent)) {
         ownedSlotFragment = resolvedContent
         trackInteropFallbackChanges(vnode.vs!.scope, slotState, () =>
           markInteropFallbackDirty(),

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -70,6 +70,7 @@ import {
   type VaporTransitionHooks,
   insert,
   isValidBlock,
+  isValidSlot,
   move,
   remove,
 } from './block'
@@ -1415,7 +1416,7 @@ function renderVDOMSlot(
   frag.isBlockValid = () => {
     if (validityPending) return true
     return slotResolutionState.activeFallback
-      ? isValidBlock(slotResolutionState.activeFallback)
+      ? isValidSlot(slotResolutionState.activeFallback)
       : contentState.valid
   }
   const boundary: SlotBoundaryContext = {
@@ -1465,7 +1466,7 @@ function renderVDOMSlot(
     } else if (rendered) {
       contentState.nodes = rendered
       contentState.valid =
-        knownValid === undefined ? isValidBlock(rendered) : knownValid
+        knownValid === undefined ? isValidSlot(rendered) : knownValid
     } else {
       contentState.nodes = EMPTY_BLOCK
       contentState.valid = false
@@ -1586,7 +1587,7 @@ function renderVDOMSlot(
                   slotContentValid = true
                 }
               } else if (slotContent) {
-                slotContentValid = isValidBlock(slotContent)
+                slotContentValid = isValidSlot(slotContent)
               }
             }
 
@@ -1912,8 +1913,7 @@ function renderVaporSlot(
     // fallback blocks that can later resolve to an empty vnode list.
     const frag = createInteropFragment()
     let validityPending = !isHydrating
-    frag.isBlockValid = () =>
-      validityPending ? true : isValidBlock(frag.nodes)
+    frag.isBlockValid = () => (validityPending ? true : isValidSlot(frag.nodes))
     const slotBoundary = frag.slotBoundary
     let contentNodes: Block = EMPTY_BLOCK
     let isResolvingContent = false
@@ -1972,7 +1972,7 @@ function renderVaporSlot(
       getAnchor: () => currentAnchor,
       isBusy: () => isResolvingContent,
       isDisposed: () => disposed,
-      isContentValid: () => isValidBlock(contentNodes),
+      isContentValid: () => isValidSlot(contentNodes),
       syncNodes: () => {
         frag.nodes = slotResolutionState.activeFallback || contentNodes
         validityPending = false

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -47,8 +47,8 @@ export enum VaporBlockShape {
  * - bits 0-1: true branch VaporBlockShape
  * - bits 2-3: false branch VaporBlockShape
  * - bit 4: v-once
- * - bit 5: true branch does not need EffectScope
- * - bit 6: false branch does not need EffectScope
+ * - bit 5: true branch is static and can skip branch-owned EffectScope
+ * - bit 6: false branch is static and can skip branch-owned EffectScope
  * - bit 7: v-if sits on a slot content/fallback root chain
  * - bits 8+: branch index + 1 for keyed dynamic fragments
  *
@@ -67,13 +67,13 @@ export enum VaporIfFlags {
    */
   ONCE = 1 << 4,
   /**
-   * The compiler proved that the true branch does not create branch-owned
-   * effects or disposers.
+   * The compiler proved that the true branch only returns static template nodes,
+   * so runtime can skip creating a branch-owned EffectScope.
    */
   TRUE_NO_SCOPE = 1 << 5,
   /**
-   * The compiler proved that the false branch does not create branch-owned
-   * effects or disposers.
+   * The compiler proved that the false branch only returns static template
+   * nodes, so runtime can skip creating a branch-owned EffectScope.
    */
   FALSE_NO_SCOPE = 1 << 6,
   /**


### PR DESCRIPTION
Ensure slot boundary dirtying relies on paired before/updated hooks instead of
refreshing its previous validity during updated.

Also trigger beforeUpdate for VDOM slot content refreshes and VNode children
fragment updates, and cover the vdom slot child root update order in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified slot resolution and fragment boundary handling across runtime and vDOM interop, improving consistency for slot rendering and updates.
  * Refined fragment-context execution in Teleport and tightened async component pending-validity behavior.
* **Bug Fixes**
  * Fixed slot fragment lifecycle ordering and improved hydration marker/layout correctness during updates (including `v-for` and branch switching).
  * Corrected slot-vs-block validity calculations, including interop and component-validity edge cases.
* **Tests**
  * Updated and expanded runtime, compiler, interop, and hydration test coverage for the new slot-resolution model.
* **Documentation**
  * Clarified slot boundary invalidation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->