### PR TITLE
fix(types): infer emits declared in mixins/extends

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -691,6 +691,73 @@ describe('with mixins', () => {
   ;<MyComponent aP1={1} bP2={[1]} />
 })
 
+// #13254 emits declared in mixins/extends should be inferred on `$emit`
+describe('with mixins and emits inference', () => {
+  const MixinArray = defineComponent({
+    emits: ['bar'],
+  })
+  const MixinObject = defineComponent({
+    emits: {
+      baz: (n: number) => typeof n === 'number',
+    },
+  })
+  const Base = defineComponent({
+    emits: ['foo'],
+  })
+  // a mixin whose emits come from its own (nested) mixin
+  const MixinNested = defineComponent({
+    mixins: [MixinArray],
+  })
+
+  defineComponent({
+    extends: Base,
+    mixins: [MixinObject, MixinNested],
+    emits: ['click'],
+    created() {
+      // own emits
+      this.$emit('click')
+      // from extends
+      this.$emit('foo')
+      // from object mixin (with payload)
+      this.$emit('baz', 1)
+      // from array mixin
+      this.$emit('bar')
+      // from nested mixin (mixin of a mixin)
+      this.$emit('bar', 'anything')
+
+      // @ts-expect-error not a declared event
+      this.$emit('nope')
+      // @ts-expect-error wrong payload type for object mixin emit
+      this.$emit('baz', 'string')
+    },
+  })
+
+  // emits declared only in mixins, none on the component itself
+  defineComponent({
+    mixins: [MixinArray],
+    created() {
+      this.$emit('bar')
+      // @ts-expect-error not a declared event
+      this.$emit('nope')
+    },
+  })
+
+  // a component whose own emits are wide (`string[]`) keeps a wide `$emit` even
+  // when inheriting concrete events from a mixin — the wide signature already
+  // covers them and must not be narrowed away
+  const wideEmits: string[] = ['whatever']
+  defineComponent({
+    mixins: [MixinArray],
+    emits: wideEmits,
+    created() {
+      this.$emit('bar')
+      // any event name is still accepted because own emits are wide
+      this.$emit('anything')
+      this.$emit('whatever', 1, 2, 3)
+    },
+  })
+})
+
 describe('with extends', () => {
   const Base = defineComponent({
     props: {

--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -610,7 +610,7 @@ describe('component: emit', () => {
     const CompA = {
       render,
     }
-    const validateByMixin = vi.fn(() => true)
+    const validateByMixin = vi.fn((_n: number) => true)
     const validateByGlobalMixin = vi.fn(() => true)
 
     const mixin = {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -478,7 +478,7 @@ export type MergedComponentOptionsOverride = {
   errorCaptured?: MergedHook<ErrorCapturedHook>
 }
 
-export type OptionTypesKeys = 'P' | 'B' | 'D' | 'C' | 'M' | 'Defaults'
+export type OptionTypesKeys = 'P' | 'B' | 'D' | 'C' | 'M' | 'E' | 'Defaults'
 
 export type OptionTypesType<
   P = {},
@@ -486,6 +486,7 @@ export type OptionTypesType<
   D = {},
   C extends ComputedOptions = {},
   M extends MethodOptions = {},
+  E extends EmitsOptions = {},
   Defaults = {},
 > = {
   P: P
@@ -493,6 +494,7 @@ export type OptionTypesType<
   D: D
   C: C
   M: M
+  E: E
   Defaults: Defaults
 }
 

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -49,7 +49,7 @@ import {
   resolveMergedOptions,
   shouldCacheAccess,
 } from './componentOptions'
-import type { EmitFn, EmitsOptions } from './componentEmits'
+import type { EmitFn, EmitsOptions, ObjectEmitsOptions } from './componentEmits'
 import type { SlotsType, UnwrapSlotsType } from './componentSlots'
 import { markAttrsAccessed } from './componentRenderUtils'
 import { currentRenderingInstance } from './componentRenderContext'
@@ -110,10 +110,100 @@ type MixinToOptionTypes<T> =
     any,
     any
   >
-    ? OptionTypesType<P & {}, B & {}, D & {}, C & {}, M & {}, Defaults & {}> &
+    ? OptionTypesType<
+        P & {},
+        B & {},
+        D & {},
+        C & {},
+        M & {},
+        // #13254 emits are resolved through a separate, isolated inference
+        // (`ExtractEmitsOption`). Inferring the emits position in the
+        // conditional above destabilizes inference of props/data/etc.
+        ExtractEmitsOption<T>,
+        Defaults & {}
+      > &
         IntersectionMixin<Mixin> &
         IntersectionMixin<Extends>
     : never
+
+// Extract (and normalize) only the emits option of a single component. Kept as
+// a standalone conditional so inferring `E` does not interfere with the
+// inference of the other options in `MixinToOptionTypes`. (#13254)
+type ExtractEmitsOption<T> =
+  T extends ComponentOptionsBase<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    infer E,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
+    ? NormalizeEmitsOptions<E>
+    : {}
+
+// Normalize a single emits option into object form so emits coming from
+// multiple mixins/extends can be merged together via intersection. The array
+// form `['foo']` becomes `{ foo: (...args: any[]) => any }`. Wide `string[]`
+// and the default `EmitsOptions` (e.g. from `emits: []`) carry no event names
+// and contribute nothing.
+type NormalizeEmitsMember<E> = E extends string[]
+  ? string extends E[number]
+    ? {}
+    : { [K in E[number]]: (...args: any[]) => any }
+  : E extends ObjectEmitsOptions
+    ? ObjectEmitsOptions extends E
+      ? {}
+      : E
+    : {}
+
+// `defineComponent` widens object emits to a union such as
+// `string[] | { foo: ... }`, so distribute over members and intersect.
+export type NormalizeEmitsOptions<E> = UnionToIntersection<
+  NormalizeEmitsMember<E>
+>
+
+// Whether the component's own emits accept arbitrary event names — a wide
+// `string[]` (non-literal) or the generic `ObjectEmitsOptions`. `[E]` tuples
+// avoid distributing over the `string[] | { ... }` union that object emits
+// widen to, so only genuinely wide declarations match. (#13254)
+type IsWideEmits<E> = [E] extends [string[]]
+  ? string extends E[number]
+    ? true
+    : false
+  : string extends keyof E
+    ? true
+    : false
+
+// Merge emits inherited from mixins/extends with the component's own emits.
+// When no emits are inherited, the component's own emits are used as-is to
+// preserve the exact `$emit` behavior (e.g. `emits: []` rejecting all events).
+// When the component's own emits are wide (accept any event), that wide signature
+// is kept — it already covers the inherited events, and narrowing it to just the
+// inherited ones would be wrong. Otherwise concrete inherited event names are
+// intersected with the component's own. The `infer R extends EmitsOptions` guard
+// keeps the result provably assignable to `EmitsOptions` (UnionToIntersection is
+// otherwise opaque to the checker).
+export type ResolveMergedEmits<
+  MixinE,
+  E extends EmitsOptions,
+> = {} extends MixinE
+  ? E
+  : IsWideEmits<E> extends true
+    ? E
+    : MixinE & NormalizeEmitsOptions<E> extends infer R extends EmitsOptions
+      ? R
+      : E
 
 // ExtractMixin(map type) is used to resolve circularly references
 type ExtractMixin<T> = {
@@ -175,13 +265,19 @@ export type CreateComponentPublicInstance<
     EnsureNonVoid<M>,
   PublicDefaults = UnwrapMixinsType<PublicMixin, 'Defaults'> &
     EnsureNonVoid<Defaults>,
+  // emits declared in mixins/extends are merged with the component's own emits
+  // so that `$emit` is correctly typed (#13254)
+  PublicE extends EmitsOptions = ResolveMergedEmits<
+    UnwrapMixinsType<PublicMixin, 'E'>,
+    E
+  >,
 > = ComponentPublicInstance<
   PublicP,
   PublicB,
   PublicD,
   PublicC,
   PublicM,
-  E,
+  PublicE,
   PublicProps,
   PublicDefaults,
   MakeDefaultsOptional,
@@ -242,13 +338,19 @@ export type CreateComponentPublicInstanceWithMixins<
     EnsureNonVoid<M>,
   PublicDefaults = UnwrapMixinsType<PublicMixin, 'Defaults'> &
     EnsureNonVoid<Defaults>,
+  // emits declared in mixins/extends are merged with the component's own emits
+  // so that `$emit` is correctly typed (#13254)
+  PublicE extends EmitsOptions = ResolveMergedEmits<
+    UnwrapMixinsType<PublicMixin, 'E'>,
+    E
+  >,
 > = ComponentPublicInstance<
   PublicP,
   PublicB,
   PublicD,
   PublicC,
   PublicM,
-  E,
+  PublicE,
   PublicProps,
   PublicDefaults,
   MakeDefaultsOptional,


### PR DESCRIPTION
Emits declared in a mixin (or via `extends`) were not propagated to the component's `$emit`, so `this.$emit` fell back to the untyped `(event: string, ...args: any[])` signature even though the events were declared and merged at runtime.

Resolve emits through the existing mixin option-type recursion by adding an `E` key to `OptionTypesType`. Because inferring the emits position directly inside `MixinToOptionTypes` destabilizes inference of the other options, emits are extracted via a separate, isolated `ExtractEmitsOption` conditional and normalized to object form (array forms become objects, and the widened `string[]`/`EmitsOptions` placeholders contribute nothing) so emits from multiple mixins/extends can be merged via intersection. `$emit` then uses the component's own emits merged with the inherited ones, while preserving the exact behavior when nothing is inherited (e.g. `emits: []` still rejecting all events).

closes #13254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved typing for component events, including events inherited from `extends` and mixins (including nested mixins).
  * `$emit` now offers more accurate autocompletion and payload validation for merged event definitions, while preserving correct “wide” typings when a component’s emits are broadly declared.
* **Bug Fixes**
  * Fixed cases where inherited or mixin-derived event names and payloads were not inferred correctly.
* **Tests**
  * Added TypeScript assertions to verify event-name and payload inference across inherited and mixed emits scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->