### PR TITLE
fix(runtime-core): resolve $el to root el for dev root fragment

### DIFF
--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -1,5 +1,8 @@
 import {
+  Fragment,
   KeepAlive,
+  createCommentVNode,
+  createVNode,
   defineAsyncComponent,
   defineComponent,
   h,
@@ -12,6 +15,7 @@ import {
   shallowRef,
   watch,
 } from '@vue/runtime-test'
+import { PatchFlags } from '@vue/shared'
 
 describe('api: template refs', () => {
   it('string ref mount', () => {
@@ -738,5 +742,36 @@ describe('api: template refs', () => {
     toggle.value = true
     await nextTick()
     expect(instanceRef.value.name).toBe('AsyncComp')
+  })
+
+  // #12680
+  it('$el of a component with a DEV_ROOT_FRAGMENT root (leading comment + single element) points to the element', () => {
+    const childRef = ref<any>(null)
+
+    // mimics what the compiler produces in dev for a template like
+    // `<!-- comment --><div>hello</div>`: a root fragment flagged as
+    // DEV_ROOT_FRAGMENT whose `el` is the fragment's text anchor.
+    const Child = {
+      render() {
+        return createVNode(
+          Fragment,
+          null,
+          [createCommentVNode('comment'), h('div', 'hello')],
+          PatchFlags.DEV_ROOT_FRAGMENT,
+        )
+      },
+    }
+
+    const Comp = {
+      render() {
+        return h(Child, { ref: childRef })
+      },
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+
+    // $el should resolve to the real <div>, not the comment/anchor node
+    expect(childRef.value.$el.tag).toBe('div')
   })
 })

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -17,6 +17,7 @@ import {
   EMPTY_OBJ,
   type IfAny,
   NOOP,
+  PatchFlags,
   type Prettify,
   type UnionToIntersection,
   extend,
@@ -51,7 +52,8 @@ import {
 } from './componentOptions'
 import type { EmitFn, EmitsOptions } from './componentEmits'
 import type { SlotsType, UnwrapSlotsType } from './componentSlots'
-import { markAttrsAccessed } from './componentRenderUtils'
+import { filterSingleRoot, markAttrsAccessed } from './componentRenderUtils'
+import type { VNodeArrayChildren } from './vnode'
 import { currentRenderingInstance } from './componentRenderContext'
 import { warn } from './warning'
 import { installCompatInstanceProperties } from './compat/instance'
@@ -363,7 +365,24 @@ export const publicPropertiesMap: PublicPropertiesMap =
   // due to type annotation
   /*@__PURE__*/ extend(Object.create(null), {
     $: i => i,
-    $el: i => i.vnode.el,
+    $el: i => {
+      // #12680: a DEV_ROOT_FRAGMENT (leading comment + single element) sets
+      // `vnode.el` to the fragment anchor, so resolve the real root element
+      if (
+        __DEV__ &&
+        i.subTree &&
+        i.subTree.patchFlag > 0 &&
+        i.subTree.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
+      ) {
+        const singleRoot = filterSingleRoot(
+          i.subTree.children as VNodeArrayChildren,
+        )
+        if (singleRoot && singleRoot.el) {
+          return singleRoot.el
+        }
+      }
+      return i.vnode.el
+    },
     $data: i => i.data,
     $props: i => (__DEV__ ? shallowReadonly(i.props) : i.props),
     $attrs: i => (__DEV__ ? shallowReadonly(i.attrs) : i.attrs),


### PR DESCRIPTION
In dev, a leading comment followed by a single root element compiles to a root fragment flagged `DEV_ROOT_FRAGMENT`, whose `vnode.el` points at the fragment's text anchor rather than the real element, so `$el` returned the anchor instead of the element.

Resolve the real single root via `filterSingleRoot`, mirroring the existing scopeId/attr-fallthrough handling. Dev-only and gated.

close #12680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template refs now resolve `$el` to the actual rendered element when a component returns a fragment with a single root node.
  * Improved the element reported by component instances in development so it no longer points to fragment placeholder nodes in this case.
  * Added coverage for this template ref behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->