### PR TITLE
fix(compiler-sfc): infer boolean prop types from generic constraints

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -282,6 +282,34 @@ return { props, get propsModel() { return propsModel } }
 }"
 `;
 
+exports[`defineProps > w/ generic boolean constraints 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+type Nullable<T> = T | null | undefined
+type Props<TMultiple extends boolean> = {
+  primitive: boolean
+  wrapped: Nullable<boolean>
+  multiple: TMultiple
+  checked: TMultiple extends true ? boolean : never
+}
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    primitive: { type: Boolean, required: true },
+    wrapped: { type: [Boolean, null], required: true, skipCheck: true },
+    multiple: { type: Boolean, required: true },
+    checked: { type: Boolean, required: true }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+
+
+return {  }
+}
+
+})"
+`;
+
 exports[`defineProps > w/ interface 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 interface Props { x?: number }

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -237,6 +237,39 @@ const props = defineProps({ foo: String })
     })
   })
 
+  // #13787
+  test('w/ generic boolean constraints', () => {
+    const source = `<script setup lang="ts" generic="TMultiple extends boolean">
+type Nullable<T> = T | null | undefined
+type Props<TMultiple extends boolean> = {
+  primitive: boolean
+  wrapped: Nullable<boolean>
+  multiple: TMultiple
+  checked: TMultiple extends true ? boolean : never
+}
+defineProps<Props<TMultiple>>()
+</script>`
+
+    const { content, bindings } = compile(source)
+    assertCode(content)
+    expect(content).toMatch(`primitive: { type: Boolean, required: true }`)
+    expect(content).toMatch(
+      `wrapped: { type: [Boolean, null], required: true, skipCheck: true }`,
+    )
+    expect(content).toMatch(`multiple: { type: Boolean, required: true }`)
+    expect(content).toMatch(`checked: { type: Boolean, required: true }`)
+    expect(bindings).toStrictEqual({
+      primitive: BindingTypes.PROPS,
+      wrapped: BindingTypes.PROPS,
+      multiple: BindingTypes.PROPS,
+      checked: BindingTypes.PROPS,
+    })
+
+    const { content: prod } = compile(source, { isProd: true })
+    expect(prod).toMatch(`multiple: { type: Boolean }`)
+    expect(prod).toMatch(`checked: { type: Boolean }`)
+  })
+
   test('w/ interface', () => {
     const { content, bindings } = compile(`
     <script setup lang="ts">

--- a/packages/compiler-sfc/src/script/defineProps.ts
+++ b/packages/compiler-sfc/src/script/defineProps.ts
@@ -230,7 +230,7 @@ function resolveRuntimePropsFromType(
     props.push({
       key,
       required: !e.optional,
-      type: type || [`null`],
+      type: type.length ? type : [`null`],
       skipCheck,
     })
   }

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -20,6 +20,7 @@ import type {
   TSTypeAnnotation,
   TSTypeElement,
   TSTypeLiteral,
+  TSTypeParameter,
   TSTypeQuery,
   TSTypeReference,
   TemplateLiteral,
@@ -274,7 +275,13 @@ function innerResolveTypeElements(
           resolved.typeParameters.params.forEach((p, i) => {
             let param = typeParameters && typeParameters[p.name]
             if (!param) param = node.typeParameters!.params[i]
-            typeParams![p.name] = param
+            typeParams![p.name] = resolveGenericTypeParameter(
+              ctx,
+              param,
+              p,
+              scope,
+              typeParameters,
+            )
           })
         }
         return resolveTypeElements(
@@ -323,6 +330,11 @@ function innerResolveTypeElements(
         )
       }
     }
+    case 'TSTypeParameter':
+      if (node.constraint) {
+        return resolveTypeElements(ctx, node.constraint, scope, typeParameters)
+      }
+      break
     case 'TSImportType': {
       if (
         getId(node.argument) === 'vue' &&
@@ -1774,7 +1786,13 @@ export function inferRuntimeType(
               const typeParams: Record<string, Node> = Object.create(null)
               if (resolved.typeParameters) {
                 resolved.typeParameters.params.forEach((p, i) => {
-                  typeParams![p.name] = node.typeParameters!.params[i]
+                  typeParams![p.name] = resolveGenericTypeParameter(
+                    ctx,
+                    node.typeParameters!.params[i],
+                    p,
+                    scope,
+                    typeParameters,
+                  )
                 })
               }
               return inferRuntimeType(
@@ -1787,7 +1805,12 @@ export function inferRuntimeType(
             }
           }
 
-          return inferRuntimeType(ctx, resolved, resolved._ownerScope, isKeyOf)
+          return inferRuntimeType(
+            ctx,
+            resolved,
+            resolved._ownerScope || scope,
+            isKeyOf,
+          )
         }
         if (node.typeName.type === 'Identifier') {
           if (typeParameters && typeParameters[node.typeName.name]) {
@@ -1960,6 +1983,14 @@ export function inferRuntimeType(
 
       case 'TSUnionType':
         return flattenTypes(ctx, node.types, scope, isKeyOf, typeParameters)
+      case 'TSConditionalType':
+        return flattenTypes(
+          ctx,
+          [node.trueType, node.falseType],
+          scope,
+          isKeyOf,
+          typeParameters,
+        )
       case 'TSIntersectionType': {
         return flattenTypes(
           ctx,
@@ -2017,6 +2048,9 @@ export function inferRuntimeType(
       case 'TSSymbolKeyword':
         return ['Symbol']
 
+      case 'TSNeverKeyword':
+        return []
+
       case 'TSIndexedAccessType': {
         const types = resolveIndexType(ctx, node, scope)
         return flattenTypes(ctx, types, scope, isKeyOf)
@@ -2067,6 +2101,18 @@ export function inferRuntimeType(
         }
         break
       }
+
+      case 'TSTypeParameter':
+        if (node.constraint) {
+          return inferRuntimeType(
+            ctx,
+            node.constraint,
+            scope,
+            isKeyOf,
+            typeParameters,
+          )
+        }
+        break
     }
   } catch (e) {
     // always soft fail on failed runtime type inference
@@ -2074,6 +2120,43 @@ export function inferRuntimeType(
     ctx.silentOnExtendsFailure = prevSilent
   }
   return [UNKNOWN_TYPE] // no runtime check
+}
+
+function resolveGenericTypeParameter(
+  ctx: TypeResolveContext,
+  param: Node | undefined,
+  typeParam: TSTypeParameter,
+  scope: TypeScope,
+  typeParameters?: Record<string, Node>,
+): Node {
+  if (
+    param &&
+    typeParam.constraint &&
+    isUnresolvableTypeReference(ctx, param, scope, typeParameters)
+  ) {
+    return typeParam
+  }
+  return param || typeParam
+}
+
+function isUnresolvableTypeReference(
+  ctx: TypeResolveContext,
+  node: Node,
+  scope: TypeScope,
+  typeParameters?: Record<string, Node>,
+): boolean {
+  if (
+    node.type !== 'TSTypeReference' ||
+    node.typeName.type !== 'Identifier' ||
+    typeParameters?.[node.typeName.name]
+  ) {
+    return false
+  }
+  try {
+    return !resolveTypeReference(ctx, node, scope)
+  } catch {
+    return true
+  }
 }
 
 function flattenTypes(


### PR DESCRIPTION
## Summary

- infer runtime types from generic parameter constraints when unresolved type parameters are used as type-only props
- infer conditional type runtime constructors from both branches so `T extends true ? boolean : never` can preserve `Boolean`
- fall back to `null` when runtime inference returns an empty type list, e.g. from `never`

## Root Cause

When a generic props alias such as `Props<T extends boolean>` was instantiated with an unresolved SFC generic, runtime prop inference kept the unresolved outer type parameter and lost the alias constraint. That made props like `multiple: T` and `checked: T extends true ? boolean : never` compile without a `Boolean` runtime constructor, so Vue could not apply boolean casting.

Fixes #13787.

## Validation

- `pnpm vitest --project unit packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts --run`
- `pnpm vitest --project unit packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts --run`
- `pnpm vitest --project unit packages/compiler-sfc/__tests__ --run`
- `pnpm check`
- `pnpm exec prettier --check packages/compiler-sfc/src/script/resolveType.ts packages/compiler-sfc/src/script/defineProps.ts packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type handling for props so generic constraints, conditional types, and `never`-like cases are reflected more accurately in generated output.
  * Fixed prop normalization so empty inferred types now fall back consistently, helping avoid incorrect runtime prop shapes.
  * Production builds now omit extra development-only prop details while keeping type information intact.

* **Tests**
  * Added coverage for generic boolean-constrained prop scenarios, including binding classification and production-mode output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->