### PR TITLE
fix(runtime-core): defer component function refs

### DIFF
--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -131,6 +131,30 @@ describe('api: template refs', () => {
     expect(fn).toHaveBeenCalledTimes(1)
   })
 
+  // #15039
+  it('component function ref can access exposed template refs', () => {
+    const root = nodeOps.createElement('div')
+    let calls = 0
+    let exposedEl: any = null
+    const fn = (vm: any) => {
+      calls++
+      exposedEl = vm?.rootEl
+    }
+
+    const Child = defineComponent({
+      setup(_, { expose }) {
+        const rootEl = ref(null)
+        expose({ rootEl })
+        return () => h('div', { ref: rootEl })
+      },
+    })
+    const App = defineComponent(() => () => h(Child, { ref: fn }))
+
+    render(h(App), root)
+    expect(calls).toBe(1)
+    expect(exposedEl === root.children[0]).toBe(true)
+  })
+
   it('function ref unmount', async () => {
     const root = nodeOps.createElement('div')
     const fn = vi.fn()

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -136,11 +136,29 @@ export function setRef(
   }
 
   if (isFunction(ref)) {
-    pauseTracking()
-    try {
-      callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [value, refs])
-    } finally {
-      resetTracking()
+    const call = () => {
+      pauseTracking()
+      try {
+        callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [
+          value,
+          refs,
+        ])
+      } finally {
+        resetTracking()
+      }
+    }
+    if (!isUnmount && vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+      const job: SchedulerJob = () => {
+        call()
+        pendingSetRefMap.delete(rawRef)
+      }
+      job.id = -1
+      pendingSetRefMap.set(rawRef, job)
+      // allow child template refs exposed by the component to resolve first
+      queuePostRenderEffect(job, parentSuspense)
+    } else {
+      invalidatePendingSetRef(rawRef)
+      call()
     }
   } else {
     const _isString = isString(ref)


### PR DESCRIPTION
close #15039

﻿## What changed

- Defer non-null function refs on stateful component VNodes to the post-render queue.
- Keep function ref callbacks wrapped in `pauseTracking()` so #14985 remains fixed.
- Add a regression test for component function refs reading exposed child template refs.

## Why

- Since #14985, function ref callbacks no longer track dependencies they read.
- Component function refs still ran synchronously before child template ref post-render jobs, so exposed template refs were still `null` and no later tracked update re-ran the callback.
- Deferring only stateful component function refs lets exposed child template refs resolve first without restoring dependency tracking for function ref callbacks.

## How tested

- `pnpm test-unit packages/runtime-core/__tests__/rendererTemplateRef.spec.ts -t "component function ref can access exposed template refs" --run`
- `pnpm test-unit packages/runtime-core/__tests__/rendererTemplateRef.spec.ts -t "function ref should not track dependencies read by callback" --run`
- `pnpm test-unit packages/runtime-core/__tests__/rendererTemplateRef.spec.ts --run`
- `pnpm test-unit packages/runtime-core --run`
- `pnpm exec prettier --check packages/runtime-core/src/rendererTemplateRef.ts packages/runtime-core/__tests__/rendererTemplateRef.spec.ts`
- `pnpm exec eslint packages/runtime-core/src/rendererTemplateRef.ts packages/runtime-core/__tests__/rendererTemplateRef.spec.ts`
- `pnpm check`

## Risk and rollout

- Risk: low to medium. This changes non-null stateful component function ref timing from immediate patch-time invocation to post-render invocation. In root `render()`, post-render callbacks are still flushed before `render()` returns and before mounted hooks.
- Rollback: revert this commit.

## Notes for reviewers

- Checked for duplicate open PRs before opening: searched `15039`, `function ref exposed template ref`, and `rendererTemplateRef function ref`; no open matches found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of component template refs so callback refs receive the expected exposed element reference.
  * Fixed timing issues where ref callbacks could run before the referenced element was ready in some component updates.
  * Added coverage for function-based refs to ensure they are called once and return the correct value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->