### PR TITLE
docs(sfc-playground): update downloaded template Node.js requirement

### DIFF
--- a/packages-private/sfc-playground/src/download/template/README.md
+++ b/packages-private/sfc-playground/src/download/template/README.md
@@ -1,6 +1,6 @@
 # Vite Vue Starter
 
-This is a project template using [Vite](https://vitejs.dev/). It requires [Node.js](https://nodejs.org) version 18+ or 20+.
+This is a project template using [Vite](https://vitejs.dev/). It requires [Node.js](https://nodejs.org) version 20.19+ or 22.12+.
 
 To start:
 


### PR DESCRIPTION
Update the downloaded SFC Playground template README to match Vite's current Node.js version requirements.

Vite now requires Node.js 20.19+ or 22.12+, so the previous `18+ or 20+` wording was outdated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the starter template requirements to reflect the latest supported Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->