### PR TITLE
fix(runtime-vapor): warn on direct slot invocation during hydration

### DIFF
--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -148,6 +148,29 @@ describe('component: slots', () => {
     expect(slots.default()).toMatchObject(document.createElement('span'))
   })
 
+  test('direct slot invocation should warn and return undefined during hydration', () => {
+    let slotResult: any
+    const Child = defineVaporComponent({
+      setup(_, { slots }) {
+        slotResult = slots.default!()
+        return template('child')()
+      },
+    })
+    const App = {
+      render() {
+        return createComponent(Child, {}, { default: () => template('msg')() })!
+      },
+    }
+
+    const hydrationContainer = document.createElement('div')
+    hydrationContainer.innerHTML = 'child'
+    createVaporSSRApp(App).mount(hydrationContainer)
+    expect(slotResult).toBeUndefined()
+    expect(
+      'Directly invoking Vapor slot "default" during hydration will claim SSR DOM and cause hydration mismatch',
+    ).toHaveBeenWarned()
+  })
+
   test('updateSlots: instance.slots should be updated correctly', async () => {
     const flag1 = ref(true)
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -18,6 +18,7 @@ import {
   currentInstance,
   isAsyncWrapper,
   isRef,
+  warn,
 } from '@vue/runtime-dom'
 import type { LooseRawProps, VaporComponentInstance } from './component'
 import { renderEffect } from './renderEffect'
@@ -164,10 +165,10 @@ function getOwnedSlot(
 }
 
 export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
-  get: getSlot,
+  get: __DEV__ ? getDevSlot : getSlot,
   has: (target, key: string) => !!getSlot(target, key),
   getOwnPropertyDescriptor(target, key: string) {
-    const slot = getSlot(target, key)
+    const slot = __DEV__ ? getDevSlot(target, key) : getSlot(target, key)
     if (slot) {
       return {
         configurable: true,
@@ -201,6 +202,52 @@ export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
   },
   set: NO,
   deleteProperty: NO,
+}
+
+const devSlotWrappersCache = __DEV__
+  ? new WeakMap<
+      RawSlots,
+      Map<
+        string,
+        {
+          slot: VaporSlot
+          wrapped: VaporSlot
+        }
+      >
+    >()
+  : undefined
+
+/**
+ * dev-only
+ */
+function getDevSlot(target: RawSlots, key: string): VaporSlot | undefined {
+  const slot = getSlot(target, key)
+  if (slot) {
+    let wrappers = devSlotWrappersCache!.get(target)
+    if (!wrappers) {
+      devSlotWrappersCache!.set(target, (wrappers = new Map()))
+    }
+    const cached = wrappers.get(key)
+    if (cached && cached.slot === slot) {
+      return cached.wrapped
+    }
+    const wrapped = ((...args: any[]) => {
+      // slots.default() is not safe during hydration because it claims SSR DOM
+      // causing hydration mismatch.
+      if (isHydrating) {
+        warn(
+          `Directly invoking Vapor slot "${key}" during hydration will ` +
+            `claim SSR DOM and cause hydration mismatch. Use <slot/> instead.`,
+        )
+        return
+      }
+      return slot(...args)
+    }) as VaporSlot
+    wrapped._ = slot._
+    wrappers.set(key, { slot, wrapped })
+    return wrapped
+  }
+  return slot
 }
 
 export function getSlot(target: RawSlots, key: string): VaporSlot | undefined {

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -47,6 +47,7 @@ import {
   withCurrentCacheKey,
   withKeepAliveEnabled,
 } from '../keepAlive'
+import { getSlot } from '../componentSlots'
 
 export interface KeepAliveInstance extends VaporComponentInstance {
   ctx: VaporKeepAliveContext & {
@@ -75,7 +76,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
     exclude: [String, RegExp, Array],
     max: [String, Number],
   },
-  setup(props: KeepAliveProps, { slots, expose }) {
+  setup(props: KeepAliveProps, { expose }) {
     let exposed!: Record<string, any>
     // for e2e test
     if (__E2E_TEST__) {
@@ -85,11 +86,12 @@ const VaporKeepAliveImpl = defineVaporComponent({
     }
     expose(exposed)
 
-    if (!slots.default) {
+    const keepAliveInstance = currentInstance! as KeepAliveInstance
+    const defaultSlot = getSlot(keepAliveInstance.rawSlots, 'default')
+    if (!defaultSlot) {
       return undefined
     }
 
-    const keepAliveInstance = currentInstance! as KeepAliveInstance
     const cache: Cache = new Map()
     const keys: Keys = new Set()
     const storageContainer = createElement('div')
@@ -398,7 +400,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
     }
 
     keepAliveInstance.ctx = keepAliveCtx
-    let children = slots.default()
+    let children = defaultSlot()
     registerDynamicFragmentHooks(children, keepAliveCtx)
 
     if (isArray(children)) {

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -56,6 +56,7 @@ import {
 } from '../dom/hydration'
 import { type PendingVShow, setCurrentPendingVShows } from '../directives/vShow'
 import { isInteropEnabled } from '../vdomInteropState'
+import { getSlot } from '../componentSlots'
 
 export type ResolvedTransitionBlock = (
   | Element
@@ -130,7 +131,7 @@ const decorate = (t: typeof VaporTransition) => {
 }
 
 export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
-  /*@__PURE__*/ decorate((props, { slots, expose }) => {
+  /*@__PURE__*/ decorate((props, { expose }) => {
     // @ts-expect-error
     expose()
 
@@ -152,9 +153,10 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
 
     const shouldCaptureVShow = !isHydrating && !!props.appear
     const shouldPerformAppear = !!props.appear && !!performAppear
+    const rawSlots = instance.rawSlots
     // Dynamic slot sources can add/remove the default slot after setup, so
     // Transition needs a DynamicFragment to drive enter/leave on updates.
-    if (instance.rawSlots.$) {
+    if (rawSlots.$) {
       const frag = new DynamicFragment('transition')
       let isMounted = false
       renderEffect(() => {
@@ -172,7 +174,7 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
         }
         const [, pendingVShows] = capturePendingVShows(
           shouldCaptureVShow && !isMounted,
-          () => frag.update(slots.default),
+          () => frag.update(getSlot(rawSlots, 'default')),
         )
         applyPendingVShows(
           frag.$transition!,
@@ -184,10 +186,11 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
       })
       return frag
     }
+    const defaultSlot = getSlot(rawSlots, 'default')
 
     const [children, pendingVShows] = capturePendingVShows(
       shouldCaptureVShow,
-      () => ((slots.default && slots.default()) || []) as any as Block,
+      () => ((defaultSlot && defaultSlot()) || []) as any as Block,
     )
 
     let appliedHooks = {

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -60,6 +60,7 @@ import {
   nextLogicalSibling,
   setCurrentHydrationNode,
 } from '../dom/hydration'
+import { getSlot } from '../componentSlots'
 
 const positionMap = new WeakMap<TransitionBlock, DOMRect>()
 const newPositionMap = new WeakMap<TransitionBlock, DOMRect>()
@@ -121,7 +122,7 @@ const VaporTransitionGroupImpl = defineVaporComponent({
     moveClass: String,
   }),
 
-  setup(props: TransitionGroupProps, { slots, expose }) {
+  setup(props: TransitionGroupProps, { expose }) {
     // @ts-expect-error
     expose()
 
@@ -233,7 +234,7 @@ const VaporTransitionGroupImpl = defineVaporComponent({
 
     renderEffect(() => {
       const tag = props.tag
-      const slot = slots.default
+      const slot = getSlot(instance.rawSlots, 'default')
       // if the tag and slot are the same as previous render, no need to update.
       if (isMounted && tag === currentTag && slot === currentSlot) return
 


### PR DESCRIPTION
Warn and return undefined when Vapor slots are invoked directly during hydration in dev. Direct slot invocation can claim SSR DOM outside the managed <slot/> outlet path and cause hydration mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration behavior for directly invoked slots so they no longer cause mismatches during server-side rendering.
  * Updated built-in transition and keep-alive behavior to resolve slots more reliably in dynamic scenarios.

* **Tests**
  * Added coverage for slot invocation during hydration to verify the warning and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->