### PR TITLE
fix(reactivity): support Set composition methods on reactive sets (fix #11398)

### DIFF
--- a/packages/reactivity/__tests__/collections/Set.spec.ts
+++ b/packages/reactivity/__tests__/collections/Set.spec.ts
@@ -545,6 +545,26 @@ describe('reactivity/collections', () => {
       },
     )
     ;(hasSetMethods ? it : it.skip)(
+      'should observe object identities in reactive Set method arguments',
+      () => {
+        const value = {}
+        const otherValue = {}
+        let dummy: object[] = []
+        const set = reactive(new Set([value, otherValue])) as any
+        const other = reactive(new Set([value]))
+
+        effect(() => {
+          dummy = [...set.intersection(other)]
+        })
+
+        expect(dummy).toEqual([value])
+        other.delete(value)
+        expect(dummy).toEqual([])
+        other.add(otherValue)
+        expect(dummy).toEqual([otherValue])
+      },
+    )
+    ;(hasSetMethods ? it : it.skip)(
       'should support Set methods on refs',
       () => {
         const set = ref(new Set([1, 2]))

--- a/packages/reactivity/__tests__/collections/Set.spec.ts
+++ b/packages/reactivity/__tests__/collections/Set.spec.ts
@@ -3,6 +3,7 @@ import {
   isReactive,
   reactive,
   readonly,
+  ref,
   shallowReactive,
   toRaw,
 } from '../../src'
@@ -494,5 +495,69 @@ describe('reactivity/collections', () => {
       const result = set.add('a')
       expect(result).toBe(set)
     })
+
+    const hasSetMethods =
+      typeof (Set.prototype as any).intersection === 'function'
+    ;(hasSetMethods ? it : it.skip)(
+      'should support Set methods on reactive sets',
+      () => {
+        const set = reactive(new Set([1, 2])) as any
+
+        expect([...set.intersection(new Set([2, 3]))]).toEqual([2])
+        expect([...set.union(new Set([2, 3]))]).toEqual([1, 2, 3])
+        expect([...set.difference(new Set([2]))]).toEqual([1])
+        expect([...set.symmetricDifference(new Set([2, 3]))]).toEqual([1, 3])
+        expect(set.isSubsetOf(new Set([1, 2, 3]))).toBe(true)
+        expect(set.isSupersetOf(new Set([1]))).toBe(true)
+        expect(set.isDisjointFrom(new Set([3]))).toBe(true)
+      },
+    )
+    ;(hasSetMethods ? it : it.skip)('should observe Set method results', () => {
+      let dummy: number[] = []
+      const set = reactive(new Set([1]))
+
+      effect(() => {
+        dummy = [...(set as any).intersection(new Set([1, 2]))]
+      })
+
+      expect(dummy).toEqual([1])
+      set.delete(1)
+      expect(dummy).toEqual([])
+      set.add(2)
+      expect(dummy).toEqual([2])
+    })
+    ;(hasSetMethods ? it : it.skip)(
+      'should observe reactive Set method arguments',
+      () => {
+        let dummy: number[] = []
+        const set = reactive(new Set([1, 2]))
+        const other = reactive(new Set([2]))
+
+        effect(() => {
+          dummy = [...(set as any).intersection(other)]
+        })
+
+        expect(dummy).toEqual([2])
+        other.delete(2)
+        expect(dummy).toEqual([])
+        other.add(1)
+        expect(dummy).toEqual([1])
+      },
+    )
+    ;(hasSetMethods ? it : it.skip)(
+      'should support Set methods on refs',
+      () => {
+        const set = ref(new Set([1, 2]))
+        const value = set.value as any
+
+        expect([...value.intersection(new Set([2, 3]))]).toEqual([2])
+        expect([...value.union(new Set([2, 3]))]).toEqual([1, 2, 3])
+        expect([...value.difference(new Set([2]))]).toEqual([1])
+        expect([...value.symmetricDifference(new Set([2, 3]))]).toEqual([1, 3])
+        expect(value.isSubsetOf(new Set([1, 2, 3]))).toBe(true)
+        expect(value.isSupersetOf(new Set([1]))).toBe(true)
+        expect(value.isDisjointFrom(new Set([3]))).toBe(true)
+      },
+    )
   })
 })

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -14,6 +14,7 @@ import {
   hasChanged,
   hasOwn,
   isMap,
+  isSet,
   toRawType,
 } from '@vue/shared'
 import { warn } from './warning'
@@ -98,7 +99,22 @@ function createSetMethod(method: string, readonly: boolean): Function {
 
     !readonly && track(rawTarget, TrackOpTypes.ITERATE, ITERATE_KEY)
 
-    return (rawTarget as any)[method](...args)
+    const rawArgs = args.map(arg => {
+      const rawArg = toRaw(arg)
+      const rawArgIsMap = isMap(rawArg)
+      if (rawArg !== arg && (rawArgIsMap || isSet(rawArg))) {
+        !isReadonly(arg) &&
+          track(
+            rawArg,
+            TrackOpTypes.ITERATE,
+            rawArgIsMap ? MAP_KEY_ITERATE_KEY : ITERATE_KEY,
+          )
+        return rawArg
+      }
+      return arg
+    })
+
+    return (rawTarget as any)[method](...rawArgs)
   }
 }
 

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -91,6 +91,17 @@ function createReadonlyMethod(type: TriggerOpTypes): Function {
   }
 }
 
+function createSetMethod(method: string, readonly: boolean): Function {
+  return function (this: IterableCollections, ...args: unknown[]) {
+    const target = this[ReactiveFlags.RAW]
+    const rawTarget = toRaw(target)
+
+    !readonly && track(rawTarget, TrackOpTypes.ITERATE, ITERATE_KEY)
+
+    return (rawTarget as any)[method](...args)
+  }
+}
+
 type Instrumentations = Record<string | symbol, Function | number>
 
 function createInstrumentations(
@@ -252,6 +263,20 @@ function createInstrumentations(
           },
         },
   )
+
+  const setMethods = [
+    'union',
+    'intersection',
+    'difference',
+    'symmetricDifference',
+    'isSubsetOf',
+    'isSupersetOf',
+    'isDisjointFrom',
+  ] as const
+
+  setMethods.forEach(method => {
+    instrumentations[method] = createSetMethod(method, readonly)
+  })
 
   const iteratorMethods = [
     'keys',


### PR DESCRIPTION
## What changed

- Add collection instrumentation for ES Set composition and predicate methods.
- Call these methods on the raw Set target so reactive Set proxies do not fail native Set brand checks.
- Track iteration for non-readonly calls so effects using derived Set method results update when the source Set changes.
- Add regression coverage for reactive Sets, ref-wrapped Sets, and reactive Set arguments.

## Why

Reactive Set proxies currently throw when calling methods like `intersection`, because native Set methods reject the proxy receiver.

Fixes #11398.

## How tested

- `pnpm test-unit packages/reactivity/__tests__/collections/Set.spec.ts`
- `pnpm exec prettier --check packages/reactivity/src/collectionHandlers.ts packages/reactivity/__tests__/collections/Set.spec.ts`
- `pnpm exec eslint packages/reactivity/src/collectionHandlers.ts packages/reactivity/__tests__/collections/Set.spec.ts`
- `pnpm check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reactive Set operations now participate in reactivity for: `intersection`, `union`, `difference`, `symmetricDifference`, and predicate helpers like `isSubsetOf`, `isSupersetOf`, and `isDisjointFrom`.
  * Computed values and effects update correctly when the source reactive Set changes, including when using Sets wrapped in a `ref`.
* **Tests**
  * Expanded coverage to verify reactivity for these Set operations and when reactive Sets are passed as arguments (with identity-based behavior for object keys).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->