### PR TITLE
fix(runtime-core): defer functional ref resolution to post-render phase

### DIFF
--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -136,11 +136,24 @@ export function setRef(
   }
 
   if (isFunction(ref)) {
-    pauseTracking()
-    try {
-      callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [value, refs])
-    } finally {
-      resetTracking()
+    const isComponent = !!(vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT)
+    if (value && isComponent) {
+      const job: SchedulerJob = () => {
+        pauseTracking()
+        try {
+          callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [value, refs])
+        } finally {
+          resetTracking()
+        }
+      }
+      queuePostRenderEffect(job, parentSuspense)
+    } else {
+      pauseTracking()
+      try {
+        callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [value, refs])
+      } finally {
+        resetTracking()
+      }
     }
   } else {
     const _isString = isString(ref)


### PR DESCRIPTION
### Description
This PR fixes a runtime bug where a component's functional ref cannot access exposed elements from a child component because the child's internal template refs haven't been resolved yet.

### Key Changes
- Deferred the invocation of functional refs **only for stateful components** (`vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT`) to the post-render phase using `queuePostRenderEffect`. This ensures that all exposed child elements are fully available when the callback runs.
- Plain HTML elements and unmount callbacks (`value === null`) remain synchronous during the patch phase to maintain performance and full backward compatibility.

Fixes #15039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved when function-based references are updated for component content, helping ensure they run at the correct time during rendering.
  * Kept immediate updates for cases like clearing a reference or non-component values, preserving existing behavior where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->