### PR TITLE
fix(compiler-ssr): handle empty directive expressions

### DIFF
--- a/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
@@ -428,5 +428,19 @@ describe('ssr: components', () => {
         }"
       `)
     })
+
+    test('empty expression', () => {
+      expect(compile(`<foo v-xxx:foo="" />`).code).toMatchInlineSnapshot(`
+        "const { resolveComponent: _resolveComponent, resolveDirective: _resolveDirective, mergeProps: _mergeProps } = require("vue")
+        const { ssrGetDirectiveProps: _ssrGetDirectiveProps, ssrRenderComponent: _ssrRenderComponent } = require("vue/server-renderer")
+
+        return function ssrRender(_ctx, _push, _parent, _attrs) {
+          const _component_foo = _resolveComponent("foo")
+          const _directive_xxx = _resolveDirective("xxx")
+
+          _push(_ssrRenderComponent(_component_foo, _mergeProps(_attrs, _ssrGetDirectiveProps(_ctx, _directive_xxx, void 0, "foo")), null, _parent))
+        }"
+      `)
+    })
   })
 })

--- a/packages/compiler-ssr/__tests__/ssrElement.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrElement.spec.ts
@@ -312,6 +312,21 @@ describe('ssr: element', () => {
       `)
     })
 
+    test('custom dir with empty expression', () => {
+      expect(getCompiledString(`<div v-xxx="">hello</div>`))
+        .toMatchInlineSnapshot(`
+        "\`<div\${
+            _ssrRenderAttrs(_ssrGetDirectiveProps(_ctx, _directive_xxx, void 0))
+          }>hello</div>\`"
+      `)
+      expect(getCompiledString(`<div v-xxx:foo="">hello</div>`))
+        .toMatchInlineSnapshot(`
+        "\`<div\${
+            _ssrRenderAttrs(_ssrGetDirectiveProps(_ctx, _directive_xxx, void 0, "foo"))
+          }>hello</div>\`"
+      `)
+    })
+
     test('custom dir with normal attrs', () => {
       expect(getCompiledString(`<div class="foo" v-xxx />`))
         .toMatchInlineSnapshot(`

--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -390,7 +390,7 @@ export function buildSSRProps(
       mergePropsArgs.push(
         createCallExpression(context.helper(SSR_GET_DIRECTIVE_PROPS), [
           `_ctx`,
-          ...buildDirectiveArgs(dir, context).elements,
+          ...buildSSRDirectiveArgs(dir, context),
         ] as JSChildNode[]),
       )
     }
@@ -399,6 +399,21 @@ export function buildSSRProps(
   return mergePropsArgs.length > 1
     ? createCallExpression(context.helper(MERGE_PROPS), mergePropsArgs)
     : mergePropsArgs[0]
+}
+
+function buildSSRDirectiveArgs(
+  dir: DirectiveNode,
+  context: TransformContext,
+): JSChildNode[] {
+  const args = buildDirectiveArgs(dir, context).elements as JSChildNode[]
+  if (
+    dir.exp &&
+    dir.exp.type === NodeTypes.SIMPLE_EXPRESSION &&
+    !dir.exp.content.trim()
+  ) {
+    args[1] = createSimpleExpression(`void 0`, false, dir.exp.loc)
+  }
+  return args
 }
 
 function isTrueFalseValue(prop: DirectiveNode | AttributeNode) {


### PR DESCRIPTION
﻿## Summary

Fixes vuejs/core#6283.

SSR custom directive codegen now emits `void 0` for empty directive expressions before passing args to `_ssrGetDirectiveProps()`. This avoids generating invalid function-call argument lists such as `_ssrGetDirectiveProps(_ctx, _directive_xxx, , "foo")` while preserving `undefined` as the binding value.

The change is scoped to SSR directive prop generation and does not alter normal client directive array codegen.

## Tests

- pnpm vitest run packages/compiler-ssr/__tests__/ssrElement.spec.ts packages/compiler-ssr/__tests__/ssrComponent.spec.ts --project unit
- pnpm exec prettier --check packages/compiler-ssr/src/transforms/ssrTransformElement.ts packages/compiler-ssr/__tests__/ssrElement.spec.ts packages/compiler-ssr/__tests__/ssrComponent.spec.ts
- pnpm exec eslint packages/compiler-ssr/src/transforms/ssrTransformElement.ts packages/compiler-ssr/__tests__/ssrElement.spec.ts packages/compiler-ssr/__tests__/ssrComponent.spec.ts
- pnpm check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSR handling for custom directives with empty expressions, ensuring they compile to `void 0` instead of an empty string.
  * Preserved directive arguments while generating the expected server-side output for both plain and argument-based directive syntax.
  * Added test coverage for these directive cases to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->