### PR TITLE
fix(server-renderer): cleanup stream watcher handles on render errors

### DIFF
--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -64,6 +64,8 @@ const pipeToWritable = (app: any, context?: any) => {
 testRender(`renderToString`, renderToString)
 testRender(`renderToNodeStream`, renderToStream)
 testRender(`pipeToNodeWritable`, pipeToWritable)
+testStreamCleanupOnRenderError(`renderToNodeStream`, renderToStream)
+testStreamCleanupOnRenderError(`pipeToNodeWritable`, pipeToWritable)
 
 function testRender(type: string, render: typeof renderToString) {
   describe(`ssr: ${type}`, () => {
@@ -1246,6 +1248,75 @@ function testRender(type: string, render: typeof renderToString) {
       })
       const html = await render(app)
       expect(html).toBe(`<div attr="attr">Functional Component</div>`)
+    })
+  })
+}
+
+function testStreamCleanupOnRenderError(
+  type: string,
+  render: typeof renderToString,
+) {
+  describe(`ssr: ${type} error cleanup`, () => {
+    test('stops sync SSR watchers if render throws', async () => {
+      const source = ref(0)
+      let runs = 0
+      const app = createSSRApp(
+        defineComponent(() => {
+          watchEffect(
+            () => {
+              source.value
+              runs++
+            },
+            { flush: 'sync' },
+          )
+
+          return () => {
+            throw new Error('boom')
+          }
+        }),
+      )
+
+      await expect(render(app)).rejects.toBe(``)
+
+      expect(
+        `Unhandled error during execution of render function`,
+      ).toHaveBeenWarned()
+      expect(runs).toBe(1)
+      source.value++
+      expect(runs).toBe(1)
+    })
+
+    test('stops async SSR watchers if render rejects', async () => {
+      const source = ref(0)
+      let runs = 0
+      const app = createSSRApp(
+        defineComponent({
+          async setup() {
+            watchEffect(
+              () => {
+                source.value
+                runs++
+              },
+              { flush: 'sync' },
+            )
+
+            await Promise.resolve()
+
+            return () => {
+              throw new Error('boom')
+            }
+          },
+        }),
+      )
+
+      await expect(render(app)).rejects.toBe(``)
+
+      expect(
+        `Unhandled error during execution of render function`,
+      ).toHaveBeenWarned()
+      expect(runs).toBe(1)
+      source.value++
+      expect(runs).toBe(1)
     })
   })
 }

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -73,18 +73,28 @@ export function renderToSimpleStream<T extends SimpleReadable>(
   // provide the ssr context to the tree
   input.provide(ssrContextKey, context)
 
-  Promise.resolve(renderComponentVNode(vnode))
+  let cleaned = false
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+
+    if (context.__watcherHandles) {
+      for (const unwatch of context.__watcherHandles) {
+        unwatch()
+      }
+    }
+  }
+
+  Promise.resolve()
+    .then(() => renderComponentVNode(vnode))
     .then(buffer => unrollBuffer(buffer, stream))
     .then(() => resolveTeleports(context))
     .then(() => {
-      if (context.__watcherHandles) {
-        for (const unwatch of context.__watcherHandles) {
-          unwatch()
-        }
-      }
+      cleanup()
     })
     .then(() => stream.push(null))
     .catch(error => {
+      cleanup()
       stream.destroy(error)
     })
 


### PR DESCRIPTION
## Summary
- clean up SSR watcher handles when stream renders fail
- move `renderComponentVNode()` inside the promise chain so sync render throws also flow through stream cleanup
- add stream-only regression tests for sync and async render failures

## Why
`renderToSimpleStream()` only stopped `context.__watcherHandles` on the success path, so failed stream renders could leave SSR watchers alive after the request errored.

Sync render throws also bypassed the promise chain entirely because `renderComponentVNode(vnode)` was evaluated before `Promise.resolve(...)` had a chance to wrap it.

This keeps the fix scoped to stream APIs and watcher-handle cleanup only, without bringing back the broader SSR effect-scope cleanup that was reverted in #14674.

## Validation
- `pnpm exec vitest run --project unit packages/server-renderer/__tests__/render.spec.ts`
- `tsc --incremental --noEmit` via the repo commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering cleanup so reactive watchers are stopped even if rendering fails, preventing them from continuing to run after an error.
  * Applied the same cleanup behavior across stream-based render paths for both successful and failed renders.

* **Tests**
  * Added coverage for render failures to verify watcher cleanup works for synchronous errors and asynchronous rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->