### PR TITLE
refactor(runtime-vapor): resolve KeepAlive context from owner instance

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -112,11 +112,7 @@ import {
   isVaporTeleport,
 } from './teleport'
 import type { KeepAliveInstance } from './components/KeepAlive'
-import {
-  currentKeepAliveCtx,
-  isKeepAliveEnabled,
-  setCurrentKeepAliveCtx,
-} from './keepAlive'
+import { getKeepAliveContext, isKeepAliveEnabled } from './keepAlive'
 import {
   insertionAnchor,
   insertionParent,
@@ -391,18 +387,11 @@ export function createComponent(
       ce,
     )
 
-    // handle currentKeepAliveCtx for component boundary isolation
-    // AsyncWrapper should NOT clear currentKeepAliveCtx so its internal
-    // DynamicFragment can capture it
-    if (
-      isKeepAliveEnabled &&
-      currentKeepAliveCtx &&
-      !isAsyncWrapper(instance)
-    ) {
-      currentKeepAliveCtx.processShapeFlag(instance)
-      // clear currentKeepAliveCtx so child components don't associate
-      // with parent's KeepAlive
-      setCurrentKeepAliveCtx(null)
+    // Async wrappers are skipped here: their DynamicFragment resolves the outer
+    // KeepAlive context from the wrapper's parent chain during setup.
+    if (isKeepAliveEnabled && !isAsyncWrapper(instance)) {
+      const keepAliveCtx = getKeepAliveContext(currentInstance)
+      if (keepAliveCtx) keepAliveCtx.processShapeFlag(instance)
     }
 
     // reset currentSlotOwner to null to avoid affecting the child components

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -44,13 +44,12 @@ import { isInteropEnabled } from '../vdomInteropState'
 import {
   type VaporKeepAliveContext,
   currentCacheKey,
-  setCurrentKeepAliveCtx,
   withCurrentCacheKey,
   withKeepAliveEnabled,
 } from '../keepAlive'
 
 export interface KeepAliveInstance extends VaporComponentInstance {
-  ctx: {
+  ctx: VaporKeepAliveContext & {
     activate: (
       instance: VaporComponentInstance,
       parentNode: ParentNode,
@@ -61,7 +60,6 @@ export interface KeepAliveInstance extends VaporComponentInstance {
       comp: VaporComponent | VNode['type'] | VNode,
       key?: any,
     ) => VaporComponentInstance | VaporFragment | undefined
-    getStorageContainer: () => ParentNode
   }
 }
 
@@ -148,24 +146,6 @@ const VaporKeepAliveImpl = defineVaporComponent({
         current = undefined
         rerender!()
       }
-    }
-
-    keepAliveInstance.ctx = {
-      getStorageContainer: () => storageContainer,
-      getCachedComponent: (comp, key) => {
-        if (isInteropEnabled && isVNode(comp)) {
-          return cache.get(comp.key ?? currentCacheKey ?? comp.type)
-        }
-        return cache.get(key ?? currentCacheKey ?? comp)
-      },
-      activate: (instance, parentNode, anchor) => {
-        current = instance
-        activate(instance, parentNode, anchor)
-      },
-      deactivate: instance => {
-        current = undefined
-        deactivate(instance, storageContainer)
-      },
     }
 
     const innerCacheBlock = (
@@ -361,7 +341,22 @@ const VaporKeepAliveImpl = defineVaporComponent({
       keptAliveScopes.clear()
     })
 
-    const keepAliveCtx: VaporKeepAliveContext = {
+    const keepAliveCtx: KeepAliveInstance['ctx'] = {
+      getStorageContainer: () => storageContainer,
+      getCachedComponent: (comp, key) => {
+        if (isInteropEnabled && isVNode(comp)) {
+          return cache.get(comp.key ?? currentCacheKey ?? comp.type)
+        }
+        return cache.get(key ?? currentCacheKey ?? comp)
+      },
+      activate: (instance, parentNode, anchor) => {
+        current = instance
+        activate(instance, parentNode, anchor)
+      },
+      deactivate: instance => {
+        current = undefined
+        deactivate(instance, storageContainer)
+      },
       acquireBranchScope(key) {
         return deleteScope(key)
       },
@@ -402,9 +397,8 @@ const VaporKeepAliveImpl = defineVaporComponent({
       },
     }
 
-    const prevCtx = setCurrentKeepAliveCtx(keepAliveCtx)
+    keepAliveInstance.ctx = keepAliveCtx
     let children = slots.default()
-    setCurrentKeepAliveCtx(prevCtx)
     registerDynamicFragmentHooks(children, keepAliveCtx)
 
     if (isArray(children)) {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -46,9 +46,8 @@ import {
 import { setBlockKey } from './helpers/setKey'
 import {
   type VaporKeepAliveContext,
-  currentKeepAliveCtx,
+  getKeepAliveContext,
   isKeepAliveEnabled,
-  setCurrentKeepAliveCtx,
 } from './keepAlive'
 import {
   applyTransitionHooks,
@@ -117,7 +116,7 @@ export class RenderContextFragment<
   constructor(nodes: T) {
     super(nodes)
     if (isKeepAliveEnabled) {
-      this.keepAliveCtx = currentKeepAliveCtx
+      this.keepAliveCtx = getKeepAliveContext(currentInstance)
     }
   }
 
@@ -145,30 +144,21 @@ export function runWithFragmentCtxOnly<R>(
   fragment: RenderContextFragment,
   fn: () => R,
 ): R {
-  const keepAliveCtx = isKeepAliveEnabled ? fragment.keepAliveCtx || null : null
   // When ambient fragment context already matches, no ambient state needs
   // restoring. This keeps ordinary branch renders on the cheap path.
   if (
     currentSlotOwner === fragment.slotOwner &&
-    currentSlotBoundary === fragment.slotBoundary &&
-    (!isKeepAliveEnabled || currentKeepAliveCtx === keepAliveCtx)
+    currentSlotBoundary === fragment.slotBoundary
   ) {
     return fn()
   }
 
   const prevSlotOwner = setCurrentSlotOwner(fragment.slotOwner)
-  let prevKeepAliveCtx: VaporKeepAliveContext | null = null
-  if (isKeepAliveEnabled) {
-    prevKeepAliveCtx = setCurrentKeepAliveCtx(keepAliveCtx)
-  }
   const prevBoundary = setCurrentSlotBoundary(fragment.slotBoundary)
   try {
     return fn()
   } finally {
     setCurrentSlotBoundary(prevBoundary)
-    if (isKeepAliveEnabled) {
-      setCurrentKeepAliveCtx(prevKeepAliveCtx)
-    }
     setCurrentSlotOwner(prevSlotOwner)
   }
 }

--- a/packages/runtime-vapor/src/keepAlive.ts
+++ b/packages/runtime-vapor/src/keepAlive.ts
@@ -1,3 +1,8 @@
+import {
+  type GenericComponentInstance,
+  isAsyncWrapper,
+  isKeepAlive,
+} from '@vue/runtime-dom'
 import type { EffectScope } from '@vue/reactivity'
 import type { Block } from './block'
 import type { DynamicFragment } from './fragment'
@@ -12,10 +17,10 @@ export interface VaporKeepAliveContext {
   processShapeFlag(block: Block): any | false
   cacheBlock(block?: Block): void
   cacheScope(cacheKey: any, scopeLookupKey: any, scope: EffectScope): void
+  getStorageContainer(): ParentNode
 }
 
 export let isKeepAliveEnabled = false
-export let currentKeepAliveCtx: VaporKeepAliveContext | null = null
 export let currentCacheKey: any | undefined
 
 export function enableKeepAlive(): void {
@@ -27,14 +32,19 @@ export function withKeepAliveEnabled<T>(value: T): T {
   return value
 }
 
-export function setCurrentKeepAliveCtx(
-  ctx: VaporKeepAliveContext | null,
+export function getKeepAliveContext(
+  instance: GenericComponentInstance | null,
 ): VaporKeepAliveContext | null {
-  try {
-    return currentKeepAliveCtx
-  } finally {
-    currentKeepAliveCtx = ctx
+  let owner = instance
+  // Async wrappers are transparent for KeepAlive context lookup: their setup
+  // and resolved renders still belong to the outer KeepAlive owner.
+  while (owner && owner.vapor && isAsyncWrapper(owner)) {
+    owner = owner.parent
   }
+
+  return owner && owner.vapor && isKeepAlive(owner)
+    ? (owner as GenericComponentInstance & { ctx: VaporKeepAliveContext }).ctx
+    : null
 }
 
 export function withCurrentCacheKey<T>(key: any, fn: () => T): T {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -161,10 +161,9 @@ import {
   deactivate,
 } from './components/KeepAlive'
 import {
-  currentKeepAliveCtx,
   enableKeepAlive,
+  getKeepAliveContext,
   isKeepAliveEnabled,
-  setCurrentKeepAliveCtx,
 } from './keepAlive'
 import {
   parentSuspense as currentParentSuspense,
@@ -1014,16 +1013,14 @@ function createVDOMComponent(
     rawProps && extend({}, new Proxy(rawProps, rawPropsProxyHandlers)),
   )
   const { frag, syncNodes } = createVNodeFragment(vnode)
+  const keepAliveCtx = isKeepAliveEnabled
+    ? getKeepAliveContext(parentComponent)
+    : null
 
-  if (
-    !isCollectingVdomSlotVNodes &&
-    isKeepAliveEnabled &&
-    currentKeepAliveCtx
-  ) {
-    currentKeepAliveCtx.processShapeFlag(frag)
+  if (!isCollectingVdomSlotVNodes && keepAliveCtx) {
+    keepAliveCtx.processShapeFlag(frag)
     // for VDOM async components, trigger cacheBlock after resolution
     if ((component as any).__asyncLoader) {
-      const keepAliveCtx = currentKeepAliveCtx
       // guard against stale resolution after unmount or branch switch
       let disposed = false
       onScopeDispose(() => (disposed = true))
@@ -1034,7 +1031,6 @@ function createVDOMComponent(
         })
         .catch(NOOP)
     }
-    setCurrentKeepAliveCtx(null)
   }
 
   const wrapper = new VaporComponentInstance<Record<string, unknown>>(
@@ -1111,7 +1107,7 @@ function createVDOMComponent(
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
       vdomDeactivate(
         vnode,
-        (parentComponent as KeepAliveInstance)!.ctx.getStorageContainer(),
+        keepAliveCtx!.getStorageContainer(),
         internals,
         parentComponent as any,
         null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KeepAlive behavior by using the correct context for nested and async components.
  * Reduced context leakage between component boundaries and fragment handling.
  * Stabilized caching and unmount behavior for KeepAlive-wrapped content.

* **Refactor**
  * Simplified internal KeepAlive context handling across runtime and VDOM integration.
  * Reworked how KeepAlive state is passed and restored during component setup and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->