### PR TITLE
types(runtime-core): type root component's props

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -910,6 +910,8 @@ describe('compatibility w/ createApp', () => {
     props: { foo: String },
   })
   createApp(comp2).mount('#hello')
+  // @ts-expect-error `bar` does not exist in type `Props`
+  createApp(comp2, { bar: 'a' }).mount('#hello')
 
   const comp3 = defineComponent({
     setup() {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -243,10 +243,12 @@ export function createAppContext(): AppContext {
   }
 }
 
-export type CreateAppFunction<HostElement> = (
-  rootComponent: Component,
-  rootProps?: Data | null,
-) => App<HostElement>
+export interface CreateAppFunction<HostElement> {
+  <Props extends Data = Data>(
+    rootComponent: Component<Props>,
+    rootProps?: Props | null,
+  ): App<HostElement>
+}
 
 let uid = 0
 


### PR DESCRIPTION
This feature will allow TypeScript to infer the root component's props type in `createApp`, improving type safety and autocomplete suggestions for said props.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking when creating apps so component options must match the component’s declared props.
  * Passing unsupported props now correctly produces a TypeScript error, helping catch mistakes earlier.

* **Tests**
  * Added coverage for app creation with invalid props to ensure the updated type behavior stays enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->