### PR TITLE
fix(runtime-core): handle non-isomorphic block element update

### DIFF
--- a/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
+++ b/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
@@ -825,6 +825,24 @@ describe('renderer: optimized mode', () => {
     expect(inner(root)).toBe('<div><div><span>loading</span></div></div>')
   })
 
+  // #6385
+  test('should fall back to full diff when the user patches a compiled slot', () => {
+    render(h('div', { id: 'placeholder' }), root)
+
+    render(
+      (openBlock(),
+      createElementBlock('div', { id: 'resolved' }, [
+        createTextVNode('hello '),
+        createElementVNode('button', null, '0', PatchFlags.TEXT),
+      ])),
+      root,
+    )
+
+    expect(inner(root)).toBe(
+      '<div id="resolved">hello <button>0</button></div>',
+    )
+  })
+
   // #3828
   test('patch Suspense in optimized mode w/ nested dynamic nodes', async () => {
     const show = ref(false)

--- a/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
+++ b/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
@@ -826,20 +826,25 @@ describe('renderer: optimized mode', () => {
   })
 
   // #6385
-  test('should fall back to full diff when the user patches a compiled slot', () => {
+  test('should fully diff props when falling back from a non-isomorphic block', () => {
     render(h('div', { id: 'placeholder' }), root)
 
     render(
       (openBlock(),
-      createElementBlock('div', { id: 'resolved' }, [
-        createTextVNode('hello '),
-        createElementVNode('button', null, '0', PatchFlags.TEXT),
-      ])),
+      createElementBlock(
+        'div',
+        { class: 'resolved' },
+        [
+          createTextVNode('hello '),
+          createElementVNode('button', null, '0', PatchFlags.TEXT),
+        ],
+        PatchFlags.CLASS,
+      )),
       root,
     )
 
     expect(inner(root)).toBe(
-      '<div id="resolved">hello <button>0</button></div>',
+      '<div class="resolved">hello <button>0</button></div>',
     )
   })
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -855,8 +855,8 @@ function baseCreateRenderer(
     }
     parentComponent && toggleRecurse(parentComponent, true)
 
-    // HMR updated, force full diff
     if (__DEV__ && isHmrUpdating) {
+      // HMR updated, force full diff
       patchFlag = 0
       optimized = false
       dynamicChildren = null

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -855,8 +855,15 @@ function baseCreateRenderer(
     }
     parentComponent && toggleRecurse(parentComponent, true)
 
-    if (__DEV__ && isHmrUpdating) {
-      // HMR updated, force full diff
+    // #6385 the old vnode may be a user-wrapped non-isomorphic block
+    const isFullDiffRequired = !(
+      dynamicChildren &&
+      n1.dynamicChildren &&
+      n1.dynamicChildren.length === dynamicChildren.length
+    )
+
+    // HMR updated, force full diff
+    if (isFullDiffRequired || (__DEV__ && isHmrUpdating)) {
       patchFlag = 0
       optimized = false
       dynamicChildren = null
@@ -871,22 +878,7 @@ function baseCreateRenderer(
       hostSetElementText(el, '')
     }
 
-    if (dynamicChildren) {
-      patchBlockChildren(
-        n1.dynamicChildren!,
-        dynamicChildren,
-        el,
-        parentComponent,
-        parentSuspense,
-        resolveChildrenNamespace(n2, namespace),
-        slotScopeIds,
-      )
-      if (__DEV__) {
-        // necessary for HMR
-        traverseStaticChildren(n1, n2)
-      }
-    } else if (!optimized) {
-      // full diff
+    if (isFullDiffRequired) {
       patchChildren(
         n1,
         n2,
@@ -898,6 +890,20 @@ function baseCreateRenderer(
         slotScopeIds,
         false,
       )
+    } else {
+      patchBlockChildren(
+        n1.dynamicChildren!,
+        dynamicChildren!,
+        el,
+        parentComponent,
+        parentSuspense,
+        resolveChildrenNamespace(n2, namespace),
+        slotScopeIds,
+      )
+      if (__DEV__) {
+        // necessary for HMR
+        traverseStaticChildren(n1, n2)
+      }
     }
 
     if (patchFlag > 0) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -855,8 +855,15 @@ function baseCreateRenderer(
     }
     parentComponent && toggleRecurse(parentComponent, true)
 
-    if (__DEV__ && isHmrUpdating) {
+    if (
       // HMR updated, force full diff
+      (__DEV__ && isHmrUpdating) ||
+      // #6385 the old vnode may be a user-wrapped non-isomorphic block
+      // Force full diff when block metadata is unstable.
+      (dynamicChildren &&
+        (!n1.dynamicChildren ||
+          n1.dynamicChildren.length !== dynamicChildren.length))
+    ) {
       patchFlag = 0
       optimized = false
       dynamicChildren = null
@@ -871,14 +878,9 @@ function baseCreateRenderer(
       hostSetElementText(el, '')
     }
 
-    // #6385 the old vnode may be a user-wrapped non-isomorphic block
-    if (
-      dynamicChildren &&
-      n1.dynamicChildren &&
-      n1.dynamicChildren.length === dynamicChildren.length
-    ) {
+    if (dynamicChildren) {
       patchBlockChildren(
-        n1.dynamicChildren,
+        n1.dynamicChildren!,
         dynamicChildren,
         el,
         parentComponent,
@@ -890,7 +892,7 @@ function baseCreateRenderer(
         // necessary for HMR
         traverseStaticChildren(n1, n2)
       }
-    } else if (!optimized || dynamicChildren) {
+    } else if (!optimized) {
       // full diff
       patchChildren(
         n1,
@@ -903,8 +905,6 @@ function baseCreateRenderer(
         slotScopeIds,
         false,
       )
-      optimized = false
-      dynamicChildren = null
     }
 
     if (patchFlag > 0) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -855,15 +855,8 @@ function baseCreateRenderer(
     }
     parentComponent && toggleRecurse(parentComponent, true)
 
-    // #6385 the old vnode may be a user-wrapped non-isomorphic block
-    const isFullDiffRequired = !(
-      dynamicChildren &&
-      n1.dynamicChildren &&
-      n1.dynamicChildren.length === dynamicChildren.length
-    )
-
     // HMR updated, force full diff
-    if (isFullDiffRequired || (__DEV__ && isHmrUpdating)) {
+    if (__DEV__ && isHmrUpdating) {
       patchFlag = 0
       optimized = false
       dynamicChildren = null
@@ -878,7 +871,27 @@ function baseCreateRenderer(
       hostSetElementText(el, '')
     }
 
-    if (isFullDiffRequired) {
+    // #6385 the old vnode may be a user-wrapped non-isomorphic block
+    if (
+      dynamicChildren &&
+      n1.dynamicChildren &&
+      n1.dynamicChildren.length === dynamicChildren.length
+    ) {
+      patchBlockChildren(
+        n1.dynamicChildren,
+        dynamicChildren,
+        el,
+        parentComponent,
+        parentSuspense,
+        resolveChildrenNamespace(n2, namespace),
+        slotScopeIds,
+      )
+      if (__DEV__) {
+        // necessary for HMR
+        traverseStaticChildren(n1, n2)
+      }
+    } else if (!optimized || dynamicChildren) {
+      // full diff
       patchChildren(
         n1,
         n2,
@@ -890,20 +903,8 @@ function baseCreateRenderer(
         slotScopeIds,
         false,
       )
-    } else {
-      patchBlockChildren(
-        n1.dynamicChildren!,
-        dynamicChildren!,
-        el,
-        parentComponent,
-        parentSuspense,
-        resolveChildrenNamespace(n2, namespace),
-        slotScopeIds,
-      )
-      if (__DEV__) {
-        // necessary for HMR
-        traverseStaticChildren(n1, n2)
-      }
+      optimized = false
+      dynamicChildren = null
     }
 
     if (patchFlag > 0) {


### PR DESCRIPTION
fix #6385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering updates where placeholder output was not fully replaced during dynamic/compiled updates, ensuring the final DOM matches the fully resolved UI.
  * Improved renderer fallback behavior when block metadata is inconsistent, forcing a full children diff to keep nested elements, text, and classes in sync.
* **Tests**
  * Added a new optimized-mode test to verify correct DOM results when re-rendering from placeholder content to a compiled-style vnode tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->