### PR TITLE
fix(types): infer components registered in mixins

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -691,6 +691,72 @@ describe('with mixins', () => {
   ;<MyComponent aP1={1} bP2={[1]} />
 })
 
+// #13253
+describe('with mixins: components inference', () => {
+  const Foo = defineComponent({ render: () => null })
+  const Bar = defineComponent({ render: () => null })
+  const MixinFoo = defineComponent({ components: { Foo } })
+  const MixinBar = defineComponent({ components: { Bar } })
+  const MixinExtendsFoo = defineComponent({ extends: MixinFoo })
+
+  // a component registered in a mixin is inferred on the consumer
+  defineComponent({
+    mixins: [MixinFoo],
+    render() {
+      const c = this.$options.components!
+      expectType<typeof Foo>(c.Foo)
+      // reverse direction guards against a vacuous never/any pass
+      expectType<typeof c.Foo>(Foo)
+      return null
+    },
+  })
+
+  // components from multiple mixins are merged
+  defineComponent({
+    mixins: [MixinFoo, MixinBar],
+    render() {
+      const c = this.$options.components!
+      expectType<typeof Foo>(c.Foo)
+      expectType<typeof Bar>(c.Bar)
+      return null
+    },
+  })
+
+  // components surface through an extends-chain
+  defineComponent({
+    mixins: [MixinExtendsFoo],
+    render() {
+      expectType<typeof Foo>(this.$options.components!.Foo)
+      return null
+    },
+  })
+
+  // a local component overrides a mixin component of the same name, matching
+  // the runtime merge (own wins) rather than intersecting the two
+  defineComponent({
+    mixins: [MixinFoo],
+    components: { Foo: Bar },
+    render() {
+      const c = this.$options.components!
+      expectType<typeof Bar>(c.Foo)
+      expectType<typeof c.Foo>(Bar)
+      return null
+    },
+  })
+
+  // declaring own components still preserves non-colliding inherited ones
+  defineComponent({
+    mixins: [MixinFoo],
+    components: { Bar },
+    render() {
+      const c = this.$options.components!
+      expectType<typeof Foo>(c.Foo)
+      expectType<typeof Bar>(c.Bar)
+      return null
+    },
+  })
+})
+
 describe('with extends', () => {
   const Base = defineComponent({
     props: {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -478,7 +478,7 @@ export type MergedComponentOptionsOverride = {
   errorCaptured?: MergedHook<ErrorCapturedHook>
 }
 
-export type OptionTypesKeys = 'P' | 'B' | 'D' | 'C' | 'M' | 'Defaults'
+export type OptionTypesKeys = 'P' | 'B' | 'D' | 'C' | 'M' | 'Defaults' | 'LC'
 
 export type OptionTypesType<
   P = {},
@@ -487,6 +487,7 @@ export type OptionTypesType<
   C extends ComputedOptions = {},
   M extends MethodOptions = {},
   Defaults = {},
+  LC extends Record<string, Component> = {},
 > = {
   P: P
   B: B
@@ -494,6 +495,7 @@ export type OptionTypesType<
   C: C
   M: M
   Defaults: Defaults
+  LC: LC
 }
 
 enum OptionTypes {

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -105,12 +105,20 @@ type MixinToOptionTypes<T> =
     any,
     any,
     any,
-    any,
+    infer LC,
     any,
     any,
     any
   >
-    ? OptionTypesType<P & {}, B & {}, D & {}, C & {}, M & {}, Defaults & {}> &
+    ? OptionTypesType<
+        P & {},
+        B & {},
+        D & {},
+        C & {},
+        M & {},
+        Defaults & {},
+        LC & {}
+      > &
         IntersectionMixin<Mixin> &
         IntersectionMixin<Extends>
     : never
@@ -131,6 +139,19 @@ export type UnwrapMixinsType<
 > = T extends OptionTypesType ? T[Type] : never
 
 type EnsureNonVoid<T> = T extends void ? {} : T
+
+// drop `string`/`number` index signatures, keeping only explicitly declared
+// keys. `components` is typed as `LC & Record<string, Component>`, so the
+// inferred local-component maps carry a `Record<string, Component>` index
+// signature; without removing it, `keyof`/`Omit` operate on `string` and
+// collapse every component to the wide `Component` type. (#13253)
+type OmitIndexSignature<T> = {
+  [K in keyof T as string extends K
+    ? never
+    : number extends K
+      ? never
+      : K]: T[K]
+}
 
 export type ComponentPublicInstanceConstructor<
   T extends ComponentPublicInstance<Props, RawBindings, D, C, M> =
@@ -242,6 +263,16 @@ export type CreateComponentPublicInstanceWithMixins<
     EnsureNonVoid<M>,
   PublicDefaults = UnwrapMixinsType<PublicMixin, 'Defaults'> &
     EnsureNonVoid<Defaults>,
+  // a component's own `components` override those registered in mixins/extends
+  // when names collide (matching the runtime merge). The inherited map has its
+  // index signature stripped so `Omit` operates on the declared component names
+  // instead of collapsing them to `Component`, and only the declared (literal)
+  // keys of `LC` are removed before merging the own components back in. (#13253)
+  PublicLC extends Record<string, Component> = Omit<
+    OmitIndexSignature<UnwrapMixinsType<PublicMixin, 'LC'>>,
+    keyof OmitIndexSignature<LC>
+  > &
+    LC,
 > = ComponentPublicInstance<
   PublicP,
   PublicB,
@@ -266,7 +297,7 @@ export type CreateComponentPublicInstanceWithMixins<
     {},
     string,
     S,
-    LC,
+    PublicLC,
     Directives,
     Exposed,
     Provide


### PR DESCRIPTION
Components registered via the `components` option in a mixin were not inferred on a consuming component, so `$options.components` and template resolution lost them.

Infer the local-components generic `LC` in `MixinToOptionTypes` and thread it through `OptionTypesType` and
`CreateComponentPublicInstanceWithMixins`.

close #13253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript inference for component typings when components are supplied via mixins, `extends`, and `components`.
  * Mixin-provided components are now merged for type checks and remain accessible by key.
  * Local `components` entries correctly take precedence over mixin-registered components with the same name.
  * Public instance typings now surface “local components” more consistently.

* **Tests**
  * Added a TypeScript definition test suite covering mixin and `extends` component inference scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->