### PR TITLE
fix(types): don't constrain component $el type to Element

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1960,6 +1960,22 @@ describe('__typeEl backdoor', () => {
   expectType<HTMLAnchorElement>(c.$el)
 })
 
+describe('__typeEl with a non-DOM host node (custom renderer)', () => {
+  // Custom renderers (TUI, canvas, native, …) have host nodes that are not
+  // DOM Elements. `$el` must accept them — `TypeEl` is not constrained to
+  // `Element`.
+  interface CustomElement {
+    foo: string
+  }
+  const Comp = defineComponent({
+    __typeEl: {} as CustomElement,
+  })
+  const c = new Comp()
+
+  expectType<CustomElement>(c.$el)
+  expectType<string>(c.$el.foo)
+})
+
 defineComponent({
   props: {
     foo: [String, null],

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -68,7 +68,7 @@ export type DefineComponent<
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
   MakeDefaultsOptional extends boolean = true,
   TypeRefs extends Record<string, unknown> = {},
-  TypeEl extends Element = any,
+  TypeEl = any,
 > = ComponentPublicInstanceConstructor<
   CreateComponentPublicInstanceWithMixins<
     Props,
@@ -216,7 +216,7 @@ export function defineComponent<
         : ExtractPropTypes<RuntimePropsOptions>
       : { [key in RuntimePropsKeys]?: any },
   TypeRefs extends Record<string, unknown> = {},
-  TypeEl extends Element = any,
+  TypeEl = any,
 >(
   options: {
     props?: (RuntimePropsOptions & ThisType<void>) | RuntimePropsKeys[]

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -229,7 +229,7 @@ export type CreateComponentPublicInstanceWithMixins<
   Directives extends Record<string, Directive> = {},
   Exposed extends string = string,
   TypeRefs extends Data = {},
-  TypeEl extends Element = any,
+  TypeEl = any,
   Provide extends ComponentProvideOptions = ComponentProvideOptions,
   // mixin inference
   PublicMixin = IntersectionMixin<Mixin> & IntersectionMixin<Extends>,
@@ -300,7 +300,7 @@ export type ComponentPublicInstance<
   S extends SlotsType = {},
   Exposed extends string = '',
   TypeRefs extends Data = {},
-  TypeEl extends Element = any,
+  TypeEl = any,
 > = {
   $: ComponentInternalInstance
   $data: D


### PR DESCRIPTION
`$el`'s type param (`TypeEl`) lives in `@vue/runtime-core`, which is renderer-agnostic, yet it's constrained to the DOM `Element` interface. Custom renderers have host nodes that aren't DOM `Element`s, so they can't type `$el` properly. Also, it fully breaks if the `dom` is not added to `lib` in tsconfig and makes `$el` become `any`.

This relaxes the `TypeEl` bound to unconstrained (default stays `any`): DOM elements still qualify, non-DOM host nodes now do too. Backward compatible.

### Repro (before this PR)

```ts
import { defineComponent } from 'vue'

interface MyNode {
  focus(): void
}

const Comp = defineComponent({
  // Type 'MyNode' is not assignable to type 'Element'
  __typeEl: {} as MyNode,
})
```

Added a `dts` regression test asserting a non-DOM `$el` type is accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for component instances so `$el` can now reflect custom host node types instead of being limited to standard DOM elements.
  * This makes property access on `$el` work correctly for custom renderers and non-DOM environments.

* **Tests**
  * Added type coverage for components using custom element-like host nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->