### PR TITLE
fix(runtime-vapor): preserve vapor slot owner during interop slot dry run

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -2140,6 +2140,49 @@ describe('vdomInterop', () => {
       expect(getLabels()).toEqual(['Vitest', 'Cypress'])
     })
 
+    test('slots.default() delayed by VDOM child should not warn when vapor slot contains v-for', async () => {
+      const data = ref(['Vue', 'Vapor'])
+
+      const VDomClientOnly = defineComponent({
+        setup(_, { slots }) {
+          const show = ref(false)
+          onMounted(() => {
+            show.value = true
+          })
+          return () => h('section', null, show.value ? slots.default?.() : [])
+        },
+      })
+
+      const VaporChild = compile(
+        `<template>
+          <components.VDomClientOnly>
+            <span v-for="item in data" :key="item">{{ item }}</span>
+          </components.VDomClientOnly>
+        </template>`,
+        data,
+        {
+          VDomClientOnly,
+        },
+      )
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporChild as any)
+        },
+      }).render()
+
+      expect(html()).toBe('<section></section>')
+
+      await nextTick()
+
+      expect(html()).toBe(
+        '<section><span>Vue</span><span>Vapor</span><!--for--></section>',
+      )
+      expect(
+        'createFor() can only be used inside setup()',
+      ).not.toHaveBeenWarned()
+    })
+
     test('slots.default() access should return a stable wrapper', () => {
       const VDomChild = defineComponent({
         setup(_, { slots }) {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -109,6 +109,12 @@ const rawSlotWrappersCache = new WeakMap<
   >
 >()
 
+export function getRawSlotsOwner(
+  slots: RawSlots,
+): VaporComponentInstance | null {
+  return rawSlotsOwnerMap.get(slots) || null
+}
+
 export function normalizeRawSlots(
   rawSlots?: LooseRawSlots | null,
 ): RawSlots | null | undefined {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -94,6 +94,7 @@ import {
   dynamicSlotsProxyHandlers,
   getRawSlotsOwner,
   getSlot,
+  setCurrentSlotOwner,
   withOnceSlot,
 } from './componentSlots'
 import { renderEffect } from './renderEffect'
@@ -722,6 +723,7 @@ function normalizeVaporSlotVNodes(
     value = runVdomSlotVNodeCollection(() =>
       scope.run(() =>
         withVdomSlotVNodeCollection(() => {
+          const prevSlotOwner = setCurrentSlotOwner(owner)
           const prevInstance = owner && setCurrentInstance(owner, scope)
           try {
             return slot(props)
@@ -729,6 +731,7 @@ function normalizeVaporSlotVNodes(
             if (prevInstance) {
               setCurrentInstance(...prevInstance)
             }
+            setCurrentSlotOwner(prevSlotOwner)
           }
         }),
       ),

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -40,6 +40,7 @@ import {
   onScopeDispose,
   queuePostFlushCb,
   renderSlot,
+  setCurrentInstance,
   setTransitionHooks as setVNodeTransitionHooks,
   shallowReactive,
   shallowRef,
@@ -91,6 +92,7 @@ import type { RawSlots, VaporSlot } from './componentSlots'
 import {
   currentSlotScopeIds,
   dynamicSlotsProxyHandlers,
+  getRawSlotsOwner,
   getSlot,
   withOnceSlot,
 } from './componentSlots'
@@ -681,7 +683,7 @@ const vaporSlotsProxyHandler: ProxyHandler<any> = {
       // represented as VDOM vnodes, fall back to the real renderSlot protocol.
       const wrapped = (props?: Record<string, any>) => {
         return (
-          normalizeVaporSlotVNodes(slot, props) || [
+          normalizeVaporSlotVNodes(target, slot, props) || [
             renderSlot({ [key]: slot }, key as string, props),
           ]
         )
@@ -706,6 +708,7 @@ const vaporSlotsProxyHandler: ProxyHandler<any> = {
 const collectedVdomSlotVNodes = new WeakMap<VaporFragment, VNode>()
 
 function normalizeVaporSlotVNodes(
+  rawSlots: RawSlots,
   slot: Function,
   props: Record<string, any> | undefined,
 ): VNode[] | undefined {
@@ -713,10 +716,22 @@ function normalizeVaporSlotVNodes(
     return
   }
   const scope = effectScope()
+  const owner = getRawSlotsOwner(rawSlots)
   let value: any
   try {
     value = runVdomSlotVNodeCollection(() =>
-      scope.run(() => withVdomSlotVNodeCollection(() => slot(props))),
+      scope.run(() =>
+        withVdomSlotVNodeCollection(() => {
+          const prevInstance = owner && setCurrentInstance(owner, scope)
+          try {
+            return slot(props)
+          } finally {
+            if (prevInstance) {
+              setCurrentInstance(...prevInstance)
+            }
+          }
+        }),
+      ),
     )
   } finally {
     scope.stop()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slot content now renders with the correct component context, preventing unexpected dev warnings in nested or delayed slot usage.
  * Improved handling for slot content that includes lists, ensuring it renders correctly after mount.
  * Added coverage for delayed slot invocation and list rendering to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->