### PR TITLE
fix(runtime-vapor): defer slot content anchors during hydration

### DIFF
--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -792,10 +792,8 @@ describe('component: slots', () => {
       }
       await nextTick()
 
-      expect(host.innerHTML).toBe(
-        '<!--[--><!--]--><!--slot--><footer>footer</footer>',
-      )
-      expect(frag.anchor).not.toBe(end)
+      expect(host.innerHTML).toBe('<!--[--><!--]--><footer>footer</footer>')
+      expect(frag.anchor).toBe(end)
       expect(isHydrationAnchor(end)).toBe(true)
       expect(`Hydration children mismatch`).not.toHaveBeenWarned()
     })

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -74,9 +74,9 @@ import {
 import {
   getCurrentSlotEndAnchor,
   hydrateDynamicFragmentAnchor,
-  isHydratingSlotFallbackActive,
+  isPendingSlotContent,
+  startPendingSlotContent,
   withHydratingSlotBoundary,
-  withHydratingSlotFallbackActive,
 } from '../src/dom/hydrateFragment'
 
 const define = makeRender<any>()
@@ -727,7 +727,7 @@ describe('component: slots', () => {
       expect(cleanup).toHaveBeenCalledTimes(1)
     })
 
-    test('withHydratingSlotBoundary isolates fallback-active state between boundaries without local markers', () => {
+    test('withHydratingSlotBoundary isolates pending content state between boundaries without local markers', () => {
       const start = document.createComment('[')
       const end = document.createComment(']')
       const host = document.createElement('div')
@@ -742,24 +742,28 @@ describe('component: slots', () => {
 
           withHydratingSlotBoundary(() => {
             expect(getCurrentSlotEndAnchor()).toBe(end)
-            expect(isHydratingSlotFallbackActive()).toBe(false)
+            expect(isPendingSlotContent()).toBe(false)
 
-            withHydratingSlotFallbackActive(() => {
-              expect(isHydratingSlotFallbackActive()).toBe(true)
+            const finish = startPendingSlotContent(start)
+            try {
+              expect(isPendingSlotContent()).toBe(true)
 
               setCurrentHydrationNode(end)
               withHydratingSlotBoundary(() => {
                 expect(getCurrentSlotEndAnchor()).toBe(end)
-                expect(isHydratingSlotFallbackActive()).toBe(false)
+                expect(isPendingSlotContent()).toBe(false)
               })
-            })
+              expect(isPendingSlotContent()).toBe(true)
+            } finally {
+              finish(true)
+            }
 
             expect(getCurrentSlotEndAnchor()).toBe(end)
-            expect(isHydratingSlotFallbackActive()).toBe(false)
+            expect(isPendingSlotContent()).toBe(false)
           })
 
           expect(getCurrentSlotEndAnchor()).toBe(end)
-          expect(isHydratingSlotFallbackActive()).toBe(false)
+          expect(isPendingSlotContent()).toBe(false)
         })
       })
     })
@@ -848,7 +852,7 @@ describe('component: slots', () => {
       expect(`Hydration children mismatch`).toHaveBeenWarned()
     })
 
-    test('slot fallback empty inner v-if hydrates before parent close anchor', async () => {
+    test('pending slot content empty inner v-if keeps detached anchor on fallback', async () => {
       const start = document.createComment('[')
       const end = document.createComment(']')
       const host = document.createElement('div')
@@ -859,10 +863,13 @@ describe('component: slots', () => {
       try {
         hydrateNode(start, () => {
           withHydratingSlotBoundary(() => {
-            withHydratingSlotFallbackActive(() => {
+            const finish = startPendingSlotContent(start)
+            try {
               frag = new DynamicFragment('if', false, false)
               hydrateDynamicFragmentAnchor(frag, true)
-            })
+            } finally {
+              finish(false)
+            }
           })
         })
       } finally {
@@ -870,8 +877,42 @@ describe('component: slots', () => {
       }
       await nextTick()
 
-      expect(host.innerHTML).toBe('<!--[--><!--if--><!--]-->')
-      expect(frag.anchor).toBe(end.previousSibling)
+      expect(host.innerHTML).toBe('<!--[--><!--]-->')
+      expect(frag.anchor.parentNode).toBeNull()
+    })
+
+    test('pending slot content empty inner branches adopt anchors in order', () => {
+      const start = document.createComment('[')
+      const first = document.createComment('')
+      const second = document.createComment('')
+      const end = document.createComment(']')
+      const host = document.createElement('div')
+      host.append(start, first, second, end)
+      let firstFrag!: DynamicFragment
+      let secondFrag!: DynamicFragment
+
+      setIsHydratingEnabled(true)
+      try {
+        hydrateNode(start, () => {
+          withHydratingSlotBoundary(() => {
+            const finish = startPendingSlotContent(start)
+            try {
+              firstFrag = new DynamicFragment('if', false, false)
+              hydrateDynamicFragmentAnchor(firstFrag, true)
+              secondFrag = new DynamicFragment('if', false, false)
+              hydrateDynamicFragmentAnchor(secondFrag, true)
+              finish(true)
+            } finally {
+              finish(true)
+            }
+          })
+        })
+      } finally {
+        setIsHydratingEnabled(false)
+      }
+
+      expect(firstFrag.anchor).toBe(first)
+      expect(secondFrag.anchor).toBe(second)
     })
 
     test('slot resolution state stops fallback scope when fallback body throws', async () => {
@@ -2073,14 +2114,16 @@ describe('component: slots', () => {
       }
 
       const items = ref([{ text: 'bar', show: false }])
+      let ifFrag!: DynamicFragment
+      let forFrag!: any
       const { html } = define({
         setup() {
           return createComponent(Child, null, {
             default: extend(() => {
-              return createFor(
+              forFrag = createFor(
                 () => items.value,
                 for_item0 => {
-                  return createIf(
+                  ifFrag = createIf(
                     () => for_item0.value.show,
                     () => {
                       const n5 = template('<span> </span>')() as any
@@ -2092,17 +2135,21 @@ describe('component: slots', () => {
                     },
                     undefined,
                     keyedSlotRootIfShape,
-                  )
+                  ) as DynamicFragment
+                  return ifFrag
                 },
                 item => item.text,
                 slotRootForFlags,
               )
+              return forFrag
             }, nonStableSlot),
           })
         },
       }).render()
 
       expect(html()).toBe('fallback<!--slot-->')
+      expect(ifFrag.anchor.parentNode).toBeNull()
+      expect((forFrag.nodes[1] as Node).parentNode).toBeNull()
 
       items.value[0].show = true
       await nextTick()

--- a/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
@@ -1,5 +1,9 @@
 import { DynamicFragment, SlotFragment } from '../../src/fragment'
-import { hydrateNode, setIsHydratingEnabled } from '../../src/dom/hydration'
+import {
+  hydrateNode,
+  markHydrationAnchor,
+  setIsHydratingEnabled,
+} from '../../src/dom/hydration'
 import {
   type AnchorPlan,
   resolveDynamicAnchor,
@@ -144,10 +148,29 @@ describe('resolveDynamicAnchor', () => {
     expect(reuse.resetNodes).toBeUndefined()
   })
 
-  test('empty forwarded slot creates after the boundary close anchor', () => {
+  test('empty forwarded slot reuses the boundary close anchor', () => {
     const host = document.createElement('div')
     const start = document.createComment('[')
     const end = document.createComment(']')
+    host.append(start, end)
+
+    const plan = resolveWithCursor(start, () =>
+      withHydratingSlotBoundary(() => {
+        const frag = new SlotFragment()
+        frag.forwarded = true
+        return resolveDynamicAnchor(frag, true)
+      }),
+    )
+
+    const reuse = expectKind(plan, 'reuse')
+    expect(reuse.node).toBe(end)
+    expect(reuse.resetNodes).toBeUndefined()
+  })
+
+  test('empty forwarded slot creates after an already reused boundary close anchor', () => {
+    const host = document.createElement('div')
+    const start = document.createComment('[')
+    const end = markHydrationAnchor(document.createComment(']'))
     const footer = document.createElement('footer')
     host.append(start, end, footer)
 
@@ -162,7 +185,7 @@ describe('resolveDynamicAnchor', () => {
     const create = expectKind(plan, 'create')
     expect(create.parent).toBe(host)
     expect(create.next).toBe(footer)
-    expect(create.mark).toBe(end)
+    expect(create.mark).toBeUndefined()
   })
 
   test('empty inner v-if under pending slot content creates before fallback', () => {
@@ -190,7 +213,7 @@ describe('resolveDynamicAnchor', () => {
     expect(pending.slotEnd).toBe(end)
   })
 
-  test('empty inner v-if that consumed the slot range creates before the slot end anchor', () => {
+  test('empty inner v-if that consumed the slot range reuses the slot end anchor', () => {
     const host = document.createElement('div')
     const start = document.createComment('[')
     const end = document.createComment(']')
@@ -202,10 +225,27 @@ describe('resolveDynamicAnchor', () => {
       ),
     )
 
+    const reuse = expectKind(plan, 'reuse')
+    expect(reuse.node).toBe(end)
+    expect(reuse.resetNodes).toBeUndefined()
+  })
+
+  test('empty fragment creates after an already reused placeholder', () => {
+    const host = document.createElement('div')
+    const comment = markHydrationAnchor(document.createComment(''))
+    const footer = document.createElement('footer')
+    host.append(comment, footer)
+
+    const plan = resolveWithCursor(comment, () => {
+      const frag = new DynamicFragment('dynamic-component', false, false)
+      frag.nodes = comment
+      return resolveDynamicAnchor(frag, false)
+    })
+
     const create = expectKind(plan, 'create')
     expect(create.parent).toBe(host)
-    expect(create.next).toBe(end)
-    expect(create.mark).toBeUndefined()
+    expect(create.next).toBe(footer)
+    expect(create.resetNodes).toBe(true)
   })
 
   test('keyed fragment creates from its block boundary', () => {

--- a/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
@@ -3,8 +3,8 @@ import { hydrateNode, setIsHydratingEnabled } from '../../src/dom/hydration'
 import {
   type AnchorPlan,
   resolveDynamicAnchor,
+  startPendingSlotContent,
   withHydratingSlotBoundary,
-  withHydratingSlotFallbackActive,
 } from '../../src/dom/hydrateFragment'
 
 function resolveWithCursor(cursor: Node, fn: () => AnchorPlan): AnchorPlan {
@@ -165,22 +165,29 @@ describe('resolveDynamicAnchor', () => {
     expect(create.mark).toBe(end)
   })
 
-  test('empty inner v-if under active slot fallback creates before the slot end', () => {
+  test('empty inner v-if under pending slot content creates before fallback', () => {
     const host = document.createElement('div')
     const start = document.createComment('[')
     const end = document.createComment(']')
     host.append(start, end)
 
     const plan = resolveWithCursor(start, () =>
-      withHydratingSlotBoundary(() =>
-        withHydratingSlotFallbackActive(() =>
-          resolveDynamicAnchor(new DynamicFragment('if', false, false), true),
-        ),
-      ),
+      withHydratingSlotBoundary(() => {
+        const finish = startPendingSlotContent(start)
+        try {
+          return resolveDynamicAnchor(
+            new DynamicFragment('if', false, false),
+            true,
+          )
+        } finally {
+          finish(false)
+        }
+      }),
     )
 
-    const before = expectKind(plan, 'create-before-slot-end')
-    expect(before.end).toBe(end)
+    const pending = expectKind(plan, 'pending')
+    expect(pending.parent).toBe(host)
+    expect(pending.slotEnd).toBe(end)
   })
 
   test('empty inner v-if that consumed the slot range creates before the slot end anchor', () => {

--- a/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '../../src/dom/hydration'
 import {
   type AnchorPlan,
+  queuePendingSlotContentAnchor,
   resolveDynamicAnchor,
   startPendingSlotContent,
   withHydratingSlotBoundary,
@@ -211,6 +212,42 @@ describe('resolveDynamicAnchor', () => {
     const pending = expectKind(plan, 'pending')
     expect(pending.parent).toBe(host)
     expect(pending.slotEnd).toBe(end)
+  })
+
+  test('nested invalid pending slot content preserves outer pending anchors', () => {
+    const host = document.createElement('div')
+    const start = document.createComment('[')
+    const end = document.createComment(']')
+    host.append(start, end)
+    const calls: string[] = []
+
+    setIsHydratingEnabled(true)
+    try {
+      hydrateNode(start, () => {
+        withHydratingSlotBoundary(() => {
+          const finishOuter = startPendingSlotContent(start)
+          queuePendingSlotContentAnchor({
+            onContent: () => calls.push('outer content'),
+            onFallback: () => calls.push('outer fallback'),
+          })
+
+          const finishNested = startPendingSlotContent(start)
+          queuePendingSlotContentAnchor({
+            onContent: () => calls.push('nested content'),
+            onFallback: () => calls.push('nested fallback'),
+          })
+          finishNested(false)
+
+          expect(calls).toEqual(['nested fallback'])
+
+          finishOuter(true)
+        })
+      })
+    } finally {
+      setIsHydratingEnabled(false)
+    }
+
+    expect(calls).toEqual(['nested fallback', 'outer content'])
   })
 
   test('empty inner v-if that consumed the slot range reuses the slot end anchor', () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -12100,6 +12100,7 @@ describe('VDOM interop', () => {
     )
 
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
       "<div>
       <!--[-->
@@ -12125,6 +12126,72 @@ describe('VDOM interop', () => {
       <!--[-->
       <!--[--><span>bar</span><!--]-->
       <!--slot--><!--]-->
+      </div>"
+    `)
+  })
+
+  test('hydrate forwarded slot content with empty v-for before nested invalid slot', async () => {
+    const data = reactive({
+      items: [] as string[],
+      tail: 'tail',
+    })
+    const { container } = await testWithVaporApp(
+      `<script setup>
+        const components = _components
+      </script>
+      <template>
+        <components.Outer />
+      </template>`,
+      {
+        Outer: {
+          code: `<script setup>
+            const components = _components
+            const data = _data
+          </script>
+          <template>
+            <components.Child>
+              <template #foo>
+                <span v-for="item in data.items" :key="item">{{ item }}</span>
+                <slot name="bar" />
+                <b>{{ data.tail }}</b>
+              </template>
+            </components.Child>
+          </template>`,
+          vapor: true,
+        },
+        Child: {
+          code: `<template>
+            <div>
+              <slot name="foo">
+                <i>outer fallback</i>
+              </slot>
+            </div>
+          </template>`,
+          vapor: true,
+        },
+      },
+      data,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "<div>
+      <!--[-->
+      <!--[--><!--]-->
+      <!--[--><!--]-->
+      <b>tail</b><!--]-->
+      </div>"
+    `)
+
+    data.items = ['foo']
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "<div>
+      <!--[-->
+      <!--[--><span>foo</span><!--]-->
+      <!--[--><!--]-->
+      <b>tail</b><!--]-->
       </div>"
     `)
   })

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -3845,6 +3845,88 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test('slot content mismatch recovery keeps leading empty branch anchor', async () => {
+      const appCode = `<template>
+        <components.Child>
+          <template #default>
+            <template v-if="data.showPrefix">
+              <span>prefix</span>
+            </template>
+            <template v-if="data.showTail">
+              <i>{{ data.tail }}</i>
+            </template>
+          </template>
+        </components.Child>
+      </template>`
+      const childCode = `<template>
+        <slot><div>{{ data.fallback }}</div></slot>
+      </template>`
+      // SSR renders fallback, but the client slot content wins. The leading
+      // empty branch has no SSR content anchor to reuse, so hydration must
+      // create one before the recovered content for future branch updates.
+      const ssrData = ref({
+        showPrefix: false,
+        showTail: false,
+        tail: 'tail',
+        fallback: 'foo',
+      })
+      const clientData = ref({
+        showPrefix: false,
+        showTail: true,
+        tail: 'tail',
+        fallback: 'foo',
+      })
+      const ssrComponents: Record<string, any> = {}
+      ssrComponents.Child = compile(childCode, ssrData, ssrComponents, {
+        vapor: true,
+        ssr: true,
+      })
+      const SSRComp = compile(appCode, ssrData, ssrComponents, {
+        vapor: true,
+        ssr: true,
+      })
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const clientComponents: Record<string, any> = {}
+      clientComponents.Child = compile(
+        childCode,
+        clientData,
+        clientComponents,
+        {
+          vapor: true,
+        },
+      )
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const clientComp = compile(appCode, clientData, clientComponents, {
+        vapor: true,
+      })
+      const app = createVaporSSRApp(clientComp)
+      app.mount(container)
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><!--if--><i>tail</i><!--if--><!--]-->
+        "
+      `,
+      )
+
+      clientData.value.showPrefix = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><span>prefix</span><!--if--><i>tail</i><!--if--><!--]-->
+        "
+      `,
+      )
+    })
+
     test('slot fallback from empty v-for branch', async () => {
       const data = reactive({
         items: [] as string[],

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -3574,7 +3574,7 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "
-        <!--[--><div>foo</div><!--if--><!--]-->
+        <!--[--><div>foo</div><!--]-->
         "
       `,
       )
@@ -3586,7 +3586,7 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "
-        <!--[--><div>baz</div><!--if--><!--]-->
+        <!--[--><div>baz</div><!--]-->
         "
       `,
       )
@@ -3607,6 +3607,239 @@ describe('Vapor Mode hydration', () => {
         `
         "
         <!--[--><span>qux</span><!--if--><!--]-->
+        "
+      `,
+      )
+    })
+
+    test('slot fallback leading empty branch keeps its own hydration anchor', async () => {
+      const data = reactive({
+        showSlot: false,
+        showFallbackPrefix: false,
+        fallback: 'foo',
+        slot: 'bar',
+      })
+      const { container } = await testHydration(
+        `<template>
+          <components.Child>
+            <template #default>
+              <template v-if="data.showSlot">
+                <span>{{ data.slot }}</span>
+              </template>
+            </template>
+          </components.Child>
+        </template>`,
+        {
+          Child: `<template>
+            <slot>
+              <i v-if="data.showFallbackPrefix">prefix</i>
+              <div>{{ data.fallback }}</div>
+            </slot>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><!----><div>foo</div><!--]-->
+        "
+      `,
+      )
+
+      data.showFallbackPrefix = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><i>prefix</i><!----><div>foo</div><!--]-->
+        "
+      `,
+      )
+
+      data.showSlot = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><span>bar</span><!--if--><!--]-->
+        "
+      `,
+      )
+
+      data.showSlot = false
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><i>prefix</i><!--if--><div>foo</div><!--]-->
+        "
+      `,
+      )
+    })
+
+    test('slot content hydrates over mismatched SSR fallback', async () => {
+      const appCode = `<template>
+        <components.Child>
+          <template #default>
+            <template v-if="data.showSlot">
+              <span>{{ data.slot }}</span>
+            </template>
+          </template>
+        </components.Child>
+      </template>`
+      const childCode = `<template>
+        <slot>
+          <div>{{ data.fallback }}</div>
+          <i>suffix</i>
+        </slot>
+      </template>`
+      const ssrData = ref({
+        showSlot: false,
+        fallback: 'foo',
+        slot: 'bar',
+      })
+      const clientData = ref({
+        showSlot: true,
+        fallback: 'foo',
+        slot: 'bar',
+      })
+      const ssrComponents: Record<string, any> = {}
+      ssrComponents.Child = compile(childCode, ssrData, ssrComponents, {
+        vapor: true,
+        ssr: true,
+      })
+      const SSRComp = compile(appCode, ssrData, ssrComponents, {
+        vapor: true,
+        ssr: true,
+      })
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      const clientComponents: Record<string, any> = {}
+      clientComponents.Child = compile(
+        childCode,
+        clientData,
+        clientComponents,
+        {
+          vapor: true,
+        },
+      )
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const clientComp = compile(appCode, clientData, clientComponents, {
+        vapor: true,
+      })
+      const app = createVaporSSRApp(clientComp)
+      app.mount(container)
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration children mismatch`).toHaveBeenWarned()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><span>bar</span><!--if--><!--]-->
+        "
+      `,
+      )
+    })
+
+    test('slot fallback trailing empty branch keeps fallback DOM intact', async () => {
+      const data = reactive({
+        showSlot: false,
+        showFallbackSuffix: false,
+        fallback: 'foo',
+        slot: 'bar',
+      })
+      const { container } = await testHydration(
+        `<template>
+          <components.Child>
+            <template #default>
+              <template v-if="data.showSlot">
+                <span>{{ data.slot }}</span>
+              </template>
+            </template>
+          </components.Child>
+        </template>`,
+        {
+          Child: `<template>
+            <slot>
+              <div>{{ data.fallback }}</div>
+              <i v-if="data.showFallbackSuffix">suffix</i>
+            </slot>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><div>foo</div><!----><!--]-->
+        "
+      `,
+      )
+
+      data.showFallbackSuffix = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><div>foo</div><i>suffix</i><!----><!--]-->
+        "
+      `,
+      )
+
+      data.showSlot = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><span>bar</span><!--if--><!--]-->
+        "
+      `,
+      )
+    })
+
+    test('valid slot content keeps leading empty branch anchor before fallback', async () => {
+      const data = reactive({
+        showPrefix: false,
+        tail: 'tail',
+        fallback: 'foo',
+      })
+      const { container } = await testHydration(
+        `<template>
+          <components.Child>
+            <template #default>
+              <template v-if="data.showPrefix">
+                <span>prefix</span>
+              </template>
+              <i>{{ data.tail }}</i>
+            </template>
+          </components.Child>
+        </template>`,
+        {
+          Child: `<template><slot><div>{{ data.fallback }}</div></slot></template>`,
+        },
+        data,
+      )
+
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><!----><i>tail</i><!--]-->
+        "
+      `,
+      )
+
+      data.showPrefix = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `
+        "
+        <!--[--><span>prefix</span><!----><i>tail</i><!--]-->
         "
       `,
       )
@@ -3634,7 +3867,7 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "
-        <!--[--><div>foo</div><!--for--><!--]-->
+        <!--[--><div>foo</div><!--]-->
         "
       `,
       )
@@ -3646,7 +3879,7 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "
-        <!--[--><div>baz</div><!--for--><!--]-->
+        <!--[--><div>baz</div><!--]-->
         "
       `,
       )
@@ -3777,7 +4010,7 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "
-        <!--[--><div>foo</div><!--if--><!--for--><!--]-->
+        <!--[--><div>foo</div><!--]-->
         "
       `,
       )
@@ -3789,7 +4022,7 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "
-        <!--[--><div>baz</div><!--if--><!--for--><!--]-->
+        <!--[--><div>baz</div><!--]-->
         "
       `,
       )
@@ -11231,7 +11464,7 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
       `
       "
-      <!--[--><div>foo</div><!--if--><!--]-->
+      <!--[--><div>foo</div><!--]-->
       "
     `,
     )
@@ -11243,7 +11476,7 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
       `
       "
-      <!--[--><div>baz</div><!--if--><!--]-->
+      <!--[--><div>baz</div><!--]-->
       "
     `,
     )
@@ -11264,6 +11497,73 @@ describe('VDOM interop', () => {
       `
       "
       <!--[--><span>qux</span><!--if--><!--]-->
+      "
+    `,
+    )
+  })
+
+  test('hydrate interop vapor slot fallback leading empty branch', async () => {
+    const data = reactive({
+      showSlot: false,
+      showFallbackPrefix: false,
+      fallback: 'foo',
+      slot: 'bar',
+    })
+    const { container } = await testWithVDOMApp(
+      `<script setup>
+        const components = _components
+      </script>
+      <template>
+        <components.VaporChild />
+      </template>`,
+      {
+        VaporChild: {
+          code: `<script setup>
+            const data = _data
+            const components = _components
+          </script>
+          <template>
+            <components.VdomChild>
+              <template #default>
+                <template v-if="data.showSlot">
+                  <span>{{ data.slot }}</span>
+                </template>
+              </template>
+            </components.VdomChild>
+          </template>`,
+          vapor: true,
+        },
+        VdomChild: {
+          code: `<script setup>const data = _data</script>
+          <template>
+            <slot>
+              <i v-if="data.showFallbackPrefix">prefix</i>
+              <div>{{ data.fallback }}</div>
+            </slot>
+          </template>`,
+          vapor: false,
+        },
+      },
+      data,
+    )
+
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[--><!----><div>foo</div><!--]-->
+      "
+    `,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+    data.showFallbackPrefix = true
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[--><i>prefix</i><div>foo</div><!--]-->
       "
     `,
     )
@@ -11477,7 +11777,7 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
       `
         "
-        <!--[--><div>foo</div><p>bar</p><!--if--><!--]-->
+        <!--[--><div>foo</div><p>bar</p><!--]-->
         "
       `,
     )
@@ -11490,7 +11790,7 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
       `
         "
-        <!--[--><div>qux</div><p>quux</p><!--if--><!--]-->
+        <!--[--><div>qux</div><p>quux</p><!--]-->
         "
       `,
     )
@@ -11557,7 +11857,7 @@ describe('VDOM interop', () => {
       `
         "
         <!--[-->
-        <!--[--><div>foo</div><!----><!--if--><!--]-->
+        <!--[--><div>foo</div><!----><!--]-->
         <i>tail</i><!--]-->
         "
       `,
@@ -11569,7 +11869,7 @@ describe('VDOM interop', () => {
       `
         "
         <!--[-->
-        <!--[--><div>foo</div><!--if--><p>bar</p><!--]-->
+        <!--[--><div>foo</div><p>bar</p><!--]-->
         <i>tail</i><!--]-->
         "
       `,
@@ -12660,7 +12960,7 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
       `
       "
-      <!--[--><div>foo</div><!--if--><!--]-->
+      <!--[--><div>foo</div><!--]-->
       "
     `,
     )
@@ -12672,7 +12972,7 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
       `
       "
-      <!--[--><div>baz</div><!--if--><!--]-->
+      <!--[--><div>baz</div><!--]-->
       "
     `,
     )

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4308,8 +4308,8 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "<div>
-        <!--[-->foo<!--]-->
-        <!--slot--></div>"
+        <!--[-->foo<!--slot--><!--]-->
+        </div>"
       `,
       )
 
@@ -4318,8 +4318,8 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
         "<div>
-        <!--[-->foo1<!--]-->
-        <!--slot--></div>"
+        <!--[-->foo1<!--slot--><!--]-->
+        </div>"
       `,
       )
     })
@@ -11995,8 +11995,8 @@ describe('VDOM interop', () => {
       `
         "
         <!--[--><div>
-        <!--[-->foo<!--]-->
-        <!--slot--></div><!--]-->
+        <!--[-->foo<!--slot--><!--]-->
+        </div><!--]-->
         "
       `,
     )
@@ -12009,8 +12009,8 @@ describe('VDOM interop', () => {
       `
         "
         <!--[--><div>
-        <!--[-->bar<!--]-->
-        <!--slot--></div><!--]-->
+        <!--[-->bar<!--slot--><!--]-->
+        </div><!--]-->
         "
       `,
     )
@@ -12065,7 +12065,66 @@ describe('VDOM interop', () => {
       "<div>
       <!--[-->
       <!--[--><span>foo</span><!--if--><!--if--><!--if--><!--]-->
-      <!--]-->
+      <!--slot--><!--]-->
+      </div>"
+    `)
+  })
+
+  test('hydrate forwarded slot fallback with empty v-for before becoming valid', async () => {
+    const items = ref<string[]>([])
+    const { container } = await testWithVaporApp(
+      `<script setup>
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <template #foo><slot name="foo" /></template>
+        </components.Child>
+      </template>`,
+      {
+        Child: {
+          code: `<script setup>
+              const items = _data
+            </script>
+            <template>
+              <div>
+                <slot name="foo">
+                  <span v-for="item in items" :key="item">{{ item }}</span>
+                </slot>
+              </div>
+            </template>`,
+          vapor: true,
+        },
+      },
+      items,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "<div>
+      <!--[-->
+      <!--[--><!--]-->
+      <!--slot--><!--]-->
+      </div>"
+    `)
+
+    items.value = ['foo']
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "<div>
+      <!--[-->
+      <!--[--><span>foo</span><!--]-->
+      <!--slot--><!--]-->
+      </div>"
+    `)
+
+    items.value = ['bar']
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "<div>
+      <!--[-->
+      <!--[--><span>bar</span><!--]-->
+      <!--slot--><!--]-->
       </div>"
     `)
   })
@@ -13358,7 +13417,7 @@ describe('VDOM interop', () => {
       "<div>
       <!--[--><div>banner</div><!--]-->
       <div><main><span>content</span></main>
-      <!--[--><!--]-->
+      <!--[--><!--slot--><!--]-->
       <p>footer</p></div></div>"
       `,
     )

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -2786,8 +2786,8 @@ describe('Vapor Mode hydration', () => {
         `
         "
         <!--[--><div>
-        <!--[--><!--if--><!--]-->
-        </div><span>tail</span><!--]-->
+        <!--[--><!--]-->
+        <!--slot--></div><span>tail</span><!--]-->
         "
       `,
       )
@@ -2801,8 +2801,8 @@ describe('Vapor Mode hydration', () => {
         `
         "
         <!--[--><div>
-        <!--[--><span>bar</span><!--if--><!--]-->
-        </div><span>tail updated</span><!--]-->
+        <!--[--><span>bar</span><!--]-->
+        <!--slot--></div><span>tail updated</span><!--]-->
         "
       `,
       )
@@ -2814,8 +2814,8 @@ describe('Vapor Mode hydration', () => {
         `
         "
         <!--[--><div>
-        <!--[--><!--if--><!--]-->
-        </div><span>tail updated</span><!--]-->
+        <!--[--><!--]-->
+        <!--slot--></div><span>tail updated</span><!--]-->
         "
       `,
       )
@@ -4309,7 +4309,7 @@ describe('Vapor Mode hydration', () => {
         `
         "<div>
         <!--[-->foo<!--]-->
-        </div>"
+        <!--slot--></div>"
       `,
       )
 
@@ -4319,7 +4319,7 @@ describe('Vapor Mode hydration', () => {
         `
         "<div>
         <!--[-->foo1<!--]-->
-        </div>"
+        <!--slot--></div>"
       `,
       )
     })
@@ -4473,9 +4473,9 @@ describe('Vapor Mode hydration', () => {
       await nextTick()
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
-      	"<div>
-      	<!--[--><!--]-->
-      	<span>foo</span><!--slot--><div>bar</div></div>"
+        "<div>
+        <!--[--><span>foo</span><!--]-->
+        <!--slot--><div>bar</div></div>"
       `,
       )
 
@@ -4484,9 +4484,9 @@ describe('Vapor Mode hydration', () => {
       await nextTick()
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
         `
-      	"<div>
-      	<!--[--><!--]-->
-      	<span>foo1</span><!--slot--><div>bar1</div></div>"
+        "<div>
+        <!--[--><span>foo1</span><!--]-->
+        <!--slot--><div>bar1</div></div>"
       `,
       )
     })
@@ -6445,9 +6445,9 @@ describe('Vapor Mode hydration', () => {
       expect(`Hydration node mismatch`).toHaveBeenWarned()
       expect(`Hydration text mismatch`).not.toHaveBeenWarned()
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
-      	"<div>
-      	<!--[--><span>bar</span><!--if--><!--]-->
-      	</div><!--async component-->"
+        "<div>
+        <!--[--><span>bar</span><!--if--><!--]-->
+        <!--slot--></div><!--async component-->"
       `)
     })
 
@@ -11996,7 +11996,7 @@ describe('VDOM interop', () => {
         "
         <!--[--><div>
         <!--[-->foo<!--]-->
-        </div><!--]-->
+        <!--slot--></div><!--]-->
         "
       `,
     )
@@ -12010,7 +12010,7 @@ describe('VDOM interop', () => {
         "
         <!--[--><div>
         <!--[-->bar<!--]-->
-        </div><!--]-->
+        <!--slot--></div><!--]-->
         "
       `,
     )
@@ -13359,7 +13359,7 @@ describe('VDOM interop', () => {
       <!--[--><div>banner</div><!--]-->
       <div><main><span>content</span></main>
       <!--[--><!--]-->
-      <!--slot--><p>footer</p></div></div>"
+      <p>footer</p></div></div>"
       `,
     )
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -50,7 +50,8 @@ import {
 import { ForBlock, ForFragment, type VaporFragment } from './fragment'
 import {
   getCurrentSlotEndAnchor,
-  isHydratingSlotFallbackActive,
+  isPendingSlotContent,
+  queuePendingSlotContentAnchor,
 } from './dom/hydrateFragment'
 import {
   type ChildItem,
@@ -484,7 +485,7 @@ export const createFor = (
       isComment(hydrationStart, ']') &&
       isComment(hydrationStart.previousSibling!, '[')
     const slotEndAnchor = getCurrentSlotEndAnchor()
-    const slotFallbackRange = isHydratingSlotFallbackActive() && slotEndAnchor
+    const slotFallbackRange = isPendingSlotContent() && slotEndAnchor
 
     const reuseBoundaryClose = (close: Node): void => {
       parentAnchor = markHydrationAnchor(close)
@@ -523,10 +524,9 @@ export const createFor = (
         } else if (slotFallbackRange && !isValidBlock(newBlocks)) {
           // Slot fallback can fall through an empty/invalid `v-for`. In that
           // case SSR only rendered the parent slot range, so this `v-for` has no
-          // own `<!--]-->` to reuse. If `hydrationStart` is not the parent slot
-          // end anchor, use `hydrationStart.nextSibling` as the insertion point
-          // so the runtime `<!--for-->` lands immediately after that local SSR
-          // range. Otherwise insert it before the parent slot end anchor.
+          // own `<!--]-->` to reuse. Keep its runtime anchor detached if
+          // fallback wins; if content wins, insert it at the local slot-content
+          // boundary below.
           const anchor =
             // The invalid list still consumed local SSR item ranges.
             currentHydrationNode !== hydrationStart
@@ -545,9 +545,14 @@ export const createFor = (
           ) {
             setCurrentHydrationNode(hydrationStart)
           }
-          queuePostFlushCb(() => {
-            const parentNode = anchor.parentNode
-            if (parentNode) parentNode.insertBefore(parentAnchor, anchor)
+          queuePendingSlotContentAnchor({
+            onContent: () => {
+              queuePostFlushCb(() => {
+                const parentNode = anchor.parentNode
+                if (parentNode) parentNode.insertBefore(parentAnchor, anchor)
+              })
+            },
+            onFallback: () => {},
           })
         } else {
           const close = locateHydrationBoundaryClose(currentHydrationNode!)

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -127,6 +127,7 @@ import type {
   VaporRenderResult,
 } from './apiDefineComponent'
 import { DynamicFragment, isDynamicFragment, isFragment } from './fragment'
+import { resolvePendingSlotContent } from './dom/hydrateFragment'
 import type { VaporElement } from './apiDefineCustomElement'
 import {
   isSuspenseEnabled,
@@ -282,6 +283,7 @@ export function createComponent(
     }
   }
   if (isHydrating) {
+    resolvePendingSlotContent()
     hydrationCursor = enterHydrationCursor()
     if (component.__multiRoot && isComment(currentHydrationNode!, '[')) {
       hydrationClose = locateEndAnchor(currentHydrationNode!)
@@ -981,6 +983,7 @@ export function createPlainElement(
   const _insertionAnchor = insertionAnchor
   let hydrationCursor: HydrationCursor | null = null
   if (isHydrating) {
+    resolvePendingSlotContent()
     hydrationCursor = enterHydrationCursor()
   } else {
     resetInsertionState()

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -30,10 +30,17 @@ import { type DynamicFragment, isSlotFragment } from '../fragment'
 
 interface HydratingSlotBoundaryState {
   endAnchor: Node | null
-  fallbackActive: boolean
+  // Slot content is still resolving whether it should claim the SSR range.
+  pending: boolean
+  pendingAnchors: PendingSlotContentAnchor[] | null
 }
 
 let currentHydratingSlotBoundaryState: HydratingSlotBoundaryState | null = null
+
+interface PendingSlotContentAnchor {
+  onContent: () => void
+  onFallback: () => void
+}
 
 function setCurrentHydratingSlotBoundaryState(
   state: HydratingSlotBoundaryState | null,
@@ -63,7 +70,8 @@ export function withHydratingSlotBoundary<R>(fn: () => R): R {
   }
   const prevState = setCurrentHydratingSlotBoundaryState({
     endAnchor,
-    fallbackActive: false,
+    pending: false,
+    pendingAnchors: null,
   })
 
   try {
@@ -74,40 +82,66 @@ export function withHydratingSlotBoundary<R>(fn: () => R): R {
   }
 }
 
-// Tracks hydration while a slot boundary is resolving fallback through inner
-// empty control-flow fragments, e.g.
-// - `<slot><template v-if="false" /></slot>`
-// - `<slot><span v-for="item in items" /></slot>`.
-// We need a boundary-level marker because the inner empty fragment can hydrate
-// before slot render finishes deciding whether fallback will take over. While
-// active, empty inner fragments should create their own runtime anchor instead
-// of assuming SSR already provided the final insertion point.
-export function isHydratingSlotFallbackActive(): boolean {
-  return !!(
-    currentHydratingSlotBoundaryState &&
-    currentHydratingSlotBoundaryState.fallbackActive
-  )
-}
-
-export function setCurrentHydratingSlotFallbackActive(
-  active: boolean,
-): boolean {
-  try {
-    return isHydratingSlotFallbackActive()
-  } finally {
-    if (currentHydratingSlotBoundaryState) {
-      currentHydratingSlotBoundaryState.fallbackActive = active
+function resolvePendingSlotContentAnchors(
+  state: HydratingSlotBoundaryState,
+  contentValid: boolean,
+): void {
+  // Empty fragments rendered before the slot decision cannot know whether
+  // their anchor belongs to content SSR or needs to be created for fallback.
+  const pendingAnchors = state.pendingAnchors
+  if (!pendingAnchors) return
+  state.pendingAnchors = null
+  for (let i = 0; i < pendingAnchors.length; i++) {
+    const pendingAnchor = pendingAnchors[i]
+    if (contentValid) {
+      pendingAnchor.onContent()
+    } else {
+      pendingAnchor.onFallback()
     }
   }
 }
 
-export function withHydratingSlotFallbackActive<R>(fn: () => R): R {
-  const prevState = setCurrentHydratingSlotFallbackActive(true)
-  try {
-    return fn()
-  } finally {
-    setCurrentHydratingSlotFallbackActive(prevState)
+export function queuePendingSlotContentAnchor(
+  anchor: PendingSlotContentAnchor,
+): void {
+  const state = currentHydratingSlotBoundaryState
+  if (state && state.pending) {
+    ;(state.pendingAnchors ||= []).push(anchor)
   }
+}
+
+// Slot content with fallback is unresolved until it creates a valid node.
+// While unresolved, empty content branches must not consume fallback SSR anchors.
+export function startPendingSlotContent(
+  start: Node | null,
+): (contentValid: boolean) => void {
+  const state = currentHydratingSlotBoundaryState
+  if (!state) return () => {}
+  const prevPending = state.pending
+  state.pending = true
+  let active = true
+  return contentValid => {
+    if (!active) return
+    active = false
+    resolvePendingSlotContentAnchors(state, contentValid)
+    state.pending = prevPending
+    if (!contentValid) {
+      setCurrentHydrationNode(start)
+    }
+  }
+}
+
+export function resolvePendingSlotContent(): void {
+  const state = currentHydratingSlotBoundaryState
+  if (state && state.pending) {
+    resolvePendingSlotContentAnchors(state, true)
+    state.pending = false
+  }
+}
+
+export function isPendingSlotContent(): boolean {
+  const state = currentHydratingSlotBoundaryState
+  return !!(state && state.pending)
 }
 
 const enum CloseAnchorOwner {
@@ -140,18 +174,6 @@ function getDynamicCloseOwner(
     return CloseAnchorOwner.Self
   }
 
-  // Slot fallback can fall through an inner `v-if`. When the `if` resolves
-  // to an invalid block and the fallback is selected, the `if` still needs
-  // its own runtime anchor instead of reusing the parent slot's end anchor.
-  if (
-    anchorLabel === 'if' &&
-    currentSlotEndAnchor &&
-    isHydratingSlotFallbackActive() &&
-    !isValidBlock(nodes)
-  ) {
-    return CloseAnchorOwner.ParentBefore
-  }
-
   return CloseAnchorOwner.None
 }
 
@@ -159,12 +181,20 @@ function queueAnchorInsert(
   parentNode: Node,
   nextNode: Node | null,
   createAnchor: () => Node,
+  fallbackNextNode?: Node | null,
 ): void {
-  // Create the runtime anchor only after insertion is flushed so traversal
-  // cannot observe a detached anchor too early.
+  // Create the runtime anchor during the queued insertion so hydration
+  // traversal never observes it before it is in its final position.
   queuePostFlushCb(() => {
-    const anchor =
+    let anchor =
       nextNode && getParentNode(nextNode) === parentNode ? nextNode : null
+    if (
+      !anchor &&
+      fallbackNextNode &&
+      getParentNode(fallbackNextNode) === parentNode
+    ) {
+      anchor = fallbackNextNode
+    }
     parentNode.insertBefore(createAnchor(), anchor)
   })
 }
@@ -224,9 +254,22 @@ export function prepareDeferredHydrationAnchor(
 export type AnchorPlan =
   // Adopt an existing SSR comment node as the fragment anchor.
   | { kind: 'reuse'; node: Node; resetNodes?: boolean }
+  // Delay an empty slot-content anchor until content/fallback ownership is
+  // known. Fallback-owned content anchors are inserted before the slot end.
+  | {
+      kind: 'pending'
+      parent: Node
+      slotEnd: Node
+    }
   // Insert a fresh runtime anchor before `next` once insertion flushes.
   // `mark` keeps an SSR node structural so boundary cleanup preserves it.
-  | { kind: 'create'; parent: Node; next: Node | null; mark?: Node }
+  | {
+      kind: 'create'
+      parent: Node
+      next: Node | null
+      mark?: Node
+      fallbackNext?: Node | null
+    }
   // Trim unclaimed SSR content first, then insert a fresh runtime anchor.
   // Only arises for empty fragments, so the stale block reference is cleared.
   | {
@@ -268,6 +311,15 @@ export function resolveDynamicAnchor(
   // reuse `<!---->` as anchor
   // `<div v-if="false"></div>` -> `<!---->`
   if (isEmpty) {
+    if (isPendingSlotContent()) {
+      const slotEnd = getCurrentSlotEndAnchor()!
+      const node = currentHydrationNode || slotEnd
+      return {
+        kind: 'pending',
+        parent: getParentNode(node)!,
+        slotEnd,
+      }
+    }
     if (currentHydrationNode && isComment(currentHydrationNode, '')) {
       return { kind: 'reuse', node: currentHydrationNode }
     }
@@ -293,7 +345,6 @@ export function resolveDynamicAnchor(
       !frag.isSlot &&
       ownsDynamicAnchor &&
       currentHydrationNode &&
-      !isHydratingSlotFallbackActive() &&
       !isComment(currentHydrationNode, ']')
     ) {
       const parentNode = getParentNode(currentHydrationNode)
@@ -439,7 +490,18 @@ export function resolveDynamicAnchor(
     parentNode = node.parentNode
     nextNode = node.nextNode
   }
-  return { kind: 'create', parent: parentNode!, next: nextNode }
+  let fallbackNext: Node | null = null
+  if (
+    currentSlotEndAnchor &&
+    nextNode === currentHydrationNode &&
+    parentNode &&
+    getParentNode(currentSlotEndAnchor) === parentNode
+  ) {
+    // `nextNode` can be stale fallback DOM that slot cleanup removes before the
+    // queued anchor insertion flushes. Keep the anchor inside the slot range.
+    fallbackNext = currentSlotEndAnchor
+  }
+  return { kind: 'create', parent: parentNode!, next: nextNode, fallbackNext }
 }
 
 export function executeAnchorPlan(
@@ -469,9 +531,44 @@ export function executeAnchorPlan(
         }
         break
       }
+      case 'pending': {
+        const slotEnd = plan.slotEnd
+        queuePendingSlotContentAnchor({
+          onContent: () => {
+            // Content won: adopt the pending SSR anchor for this empty
+            // fragment and advance past it before hydrating following content.
+            const node = currentHydrationNode
+            if (
+              node &&
+              getParentNode(node) === plan.parent &&
+              node.nodeType === 8 &&
+              (isComment(node, '') ||
+                (frag.anchorLabel !== undefined &&
+                  isReusableDynamicFragmentAnchor(
+                    node as Comment,
+                    frag.anchorLabel,
+                  )))
+            ) {
+              frag.anchor = markHydrationAnchor(node)
+              advanceHydrationNode(node)
+            }
+          },
+          onFallback: () => {
+            // Match CSR by always creating the content fragment anchor, even
+            // when fallback wins and keeps the anchor detached from the DOM.
+            createRuntimeAnchor()
+          },
+        })
+        break
+      }
       case 'create': {
         if (plan.mark) markHydrationAnchor(plan.mark)
-        queueAnchorInsert(plan.parent, plan.next, createRuntimeAnchor)
+        queueAnchorInsert(
+          plan.parent,
+          plan.next,
+          createRuntimeAnchor,
+          plan.fallbackNext,
+        )
         break
       }
       case 'create-cleanup': {

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -20,13 +20,8 @@ import {
   createTextNode,
   parentNode as getParentNode,
 } from './node'
-import {
-  type Block,
-  EMPTY_BLOCK,
-  findBlockBoundary,
-  isValidBlock,
-} from '../block'
-import { type DynamicFragment, isSlotFragment } from '../fragment'
+import { EMPTY_BLOCK, findBlockBoundary, isValidBlock } from '../block'
+import type { DynamicFragment } from '../fragment'
 
 interface HydratingSlotBoundaryState {
   endAnchor: Node | null
@@ -86,8 +81,8 @@ function resolvePendingSlotContentAnchors(
   state: HydratingSlotBoundaryState,
   contentValid: boolean,
 ): void {
-  // Empty fragments rendered before the slot decision cannot know whether
-  // their anchor belongs to content SSR or needs to be created for fallback.
+  // Empty fragments rendered before the slot decision wait until content wins
+  // before claiming the current SSR anchor candidate.
   const pendingAnchors = state.pendingAnchors
   if (!pendingAnchors) return
   state.pendingAnchors = null
@@ -144,39 +139,6 @@ export function isPendingSlotContent(): boolean {
   return !!(state && state.pending)
 }
 
-const enum CloseAnchorOwner {
-  None,
-  Self,
-  ParentBefore,
-  ParentAfter,
-}
-
-function getDynamicCloseOwner(
-  isSlot: boolean,
-  forwardedSlot: boolean,
-  anchorLabel: string | undefined,
-  nodes: Block,
-  currentSlotEndAnchor: Node | null,
-): CloseAnchorOwner {
-  // Slot fragments own the close marker unless this is an empty forwarded slot.
-  // Empty forwarded slots must leave the close marker to the parent boundary
-  // and create their runtime anchor after it.
-  if (isSlot) {
-    if (!forwardedSlot) return CloseAnchorOwner.Self
-    return isValidBlock(nodes)
-      ? CloseAnchorOwner.Self
-      : CloseAnchorOwner.ParentAfter
-  }
-
-  // SSR wraps multi-root `v-if` branches in a fragment range, so the closing
-  // `<!--]-->` belongs to the branch itself.
-  if (anchorLabel === 'if' && isArray(nodes) && nodes.length > 1) {
-    return CloseAnchorOwner.Self
-  }
-
-  return CloseAnchorOwner.None
-}
-
 function queueAnchorInsert(
   parentNode: Node,
   nextNode: Node | null,
@@ -199,17 +161,26 @@ function queueAnchorInsert(
   })
 }
 
-function isReusableDynamicFragmentAnchor(
-  node: Comment,
-  anchorLabel: string,
-): boolean {
+function isReusableAnchorCandidate(
+  node: Node | null,
+  anchorLabel?: string,
+): node is Comment {
   return (
-    isComment(node, anchorLabel) ||
-    (isComment(node, '') &&
-      (anchorLabel === 'dynamic-component' ||
-        anchorLabel === 'async component' ||
-        anchorLabel === 'keyed'))
+    !!node &&
+    (isComment(node, '') ||
+      isComment(node, ']') ||
+      (anchorLabel !== undefined && isComment(node, anchorLabel)))
   )
+}
+
+function reuseOrCreateAfterAnchor(
+  node: Node,
+  resetNodes?: boolean,
+): AnchorPlan {
+  const parent = getParentNode(node)
+  return isHydrationAnchor(node) && parent
+    ? { kind: 'create', parent, next: node.nextSibling, resetNodes }
+    : { kind: 'reuse', node, resetNodes }
 }
 
 export function prepareDeferredHydrationAnchor(
@@ -252,10 +223,10 @@ export function prepareDeferredHydrationAnchor(
  * performs all side effects.
  */
 export type AnchorPlan =
-  // Adopt an existing SSR comment node as the fragment anchor.
+  // Adopt an existing comment node as the fragment anchor.
   | { kind: 'reuse'; node: Node; resetNodes?: boolean }
-  // Delay an empty slot-content anchor until content/fallback ownership is
-  // known. Fallback-owned content anchors are inserted before the slot end.
+  // Delay an empty slot-content anchor until content/fallback is decided.
+  // If fallback wins, the content anchor is created detached.
   | {
       kind: 'pending'
       parent: Node
@@ -269,6 +240,7 @@ export type AnchorPlan =
       next: Node | null
       mark?: Node
       fallbackNext?: Node | null
+      resetNodes?: boolean
     }
   // Trim unclaimed SSR content first, then insert a fresh runtime anchor.
   // Only arises for empty fragments, so the stale block reference is cleared.
@@ -280,9 +252,6 @@ export type AnchorPlan =
       cleanupUntil: Node | null
       cleanupContainer?: ParentNode
     }
-  // Insert a fresh runtime anchor right before the enclosing slot end anchor,
-  // skipping insertion entirely if that anchor leaves the DOM before flush.
-  | { kind: 'create-before-slot-end'; end: Node }
 
 export function resolveDynamicAnchor(
   frag: DynamicFragment,
@@ -308,8 +277,8 @@ export function resolveDynamicAnchor(
     return { kind: 'reuse', node: currentHydrationNode! }
   }
 
-  // reuse `<!---->` as anchor
-  // `<div v-if="false"></div>` -> `<!---->`
+  // Empty fragments claim a current SSR anchor candidate directly. Later
+  // fragments that need the same candidate create a fresh anchor after it.
   if (isEmpty) {
     if (isPendingSlotContent()) {
       const slotEnd = getCurrentSlotEndAnchor()!
@@ -320,11 +289,11 @@ export function resolveDynamicAnchor(
         slotEnd,
       }
     }
-    if (currentHydrationNode && isComment(currentHydrationNode, '')) {
-      return { kind: 'reuse', node: currentHydrationNode }
+    if (isReusableAnchorCandidate(currentHydrationNode)) {
+      return reuseOrCreateAfterAnchor(currentHydrationNode)
     }
     if (
-      frag.anchorLabel &&
+      anchorLabel &&
       currentHydrationNode &&
       isComment(currentHydrationNode, 'teleport anchor')
     ) {
@@ -361,17 +330,13 @@ export function resolveDynamicAnchor(
         }
       }
 
-      const anchor = nextLogicalSibling(currentHydrationNode)
-      const reusableAnchor =
-        anchor &&
-        anchor.nodeType === 8 &&
-        isReusableDynamicFragmentAnchor(anchor as Comment, anchorLabel!) &&
-        getParentNode(anchor)
-          ? anchor
-          : null
       if (parentNode) {
-        if (reusableAnchor) {
-          return { kind: 'reuse', node: reusableAnchor, resetNodes: true }
+        const anchor = nextLogicalSibling(currentHydrationNode)
+        if (
+          isReusableAnchorCandidate(anchor, anchorLabel) &&
+          getParentNode(anchor)
+        ) {
+          return reuseOrCreateAfterAnchor(anchor, true)
         }
         return {
           kind: 'create-cleanup',
@@ -392,10 +357,10 @@ export function resolveDynamicAnchor(
     ownsDynamicAnchor &&
     !isValidBlock(frag.nodes) &&
     frag.nodes instanceof Comment &&
-    isReusableDynamicFragmentAnchor(frag.nodes, anchorLabel!) &&
+    isReusableAnchorCandidate(frag.nodes, anchorLabel) &&
     getParentNode(frag.nodes)
   ) {
-    return { kind: 'reuse', node: frag.nodes, resetNodes: true }
+    return reuseOrCreateAfterAnchor(frag.nodes, true)
   }
 
   // Empty dynamic fragments can also start from a detached runtime comment
@@ -424,72 +389,33 @@ export function resolveDynamicAnchor(
   }
 
   const currentSlotEndAnchor = getCurrentSlotEndAnchor()
-  const forwardedSlot = isSlotFragment(frag) ? frag.forwarded : false
   const slotAnchor = frag.isSlot ? currentSlotEndAnchor : null
 
-  // Reuse SSR `<!--]-->` as anchor.
   // SSR wraps slots and multi-root `v-if` branches with `<!--[-->...<!--]-->`.
-  // Non-forwarded slots always own the closing `<!--]-->`, even when empty.
-  // Forwarded slots only own it when they rendered valid content.
-  const closeOwner = getDynamicCloseOwner(
-    !!frag.isSlot,
-    forwardedSlot,
-    frag.anchorLabel,
-    frag.nodes,
-    currentSlotEndAnchor,
-  )
-  if (closeOwner === CloseAnchorOwner.Self) {
+  // The close marker is a valid stable anchor candidate: reuse it once, or
+  // create a fresh runtime anchor after it when another fragment already did.
+  if (
+    frag.isSlot ||
+    (anchorLabel === 'if' && isArray(frag.nodes) && frag.nodes.length > 1)
+  ) {
     const anchor = locateHydrationBoundaryClose(
       slotAnchor || currentHydrationNode!,
       slotAnchor || null,
     )
     if (isComment(anchor!, ']')) {
-      return { kind: 'reuse', node: anchor }
+      return reuseOrCreateAfterAnchor(anchor)
     } else if (__DEV__) {
       throw new Error(
-        `Failed to locate ${frag.anchorLabel} fragment anchor. this is likely a Vue internal bug.`,
+        `Failed to locate ${anchorLabel} fragment anchor. this is likely a Vue internal bug.`,
       )
     }
-  } else if (
-    closeOwner === CloseAnchorOwner.ParentAfter &&
-    currentSlotEndAnchor
-  ) {
-    // Otherwise, create a new anchor.
-    // This covers: empty forwarded slots.
-    // Keep the forwarded slot close marker structural for parent cleanup,
-    // even though this fragment uses a runtime anchor after it.
-    return {
-      kind: 'create',
-      parent: currentSlotEndAnchor.parentNode!,
-      next: currentSlotEndAnchor.nextSibling,
-      mark: currentSlotEndAnchor,
-    }
-  } else if (
-    closeOwner === CloseAnchorOwner.ParentBefore &&
-    currentSlotEndAnchor
-  ) {
-    return { kind: 'create-before-slot-end', end: currentSlotEndAnchor }
   }
 
   // Otherwise, create a new anchor.
   // This covers: dynamic-component, async component, keyed fragment.
-  let parentNode: Node | null
-  let nextNode: Node | null
-  if (
-    frag.anchorLabel === 'if' &&
-    !isValidBlock(frag.nodes) &&
-    currentSlotEndAnchor &&
-    currentHydrationNode === currentSlotEndAnchor
-  ) {
-    // Only reuse the slot end anchor as insertion point when this empty
-    // inner `v-if` has already consumed the whole local slot range.
-    parentNode = currentSlotEndAnchor.parentNode
-    nextNode = currentSlotEndAnchor
-  } else {
-    const node = findBlockBoundary(frag.nodes)
-    parentNode = node.parentNode
-    nextNode = node.nextNode
-  }
+  const node = findBlockBoundary(frag.nodes)
+  const parentNode = node.parentNode
+  const nextNode = node.nextNode
   let fallbackNext: Node | null = null
   if (
     currentSlotEndAnchor &&
@@ -535,33 +461,33 @@ export function executeAnchorPlan(
         const slotEnd = plan.slotEnd
         queuePendingSlotContentAnchor({
           onContent: () => {
-            // Content won: adopt the pending SSR anchor for this empty
-            // fragment and advance past it before hydrating following content.
+            // Content won: claim the current SSR anchor candidate, or create a
+            // fresh anchor after it if another fragment already claimed it.
             const node = currentHydrationNode
             const nodeParent = node && getParentNode(node)
             if (
               node &&
               nodeParent === plan.parent &&
-              node.nodeType === 8 &&
-              (isComment(node, '') ||
-                (frag.anchorLabel !== undefined &&
-                  isReusableDynamicFragmentAnchor(
-                    node as Comment,
-                    frag.anchorLabel,
-                  )))
+              isReusableAnchorCandidate(node, frag.anchorLabel)
             ) {
-              frag.anchor = markHydrationAnchor(node)
-              advanceHydrationNode(node)
-            } else {
-              // Mismatch recovery can leave the cursor on fallback DOM instead
-              // of a reusable content anchor. Create this empty branch's
-              // runtime anchor before that DOM so later updates have a stable
-              // insertion point.
-              const anchor = node && nodeParent === plan.parent ? node : slotEnd
-              const parentNode = getParentNode(anchor)
-              if (parentNode) {
-                parentNode.insertBefore(createRuntimeAnchor(), anchor)
+              if (isHydrationAnchor(node)) {
+                const nextNode = node.nextSibling
+                advanceHydrationNode(node)
+                nodeParent.insertBefore(createRuntimeAnchor(), nextNode)
+              } else {
+                frag.anchor = markHydrationAnchor(node)
+                advanceHydrationNode(node)
               }
+              return
+            }
+            // Mismatch recovery can leave the cursor on fallback DOM instead
+            // of a reusable content anchor. Create this empty branch's
+            // runtime anchor before that DOM so later updates have a stable
+            // insertion point.
+            const anchor = node && nodeParent === plan.parent ? node : slotEnd
+            const parentNode = getParentNode(anchor)
+            if (parentNode) {
+              parentNode.insertBefore(createRuntimeAnchor(), anchor)
             }
           },
           onFallback: () => {
@@ -573,6 +499,7 @@ export function executeAnchorPlan(
         break
       }
       case 'create': {
+        if (plan.resetNodes) frag.nodes = EMPTY_BLOCK
         if (plan.mark) markHydrationAnchor(plan.mark)
         queueAnchorInsert(
           plan.parent,
@@ -591,15 +518,6 @@ export function executeAnchorPlan(
           setCurrentHydrationNode(null)
         }
         queueAnchorInsert(plan.parent, plan.next, createRuntimeAnchor)
-        break
-      }
-      case 'create-before-slot-end': {
-        const endAnchor = plan.end
-        queuePostFlushCb(() => {
-          const parentNode = getParentNode(endAnchor)
-          if (!parentNode) return
-          parentNode.insertBefore(createRuntimeAnchor(), endAnchor)
-        })
         break
       }
     }

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -80,14 +80,18 @@ export function withHydratingSlotBoundary<R>(fn: () => R): R {
 function resolvePendingSlotContentAnchors(
   state: HydratingSlotBoundaryState,
   contentValid: boolean,
+  startIndex: number = 0,
 ): void {
   // Empty fragments rendered before the slot decision wait until content wins
   // before claiming the current SSR anchor candidate.
   const pendingAnchors = state.pendingAnchors
   if (!pendingAnchors) return
-  state.pendingAnchors = null
-  for (let i = 0; i < pendingAnchors.length; i++) {
-    const pendingAnchor = pendingAnchors[i]
+  const anchors = startIndex
+    ? pendingAnchors.splice(startIndex)
+    : pendingAnchors
+  if (!startIndex) state.pendingAnchors = null
+  for (let i = 0; i < anchors.length; i++) {
+    const pendingAnchor = anchors[i]
     if (contentValid) {
       pendingAnchor.onContent()
     } else {
@@ -113,12 +117,19 @@ export function startPendingSlotContent(
   const state = currentHydratingSlotBoundaryState
   if (!state) return () => {}
   const prevPending = state.pending
+  const pendingAnchorStart = state.pendingAnchors
+    ? state.pendingAnchors.length
+    : 0
   state.pending = true
   let active = true
   return contentValid => {
     if (!active) return
     active = false
-    resolvePendingSlotContentAnchors(state, contentValid)
+    resolvePendingSlotContentAnchors(
+      state,
+      contentValid,
+      !contentValid && prevPending ? pendingAnchorStart : 0,
+    )
     state.pending = prevPending
     if (!contentValid) {
       setCurrentHydrationNode(start)

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -538,9 +538,10 @@ export function executeAnchorPlan(
             // Content won: adopt the pending SSR anchor for this empty
             // fragment and advance past it before hydrating following content.
             const node = currentHydrationNode
+            const nodeParent = node && getParentNode(node)
             if (
               node &&
-              getParentNode(node) === plan.parent &&
+              nodeParent === plan.parent &&
               node.nodeType === 8 &&
               (isComment(node, '') ||
                 (frag.anchorLabel !== undefined &&
@@ -551,6 +552,16 @@ export function executeAnchorPlan(
             ) {
               frag.anchor = markHydrationAnchor(node)
               advanceHydrationNode(node)
+            } else {
+              // Mismatch recovery can leave the cursor on fallback DOM instead
+              // of a reusable content anchor. Create this empty branch's
+              // runtime anchor before that DOM so later updates have a stable
+              // insertion point.
+              const anchor = node && nodeParent === plan.parent ? node : slotEnd
+              const parentNode = getParentNode(anchor)
+              if (parentNode) {
+                parentNode.insertBefore(createRuntimeAnchor(), anchor)
+              }
             }
           },
           onFallback: () => {

--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -10,6 +10,7 @@ import {
 } from './hydration'
 import { type Namespace, Namespaces, TemplateFlags } from '@vue/shared'
 import { _child, createTextNode } from './node'
+import { resolvePendingSlotContent } from './hydrateFragment'
 
 let t: HTMLTemplateElement
 
@@ -20,6 +21,11 @@ export function template(html: string, flags: number = 0, ns?: Namespace) {
   let node: Node
   return (): Node & { $root?: true } => {
     if (isHydrating) {
+      // Comment templates may be empty branch anchors. Only real DOM/text
+      // templates prove that slot content is valid.
+      if (!(html[0] === '<' && html[1] === '!')) {
+        resolvePendingSlotContent()
+      }
       let adopted: Node | null = null
       // static templates only need to skip fragment markers, teleport
       // markers, and hydration anchors before advancing the hydration

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -20,21 +20,23 @@ import {
 } from '@vue/runtime-dom'
 import type { VaporComponentInstance } from './component'
 import type { NodeRef } from './apiTemplateRef'
-import { isHydrating, locateHydrationNode } from './dom/hydration'
+import {
+  currentHydrationNode,
+  isHydrating,
+  locateHydrationNode,
+} from './dom/hydration'
 import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
 import {
   type SlotBoundaryContext,
   currentSlotBoundary,
-  hasSlotFallback,
   setCurrentSlotBoundary,
   trackSlotBoundaryDirtying,
   withSlotBoundary,
 } from './slotBoundary'
 import {
   hydrateDynamicFragmentAnchor,
-  isHydratingSlotFallbackActive,
   prepareDeferredHydrationAnchor,
-  setCurrentHydratingSlotFallbackActive,
+  startPendingSlotContent,
   withHydratingSlotBoundary,
 } from './dom/hydrateFragment'
 import {
@@ -536,28 +538,25 @@ export class SlotFragment
     try {
       const shouldForce = prevLocalFallback !== fallback
       if (isHydrating) {
-        const boundaryHasFallback = hasSlotFallback(boundary)
         withHydratingSlotBoundary(() => {
-          const prev = isHydratingSlotFallbackActive()
+          const fallbackStart = currentHydrationNode
+          let finish: ((contentValid: boolean) => void) | null = null
           try {
-            if (boundaryHasFallback) {
-              setCurrentHydratingSlotFallbackActive(true)
-            }
+            // SlotFragment only exists when fallback ownership can change.
+            // Delay empty content anchors until content/fallback is decided.
+            finish = startPendingSlotContent(fallbackStart)
             this.updateContent(slotRender, key)
             const contentValid = isValidSlot(this.content)
-            recheckSlotResolution(this, shouldForce)
-            // Updates run under the temporary fallback-active marker so empty
-            // inner branches can materialize their own anchors if fallback
-            // takes over. If recheck resolves back to content, restore the
-            // outer state before hydrateDynamicFragmentAnchor(); the surrounding
-            // finally still restores nested callers when we leave this
-            // boundary.
-            if (!boundaryHasFallback || contentValid) {
-              setCurrentHydratingSlotFallbackActive(prev)
+            if (finish) {
+              finish(contentValid)
+              finish = null
             }
+            recheckSlotResolution(this, shouldForce)
             hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
           } finally {
-            setCurrentHydratingSlotFallbackActive(prev)
+            if (finish) {
+              finish(true)
+            }
           }
         })
       } else {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -16,14 +16,19 @@ import {
   type TransitionHooks,
   type VNode,
   currentInstance,
+  queuePostFlushCb,
   setCurrentInstance,
 } from '@vue/runtime-dom'
 import type { VaporComponentInstance } from './component'
 import type { NodeRef } from './apiTemplateRef'
 import {
+  advanceHydrationNode,
   currentHydrationNode,
+  isComment,
   isHydrating,
+  locateEndAnchor,
   locateHydrationNode,
+  markHydrationAnchor,
 } from './dom/hydration'
 import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
 import {
@@ -34,6 +39,7 @@ import {
   withSlotBoundary,
 } from './slotBoundary'
 import {
+  getCurrentSlotEndAnchor,
   hydrateDynamicFragmentAnchor,
   prepareDeferredHydrationAnchor,
   startPendingSlotContent,
@@ -238,8 +244,8 @@ export class DynamicFragment extends RenderContextFragment {
   // pure marker consumed by the isSlotFragment predicate; the core update
   // pipeline never reads it.
   isSlot?: boolean
-  // Hydration-only marker consumed by hydrateFragment: empty forwarded slots
-  // leave the SSR close marker to the parent slot boundary.
+  // Hydration-only marker for forwarded slots. They restore their own content
+  // anchor but leave inherited fallback resolution to the receiver slot.
   forwarded?: boolean
   // Marks the generic dynamic fragment that createPlainElement creates for the
   // default-slot children of a dynamic element resolved to a native tag
@@ -457,6 +463,7 @@ export class SlotFragment
   customElementFallback?: Block
   activeFallback: Block | null = null
   fallbackScope?: EffectScope
+  lastNodesValid?: boolean
   pendingRecheck = false
   isRenderingFallback = false
   private content: Block = EMPTY_BLOCK
@@ -521,6 +528,28 @@ export class SlotFragment
     this.content = this.nodes
   }
 
+  private updateHydratingContent(
+    render: BlockFn | undefined,
+    key: any,
+  ): { contentStart: Node | null; contentValid: boolean } {
+    const contentStart = currentHydrationNode
+    let finish: ((contentValid: boolean) => void) | null = null
+    try {
+      finish = startPendingSlotContent(contentStart)
+      this.updateContent(render, key)
+      const contentValid = isValidSlot(this.content)
+      if (finish) {
+        finish(contentValid)
+        finish = null
+      }
+      return { contentStart, contentValid }
+    } finally {
+      if (finish) {
+        finish(true)
+      }
+    }
+  }
+
   updateSlot(
     render?: BlockFn,
     fallback?: BlockFn,
@@ -538,27 +567,64 @@ export class SlotFragment
     try {
       const shouldForce = prevLocalFallback !== fallback
       if (isHydrating) {
-        withHydratingSlotBoundary(() => {
-          const fallbackStart = currentHydrationNode
-          let finish: ((contentValid: boolean) => void) | null = null
-          try {
-            // SlotFragment only exists when fallback ownership can change.
-            // Delay empty content anchors until content/fallback is decided.
-            finish = startPendingSlotContent(fallbackStart)
-            this.updateContent(slotRender, key)
-            const contentValid = isValidSlot(this.content)
-            if (finish) {
-              finish(contentValid)
-              finish = null
+        // Forwarded content without local fallback must not run inherited
+        // fallback resolution itself. It only restores its own content anchor;
+        // the receiver slot boundary decides whether inherited fallback
+        // should run.
+        if (this.forwarded && !fallback) {
+          const { contentStart, contentValid } = this.updateHydratingContent(
+            slotRender,
+            key,
+          )
+          this.syncNodes()
+          this.lastNodesValid = contentValid
+          if (contentValid) {
+            const end =
+              contentStart && isComment(contentStart, '[')
+                ? locateEndAnchor(contentStart)
+                : null
+            if (end) {
+              this.anchor = markHydrationAnchor(end)
+              advanceHydrationNode(end)
+            } else {
+              hydrateDynamicFragmentAnchor(this, !isValidBlock(this.content))
             }
-            recheckSlotResolution(this, shouldForce)
-            hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
-          } finally {
-            if (finish) {
-              finish(true)
+          } else {
+            // Empty forwarded content should not claim the receiver slot's SSR
+            // close marker. Queue its runtime anchor before that marker so
+            // fallback hydration can finish first and the final DOM matches CSR.
+            const anchor = (this.anchor = markHydrationAnchor(
+              __DEV__
+                ? createComment(this.anchorLabel ?? '')
+                : createTextNode(),
+            ))
+            const slotEnd = getCurrentSlotEndAnchor()
+            const parent = slotEnd && slotEnd.parentNode
+            if (parent) {
+              const previous = slotEnd.previousSibling
+              if (previous && isComment(previous, ']')) {
+                // When the receiver fallback is a fragment, the node right
+                // before the receiver slot end is the fallback fragment's SSR
+                // close. This forwarded slot does not own that marker, but
+                // boundary cleanup runs before the queued anchor is inserted,
+                // so mark it now.
+                markHydrationAnchor(previous)
+              }
+
+              queuePostFlushCb(() => {
+                if (slotEnd.parentNode === parent) {
+                  parent.insertBefore(anchor, slotEnd)
+                }
+              })
             }
           }
-        })
+        } else {
+          withHydratingSlotBoundary(() => {
+            this.updateHydratingContent(slotRender, key)
+            recheckSlotResolution(this, shouldForce)
+            hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
+          })
+        }
       } else {
         this.updateContent(slotRender, key)
         recheckSlotResolution(this, shouldForce)

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -140,8 +140,8 @@ import {
 } from './slotFragment'
 import {
   getCurrentSlotEndAnchor,
+  startPendingSlotContent,
   withHydratingSlotBoundary,
-  withHydratingSlotFallbackActive,
 } from './dom/hydrateFragment'
 import type { NodeRef } from './apiTemplateRef'
 import {
@@ -2032,6 +2032,12 @@ function renderVaporSlot(
       const hasInteropFallback =
         !!slotState.localFallback.value || !!slotState.outletFallback.value
       slotResolutionState.pendingRecheck = false
+      let finish: ((contentValid: boolean) => void) | undefined
+      const finishHydratingContent = (contentValid: boolean): void => {
+        if (!finish) return
+        finish(contentValid)
+        finish = undefined
+      }
       const finalizeResolvedContent = (
         resolvedContent: Block | undefined,
       ): Block | undefined => {
@@ -2039,9 +2045,11 @@ function renderVaporSlot(
           setScopeId(resolvedContent, scopeIds)
         }
         if (hasInteropFallback && isSlotFragment(resolvedContent)) {
+          finishHydratingContent(true)
           return resolvedContent
         }
         contentNodes = resolvedContent || EMPTY_BLOCK
+        finishHydratingContent(isValidSlot(contentNodes))
         recheckSlotResolution(slotResolutionState, takePendingRecheck())
         return resolvedContent
       }
@@ -2049,19 +2057,26 @@ function renderVaporSlot(
       isResolvingContent = true
       try {
         if (isHydrating) {
-          resolvedContent = withHydratingSlotBoundary(() =>
-            finalizeResolvedContent(
-              runWithFragmentCtxOnly(frag, () => {
-                const renderSlot = () =>
-                  withSlotBoundary(localFallbackBoundary, () =>
-                    invokeVaporSlot(vnode),
-                  )
-                return hasSlotFallback(localFallbackBoundary)
-                  ? withHydratingSlotFallbackActive(renderSlot)
-                  : renderSlot()
-              }),
-            ),
-          )
+          resolvedContent = withHydratingSlotBoundary(() => {
+            // SSR may currently contain fallback DOM. Delay empty content
+            // anchors until rendered content proves whether it should win.
+            if (hasSlotFallback(localFallbackBoundary)) {
+              finish = startPendingSlotContent(currentHydrationNode)
+            }
+            try {
+              return finalizeResolvedContent(
+                runWithFragmentCtxOnly(frag, () => {
+                  const renderSlot = () =>
+                    withSlotBoundary(localFallbackBoundary, () =>
+                      invokeVaporSlot(vnode),
+                    )
+                  return renderSlot()
+                }),
+              )
+            } finally {
+              finishHydratingContent(true)
+            }
+          })
         } else {
           resolvedContent = finalizeResolvedContent(
             runWithFragmentCtxOnly(frag, () =>


### PR DESCRIPTION
Slot content and slot fallback are both evaluated before hydration knows which branch should own the SSR DOM. Empty dynamic fragments inside slot content could therefore consume fallback-owned anchors too early, or miss the runtime anchor they still need after fallback wins.

Track empty slot-content anchors as pending while the slot content validity is unresolved. If content wins, reuse the matching SSR anchor. If fallback wins, insert a real runtime anchor before the slot end so later content updates still have a stable insertion point without stealing fallback DOM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved hydration handling for slots and conditional content, especially in nested and forwarded-slot scenarios.

* **Bug Fixes**
  * Fixed several edge cases where empty or fallback slot content could reuse the wrong anchor or leave DOM nodes in an inconsistent state.
  * Improved recovery when client-rendered slot content differs from SSR content, reducing hydration mismatches.
  * Updated interop behavior so slot fallback content hydrates more reliably across combined rendering paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->