### PR TITLE
chore(ci): improve workflows

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,6 +12,8 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,6 +2,11 @@ name: autofix.ci
 
 on:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - main
       - minor
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/close-cant-reproduce-issues.yml
+++ b/.github/workflows/close-cant-reproduce-issues.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   close-issues:
     if: github.repository == 'vuejs/core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: can't reproduce
         uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.0.0

--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'vuejs/core' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/ecosystem-ci run')
     steps:
       - name: Check user permission

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   action:
     if: github.repository == 'vuejs/core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/size-data.yml
+++ b/.github/workflows/size-data.yml
@@ -10,6 +10,10 @@ on:
       - main
       - minor
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/size-data.yml
+++ b/.github/workflows/size-data.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   size-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: >
       github.repository == 'vuejs/core' &&
       github.event.workflow_run.event == 'pull_request' &&
@@ -45,17 +45,18 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           path: temp/size
 
-      - name: Read PR Number
-        id: pr-number
-        uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
-        with:
-          path: temp/size/number.txt
+      - parallel:
+          - name: Read PR Number
+            id: pr-number
+            uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
+            with:
+              path: temp/size/number.txt
 
-      - name: Read base branch
-        id: pr-base
-        uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
-        with:
-          path: temp/size/base.txt
+          - name: Read base branch
+            id: pr-base
+            uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
+            with:
+              path: temp/size/base.txt
 
       - name: Download Previous Size Data
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -23,6 +23,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -33,6 +35,8 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -55,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup cache for Chromium binary
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -93,6 +99,8 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,12 @@ jobs:
 
       - run: pnpm install
 
-      - name: Run compiler unit tests
-        run: pnpm run test-unit compiler
+      - parallel:
+          - name: Run compiler unit tests
+            run: pnpm run test-unit compiler
 
-      - name: Run ssr unit tests
-        run: pnpm run test-unit server-renderer
+          - name: Run ssr unit tests
+            run: pnpm run test-unit server-renderer
 
   e2e-test:
     runs-on: ubuntu-latest
@@ -113,11 +114,12 @@ jobs:
 
       - run: pnpm install
 
-      - name: Run eslint
-        run: pnpm run lint
+      - parallel:
+          - name: Run eslint
+            run: pnpm run lint
 
-      - name: Run prettier
-        run: pnpm run format-check
+          - name: Run prettier
+            run: pnpm run format-check
 
       - name: Run tsc
         run: pnpm run check


### PR DESCRIPTION
# Description
Hi, there are a few improvements that can be made to the workflows. 

## `ubuntu-slim` runner
Use `ubuntu-slim` for `close-cant-reproduce-issues.yml`, `lock-closed-issues.yml`, `ecosystem-ci-trigger.yml`, and `size-report.yml`. The [runner readme](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md) provides more info about the tools and the [blog post](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) gives some potential use cases.

## `persist-credentials: false`
Use `persist-credentials: false` on every `actions/checkout` (none of the jobs perform subsequent git operations — `pnpm release --publishOnly` in `release.yml` doesn't touch git). See [usage](https://github.com/actions/checkout#usage) for more info.


## `parallel` keyword
Use `parallel` for independent steps in `test.yml` and `size-report.yml`

GitHub Actions [announced](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) the `parallel` keyword — syntactic sugar that groups independent steps to run concurrently within a single job, then waits for all of them before continuing. See the [workflow syntax docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel) for the full reference.

## Concurrency
Add `concurrency` to the PR-triggered workflows so a new push cancels the previous in-flight run of the same workflow. `ci.yml` and `size-data.yml` use the `|| github.ref` fallback to keep per-branch grouping for `push` events, while still cancelling on PRs.

# Related
- https://github.com/nuxt/.github/pull/41
- https://github.com/nuxt/.github/pull/42
- https://github.com/nitrojs/nitro/pull/4388
- https://github.com/nuxt/nuxt/pull/35448


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of CI and automated workflows by preventing overlapping runs on the same pull request.
  * Reduced the chance of checkout-related credential issues during automated jobs.

* **Chores**
  * Updated several automation jobs to use a lighter runner image.
  * Ran some validation steps in parallel, which may help shorten check times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->