### PR TITLE
fix(compiler-sfc): handle script setup before script in type resolve

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1964,6 +1964,33 @@ describe('resolveType', () => {
       })
     })
 
+    test('allowArbitraryExtensions with script setup before script', () => {
+      const files = {
+        '/foo.vue': `
+        <script setup lang="ts">
+        type Base = string
+        </script>
+        <script lang="ts">
+        export interface Foo {
+          foo: Base
+        }
+        </script>
+        `,
+      }
+
+      const { props } = resolve(
+        `
+        import type { Foo } from './foo.vue'
+        defineProps<Foo>()
+        `,
+        files,
+      )
+
+      expect(props).toStrictEqual({
+        foo: ['String'],
+      })
+    })
+
     // https://github.com/vuejs/router/issues/2611
     test('modular js extension', () => {
       const files = {

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1309,7 +1309,7 @@ function parseFile(
       firstBlock!.content
     if (secondBlock) {
       scriptContent +=
-        ' '.repeat(secondBlock.loc.start.offset - script!.loc.end.offset) +
+        ' '.repeat(secondBlock.loc.start.offset - firstBlock!.loc.end.offset) +
         secondBlock.content
     }
     const lang = script?.lang || scriptSetup?.lang


### PR DESCRIPTION
## Summary
- fix `.vue` type-source parsing when `<script setup>` appears before `<script>`
- use the first block's end offset when padding the gap before the second block
- add a regression test covering imported types from a `.vue` file with that block order

## Why
When `resolveType` parses a `.vue` file for imported type information, it merges the two script blocks back into a synthetic source string while preserving offsets.

That merge path already picks the earlier block as `firstBlock`, but it still calculated the gap before `secondBlock` using `script!.loc.end.offset`. If `<script setup>` comes first and normal `<script>` comes second, `script` points at the later block, so the gap becomes negative and `' '.repeat(...)` throws a `RangeError`.

Using `firstBlock!.loc.end.offset` keeps the padding based on the actual earlier block and handles both block orders correctly.

## Validation
- `pnpm exec vitest run --project unit packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts`
- `tsc --incremental --noEmit` via the repo commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type resolution for Vue files when a `<script setup lang="ts">` block appears before a separate `<script lang="ts">` block.
  * Fixed handling of spacing between script blocks so imported types resolve correctly in these cases.

* **Tests**
  * Added coverage for the above scenario to confirm props are inferred as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->