### PR TITLE
fix(ssr): dedupe inherited scope ids during vnode rendering

### DIFF
--- a/packages/server-renderer/__tests__/ssrScopeId.spec.ts
+++ b/packages/server-renderer/__tests__/ssrScopeId.spec.ts
@@ -1,6 +1,11 @@
-import { createApp, h, mergeProps, withCtx } from 'vue'
+import { createApp, createVNode, h, mergeProps, withCtx } from 'vue'
 import { renderToString } from '../src/renderToString'
-import { ssrRenderAttrs, ssrRenderComponent, ssrRenderSlot } from '../src'
+import {
+  ssrRenderAttrs,
+  ssrRenderComponent,
+  ssrRenderSlot,
+  ssrRenderVNode,
+} from '../src'
 
 describe('ssr: scopedId runtime behavior', () => {
   test('id on component root', async () => {
@@ -268,5 +273,38 @@ describe('ssr: scopedId runtime behavior', () => {
         `<!--[--><!--[--><div root slotted-s wrapper-s></div><!--]--><!--]-->` +
         `</div>`,
     )
+  })
+
+  // #12159
+  test('avoid duplicate scopeId through recursive ssr vnode roots', async () => {
+    let count = 2
+
+    const Comp = {
+      __scopeId: 'comp',
+      ssrRender: (ctx: any, push: any, parent: any, attrs: any) => {
+        if (--count) {
+          push(ssrRenderComponent(Comp, attrs, null, parent))
+        } else {
+          ssrRenderVNode(push, createVNode('div', attrs, 'vuejs'), parent)
+        }
+      },
+    }
+
+    const result = await renderToString(createApp(Comp))
+    expect(result).toBe(`<div comp>vuejs</div>`)
+  })
+
+  test('avoid duplicate scopeId through recursive render roots', async () => {
+    let count = 2
+
+    const Comp = {
+      __scopeId: 'comp',
+      render(this: any) {
+        return --count ? h(Comp, this.$attrs) : h('div', this.$attrs, 'vuejs')
+      },
+    }
+
+    const result = await renderToString(createApp(Comp))
+    expect(result).toBe(`<div comp>vuejs</div>`)
   })
 })

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -19,6 +19,7 @@ import {
   ShapeFlags,
   escapeHtml,
   escapeHtmlComment,
+  hasOwn,
   isArray,
   isFunction,
   isPromise,
@@ -303,8 +304,20 @@ function renderElementVNode(
     openTag += ssrRenderAttrs(props, tag)
   }
 
+  const renderedScopeIds: string[] = []
+  const appendScopeId = (id: string) => {
+    if (
+      id &&
+      (!props || !hasOwn(props, id)) &&
+      !renderedScopeIds.includes(id)
+    ) {
+      openTag += ` ${id}`
+      renderedScopeIds.push(id)
+    }
+  }
+
   if (scopeId) {
-    openTag += ` ${scopeId}`
+    appendScopeId(scopeId)
   }
   // inherit parent chain scope id if this is the root node
   let curParent: ComponentInternalInstance | null = parentComponent
@@ -312,12 +325,15 @@ function renderElementVNode(
   while (curParent && curVnode === curParent.subTree) {
     curVnode = curParent.vnode
     if (curVnode.scopeId) {
-      openTag += ` ${curVnode.scopeId}`
+      appendScopeId(curVnode.scopeId)
     }
     curParent = curParent.parent
   }
   if (slotScopeId) {
-    openTag += ` ${slotScopeId}`
+    const slotScopeIdList = slotScopeId.trim().split(' ')
+    for (let i = 0; i < slotScopeIdList.length; i++) {
+      appendScopeId(slotScopeIdList[i])
+    }
   }
 
   push(openTag + `>`)


### PR DESCRIPTION
close #12159
close #12175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate scope identifiers in server-rendered output for recursive component and root rendering cases.
  * Improved handling of inherited and slot-related scope IDs so they are only applied once, preventing repeated attributes in rendered HTML.
* **Tests**
  * Added coverage for recursive SSR scenarios to verify scope IDs remain unique in the final output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->