### PR TITLE
fix(reactivity): stop once watchers after callback throws

### DIFF
--- a/packages/reactivity/__tests__/watch.spec.ts
+++ b/packages/reactivity/__tests__/watch.spec.ts
@@ -157,6 +157,40 @@ describe('watch', () => {
     expect(onError.mock.calls[1]).toMatchObject(['oops in once watch'])
   })
 
+  test('once option stops after sync callback throw', () => {
+    const onError = vi.fn()
+    const call: WatchOptions['call'] = function call(fn, type, args) {
+      if (Array.isArray(fn)) {
+        fn.forEach(f => call(f, type, args))
+        return
+      }
+      try {
+        fn.apply(null, args)
+      } catch (e) {
+        onError(e, type)
+      }
+    }
+
+    const source = ref(0)
+    const cb = vi.fn(() => {
+      throw 'oops in once watch'
+    })
+
+    watch(source, cb, { call, once: true })
+
+    source.value++
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls).toMatchObject([
+      ['oops in once watch', WatchErrorCodes.WATCH_CALLBACK],
+    ])
+
+    source.value++
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls).toMatchObject([
+      ['oops in once watch', WatchErrorCodes.WATCH_CALLBACK],
+    ])
+  })
+
   test('watch with onWatcherCleanup', async () => {
     let dummy = 0
     let source: Ref<number>

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -221,9 +221,11 @@ export function watch(
   if (once && cb) {
     const _cb = cb
     cb = (...args) => {
-      const res = _cb(...args)
-      watchHandle()
-      return res
+      try {
+        return _cb(...args)
+      } finally {
+        watchHandle()
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- stop `watch(..., { once: true })` in a `finally` block
- keep the callback return value behavior from #14902 intact
- add a regression test covering a sync callback throw with `once: true`

## Why
The current `once` wrapper stops the watcher after calling the callback, but only if the callback returns normally.

If the callback throws synchronously, control leaves the wrapper before `watchHandle()` runs, so the watcher stays active and will fire again on the next change. That breaks the core `once` contract and can turn the first failing call into a repeating one.

Wrapping the callback in `try/finally` preserves the return value while still guaranteeing that `watchHandle()` runs after the first invocation.

## Validation
- `pnpm exec vitest run --project unit packages/reactivity/__tests__/watch.spec.ts`
- `pnpm exec vitest run --project unit packages/runtime-core/__tests__/apiWatch.spec.ts -t "only trigger once watch"`
- `tsc --incremental --noEmit` via the repo commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watches with the one-time option now stop correctly even if the callback throws an error.
  * Improved error handling so the callback is only triggered once and the error is reported once as expected.

* **Tests**
  * Added coverage for one-time watch behavior when a synchronous callback throws.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->