### PR TITLE
fix(runtime-core): pass context to functional rest-param fns

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -136,6 +136,32 @@ describe('component props', () => {
     expect(props).toBe(attrs)
   })
 
+  // #13182
+  test('functional component with rest params receives context', () => {
+    let args: any
+    const Comp: FunctionalComponent = (...rest) => {
+      args = rest
+      // actively exercise the slots access path so an empty or otherwise
+      // unusable context object cannot satisfy the assertions below
+      return rest[1].slots.default!()
+    }
+
+    const root = nodeOps.createElement('div')
+    render(
+      h(Comp, { foo: 1 }, () => h('span')),
+      root,
+    )
+
+    // second argument must be the render context, not null
+    expect(args[1]).not.toBeNull()
+    expect(args[1]).toMatchObject({
+      attrs: { foo: 1 },
+    })
+    expect(typeof args[1].emit).toBe('function')
+    // the slot from the context was actually rendered
+    expect(serializeInner(root)).toBe('<span></span>')
+  })
+
   test('boolean casting', () => {
     let proxy: any
     const Comp = {

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -116,9 +116,18 @@ export function renderComponentRoot(
       if (__DEV__ && attrs === props) {
         markAttrsAccessed()
       }
+      // pass the context object unless the function declares exactly one
+      // parameter (just `props`). A rest-param function `(...args)` reports
+      // `length === 0`, so the previous `length > 1` check denied it
+      // attrs/slots/emit; only skip the context for the single-`props` case
+      // to keep that fast path allocation-free. (#13182)
       result = normalizeVNode(
-        render.length > 1
+        render.length === 1
           ? render(
+              __DEV__ ? shallowReadonly(props) : props,
+              null as any /* we know it doesn't need it */,
+            )
+          : render(
               __DEV__ ? shallowReadonly(props) : props,
               __DEV__
                 ? {
@@ -130,10 +139,6 @@ export function renderComponentRoot(
                     emit,
                   }
                 : { attrs, slots, emit },
-            )
-          : render(
-              __DEV__ ? shallowReadonly(props) : props,
-              null as any /* we know it doesn't need it */,
             ),
       )
       fallthroughAttrs = Component.props


### PR DESCRIPTION
A functional component declared with rest params (`(...args)`) reports `Function.length === 0`, so the `render.length > 1` fast path passed `null` as the context argument, leaving the component without access to `attrs`, `slots` and `emit`.

Always pass the context object; rest params cannot be distinguished from zero-arg functions via `Function.length`.

close #13182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed functional component rendering so components using rest parameters consistently receive the expected render context (attributes, slots, and emit).
  * Improved development-time tracking of attribute access to avoid incorrect `$attrs`-related warnings.

* **Tests**
  * Added a new test covering functional components declared with rest parameters to ensure the render context is populated and slot rendering behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->