### PR TITLE
fix(server-renderer): cleanup string watcher handles on render errors

### DIFF
--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -64,6 +64,7 @@ const pipeToWritable = (app: any, context?: any) => {
 testRender(`renderToString`, renderToString)
 testRender(`renderToNodeStream`, renderToStream)
 testRender(`pipeToNodeWritable`, pipeToWritable)
+testStringCleanupOnRenderError()
 
 function testRender(type: string, render: typeof renderToString) {
   describe(`ssr: ${type}`, () => {
@@ -1246,6 +1247,72 @@ function testRender(type: string, render: typeof renderToString) {
       })
       const html = await render(app)
       expect(html).toBe(`<div attr="attr">Functional Component</div>`)
+    })
+  })
+}
+
+function testStringCleanupOnRenderError() {
+  describe(`ssr: renderToString error cleanup`, () => {
+    test('stops sync SSR watchers if render throws', async () => {
+      const source = ref(0)
+      let runs = 0
+      const app = createSSRApp(
+        defineComponent(() => {
+          watchEffect(
+            () => {
+              source.value
+              runs++
+            },
+            { flush: 'sync' },
+          )
+
+          return () => {
+            throw new Error('boom')
+          }
+        }),
+      )
+
+      await expect(renderToString(app)).rejects.toThrow(`boom`)
+
+      expect(
+        `Unhandled error during execution of render function`,
+      ).toHaveBeenWarned()
+      expect(runs).toBe(1)
+      source.value++
+      expect(runs).toBe(1)
+    })
+
+    test('stops async SSR watchers if render rejects', async () => {
+      const source = ref(0)
+      let runs = 0
+      const app = createSSRApp(
+        defineComponent({
+          async setup() {
+            watchEffect(
+              () => {
+                source.value
+                runs++
+              },
+              { flush: 'sync' },
+            )
+
+            await Promise.resolve()
+
+            return () => {
+              throw new Error('boom')
+            }
+          },
+        }),
+      )
+
+      await expect(renderToString(app)).rejects.toThrow(`boom`)
+
+      expect(
+        `Unhandled error during execution of render function`,
+      ).toHaveBeenWarned()
+      expect(runs).toBe(1)
+      source.value++
+      expect(runs).toBe(1)
     })
   })
 }

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -81,19 +81,25 @@ export async function renderToString(
   vnode.appContext = input._context
   // provide the ssr context to the tree
   input.provide(ssrContextKey, context)
-  const buffer = await renderComponentVNode(vnode)
-
-  const result = await unrollBuffer(buffer as SSRBuffer)
-
-  await resolveTeleports(context)
-
-  if (context.__watcherHandles) {
-    for (const unwatch of context.__watcherHandles) {
-      unwatch()
+  const cleanup = () => {
+    if (context.__watcherHandles) {
+      for (const unwatch of context.__watcherHandles) {
+        unwatch()
+      }
     }
   }
 
-  return result
+  try {
+    const buffer = await renderComponentVNode(vnode)
+
+    const result = await unrollBuffer(buffer as SSRBuffer)
+
+    await resolveTeleports(context)
+
+    return result
+  } finally {
+    cleanup()
+  }
 }
 
 export async function resolveTeleports(context: SSRContext): Promise<void> {


### PR DESCRIPTION
## Summary
- clean up SSR watcher handles when `renderToString()` fails
- wrap the render, buffer unroll, and teleport resolution path in `try/finally`
- add regression tests for sync and async render failures in the string renderer

## Why
`renderToString()` only stopped `context.__watcherHandles` after a fully successful render. If component rendering, buffer unrolling, or teleport resolution threw, request-scoped SSR watchers were left alive after the failed render.

This makes the string renderer match the expected request lifecycle by always stopping watcher handles before the call exits, even when the render fails.

## Validation
- `pnpm exec vitest run --project unit packages/server-renderer/__tests__/render.spec.ts`
- `tsc --incremental --noEmit` via the repo commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering error handling so cleanup now runs even when rendering fails.
  * Prevented leftover reactive watchers from continuing after a render error.
  * Added coverage for both synchronous and asynchronous render failures to confirm errors are surfaced and cleanup still occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->