### PR TITLE
fix(runtime-core): clear refs for v-if component roots

### DIFF
--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -245,6 +245,38 @@ describe('api: template refs', () => {
     expect(el.value).toBe(null)
   })
 
+  // #15032
+  it('clears component ref when child root is unmounted by v-if', async () => {
+    const root = nodeOps.createElement('div')
+    const childRef = ref<any>(null)
+    const show = ref(true)
+
+    const Child = defineComponent({
+      props: ['show'],
+      setup(props) {
+        return () => (props.show ? h('div') : null)
+      },
+    })
+
+    const App = {
+      render() {
+        return h(Child, {
+          ref: childRef,
+          show: show.value,
+        })
+      },
+    }
+
+    render(h(App), root)
+    expect(childRef.value === null).toBe(false)
+
+    show.value = false
+    await nextTick()
+    expect(childRef.value === null).toBe(true)
+
+    render(null, root)
+  })
+
   it('set and change ref in the same tick', async () => {
     const root = nodeOps.createElement('div')
     const show = ref(false)

--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -250,9 +250,10 @@ describe('api: template refs', () => {
     const root = nodeOps.createElement('div')
     const childRef = ref<any>(null)
     const show = ref(true)
+    const tick = ref(0)
 
     const Child = defineComponent({
-      props: ['show'],
+      props: ['show', 'tick'],
       setup(props) {
         return () => (props.show ? h('div') : null)
       },
@@ -263,6 +264,7 @@ describe('api: template refs', () => {
         return h(Child, {
           ref: childRef,
           show: show.value,
+          tick: tick.value,
         })
       },
     }
@@ -271,6 +273,10 @@ describe('api: template refs', () => {
     expect(childRef.value === null).toBe(false)
 
     show.value = false
+    await nextTick()
+    expect(childRef.value === null).toBe(true)
+
+    tick.value++
     await nextTick()
     expect(childRef.value === null).toBe(true)
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -404,6 +404,10 @@ function baseCreateRenderer(
     }
 
     const { type, ref, shapeFlag } = n2
+    const prevComponentSubTree =
+      n1 && (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) > 0
+        ? n1.component!.subTree
+        : null
     switch (type) {
       case Text:
         processText(n1, n2, container, anchor)
@@ -489,7 +493,13 @@ function baseCreateRenderer(
 
     // set ref
     if (ref != null && parentComponent) {
-      setRef(ref, n1 && n1.ref, parentSuspense, n2 || n1, !n2)
+      const clearComponentRef =
+        prevComponentSubTree &&
+        (n2.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) > 0 &&
+        prevComponentSubTree.type !== Comment &&
+        n2.component!.subTree.type === Comment
+      const unsetRef = !n2 || !!clearComponentRef
+      setRef(ref, n1 && n1.ref, parentSuspense, n2 || n1, unsetRef)
     } else if (ref == null && n1 && n1.ref != null) {
       setRef(n1.ref, null, parentSuspense, n1, true)
     }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -38,6 +38,7 @@ import {
   invokeArrayFns,
   isArray,
   isReservedProp,
+  isString,
 } from '@vue/shared'
 import {
   type SchedulerJob,
@@ -51,6 +52,7 @@ import {
 import {
   EffectFlags,
   ReactiveEffect,
+  isRef,
   pauseTracking,
   resetTracking,
 } from '@vue/reactivity'
@@ -493,11 +495,24 @@ function baseCreateRenderer(
 
     // set ref
     if (ref != null && parentComponent) {
+      let refCleared = false
+      if (!isArray(ref)) {
+        pauseTracking()
+        try {
+          refCleared = isString(ref.r)
+            ? ref.i.refs[ref.r] === null
+            : isRef(ref.r)
+              ? ref.r.value === null
+              : false
+        } finally {
+          resetTracking()
+        }
+      }
       const clearComponentRef =
         prevComponentSubTree &&
         (n2.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) > 0 &&
-        prevComponentSubTree.type !== Comment &&
-        n2.component!.subTree.type === Comment
+        n2.component!.subTree.type === Comment &&
+        (prevComponentSubTree.type !== Comment || refCleared)
       const unsetRef = !n2 || !!clearComponentRef
       setRef(ref, n1 && n1.ref, parentSuspense, n2 || n1, unsetRef)
     } else if (ref == null && n1 && n1.ref != null) {


### PR DESCRIPTION
fix #15032

## Summary

- Clear a parent component ref when an already-rendered child component root changes from a real node to the v-if comment placeholder.
- Preserve existing behavior for components that initially render a comment root.
- Add regression coverage for a component ref whose child root is unmounted by v-if.

## Verification

- `pnpm test-unit packages/runtime-core/__tests__/rendererTemplateRef.spec.ts --run`
- `pnpm exec prettier --check packages/runtime-core/src/renderer.ts packages/runtime-core/__tests__/rendererTemplateRef.spec.ts`
- `pnpm exec eslint packages/runtime-core/src/renderer.ts packages/runtime-core/__tests__/rendererTemplateRef.spec.ts`
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template refs held by a parent to a child component instance so they are cleared to `null` after the child is removed via conditional rendering.
  * Refined ref update logic during re-renders to keep parent-held refs consistent across mount/unmount cycles.
* **Tests**
  * Added a regression test covering parent-held template refs being reset after `v-if` removal and after subsequent ticks/unmounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->