### PR TITLE
refactor(runtime-vapor): simplify slot content invalidation cleanup

### DIFF
--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -119,12 +119,13 @@ function createTestSlotResolutionState(options: {
     parent: null,
     getFallback: () => options.fallback,
     run: (fn, scope) => (scope ? scope.run(fn)! : fn()),
-    markDirty: () => markSlotResolutionDirty(state),
+    markDirty: force => markSlotResolutionDirty(state, force),
   }
   state = {
     boundary,
     activeFallback: null,
     pendingRecheck: false,
+    pendingRecheckForce: false,
     isRenderingFallback: false,
     getContent: () => options.content || [],
     getParentNode: () => options.parentNode || null,
@@ -351,7 +352,7 @@ describe('component: slots', () => {
       expect(localFallback).toHaveBeenCalledTimes(1)
     })
 
-    test('compiled root v-if slot content switches local fallback without keeping the inactive anchor in DOM', async () => {
+    test('compiled root v-if slot content toggles fallback without keeping the inactive anchor in DOM', async () => {
       const show = ref(false)
       const Child = compile(`<template><slot>fallback</slot></template>`, show)
       const App = compile(
@@ -366,6 +367,16 @@ describe('component: slots', () => {
       const root = document.createElement('div')
       const app = createVaporApp(App)
       app.mount(root)
+
+      expect(root.innerHTML).toBe('fallback<!--slot-->')
+
+      show.value = true
+      await nextTick()
+
+      expect(root.innerHTML).toBe('content<!--if--><!--slot-->')
+
+      show.value = false
+      await nextTick()
 
       expect(root.innerHTML).toBe('fallback<!--slot-->')
 
@@ -428,6 +439,148 @@ describe('component: slots', () => {
       await nextTick()
 
       expect(root.innerHTML).toBe('fallback<!--slot-->')
+
+      current.value = () => document.createTextNode('restored')
+      await nextTick()
+
+      expect(root.innerHTML).toBe('restored<!--dynamic-component--><!--slot-->')
+      app.unmount()
+    })
+
+    test('compiled root v-for slot content with invalid branch switches fallback', async () => {
+      const items = ref([{ text: 'bar', show: false }])
+      const Child = compile(`<template><slot>fallback</slot></template>`, items)
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template v-for="item in data" :key="item.text">
+              <span v-if="item.show">{{ item.text }}</span>
+            </template>
+          </components.Child>
+        </template>`,
+        items,
+        { Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe('fallback<!--slot-->')
+
+      items.value[0].show = true
+      await nextTick()
+
+      expect(root.innerHTML).toBe(
+        '<span>bar</span><!--if--><!--for--><!--slot-->',
+      )
+
+      items.value[0].show = false
+      await nextTick()
+
+      expect(root.innerHTML).toBe('fallback<!--slot-->')
+      app.unmount()
+    })
+
+    test('compiled slot fallback falls through and restores local root v-if fallback without keeping inactive anchor in DOM', async () => {
+      const show = ref(false)
+      const Outer = compile(
+        `<template><slot>parent fallback</slot></template>`,
+        show,
+      )
+      const Child = compile(
+        `<template>
+          <components.Outer>
+            <slot>
+              <span v-if="data">local fallback</span>
+            </slot>
+          </components.Outer>
+        </template>`,
+        show,
+        { Outer },
+      )
+      const App = compile(
+        `<template>
+          <components.Child>
+            <span v-if="false">content</span>
+          </components.Child>
+        </template>`,
+        show,
+        { Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe('parent fallback<!--slot--><!--slot-->')
+
+      show.value = true
+      await nextTick()
+
+      expect(root.innerHTML).toBe(
+        '<span>local fallback</span><!--if--><!--slot--><!--slot-->',
+      )
+
+      show.value = false
+      await nextTick()
+
+      expect(root.innerHTML).toBe('parent fallback<!--slot--><!--slot-->')
+      app.unmount()
+    })
+
+    test('compiled forwarded fallback preserves stable root when dynamic sibling becomes invalid', async () => {
+      const show = ref(true)
+      const Outer = compile(
+        `<template><slot>parent fallback</slot></template>`,
+        show,
+      )
+      const Child = compile(
+        `<template>
+          <components.Outer>
+            <slot>
+              <input value="stable">
+              <span v-if="data">dynamic</span>
+            </slot>
+          </components.Outer>
+        </template>`,
+        show,
+        { Outer },
+      )
+      const App = compile(
+        `<template>
+          <components.Child>
+            <span v-if="false">content</span>
+          </components.Child>
+        </template>`,
+        show,
+        { Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe(
+        '<input value="stable"><span>dynamic</span><!--if--><!--slot--><!--slot-->',
+      )
+      const input = root.querySelector('input')!
+      input.value = 'typed'
+
+      show.value = false
+      await nextTick()
+
+      expect(root.querySelector('input')).toBe(input)
+      expect(input.value).toBe('typed')
+      expect(root.innerHTML).toBe(
+        '<input value="stable"><!--if--><!--slot--><!--slot-->',
+      )
+
+      show.value = true
+      await nextTick()
+
+      expect(root.querySelector('input')).toBe(input)
+      expect(input.value).toBe('typed')
+      expect(root.innerHTML).toBe(
+        '<input value="stable"><span>dynamic</span><!--if--><!--slot--><!--slot-->',
+      )
       app.unmount()
     })
 
@@ -452,12 +605,13 @@ describe('component: slots', () => {
             keyedSlotRootIfShape,
           ),
         run: fn => fn(),
-        markDirty: () => markSlotResolutionDirty(state),
+        markDirty: force => markSlotResolutionDirty(state, force),
       }
       state = {
         boundary,
         activeFallback: null,
         pendingRecheck: false,
+        pendingRecheckForce: false,
         isRenderingFallback: false,
         getContent: () => [],
         getParentNode: () => container,
@@ -496,12 +650,13 @@ describe('component: slots', () => {
         parent: parentBoundary,
         getFallback: () => localFallback,
         run: fn => fn(),
-        markDirty: () => markSlotResolutionDirty(state),
+        markDirty: force => markSlotResolutionDirty(state, force),
       }
       state = {
         boundary,
         activeFallback: null,
         pendingRecheck: false,
+        pendingRecheckForce: false,
         isRenderingFallback: false,
         getContent: () => [],
         getParentNode: () => container,

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -481,6 +481,85 @@ describe('component: slots', () => {
       app.unmount()
     })
 
+    test('compiled v-for slot content unregisters invalid callbacks for removed item roots', async () => {
+      let boundary: SlotBoundaryContext | null | undefined
+      const data = ref({
+        items: [
+          { id: 1, show: true },
+          { id: 2, show: true },
+        ],
+        capture: () => {
+          if (currentSlotBoundary) {
+            boundary = currentSlotBoundary
+          }
+          return true
+        },
+      })
+      const Child = compile(`<template><slot>fallback</slot></template>`, data)
+      const Leaf = compile(`<template><span>item</span></template>`, data)
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template v-for="item in data.items" :key="item.id">
+              <components.Leaf v-if="data.capture() && item.show" />
+            </template>
+          </components.Child>
+        </template>`,
+        data,
+        { Child, Leaf },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      const initialCallbacks = boundary!.onContentInvalid!.length
+      expect(initialCallbacks).toBeGreaterThan(1)
+
+      data.value.items = [{ id: 2, show: true }]
+      await nextTick()
+
+      expect(boundary!.onContentInvalid!.length).toBe(initialCallbacks - 1)
+      app.unmount()
+    })
+
+    test('compiled nested slot root v-if unregisters invalid callbacks for removed inner roots', async () => {
+      let boundary: SlotBoundaryContext | null | undefined
+      const data = ref({
+        outer: true,
+        inner: true,
+        capture: () => {
+          if (currentSlotBoundary) {
+            boundary = currentSlotBoundary
+          }
+          return true
+        },
+      })
+      const Child = compile(`<template><slot>fallback</slot></template>`, data)
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template v-if="data.outer">
+              <span v-if="data.capture() && data.inner">item</span>
+            </template>
+          </components.Child>
+        </template>`,
+        data,
+        { Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      const initialCallbacks = boundary!.onContentInvalid!.length
+      expect(initialCallbacks).toBeGreaterThan(1)
+
+      data.value.outer = false
+      await nextTick()
+
+      expect(boundary!.onContentInvalid!.length).toBe(initialCallbacks - 1)
+      app.unmount()
+    })
+
     test('compiled slot fallback falls through and restores local root v-if fallback without keeping inactive anchor in DOM', async () => {
       const show = ref(false)
       const Outer = compile(
@@ -524,6 +603,43 @@ describe('component: slots', () => {
       await nextTick()
 
       expect(root.innerHTML).toBe('parent fallback<!--slot--><!--slot-->')
+      app.unmount()
+    })
+
+    test('compiled slot keeps active fallback anchor when fallback becomes invalid without parent fallback', async () => {
+      const show = ref(true)
+      const Child = compile(
+        `<template>
+          <slot>
+            <span v-if="data">fallback</span>
+          </slot>
+        </template>`,
+        show,
+      )
+      const App = compile(
+        `<template>
+          <components.Child>
+            <span v-if="false">content</span>
+          </components.Child>
+        </template>`,
+        show,
+        { Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe('<span>fallback</span><!--if--><!--slot-->')
+
+      show.value = false
+      await nextTick()
+
+      expect(root.innerHTML).toBe('<!--if--><!--slot-->')
+
+      show.value = true
+      await nextTick()
+
+      expect(root.innerHTML).toBe('<span>fallback</span><!--if--><!--slot-->')
       app.unmount()
     })
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -560,6 +560,45 @@ describe('component: slots', () => {
       app.unmount()
     })
 
+    test('compiled nested slot root v-if unregisters invalid callbacks while fallback is active', async () => {
+      let boundary: SlotBoundaryContext | null | undefined
+      const data = ref({
+        outer: true,
+        inner: false,
+        capture: () => {
+          if (currentSlotBoundary) {
+            boundary = currentSlotBoundary
+          }
+          return true
+        },
+      })
+      const Child = compile(`<template><slot>fallback</slot></template>`, data)
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template v-if="data.outer">
+              <span v-if="data.capture() && data.inner">item</span>
+            </template>
+          </components.Child>
+        </template>`,
+        data,
+        { Child },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.innerHTML).toBe('fallback<!--slot-->')
+      const initialCallbacks = boundary!.onContentInvalid!.length
+      expect(initialCallbacks).toBeGreaterThan(1)
+
+      data.value.outer = false
+      await nextTick()
+
+      expect(boundary!.onContentInvalid!.length).toBe(initialCallbacks - 1)
+      app.unmount()
+    })
+
     test('compiled slot fallback falls through and restores local root v-if fallback without keeping inactive anchor in DOM', async () => {
       const show = ref(false)
       const Outer = compile(

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1795,6 +1795,67 @@ describe('vdomInterop', () => {
       )
     })
 
+    test('compiled vdom local fallback keeps outlet fallback clean across invalid updates', async () => {
+      const data = ref({
+        mode: 'local',
+        outlet: 'outlet fallback',
+      })
+      const VDomOuterSlot = compile(
+        `<script setup>const data = _data</script>
+        <template>
+          <slot name="foo"><section>{{ data.outlet }}</section></slot>
+        </template>`,
+        data,
+        {},
+        { vapor: false },
+      )
+      const VDomInnerSlot = compile(
+        `<script setup>
+          const data = _data
+          const components = _components
+        </script>
+        <template>
+          <components.VDomOuterSlot>
+            <template #foo>
+              <slot name="bar">
+                <span v-if="data.mode === 'local'">local fallback</span>
+                <template v-else-if="data.mode === 'empty-a'" />
+                <template v-else-if="data.mode === 'empty-b'" />
+              </slot>
+            </template>
+          </components.VDomOuterSlot>
+        </template>`,
+        data,
+        { VDomOuterSlot },
+        { vapor: false },
+      )
+      const VaporBridge = compile(
+        `<template>
+          <components.VDomInnerSlot>
+            <template #bar><slot name="bar" /></template>
+          </components.VDomInnerSlot>
+        </template>`,
+        data,
+        { VDomInnerSlot },
+      )
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporBridge as any)
+        },
+      }).render()
+
+      expect(html()).toBe('<span>local fallback</span>')
+
+      data.value.mode = 'empty-a'
+      await nextTick()
+      expect(html()).toBe('<section>outlet fallback</section>')
+
+      data.value.mode = 'empty-b'
+      await nextTick()
+      expect(html()).toBe('<section>outlet fallback</section>')
+    })
+
     test('preserves normalized VDOM slot functions passed to Vapor', async () => {
       const msg = ref('default slot')
       const VaporChild = defineVaporComponent(() => createSlot('default', null))

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -9,7 +9,7 @@ import {
   setCurrentRenderingInstance,
 } from '@vue/runtime-dom'
 import { ShapeFlags, VaporDynamicComponentFlags } from '@vue/shared'
-import { insert, isBlock } from './block'
+import { insert, isBlock, removeNode } from './block'
 import {
   type VaporComponentInstance,
   createComponentWithFallback,
@@ -55,10 +55,26 @@ export function createDynamicComponent(
     ? captureHydrationCursor()
     : null
 
-  const frag =
-    isHydrating || __DEV__
-      ? new DynamicFragment('dynamic-component', false, true, slotRoot)
-      : new DynamicFragment(undefined, false, true, slotRoot)
+  const frag = new DynamicFragment(
+    isHydrating || __DEV__ ? 'dynamic-component' : undefined,
+    false,
+    true,
+    slotRoot,
+    slotRoot
+      ? () => {
+          // A null <component :is> branch has a branch placeholder in `nodes`
+          // in addition to the DynamicFragment anchor. Remove both so slot
+          // fallback does not expose the placeholder as content.
+          const nodes = frag.nodes
+          if (nodes instanceof Node) {
+            const parent = nodes.parentNode
+            if (parent) removeNode(nodes, parent)
+          }
+          const anchorParent = frag.anchor.parentNode
+          if (anchorParent) removeNode(frag.anchor, anchorParent)
+        }
+      : undefined,
+  )
 
   const normalizedRawSlots = normalizeRawSlots(rawSlots)
   const scopeOwner = getScopeOwner()

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -116,7 +116,17 @@ export const createFor = (
     parentAnchor = __DEV__ ? createComment('for') : createTextNode()
   }
 
-  const frag = new ForFragment(oldBlocks, !!(flags & VaporVForFlags.SLOT_ROOT))
+  const trackSlotBoundary = !!(flags & VaporVForFlags.SLOT_ROOT)
+  const frag = new ForFragment(
+    oldBlocks,
+    trackSlotBoundary,
+    trackSlotBoundary
+      ? () => {
+          const parent = parentAnchor.parentNode
+          if (parent) removeNode(parentAnchor, parent)
+        }
+      : undefined,
+  )
   const instance = currentInstance!
   const isComponent = !!(flags & VaporVForFlags.IS_COMPONENT)
   const canUseFastRemove =

--- a/packages/runtime-vapor/src/apiCreateIf.ts
+++ b/packages/runtime-vapor/src/apiCreateIf.ts
@@ -1,4 +1,4 @@
-import { type Block, type BlockFn, insert } from './block'
+import { type Block, type BlockFn, insert, removeNode } from './block'
 import {
   type HydrationCursor,
   advanceHydrationNode,
@@ -53,10 +53,20 @@ export function createIf(
     const keyed = index > 0
     const keyBase = keyed ? (index - 1) * 2 : 0
     const trackSlotBoundary = !!(flags & VaporIfFlags.SLOT_ROOT)
-    frag =
-      isHydrating || __DEV__
-        ? new DynamicFragment('if', keyed, false, trackSlotBoundary)
-        : new DynamicFragment(undefined, keyed, false, trackSlotBoundary)
+    const dynamicFragment = new DynamicFragment(
+      isHydrating || __DEV__ ? 'if' : undefined,
+      keyed,
+      false,
+      trackSlotBoundary,
+      trackSlotBoundary
+        ? () => {
+            const anchor = dynamicFragment.anchor
+            const parent = anchor.parentNode
+            if (parent) removeNode(anchor, parent)
+          }
+        : undefined,
+    )
+    frag = dynamicFragment
     renderEffect(() => {
       const ok = condition()
       if (isHydrating) {
@@ -65,7 +75,7 @@ export function createIf(
           branchShape === VaporBlockShape.MULTI_ROOT,
         )
       }
-      ;(frag as DynamicFragment).update(
+      dynamicFragment.update(
         ok ? b1 : b2,
         keyed ? keyBase + (ok ? 0 : 1) : undefined,
         isNoScopeBranch(flags, ok),

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -308,6 +308,12 @@ export function removeFragment(
   block: VaporFragment | DynamicFragment,
   parent?: ParentNode,
 ): void {
+  const onRemove = block.onRemove
+  if (onRemove) {
+    for (let i = 0; i < onRemove.length; i++) {
+      onRemove[i]()
+    }
+  }
   if (block.remove) {
     block.remove(parent, (block as TransitionBlock).$transition)
   } else {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -97,6 +97,7 @@ export class VaporFragment<
   onBeforeInsert?: ((nodes: Block) => void)[]
   // Return true to keep the branch scope alive after removing its DOM.
   onBeforeRemove?: ((scope: EffectScope) => boolean)[]
+  onRemove?: (() => void)[]
   onBeforeUpdate?: (() => void)[]
   onUpdated?: ((nodes?: Block) => void)[]
 

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -178,9 +178,13 @@ export class ForFragment extends VaporFragment<Block[]> {
   // O(1) instead of N per-item Map.delete calls.
   resetListeners?: (() => void)[]
 
-  constructor(nodes: Block[], trackSlotBoundary: boolean) {
+  constructor(
+    nodes: Block[],
+    trackSlotBoundary: boolean,
+    onInvalid?: () => void,
+  ) {
     super(nodes)
-    if (trackSlotBoundary) trackSlotBoundaryDirtying(this)
+    if (trackSlotBoundary) trackSlotBoundaryDirtying(this, onInvalid)
   }
 
   onReset(fn: () => void): void {
@@ -253,6 +257,7 @@ export class DynamicFragment extends RenderContextFragment {
     keyed: boolean = false,
     locate: boolean = true,
     trackSlotBoundary: boolean = false,
+    onInvalid?: () => void,
   ) {
     super(EMPTY_BLOCK)
     if (keyed) this.keyed = true
@@ -271,7 +276,7 @@ export class DynamicFragment extends RenderContextFragment {
         __DEV__ && anchorLabel ? createComment(anchorLabel) : createTextNode()
       if (__DEV__) this.anchorLabel = anchorLabel
     }
-    if (trackSlotBoundary) trackSlotBoundaryDirtying(this)
+    if (trackSlotBoundary) trackSlotBoundaryDirtying(this, onInvalid)
   }
 
   // Whether update() claims the SSR anchor itself during hydration.
@@ -455,7 +460,9 @@ export class SlotFragment
   fallbackScope?: EffectScope
   lastNodesValid?: boolean
   pendingRecheck = false
+  pendingRecheckForce = false
   isRenderingFallback = false
+  private readonly onContentInvalid: (() => void)[] = []
   private content: Block = EMPTY_BLOCK
   private localFallback?: BlockFn
   private isUpdating = false
@@ -479,7 +486,8 @@ export class SlotFragment
       parent: this.slotBoundary,
       getFallback: () => this.localFallback,
       run: (fn, scope) => this.runWithRenderCtx(fn, scope),
-      markDirty: () => markSlotResolutionDirty(this),
+      markDirty: force => markSlotResolutionDirty(this, force),
+      onContentInvalid: this.onContentInvalid,
     })
   }
 
@@ -497,6 +505,7 @@ export class SlotFragment
       // so disposeSlotResolution does not remove it a second time
       this.activeFallback = null
     }
+    this.onContentInvalid.length = 0
     disposeSlotResolution(this)
   }
 
@@ -508,6 +517,9 @@ export class SlotFragment
   }
 
   private updateContent(render: BlockFn | undefined, key: any): void {
+    if (key !== this.current) {
+      this.onContentInvalid.length = 0
+    }
     // update() operates on this.nodes, but while fallback is active `nodes`
     // points at the fallback block. Aim it at the content branch so the base
     // pipeline re-renders content, then capture the result back; the
@@ -611,16 +623,17 @@ export class SlotFragment
         } else {
           withHydratingSlotBoundary(() => {
             this.updateHydratingContent(slotRender, key)
-            recheckSlotResolution(this, shouldForce)
+            recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)
             hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
           })
         }
       } else {
         this.updateContent(slotRender, key)
-        recheckSlotResolution(this, shouldForce)
+        recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)
       }
     } finally {
       this.pendingRecheck = false
+      this.pendingRecheckForce = false
       this.isUpdating = false
     }
   }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -340,7 +340,7 @@ export class DynamicFragment extends RenderContextFragment {
         setActiveSub(prevSub)
         return
       }
-      parent && remove(this.nodes, parent)
+      remove(this.nodes, parent || undefined)
     }
 
     const reusingDeferredAnchor = isHydrating

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -55,7 +55,7 @@ export function trackSlotBoundaryDirtying(
   if (!boundary) return
 
   if (onInvalid) {
-    ;(boundary.onContentInvalid ||= []).push(onInvalid)
+    registerContentInvalid(boundary, onInvalid, fragment)
   }
 
   let prevValid: boolean
@@ -67,6 +67,22 @@ export function trackSlotBoundaryDirtying(
       boundary.markDirty()
     }
   })
+}
+
+export function registerContentInvalid(
+  boundary: SlotBoundaryContext,
+  onInvalid: () => void,
+  fragment: VaporFragment,
+): void {
+  const callbacks = (boundary.onContentInvalid ||= [])
+  callbacks.push(onInvalid)
+  const unregister = () => {
+    const index = callbacks.indexOf(onInvalid)
+    if (index > -1) callbacks.splice(index, 1)
+  }
+  // The callback belongs to the slot-root fragment; remove it with that
+  // fragment so stale branches do not stay on a long-lived boundary.
+  ;(fragment.onRemove ||= []).push(unregister)
 }
 
 export function hasSlotFallback(

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -17,7 +17,8 @@ export interface SlotBoundaryContext {
   // Notifies the owning slot that the validity of a dynamic branch rendered
   // under this boundary may have changed; routes into the slot resolution
   // state machine (markSlotResolutionDirty).
-  markDirty: () => void
+  markDirty: (force?: boolean) => void
+  onContentInvalid?: (() => void)[]
 }
 
 export let currentSlotBoundary: SlotBoundaryContext | null = null
@@ -46,9 +47,16 @@ export function withSlotBoundary<R>(
 
 // Dynamic children (`v-if`, `v-for`, interop fragments) created under a slot
 // boundary dirty the boundary only when their rendered validity changes.
-export function trackSlotBoundaryDirtying(fragment: VaporFragment): void {
+export function trackSlotBoundaryDirtying(
+  fragment: VaporFragment,
+  onInvalid?: () => void,
+): void {
   const boundary = currentSlotBoundary
   if (!boundary) return
+
+  if (onInvalid) {
+    ;(boundary.onContentInvalid ||= []).push(onInvalid)
+  }
 
   let prevValid: boolean
   ;(fragment.onBeforeUpdate ||= []).push(() => {

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -302,6 +302,9 @@ export function recheckSlotResolution(
     // be in the DOM. Previously invalid fallback is inserted only after it
     // becomes valid.
     if (prevNodesValid) {
+      // If the selected fallback becomes invalid and no inherited fallback can
+      // take over, keep it active. This is an internal fallback update, so its
+      // anchors/effects must stay live until it becomes valid again.
       if (!fallbackValid && hasSlotFallback(state.boundary.parent)) {
         renderAndCommitSlotFallback(state, true)
       } else if (force && fallbackValid) {

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -1,21 +1,17 @@
 import { EffectScope } from '@vue/reactivity'
-import { isArray } from '@vue/shared'
 import {
   type Block,
   type TransitionOptions,
   insert,
   isValidSlot,
   remove,
-  removeNode,
 } from './block'
-import { isVaporComponent } from './component'
 import { isHydrating } from './dom/hydration'
 import {
   type SlotBoundaryContext,
   hasSlotFallback,
   withSlotBoundary,
 } from './slotBoundary'
-import { SlotFragment } from './fragment'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
 import { setBlockKey } from './helpers/setKey'
 
@@ -52,6 +48,7 @@ function renderSlotFallback(
     const localFallback = current.getFallback()
 
     if (localFallback) {
+      let selected = false
       const content = current.run(
         () =>
           withSlotBoundary(
@@ -60,12 +57,25 @@ function renderSlotFallback(
               // Hide the local fallback while rendering it, so slot outlets inside
               // the fallback don't resolve to the same fallback again.
               getFallback: () => undefined,
+              onContentInvalid: [],
+              // Hidden invalid fallbacks in a forwarded fallback chain must
+              // force a recheck when they become valid so the nearer fallback
+              // can win again. The selected fallback only needs a normal
+              // validity recheck because its own dynamic children update in
+              // place.
+              markDirty: force =>
+                current.markDirty(
+                  !!force || (!selected && hasSlotFallback(current.parent)),
+                ),
             },
             localFallback,
           ),
         scope,
       )
-      if (isValidSlot(content)) return content
+      if (isValidSlot(content)) {
+        selected = true
+        return content
+      }
       block = content
     }
 
@@ -92,6 +102,7 @@ export interface SlotResolutionState {
   // A dirty notification arrived while a fallback render or a host update
   // was in flight; folded into the recheck that completes that operation.
   pendingRecheck: boolean
+  pendingRecheckForce: boolean
   // Reentrancy guard, set while renderSlotFallback runs user fallback code.
   isRenderingFallback: boolean
 
@@ -111,52 +122,23 @@ export interface SlotResolutionState {
   notifyExposedValidityChange(): void
 }
 
-// Takes a block's nodes out of the DOM without tearing the block down: no
-// scopes are stopped and no remove() hooks run, so it can be re-inserted
-// later (content parked while fallback shows, or an invalid fallback parked
-// until it becomes valid). Fragment anchors are detached along with their
-// block because the generic fragment insert() re-inserts them — except a
-// SlotFragment's anchor: insertSlot() never re-inserts it and the slot
-// locates itself through it (getParentNode/getAnchor), so it must stay in
-// the DOM as the slot's persistent position marker.
-function detachBlock(block: Block, parent: ParentNode): void {
-  if (block instanceof Node) {
-    if (block.parentNode === parent) {
-      removeNode(block, parent)
-    }
-  } else if (isVaporComponent(block)) {
-    if (block.block) {
-      detachBlock(block.block, parent)
-    }
-  } else if (isArray(block)) {
-    for (let i = 0; i < block.length; i++) {
-      detachBlock(block[i], parent)
-    }
-  } else {
-    detachBlock(block.nodes, parent)
-    if (
-      !(block instanceof SlotFragment) &&
-      block.anchor &&
-      block.anchor.parentNode === parent
-    ) {
-      removeNode(block.anchor, parent)
-    }
-  }
-}
-
 // Entry point for validity-change notifications (boundary.markDirty). While
 // user fallback code is rendering or the host is mid content update, the
 // notification is folded into pendingRecheck instead of recursing: the
 // in-flight operation ends with a recheck that subsumes it.
-export function markSlotResolutionDirty(state: SlotResolutionState): void {
+export function markSlotResolutionDirty(
+  state: SlotResolutionState,
+  force: boolean = false,
+): void {
   if (state.isDisposed()) {
     return
   }
   if (state.isRenderingFallback || state.isBusy()) {
     state.pendingRecheck = true
+    state.pendingRecheckForce = state.pendingRecheckForce || force
     return
   }
-  recheckSlotResolution(state, true)
+  recheckSlotResolution(state, force)
 }
 
 function clearSlotFallback(state: SlotResolutionState): void {
@@ -225,9 +207,13 @@ function commitSlotFallback(
   scope: EffectScope,
   detachContent: boolean,
 ): void {
-  const parentNode = state.getParentNode()
-  if (detachContent && !isHydrating && parentNode) {
-    detachBlock(state.getContent(), parentNode)
+  if (detachContent && !isHydrating) {
+    const contentInvalidCallbacks = state.boundary.onContentInvalid
+    if (contentInvalidCallbacks) {
+      for (let i = 0; i < contentInvalidCallbacks.length; i++) {
+        contentInvalidCallbacks[i]()
+      }
+    }
   }
   state.activeFallback = block
   state.fallbackScope = scope
@@ -256,8 +242,10 @@ function renderAndCommitSlotFallback(
     commitSlotFallback(state, result.block, result.scope, !hadFallback)
     // drain notifications folded into this fallback render/update window
     if (state.pendingRecheck) {
+      const force = state.pendingRecheckForce
       state.pendingRecheck = false
-      recheckSlotResolution(state, true)
+      state.pendingRecheckForce = false
+      recheckSlotResolution(state, force)
     }
   }
 }
@@ -265,20 +253,23 @@ function renderAndCommitSlotFallback(
 export function disposeSlotResolution(state: SlotResolutionState): void {
   clearSlotFallback(state)
   state.pendingRecheck = false
+  state.pendingRecheckForce = false
   state.lastNodesValid = undefined
 }
 
 // Reconciles which branch the slot exposes after something may have changed.
-// `force` means a fallback source may differ from what the active fallback
-// was rendered from (a boundary was dirtied, or the fallback prop changed),
-// so a kept fallback must be re-rendered rather than merely re-inserted;
-// without `force` only the insertion state is reconciled.
+// `force` means the fallback chain may now resolve to a different block (the
+// fallback source changed, or a hidden fallback became valid), so a kept valid
+// fallback must be re-rendered. Ordinary dirty notifications from the selected
+// fallback's own dynamic children are not forced; those children update in
+// place.
 export function recheckSlotResolution(
   state: SlotResolutionState,
   force: boolean = false,
 ): void {
   if (state.isRenderingFallback) {
     state.pendingRecheck = true
+    state.pendingRecheckForce = state.pendingRecheckForce || force
     return
   }
 
@@ -311,14 +302,9 @@ export function recheckSlotResolution(
     // be in the DOM. Previously invalid fallback is inserted only after it
     // becomes valid.
     if (prevNodesValid) {
-      if (!fallbackValid && !hasSlotFallback(state.boundary.parent)) {
-        // No parent fallback can replace it, so invalid fallback leaves the
-        // slot empty.
-        const parentNode = state.getParentNode()
-        if (parentNode) {
-          detachBlock(fallback, parentNode)
-        }
-      } else if (force) {
+      if (!fallbackValid && hasSlotFallback(state.boundary.parent)) {
+        renderAndCommitSlotFallback(state, true)
+      } else if (force && fallbackValid) {
         renderAndCommitSlotFallback(state, true)
       }
     } else if (fallbackValid) {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1464,6 +1464,12 @@ function renderVDOMSlot(
   let isContentUpdateRecheck = false
   let localFallback: BlockFn | undefined
   let slotResolutionState!: SlotResolutionState
+  const cleanupInvalidContent = () => {
+    if (currentParentNode) {
+      removeAttachedNodes(contentState.nodes, currentParentNode)
+    }
+  }
+  const onContentInvalid = [cleanupInvalidContent]
   frag.isBlockValid = componentAsValid => {
     if (!contentResolved) return true
     return slotResolutionState.activeFallback
@@ -1476,12 +1482,14 @@ function renderVDOMSlot(
     },
     getFallback: (): BlockFn | undefined => localFallback,
     run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
-    markDirty: () => markSlotResolutionDirty(slotResolutionState),
+    markDirty: force => markSlotResolutionDirty(slotResolutionState, force),
+    onContentInvalid,
   }
   slotResolutionState = {
     boundary,
     activeFallback: null,
     pendingRecheck: false,
+    pendingRecheckForce: false,
     isRenderingFallback: false,
     getContent: () => contentState.nodes,
     getParentNode: () => currentParentNode,
@@ -1498,7 +1506,9 @@ function renderVDOMSlot(
       }
     },
   }
-  if (slotRoot) trackSlotBoundaryDirtying(frag)
+  if (slotRoot) {
+    trackSlotBoundaryDirtying(frag, cleanupInvalidContent)
+  }
   localFallback = fallback
     ? once
       ? () => withOnceSlot(() => fallback(internals, parentComponent))
@@ -1993,12 +2003,21 @@ function renderVaporSlot(
     let slotResolutionState!: SlotResolutionState
     let ownedSlotFragment: SlotFragment | undefined
     let ownedSlotFragmentDirtyQueued = false
-    const markInteropSlotResolutionDirty = (): void => {
+    let ownedSlotFragmentDirtyForce = false
+    const onContentInvalid = [
+      () => {
+        if (currentParentNode) {
+          removeAttachedNodes(contentNodes, currentParentNode)
+        }
+      },
+    ]
+    const markInteropSlotResolutionDirty = (force?: boolean): void => {
       const target = ownedSlotFragment
       if (!target) {
-        markSlotResolutionDirty(slotResolutionState)
+        markSlotResolutionDirty(slotResolutionState, force)
         return
       }
+      ownedSlotFragmentDirtyForce = ownedSlotFragmentDirtyForce || !!force
       // When the inner SlotFragment owns the fallback, a single vdom flush
       // can dirty this slot multiple times; batch into one post-flush recheck
       // so it observes the settled re-rendered content.
@@ -2008,7 +2027,9 @@ function renderVaporSlot(
       ownedSlotFragmentDirtyQueued = true
       queuePostFlushCb(() => {
         ownedSlotFragmentDirtyQueued = false
-        markSlotResolutionDirty(target)
+        const force = ownedSlotFragmentDirtyForce
+        ownedSlotFragmentDirtyForce = false
+        markSlotResolutionDirty(target, force)
       })
     }
     const outletFallbackBoundary: SlotBoundaryContext = {
@@ -2028,11 +2049,13 @@ function renderVaporSlot(
         slotState.localFallback.value ? localFallback : undefined,
       run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
       markDirty: markInteropSlotResolutionDirty,
+      onContentInvalid,
     }
     slotResolutionState = {
       boundary: localFallbackBoundary,
       activeFallback: null,
       pendingRecheck: false,
+      pendingRecheckForce: false,
       isRenderingFallback: false,
       getContent: () => contentNodes,
       getParentNode: () => currentParentNode,
@@ -2051,9 +2074,10 @@ function renderVaporSlot(
       },
     }
     const takePendingRecheck = (): boolean => {
-      const shouldRecheck = slotResolutionState.pendingRecheck
+      const force = slotResolutionState.pendingRecheckForce
       slotResolutionState.pendingRecheck = false
-      return shouldRecheck
+      slotResolutionState.pendingRecheckForce = false
+      return force
     }
 
     const dispose = (parentNode?: ParentNode): void => {
@@ -2086,6 +2110,7 @@ function renderVaporSlot(
       const hasInteropFallback =
         !!slotState.localFallback.value || !!slotState.outletFallback.value
       slotResolutionState.pendingRecheck = false
+      slotResolutionState.pendingRecheckForce = false
       let finish: ((contentValid: boolean) => void) | undefined
       const finishHydratingContent = (contentValid: boolean): void => {
         if (!finish) return
@@ -2160,6 +2185,7 @@ function renderVaporSlot(
       }
 
       slotResolutionState.pendingRecheck = false
+      slotResolutionState.pendingRecheckForce = false
       frag.insert = (parentNode, anchor) => {
         currentParentNode = parentNode
         currentAnchor = anchor
@@ -2324,6 +2350,14 @@ function createVNodeChildrenFragment(
   let isMounted = false
   let isRenderEffectStarted = false
   const scope = effectScope()
+  const cleanupInvalidContent = () => {
+    if (currentParentNode) {
+      removeAttachedNodes(frag.nodes, currentParentNode)
+    }
+  }
+  if (frag.slotBoundary) {
+    ;(frag.slotBoundary.onContentInvalid ||= []).push(cleanupInvalidContent)
+  }
 
   const syncResolvedNodes = (children: VNode[] = currentChildren): boolean => {
     const prevValid = contentResolved ? contentValid : true
@@ -2337,6 +2371,15 @@ function createVNodeChildrenFragment(
     }
     contentResolved = true
     return prevValid !== contentValid
+  }
+  const syncResolvedNodesAndCleanup = (
+    children: VNode[] = currentChildren,
+  ): boolean => {
+    const validityChanged = syncResolvedNodes(children)
+    if (validityChanged && !contentValid && frag.slotBoundary) {
+      cleanupInvalidContent()
+    }
+    return validityChanged
   }
 
   const notifyUpdated = (validityChanged = false): void => {
@@ -2395,7 +2438,7 @@ function createVNodeChildrenFragment(
             trackSlotVNodeUpdatesWithRefresh(
               currentVNode,
               () => {
-                notifyUpdated(syncResolvedNodes(nextChildren))
+                notifyUpdated(syncResolvedNodesAndCleanup(nextChildren))
               },
               notifyBeforeUpdate,
             )
@@ -2416,7 +2459,7 @@ function createVNodeChildrenFragment(
             trackSlotVNodeUpdatesWithRefresh(
               nextVNode,
               () => {
-                notifyUpdated(syncResolvedNodes(nextChildren))
+                notifyUpdated(syncResolvedNodesAndCleanup(nextChildren))
               },
               notifyBeforeUpdate,
             )
@@ -2435,7 +2478,7 @@ function createVNodeChildrenFragment(
             currentVNode = nextVNode
           }
 
-          const validityChanged = syncResolvedNodes()
+          const validityChanged = syncResolvedNodesAndCleanup()
           if (isHydrating) {
             if (isMounted && frag.onUpdated) {
               frag.onUpdated.forEach(hook => hook())
@@ -2472,7 +2515,7 @@ function createVNodeChildrenFragment(
         trackSlotVNodeUpdatesWithRefresh(
           currentVNode,
           () => {
-            notifyUpdated(syncResolvedNodes(currentChildren))
+            notifyUpdated(syncResolvedNodesAndCleanup(currentChildren))
           },
           notifyBeforeUpdate,
         )

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -131,6 +131,7 @@ import {
 import {
   type SlotBoundaryContext,
   hasSlotFallback,
+  registerContentInvalid,
   trackSlotBoundaryDirtying,
   withSlotBoundary,
 } from './slotBoundary'
@@ -2356,7 +2357,7 @@ function createVNodeChildrenFragment(
     }
   }
   if (frag.slotBoundary) {
-    ;(frag.slotBoundary.onContentInvalid ||= []).push(cleanupInvalidContent)
+    registerContentInvalid(frag.slotBoundary, cleanupInvalidContent, frag)
   }
 
   const syncResolvedNodes = (children: VNode[] = currentChildren): boolean => {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -2376,8 +2376,10 @@ function createVNodeChildrenFragment(
     children: VNode[] = currentChildren,
   ): boolean => {
     const validityChanged = syncResolvedNodes(children)
-    if (validityChanged && !contentValid && frag.slotBoundary) {
+    if (!contentValid && frag.slotBoundary) {
       cleanupInvalidContent()
+      currentVNode = null
+      currentChildren = EMPTY_VNODES
     }
     return validityChanged
   }


### PR DESCRIPTION
Replace recursive slot block detachment with slot-root invalidation callbacks registered on the current slot boundary. This keeps cleanup scoped to the fragment anchors owned by invalid slot content while leaving fallback removal on the normal remove path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot fallback behavior so content switches correctly when conditions, dynamic components, or list items become invalid and then valid again.
  * Prevented inactive fallback anchors and placeholder nodes from lingering in the DOM.
  * Preserved user-entered input and stable fallback rendering during invalidation and restoration.
  * Cleaned up removed slot content more reliably, reducing stale or duplicate UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->