### PR TITLE
fix(compiler-core): handle function expression handler containing semicolon

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -369,6 +369,37 @@ describe('compiler: transform v-on', () => {
     })
   })
 
+  // #14287
+  test('should NOT wrap as function if expression is a function expression containing a semicolon', () => {
+    const { node } = parseWithVOn(`<div @click="function () { foo(';') }"/>`)
+    expect((node.codegenNode as VNodeCall).props).toMatchObject({
+      properties: [
+        {
+          key: { content: `onClick` },
+          value: {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `function () { foo(';') }`,
+          },
+        },
+      ],
+    })
+
+    const { node: node2 } = parseWithVOn(
+      `<div @click="$event => { foo(';') }"/>`,
+    )
+    expect((node2.codegenNode as VNodeCall).props).toMatchObject({
+      properties: [
+        {
+          key: { content: `onClick` },
+          value: {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `$event => { foo(';') }`,
+          },
+        },
+      ],
+    })
+  })
+
   test('should NOT wrap as function if expression is complex member expression', () => {
     const { node } = parseWithVOn(`<div @click="a['b' + c]"/>`)
     expect((node.codegenNode as VNodeCall).props).toMatchObject({

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -39,6 +39,7 @@ import {
   defaultOnWarn,
 } from './errors'
 import {
+  fnExpRE,
   forAliasRE,
   isAllWhitespace,
   isCoreComponent,
@@ -363,7 +364,13 @@ const tokenizer = new Tokenizer(stack, {
               expParseMode = ExpParseMode.Params
             } else if (
               currentProp.name === 'on' &&
-              currentAttrValue.includes(';')
+              currentAttrValue.includes(';') &&
+              // #14287: a single function expression handler is not a list of
+              // inline statements even if it contains `;` (e.g. inside its body
+              // or a string), so it must be parsed as an expression. Parsing it
+              // as statements would treat an anonymous `function () {}` as an
+              // illegal function declaration.
+              !fnExpRE.test(currentAttrValue)
             ) {
               expParseMode = ExpParseMode.Statements
             }

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -189,7 +189,7 @@ export const isMemberExpression: (
   context: TransformContext,
 ) => boolean = __BROWSER__ ? isMemberExpressionBrowser : isMemberExpressionNode
 
-const fnExpRE =
+export const fnExpRE: RegExp =
   /^\s*(?:async\s*)?(?:\([^)]*?\)|[\w$_]+)\s*(?::[^=]+)?=>|^\s*(?:async\s+)?function(?:\s+[\w$]+)?\s*\(/
 
 export const isFnExpressionBrowser: (exp: ExpressionNode) => boolean = exp =>


### PR DESCRIPTION
### What does this PR do?

Fixes #14287

A `v-on` handler that is a single **function expression** but contains a `;` — either inside its body or inside a string literal — currently throws at compile time:

```html
<button @click="function () { foo(';') }">x</button>
```

```
SyntaxError: Unexpected token (1:10)
```

### Why

In `parser.ts`, a `v-on` value is parsed in `ExpParseMode.Statements` whenever it contains `;`. For a list of inline statements (`foo();bar()`) this is correct. But a lone function expression also contains `;`, and parsing it as a *statement program* turns an anonymous `function () {}` into an illegal function declaration, hence the error. Arrow handlers happened to work, so the behavior was asymmetric.

### Fix

Skip statement parse mode when the value is itself a function expression (detected with the existing `fnExpRE`). `fnExpRE` is now exported from `utils.ts` and reused in `parser.ts`.

- `function () { foo(';') }` → compiles, preserved as-is
- `$event => { foo(';') }` → compiles, preserved as-is
- `foo();bar()` → unchanged, still wrapped as multi-statement handler

Added regression tests in `transforms/vOn.spec.ts`. Full `compiler-core`, `compiler-dom` and `compiler-sfc` suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of event handler expressions in templates, especially when function bodies contain semicolons.
  * `v-on` handlers written as regular functions or arrow functions are now preserved correctly instead of being transformed into inline wrappers.
  * Added coverage to ensure these handler forms continue to compile as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->