### PR TITLE
fix(runtime-vapor): preserve VNode anchors in dynamic component hydration

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1331,6 +1331,143 @@ describe('SSR hydration', () => {
     )
   })
 
+  test('unmount hydrated Suspense branch before async component resolves', async () => {
+    const data = ref({
+      showSuspense: true,
+      tail: 'tail',
+    })
+    const ResolvedComp = {
+      render: () => h('div', 'async resolved'),
+    }
+
+    let serverResolve: any
+    let AsyncComp = defineAsyncComponent(
+      () =>
+        new Promise(r => {
+          serverResolve = r
+        }),
+    )
+
+    const App = {
+      setup() {
+        return () => [
+          data.value.showSuspense
+            ? h(
+                Suspense,
+                { timeout: 0 },
+                {
+                  default: () => h(AsyncComp),
+                  fallback: () => h('div', 'pending'),
+                },
+              )
+            : h('p', 'fallback'),
+          h('span', data.value.tail),
+        ]
+      },
+    }
+
+    const htmlPromise = renderToString(h(App))
+    serverResolve(ResolvedComp)
+    const html = await htmlPromise
+    expect(html).toMatchInlineSnapshot(
+      `"<!--[--><div>async resolved</div><span>tail</span><!--]-->"`,
+    )
+
+    let clientResolve: any
+    AsyncComp = defineAsyncComponent(
+      () =>
+        new Promise(r => {
+          clientResolve = r
+        }),
+    )
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    createSSRApp(App).mount(container)
+
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><div>async resolved</div><span>tail</span><!--]-->"`,
+    )
+
+    data.value.showSuspense = false
+    await nextTick()
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><p>fallback</p><span>tail</span><!--]-->"`,
+    )
+
+    data.value.showSuspense = true
+    await nextTick()
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><div>pending</div><span>tail</span><!--]-->"`,
+    )
+
+    clientResolve(ResolvedComp)
+    await new Promise(r => setTimeout(r))
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><div>async resolved</div><span>tail</span><!--]-->"`,
+    )
+
+    data.value.tail = 'tail-updated'
+    await nextTick()
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><div>async resolved</div><span>tail-updated</span><!--]-->"`,
+    )
+  })
+
+  test('unmount hydrated async setup Suspense branch before resolve', async () => {
+    const data = ref({
+      showSuspense: true,
+      tail: 'tail',
+    })
+    let clientResolve: any
+    let wait = Promise.resolve()
+    const AsyncComp = {
+      async setup() {
+        await wait
+        return () => h('div', 'async resolved')
+      },
+    }
+
+    const App = {
+      setup() {
+        return () => [
+          data.value.showSuspense
+            ? h(
+                Suspense,
+                { timeout: 0 },
+                {
+                  default: () => h(AsyncComp),
+                  fallback: () => h('div', 'pending'),
+                },
+              )
+            : h('p', 'fallback'),
+          h('span', data.value.tail),
+        ]
+      },
+    }
+
+    const html = await renderToString(h(App))
+
+    wait = new Promise(r => {
+      clientResolve = r
+    })
+    const container = document.createElement('div')
+    container.innerHTML = html
+    createSSRApp(App).mount(container)
+
+    data.value.showSuspense = false
+    await nextTick()
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><p>fallback</p><span>tail</span><!--]-->"`,
+    )
+
+    clientResolve()
+    await new Promise(r => setTimeout(r))
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<!--[--><p>fallback</p><span>tail</span><!--]-->"`,
+    )
+  })
+
   test('hydrate safely when property used by async setup changed before render', async () => {
     const toggle = ref(true)
 

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -388,28 +388,31 @@ export function createHydrationFunctions(
               getContainerType(container),
               optimized,
             )
-          }
 
-          // #3787
-          // if component is async, it may get moved / unmounted before its
-          // inner component is loaded, so we need to give it a placeholder
-          // vnode that matches its adopted DOM.
-          if (
-            isAsyncWrapper(vnode) &&
-            !(vnode.type as ComponentOptions).__asyncResolved
-          ) {
-            let subTree
-            if (isFragmentStart) {
-              subTree = createVNode(Fragment)
-              subTree.anchor = nextNode
-                ? nextNode.previousSibling
-                : container.lastChild
-            } else {
-              subTree =
-                node.nodeType === 3 ? createTextVNode('') : createVNode('div')
+            // #3787
+            // An async component may move or unmount before its render effect
+            // exists, so keep a placeholder vnode that matches its adopted DOM.
+            // The wrapper check preserves lazy hydration behavior; asyncDep
+            // covers plain async setup under Suspense.
+            const component = vnode.component!
+            if (
+              (isAsyncWrapper(vnode) &&
+                !(vnode.type as ComponentOptions).__asyncResolved) ||
+              (component.asyncDep && !component.asyncResolved)
+            ) {
+              let subTree
+              if (isFragmentStart) {
+                subTree = createVNode(Fragment)
+                subTree.anchor = nextNode
+                  ? nextNode.previousSibling
+                  : container.lastChild
+              } else {
+                subTree =
+                  node.nodeType === 3 ? createTextVNode('') : createVNode('div')
+              }
+              subTree.el = node
+              component.subTree = subTree
             }
-            subTree.el = node
-            vnode.component!.subTree = subTree
           }
         } else if (shapeFlag & ShapeFlags.TELEPORT) {
           if (domType !== DOMNodeTypes.COMMENT) {

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -339,7 +339,7 @@ export function createHydrationFunctions(
               vnode,
               node,
               container,
-              null,
+              nextNode,
               parentComponent,
               parentSuspense,
               () => {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2619,6 +2619,10 @@ function baseCreateRenderer(
       // so that scheduler will no longer invoke it
       effect.stop()
       unmount(subTree, instance, parentSuspense, doRemove)
+    } else if (doRemove && subTree && instance.vnode.el) {
+      // A hydrated async component may own SSR DOM before its effect exists.
+      // subTree is the placeholder vnode matching that adopted DOM.
+      remove(subTree)
     }
     // unmounted hook
     if (um) {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1057,6 +1057,87 @@ describe('component: slots', () => {
       expect(boundary.markDirty).not.toHaveBeenCalled()
     })
 
+    test('compiled vdom slot removes parked content while fallback is active', async () => {
+      const showContent = ref(true)
+      const showChild = ref(true)
+      const Child = compile(
+        `<template>
+          <slot>
+            <span>fallback</span>
+          </slot>
+        </template>`,
+        showContent,
+      )
+      const App = {
+        setup() {
+          return () =>
+            showChild.value
+              ? h(Child as any, null, {
+                  default: () => (showContent.value ? h('div', 'content') : []),
+                })
+              : null
+        },
+      }
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe('<div>content</div>')
+
+      showContent.value = false
+      await nextTick()
+      expect(root.innerHTML).toBe('<span>fallback</span>')
+
+      showChild.value = false
+      await nextTick()
+      expect(root.innerHTML).toBe('<!---->')
+
+      app.unmount()
+    })
+
+    test('compiled vdom slot keeps fallback when slots source is removed', async () => {
+      const showContent = ref(true)
+      const passSlot = ref(true)
+      const Child = compile(
+        `<template>
+          <slot>
+            <span>fallback</span>
+          </slot>
+        </template>`,
+        showContent,
+      )
+      const App = {
+        setup() {
+          return () =>
+            h(
+              Child as any,
+              null,
+              passSlot.value
+                ? {
+                    default: () =>
+                      showContent.value ? h('div', 'content') : [],
+                  }
+                : undefined,
+            )
+        },
+      }
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe('<div>content</div>')
+
+      showContent.value = false
+      await nextTick()
+      expect(root.innerHTML).toBe('<span>fallback</span>')
+
+      passSlot.value = false
+      await nextTick()
+      expect(root.innerHTML).toBe('<span>fallback</span>')
+
+      app.unmount()
+    })
+
     test('compiled slot does not reinsert active fallback while content stays invalid', async () => {
       const data = ref('first')
       const Child = compile(

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -20,6 +20,7 @@ import {
   vaporInteropPlugin,
 } from '../src'
 import {
+  Comment,
   type Ref,
   createApp,
   createSlots,
@@ -1126,6 +1127,48 @@ describe('component: slots', () => {
       await nextTick()
       expect(root.innerHTML).toBe('<span>fallback</span>')
 
+      app.unmount()
+    })
+
+    test('vdom slot keeps invalid updates parked while fallback is active', async () => {
+      const data = ref('first')
+      const Child = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        data,
+      )
+      const App = {
+        setup() {
+          return () =>
+            h(Child, null, {
+              default: () => [
+                data.value === 'first'
+                  ? h(Comment, 'first')
+                  : h(Comment, 'second'),
+              ],
+            })
+        },
+      }
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      const childNodes = () =>
+        Array.from(root.childNodes).map(node =>
+          node.nodeType === 3
+            ? `text:${JSON.stringify(node.textContent)}`
+            : node.nodeType === 8
+              ? `comment:${(node as Comment).data}`
+              : (node as Element).outerHTML,
+        )
+      app.mount(root)
+
+      expect(root.innerHTML).toBe('<span>fallback</span>')
+      const fallbackNodes = ['<span>fallback</span>', 'text:""']
+      expect(childNodes()).toEqual(fallbackNodes)
+
+      data.value = 'second'
+      await nextTick()
+
+      expect(childNodes()).toEqual(fallbackNodes)
+      expect(root.innerHTML).toBe('<span>fallback</span>')
       app.unmount()
     })
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1,10 +1,7 @@
-// NOTE: This test is implemented based on the case of `runtime-core/__test__/componentSlots.spec.ts`.
-
 import {
   VaporTeleport,
   child,
   createComponent,
-  createDynamicComponent,
   createFor,
   createForSlots,
   createIf,
@@ -38,7 +35,6 @@ import {
 } from '@vue/runtime-dom'
 import {
   VaporBlockShape,
-  VaporDynamicComponentFlags,
   VaporIfFlags,
   VaporSlotFlags,
   VaporVForFlags,
@@ -354,89 +350,84 @@ describe('component: slots', () => {
       expect(localFallback).toHaveBeenCalledTimes(1)
     })
 
-    test('slot fragment switches local fallback and root v-if content without keeping the inactive anchor in DOM', async () => {
+    test('compiled root v-if slot content switches local fallback without keeping the inactive anchor in DOM', async () => {
       const show = ref(false)
-      const Child = defineVaporComponent(() =>
-        createSlot('default', null, () => document.createTextNode('fallback')),
+      const Child = compile(`<template><slot>fallback</slot></template>`, show)
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template v-if="data">content</template>
+          </components.Child>
+        </template>`,
+        show,
+        { Child },
       )
-      const { host } = define(() =>
-        createComponent(Child, null, {
-          default: extend(
-            () =>
-              createIf(
-                () => show.value,
-                () => document.createTextNode('content'),
-                undefined,
-                keyedSlotRootIfShape,
-              ),
-            nonStableSlot,
-          ),
-        }),
-      ).render()
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
 
-      expect(host.innerHTML).toBe('fallback<!--slot-->')
+      expect(root.innerHTML).toBe('fallback<!--slot-->')
 
       show.value = true
       await nextTick()
 
-      expect(host.innerHTML).toBe('content<!--if--><!--slot-->')
+      expect(root.innerHTML).toBe('content<!--if--><!--slot-->')
+      app.unmount()
     })
 
-    test('slot fragment switches local fallback and root v-for content without keeping the inactive anchor in DOM', async () => {
+    test('compiled root v-for slot content switches local fallback without keeping the inactive anchor in DOM', async () => {
       const items = ref<string[]>([])
-      const Child = defineVaporComponent(() =>
-        createSlot('default', null, () => document.createTextNode('fallback')),
+      const Child = compile(`<template><slot>fallback</slot></template>`, items)
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template v-for="item in data">
+              {{ item }}
+            </template>
+          </components.Child>
+        </template>`,
+        items,
+        { Child },
       )
-      const { host } = define(() =>
-        createComponent(Child, null, {
-          default: extend(
-            () =>
-              createFor(
-                () => items.value,
-                item => document.createTextNode(item.value),
-                undefined,
-                slotRootForFlags,
-              ),
-            nonStableSlot,
-          ),
-        }),
-      ).render()
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
 
-      expect(host.innerHTML).toBe('fallback<!--slot-->')
+      expect(root.innerHTML).toBe('fallback<!--slot-->')
 
       items.value = ['content']
       await nextTick()
 
-      expect(host.innerHTML).toBe('content<!--for--><!--slot-->')
+      expect(root.innerHTML).toBe('content<!--for--><!--slot-->')
+      app.unmount()
     })
 
-    test('slot fragment switches root dynamic component content to fallback', async () => {
+    test('compiled root dynamic component slot content switches to fallback', async () => {
       const current = shallowRef<any>(() => document.createTextNode('content'))
-      const Child = defineVaporComponent(() =>
-        createSlot('default', null, () => document.createTextNode('fallback')),
+      const Child = compile(
+        `<template><slot>fallback</slot></template>`,
+        current,
       )
-      const { host } = define(() =>
-        createComponent(Child, null, {
-          default: extend(
-            () =>
-              createDynamicComponent(
-                () => current.value,
-                null,
-                null,
-                VaporDynamicComponentFlags.SINGLE_ROOT |
-                  VaporDynamicComponentFlags.SLOT_ROOT,
-              ),
-            nonStableSlot,
-          ),
-        }),
-      ).render()
+      const App = compile(
+        `<template>
+          <components.Child>
+            <component :is="data" />
+          </components.Child>
+        </template>`,
+        current,
+        { Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
 
-      expect(host.innerHTML).toBe('content<!--dynamic-component--><!--slot-->')
+      expect(root.innerHTML).toBe('content<!--dynamic-component--><!--slot-->')
 
       current.value = null
       await nextTick()
 
-      expect(host.innerHTML).toBe('fallback<!--slot-->')
+      expect(root.innerHTML).toBe('fallback<!--slot-->')
+      app.unmount()
     })
 
     test('slot fallback falls through and restores local root v-if fallback without keeping inactive anchor in DOM', async () => {
@@ -1354,81 +1345,78 @@ describe('component: slots', () => {
       expect(boundary.markDirty).toHaveBeenCalledTimes(2)
     })
 
-    test('vdom slot dirties parent boundary when nested fallback validity flips', async () => {
-      const showInnerFallback = ref(true)
-      const boundary = {
-        parent: null,
-        getFallback: () => undefined,
-        run: (fn: () => any) => fn(),
-        markDirty: vi.fn(),
-      }
-      const instance = renderWithSlots({})
-      const app = createApp({ render: () => null })
-      app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
-      const slotsRef = shallowRef({
-        default: () => [],
-      })
-      const renderInnerFallback = () => {
-        const child = new SlotFragment(true)
-        renderEffect(() => {
-          child.updateSlot(
-            showInnerFallback.value
-              ? () => template('inner fallback')()
-              : undefined,
-          )
-        })
-        return child
-      }
-      const frag = withSlotBoundary(boundary, () =>
-        vapor.vdomSlot(
-          slotsRef,
-          'default',
-          {},
-          instance,
-          renderInnerFallback,
-          false,
-          true,
-        ),
+    test('compiled vdom slot propagates nested fallback validity changes', async () => {
+      const show = ref(true)
+      const Receiver = compile(
+        `<template><slot><span>outer fallback</span></slot></template>`,
+        show,
       )
-      const host = document.createElement('div')
+      const Bridge = compile(
+        `<template>
+          <components.Receiver>
+            <slot>
+              <span v-if="data">inner fallback</span>
+            </slot>
+          </components.Receiver>
+        </template>`,
+        show,
+        { Receiver },
+      )
+      const App = compile(
+        `<template>
+          <components.Bridge>
+            <span v-if="false">content</span>
+          </components.Bridge>
+        </template>`,
+        show,
+        { Bridge },
+        { vapor: false },
+      )
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
 
-      insert(frag, host)
-      boundary.markDirty.mockClear()
+      expect(root.innerHTML).toBe(
+        '<span>inner fallback</span><!--if--><!--slot--><!--slot-->',
+      )
 
-      expect(host.innerHTML).toBe('inner fallback<!--slot-->')
-
-      showInnerFallback.value = false
+      show.value = false
       await nextTick()
 
-      expect(host.innerHTML).toBe('<!--slot-->')
-      expect(boundary.markDirty).toHaveBeenCalledTimes(1)
+      expect(root.innerHTML).toBe(
+        '<span>outer fallback</span><!--slot--><!--slot-->',
+      )
 
-      showInnerFallback.value = true
+      show.value = true
       await nextTick()
 
-      expect(host.innerHTML).toBe('inner fallback<!--slot-->')
-      expect(boundary.markDirty).toHaveBeenCalledTimes(2)
+      expect(root.innerHTML).toBe(
+        '<span>inner fallback</span><!--if--><!--slot--><!--slot-->',
+      )
+      app.unmount()
     })
 
-    test('vdom slot still renders vapor fallback when slot content resolves empty', () => {
-      const Child = defineVaporComponent({
-        setup() {
-          return createSlot('default', null, () => template('child fallback')())
-        },
-      })
+    test('compiled vdom slot still renders vapor fallback when slot content resolves empty', () => {
+      const data = ref(false)
+      const Child = compile(
+        `<template><slot>child fallback</slot></template>`,
+        data,
+      )
+      const App = compile(
+        `<template>
+          <components.Child>
+            <span v-if="data">content</span>
+          </components.Child>
+        </template>`,
+        data,
+        { Child },
+        { vapor: false },
+      )
       const root = document.createElement('div')
 
-      createApp({
-        render: () =>
-          h(Child as any, null, {
-            default: () => [],
-          }),
-      })
-        .use(vaporInteropPlugin)
-        .mount(root)
+      createApp(App).use(vaporInteropPlugin).mount(root)
 
-      expect(root.innerHTML).toBe('child fallback')
+      expect(root.innerHTML).toBe('child fallback<!--slot-->')
     })
   })
 

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -6814,6 +6814,105 @@ describe('Vapor Mode hydration', () => {
           expect(beforeMount).toHaveBeenCalledTimes(1)
         })
 
+        test('hydrate VDOM Suspense vapor async setup can unmount before resolve', async () => {
+          let resolveClient!: () => void
+          const data = ref({
+            showSuspense: true,
+            tail: 'tail',
+          })
+          const serverData = ref({
+            wait: Promise.resolve(),
+          })
+          const clientData = ref({
+            wait: new Promise<void>(r => {
+              resolveClient = r
+            }),
+          })
+          const vaporChildCode = `
+            <script vapor>
+              const data = _data
+              await data.value.wait
+            </script>
+            <template><div>async resolved</div></template>
+          `
+
+          let VaporChild = compile(
+            vaporChildCode,
+            serverData,
+            {},
+            {
+              vapor: true,
+              ssr: true,
+            },
+          )
+
+          const App = {
+            setup() {
+              return () => [
+                data.value.showSuspense
+                  ? h(
+                      runtimeDom.Suspense,
+                      { timeout: 0 },
+                      {
+                        default: () => h(VaporChild),
+                        fallback: () => h('div', 'pending'),
+                      },
+                    )
+                  : h('p', 'fallback'),
+                h('span', data.value.tail),
+              ]
+            },
+          }
+
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(App),
+          )
+          expect(formatHtml(html)).toMatchInlineSnapshot(`
+            "
+            <!--[--><div>async resolved</div><span>tail</span><!--]-->
+            "
+          `)
+
+          VaporChild = compile(
+            vaporChildCode,
+            clientData,
+            {},
+            {
+              vapor: true,
+              ssr: false,
+            },
+          )
+
+          const container = document.createElement('div')
+          container.innerHTML = html
+          document.body.appendChild(container)
+
+          const app = runtimeDom.createSSRApp(App)
+          app.use(runtimeVapor.vaporInteropPlugin)
+          app.mount(container)
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+            "
+            <!--[--><div>async resolved</div><span>tail</span><!--]-->
+            "
+          `)
+
+          data.value.showSuspense = false
+          await nextTick()
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+            "
+            <!--[--><p>fallback</p><span>tail</span><!--]-->
+            "
+          `)
+
+          resolveClient()
+          await new Promise(r => setTimeout(r))
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+            "
+            <!--[--><p>fallback</p><span>tail</span><!--]-->
+            "
+          `)
+        })
+
         test('hydrate VDOM Suspense vapor async multi-root setup should preserve SSR range before resolve', async () => {
           let resolveClient!: () => void
           const serverData = ref({
@@ -7208,6 +7307,7 @@ describe('Vapor Mode hydration', () => {
       describe.todo('vapor suspense', () => {
         test.todo('hydrate safely when property used by async setup changed before render', async () => {})
         test.todo('hydrate safely when property used by deep nested async setup changed before render', async () => {})
+        test.todo('hydrate vapor async setup can unmount before resolve', async () => {})
       })
     })
 
@@ -10848,7 +10948,7 @@ describe('VDOM interop', () => {
     await nextTick()
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
       "
-      <!--[--><div>async resolved</div><p>fallback</p><!--dynamic-component--><span>tail</span><!--]-->
+      <!--[--><p>fallback</p><!--dynamic-component--><span>tail</span><!--]-->
       "
     `)
 
@@ -10856,7 +10956,7 @@ describe('VDOM interop', () => {
     await nextTick()
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
       "
-      <!--[--><div>async resolved</div><div>pending</div><!--dynamic-component--><span>tail</span><!--]-->
+      <!--[--><div>pending</div><!--dynamic-component--><span>tail</span><!--]-->
       "
     `)
 
@@ -10864,7 +10964,7 @@ describe('VDOM interop', () => {
     await new Promise(r => setTimeout(r))
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
       "
-      <!--[--><div>async resolved</div><div>async resolved</div><!--dynamic-component--><span>tail</span><!--]-->
+      <!--[--><div>async resolved</div><!--dynamic-component--><span>tail</span><!--]-->
       "
     `)
 
@@ -10872,7 +10972,7 @@ describe('VDOM interop', () => {
     await nextTick()
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
       "
-      <!--[--><div>async resolved</div><div>async resolved</div><!--dynamic-component--><span>tail-updated</span><!--]-->
+      <!--[--><div>async resolved</div><!--dynamic-component--><span>tail-updated</span><!--]-->
       "
     `)
   })

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -51,6 +51,18 @@ const formatHtml = (raw: string) => {
     .replace(/\n{2,}/g, '\n')
 }
 
+const formatNodeList = (nodes: ArrayLike<ChildNode>) => {
+  return Array.from(nodes).map(node => {
+    if (node.nodeType === 8) {
+      return `<!--${(node as Comment).data}-->`
+    }
+    if (node.nodeType === 3) {
+      return `text(${JSON.stringify((node as Text).data)})`
+    }
+    return (node as Element).outerHTML
+  })
+}
+
 async function testWithVaporApp(
   code: string,
   components?: Record<string, string | { code: string; vapor: boolean }>,
@@ -9374,6 +9386,14 @@ describe('VDOM interop', () => {
     `,
     )
 
+    expect(formatNodeList(container.childNodes)).toEqual([
+      '<!--[-->',
+      '<div>foo</div>',
+      'text("")',
+      '<!--dynamic-component-->',
+      '<!--]-->',
+    ])
+
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()
 
     data.value = 'bar'
@@ -9623,11 +9643,23 @@ describe('VDOM interop', () => {
       `
       "
       <!--[-->
-      <!--[--><!--dynamic-component--><div>first</div><div>second</div><!--]-->
-      <span>tail</span><!--]-->
+      <!--[--><div>first</div><div>second</div><!--]-->
+      <!--dynamic-component--><span>tail</span><!--]-->
       "
     `,
     )
+
+    expect(formatNodeList(container.childNodes)).toEqual([
+      '<!--[-->',
+      '<!--[-->',
+      '<div>first</div>',
+      '<div>second</div>',
+      '<!--]-->',
+      'text("")',
+      '<!--dynamic-component-->',
+      '<span>tail</span>',
+      '<!--]-->',
+    ])
 
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()
 
@@ -9637,8 +9669,8 @@ describe('VDOM interop', () => {
       `
       "
       <!--[-->
-      <!--[--><p>fallback</p><!--dynamic-component--><!--]-->
-      <span>tail</span><!--]-->
+      <!--[--><!--]-->
+      <p>fallback</p><!--dynamic-component--><span>tail</span><!--]-->
       "
     `,
     )
@@ -9649,8 +9681,8 @@ describe('VDOM interop', () => {
       `
       "
       <!--[-->
-      <!--[--><div>first</div><div>second</div><!--dynamic-component--><!--]-->
-      <span>tail</span><!--]-->
+      <!--[--><!--]-->
+      <div>first</div><div>second</div><!--dynamic-component--><span>tail</span><!--]-->
       "
     `,
     )
@@ -9660,8 +9692,8 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
       "
       <!--[-->
-      <!--[--><div>first</div><div>second</div><!--dynamic-component--><!--]-->
-      <span>tail-updated</span><!--]-->
+      <!--[--><!--]-->
+      <div>first</div><div>second</div><!--dynamic-component--><span>tail-updated</span><!--]-->
       "
     `)
   })

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5942,35 +5942,33 @@ describe('Vapor Mode hydration', () => {
     })
 
     test('enabled teleport with null target should delay child setup until target becomes available', async () => {
-      const version = ref('one')
-      const target = ref<any>('#non-existent-target-hydrate-late')
-      const setups: string[] = []
-
-      const Child = defineVaporComponent({
-        props: { msg: String },
-        setup(props) {
-          setups.push(String(props.msg))
-          const n0 = template('<div> </div>')() as any
-          const x0 = child(n0) as any
-          renderEffect(() => setText(x0, String(props.msg)))
-          return n0
-        },
+      const data = ref<{
+        version: string
+        target: string | Element
+        setups: string[]
+      }>({
+        version: 'one',
+        target: '#non-existent-target-hydrate-late',
+        setups: [],
       })
-
-      const App = defineVaporComponent({
-        setup() {
-          return createComponent(
-            VaporTeleport,
-            { to: () => target.value },
-            {
-              default: () => {
-                const current = version.value
-                return createComponent(Child, { msg: () => current })
-              },
-            },
-          )
-        },
-      })
+      const Child = compile(
+        `<script setup>
+          const props = defineProps(['msg'])
+          const data = _data
+          data.value.setups.push(String(props.msg))
+        </script>
+        <template><div>{{ props.msg }}</div></template>`,
+        data,
+      )
+      const App = compile(
+        `<template>
+          <teleport :to="data.target">
+            <components.Child :msg="data.version" />
+          </teleport>
+        </template>`,
+        data,
+        { Child },
+      )
 
       const container = document.createElement('div')
       container.innerHTML = '<!--teleport start--><!--teleport end-->'
@@ -5982,20 +5980,20 @@ describe('Vapor Mode hydration', () => {
       expect(container.innerHTML).toBe(
         `<!--teleport start--><!--teleport end-->`,
       )
-      expect(setups).toEqual([])
+      expect(data.value.setups).toEqual([])
       expect('Failed to locate Teleport target').toHaveBeenWarned()
 
-      version.value = 'two'
+      data.value.version = 'two'
       await nextTick()
-      version.value = 'three'
+      data.value.version = 'three'
       await nextTick()
-      expect(setups).toEqual([])
+      expect(data.value.setups).toEqual([])
 
       const targetEl = document.createElement('div')
-      target.value = targetEl
+      data.value.target = targetEl
       await nextTick()
 
-      expect(setups).toEqual(['three'])
+      expect(data.value.setups).toEqual(['three'])
       expect(targetEl.innerHTML).toBe('<div>three</div>')
     })
 

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -355,12 +355,13 @@ export function findBlockBoundary(block: Block): {
 
   // if nodes render as a fragment and the current nextNode is fragment
   // end anchor, need to move to the next node. Skip this when the block
-  // already includes its own end anchor (for example VDOM Fragment ranges).
+  // already includes its own end or runtime empty text anchor.
   if (
     nextNode &&
     isComment(nextNode, ']') &&
     isFragmentBlock(block) &&
-    !isComment(lastChild, ']')
+    !isComment(lastChild, ']') &&
+    !(lastChild.nodeType === 3 && !(lastChild as Text).data)
   ) {
     nextNode = nextNode.nextSibling
   }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1160,7 +1160,13 @@ export function unmountComponent(
     return
   }
 
-  if (instance.isMounted && !instance.isUnmounted) {
+  if (
+    !instance.isUnmounted &&
+    (instance.isMounted ||
+      // A hydrating async setup component can be unmounted before its block exists.
+      // It still needs normal scope cleanup so a later resolve is ignored.
+      (instance.asyncDep && !instance.asyncResolved))
+  ) {
     if (__DEV__) {
       unregisterHMR(instance)
     }
@@ -1179,7 +1185,12 @@ export function unmountComponent(
   }
 
   if (parentNode) {
-    remove(instance.block, parentNode)
+    if (instance.block) {
+      remove(instance.block, parentNode)
+    } else {
+      // TODO: a hydrated async setup component may own SSR DOM before its
+      // block exists. That adopted DOM should be removed on this path.
+    }
   }
 }
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1550,6 +1550,25 @@ function renderVDOMSlot(
     notifyUpdated()
   }
 
+  const removeRenderedContent = (
+    rendered: VNode | Block,
+    parentNode?: ParentNode,
+  ): void => {
+    const contentDetached = !!slotResolutionState.activeFallback
+    // Active fallback means slot content was parked already; runtime-core
+    // Fragment removal expects a still-attached sibling range.
+    if (isVNode(rendered)) {
+      internals.um(
+        rendered,
+        parentComponent as any,
+        null,
+        !contentDetached && !!parentNode,
+      )
+    } else {
+      remove(rendered, contentDetached ? undefined : parentNode)
+    }
+  }
+
   frag.insert = (parentNode, anchor) => {
     if (isHydrating) return
     currentParentNode = parentNode
@@ -1585,17 +1604,8 @@ function renderVDOMSlot(
     }
     scope.stop()
     disposed = true
-    if (isVNode(contentState.rendered)) {
-      // When the surrounding VDOM range already owns DOM removal, unmount the
-      // vnode state only and avoid tearing down the same hydrated range twice.
-      internals.um(
-        contentState.rendered,
-        parentComponent as any,
-        null,
-        !!parentNode,
-      )
-    } else if (contentState.rendered) {
-      remove(contentState.rendered, parentNode)
+    if (contentState.rendered) {
+      removeRenderedContent(contentState.rendered, parentNode)
     }
     disposeSlotResolution(slotResolutionState)
   }
@@ -1720,7 +1730,7 @@ function renderVDOMSlot(
                   ? prevRendered
                   : null
               if (prevRendered && !prevIsVNode) {
-                remove(prevRendered, currentParentNode!)
+                removeRenderedContent(prevRendered, currentParentNode!)
               }
               internals.p(
                 prevVNode,
@@ -1741,10 +1751,8 @@ function renderVDOMSlot(
               frag.vnode = null
               frag.$key = undefined
               const prevRendered = contentState.rendered
-              if (isVNode(prevRendered)) {
-                internals.um(prevRendered, parentComponent as any, null, true)
-              } else if (prevRendered) {
-                remove(prevRendered, currentParentNode!)
+              if (prevRendered) {
+                removeRenderedContent(prevRendered, currentParentNode!)
               }
               insert(slotContent, currentParentNode!, currentAnchor)
               setRenderedContent(slotContent, slotContentValid)
@@ -1752,15 +1760,8 @@ function renderVDOMSlot(
               return
             }
 
-            if (isVNode(contentState.rendered)) {
-              internals.um(
-                contentState.rendered,
-                parentComponent as any,
-                null,
-                true,
-              )
-            } else if (contentState.rendered) {
-              remove(contentState.rendered, currentParentNode!)
+            if (contentState.rendered) {
+              removeRenderedContent(contentState.rendered, currentParentNode!)
             }
             frag.vnode = null
             frag.$key = undefined

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -820,8 +820,12 @@ function resolveVNodeRange(vnode: VNode): [Node, Node] | undefined {
     return [el as Node, anchor as Node]
   }
 
-  if ((type === Static || type === Fragment) && el && anchor && anchor !== el) {
-    return [el as Node, anchor as Node]
+  // Empty Fragments can expose only an anchor; include it so parked invalid
+  // VNode slot content can be detached from the real DOM.
+  if ((type === Static || type === Fragment) && anchor) {
+    return el && anchor !== el
+      ? [el as Node, anchor as Node]
+      : [anchor as Node, anchor as Node]
   }
   if (shapeFlag & ShapeFlags.COMPONENT) {
     const subTree = vnode.component && vnode.component.subTree
@@ -1703,6 +1707,19 @@ function renderVDOMSlot(
             }
 
             if (isVNode(slotContent)) {
+              const prevRendered = contentState.rendered
+              if (slotResolutionState.activeFallback && !slotContentValid) {
+                // Re-run the slot only to refresh validity. While fallback is
+                // active, a still-invalid VNode must stay out of the live DOM.
+                if (prevRendered) {
+                  removeRenderedContent(prevRendered, currentParentNode!)
+                }
+                frag.vnode = null
+                frag.$key = undefined
+                setRenderedContent(null)
+                finishContentUpdate()
+                return
+              }
               frag.vnode = slotContent
               frag.$key = getVNodeKey(slotContent)
               const refreshSlotVNode = () => {
@@ -1722,7 +1739,6 @@ function renderVDOMSlot(
                 refreshSlotVNode,
                 notifyBeforeUpdate,
               )
-              const prevRendered = contentState.rendered
               const prevIsVNode = isVNode(prevRendered)
               const prevVNode =
                 prevIsVNode &&

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -98,7 +98,7 @@ import {
   withOnceSlot,
 } from './componentSlots'
 import { renderEffect } from './renderEffect'
-import { _next, createTextNode } from './dom/node'
+import { createTextNode } from './dom/node'
 import { optimizePropertyLookup } from './dom/prop'
 import {
   advanceHydrationNode,
@@ -203,13 +203,8 @@ const vaporInteropImpl: Omit<
     onVnodeBeforeMount,
   ) {
     const selfAnchor = (vnode.anchor = createTextNode())
-    if (isHydrating) {
-      // avoid vdom hydration children mismatch by the selfAnchor, delay its insertion
-      queuePostFlushCb(() => container.insertBefore(selfAnchor, anchor))
-    } else {
-      vnode.el = selfAnchor
-      container.insertBefore(selfAnchor, anchor)
-    }
+    vnode.el = selfAnchor
+    container.insertBefore(selfAnchor, anchor)
     const prev = currentInstance
     simpleSetCurrentInstance(parentComponent)
 
@@ -504,7 +499,7 @@ const vaporInteropImpl: Omit<
         onVnodeBeforeMount,
       ),
     )
-    return _next(node)
+    return anchor
   },
 
   hydrateSlot(vnode, node, parentComponent, parentSuspense) {
@@ -818,9 +813,11 @@ function resolveVNodeNodes(vnode: VNode): Block {
   // Vapor component VNodes expose only their first root on `vnode.el`.
   // Use the mounted block so multi-root output keeps slot anchors and other
   // trailing anchors in the resolved block shape.
-  if (!isHydrating && vnode.component && isVaporComponent(vnode.component)) {
+  if (vnode.component && isVaporComponent(vnode.component)) {
     const block = (vnode.component as any).block as Block | undefined
     if (block) {
+      const anchor = vnode.anchor
+      if (anchor) return [block, anchor as Node]
       return block
     }
   }
@@ -945,6 +942,10 @@ function mountVNode(
       }
     } else {
       internals.um(vnode, parentComponent as any, null, !!parentNode)
+    }
+
+    if (vnode.anchor && parentNode && vnode.anchor.parentNode === parentNode) {
+      remove(vnode.anchor as Node, parentNode)
     }
   }
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -337,9 +337,8 @@ const vaporInteropImpl: Omit<
     const instance = vnode.component as any as VaporComponentInstance
     let slotStartAnchor: Node | null = null
     if (instance) {
-      // the async component may not be resolved yet, block is null
+      const anchor = vnode.anchor as Node | null
       if (instance.block) {
-        const anchor = vnode.anchor as Node | null
         unmountComponent(instance, container)
         if (!doRemove) {
           // When the surrounding VDOM fragment owns DOM removal, we still need
@@ -350,6 +349,23 @@ const vaporInteropImpl: Omit<
             ? ((anchor && anchor.parentNode) as ParentNode)
             : undefined
           remove(instance.block, blockContainer)
+        }
+      } else {
+        // The async Vapor component may not be resolved yet, so block is null.
+        // Hydration still adopted SSR DOM on vnode.el; when this VNode owns
+        // removal, clear the adopted range before the interop anchor.
+        const adoptedNode =
+          vnode.el && vnode.el !== anchor ? (vnode.el as Node) : null
+        unmountComponent(instance)
+        if (doRemove && container && adoptedNode) {
+          let cur: Node | null = adoptedNode
+          while (cur && cur !== anchor) {
+            const nextNode: ChildNode | null = cur.nextSibling
+            if (cur.parentNode === container) {
+              remove(cur, container)
+            }
+            cur = nextNode
+          }
         }
       }
     } else if (vnode.vb) {
@@ -488,8 +504,9 @@ const vaporInteropImpl: Omit<
     // In CSR (createApp/createVaporApp + vaporInteropPlugin), both are false,
     // so this logic is tree-shaken.
     if (!isHydrating && !isVdomHydrating) return node
-    vaporHydrateNode(node, () =>
-      this.mount(
+    let instance: VaporComponentInstance | undefined
+    vaporHydrateNode(node, () => {
+      instance = this.mount(
         vnode,
         container,
         anchor,
@@ -497,8 +514,13 @@ const vaporInteropImpl: Omit<
         parentSuspense,
         onBeforeMount,
         onVnodeBeforeMount,
-      ),
-    )
+      ) as VaporComponentInstance
+    })
+    if (instance && instance.asyncDep && !instance.asyncResolved) {
+      // mount() cannot expose a block before async setup resolves. Keep the SSR
+      // start node so unmount can remove the adopted range if it is discarded.
+      vnode.el = node
+    }
     return anchor
   },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration reliability for async components, Suspense, teleport content, and Vapor/VDOM interop.
  * Fixed cases where unmounted async content could reappear or leave stale DOM after late resolution.
  * Corrected boundary handling for fragments and empty text anchors to keep DOM updates aligned.
  * Ensured slot fallback and compiled-slot behavior stays stable across updates, unmounts, and invalid content states.

* **Tests**
  * Added and updated hydration regression coverage for async components, Suspense, teleport, and slot fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->