### PR TITLE
fix(shared): prevent SSR comment escaping from creating closing delimiters

### DIFF
--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -728,9 +728,12 @@ function testRender(type: string, render: typeof renderToString) {
               createCommentVNode('->foo'),
               createCommentVNode('<!--foo-->'),
               createCommentVNode('--!>foo<!-'),
+              createCommentVNode('--<!--><img src=x onerror=alert(1)>'),
             ]),
           ),
-        ).toBe(`<div><!--foo--><!--foo--><!--foo--><!--foo--></div>`)
+        ).toBe(
+          `<div><!--foo--><!--foo--><!--foo--><!--foo--><!--<img src=x onerror=alert(1)>--></div>`,
+        )
       })
 
       test('Static', async () => {

--- a/packages/shared/__tests__/escapeHtml.spec.ts
+++ b/packages/shared/__tests__/escapeHtml.spec.ts
@@ -23,6 +23,12 @@ describe('escapeHtml', () => {
     expect(result).toEqual(' Comment 1  Hello ! Comment 2  World!')
   })
 
+  test('ssr: escapeHTMLComment removes comment close sequences created by stripping', () => {
+    const input = '--<!--><img src=x onerror=alert(1)>'
+    const result = escapeHtmlComment(input)
+    expect(result).toEqual('<img src=x onerror=alert(1)>')
+  })
+
   test('should not affect non-comment strings', () => {
     const input = 'Hello World'
     const result = escapeHtmlComment(input)

--- a/packages/shared/src/escapeHtml.ts
+++ b/packages/shared/src/escapeHtml.ts
@@ -48,7 +48,12 @@ export function escapeHtml(string: unknown): string {
 const commentStripRE = /^-?>|<!--|-->|--!>|<!-$/g
 
 export function escapeHtmlComment(src: string): string {
-  return src.replace(commentStripRE, '')
+  let prev: string
+  do {
+    prev = src
+    src = src.replace(commentStripRE, '')
+  } while (src !== prev)
+  return src
 }
 
 export const cssVarNameEscapeSymbolsRE: RegExp =

--- a/packages/shared/src/escapeHtml.ts
+++ b/packages/shared/src/escapeHtml.ts
@@ -45,7 +45,7 @@ export function escapeHtml(string: unknown): string {
 }
 
 // https://www.w3.org/TR/html52/syntax.html#comments
-const commentStripRE = /^-?>|<!--|-->|--!>|<!-$/g
+const commentStripRE = /^(?:-?>)+|<!--|-->|--!>|<!-$/g
 
 export function escapeHtmlComment(src: string): string {
   let prev: string


### PR DESCRIPTION
Refs GHSA-9rff-vwfp-83hv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTML comment-like sequences so comment boundaries are processed more reliably during server-side rendering and HTML escaping.
  * Prevents malformed or unexpected markup output when inputs contain tricky comment markers alongside real HTML fragments.

* **Tests**
  * Added additional coverage for escaping comment content, including inputs resembling comment-close delimiters with HTML payloads.
  * Expanded the server-rendered HTML test case to include an additional comment-token scenario and validate the resulting rendered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->