### PR TITLE
fix(sfc-playground): fix version copy message

### DIFF
--- a/packages-private/sfc-playground/src/VersionSelect.vue
+++ b/packages-private/sfc-playground/src/VersionSelect.vue
@@ -56,7 +56,9 @@ function setVersion(v: string) {
 
 function copyVersion(v: string) {
   window.navigator.clipboard.writeText(v).then(() => {
-    alert('Vue version has been copied to clipboard.')
+    alert(
+      `${props.label.replace(/Version$/, 'version')} has been copied to clipboard.`,
+    )
   })
 }
 


### PR DESCRIPTION
- Fix the version copy success message in the SFC playground.
- Previously, all version selectors showed "Vue version has been copied to clipboard.", including the TypeScript version selector.
- After the fix, the TypeScript selector shows the TypeScript copy message, and the Vue selector shows the Vue copy message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the clipboard confirmation message so it now reflects the selected version label instead of always showing the same text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->