### PR TITLE
fix(reactivity): allow toRefs on plain objects (fix #13171)

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -625,14 +625,38 @@ describe('reactivity/ref', () => {
     expect(dummyY).toBe(5)
   })
 
-  test('toRefs should warn on plain object', () => {
-    toRefs({})
-    expect(`toRefs() expects a reactive object`).toHaveBeenWarned()
+  test('toRefs plain object', () => {
+    const object = { x: 1, y: 2 }
+    const { x, y } = toRefs(object)
+
+    expect(isRef(x)).toBe(true)
+    expect(isRef(y)).toBe(true)
+    expect(x.value).toBe(1)
+    expect(y.value).toBe(2)
+
+    object.x = 2
+    expect(x.value).toBe(2)
+
+    y.value = 3
+    expect(object.y).toBe(3)
+    expect(`toRefs() expects a reactive object`).not.toHaveBeenWarned()
   })
 
-  test('toRefs should warn on plain array', () => {
-    toRefs([])
-    expect(`toRefs() expects a reactive object`).toHaveBeenWarned()
+  test('toRefs plain array', () => {
+    const array = ['a', 'b']
+    const refs = toRefs(array)
+
+    expect(Array.isArray(refs)).toBe(true)
+    expect(isRef(refs[0])).toBe(true)
+    expect(isRef(refs[1])).toBe(true)
+    expect(refs[0].value).toBe('a')
+
+    array[0] = 'c'
+    expect(refs[0].value).toBe('c')
+
+    refs[1].value = 'd'
+    expect(array[1]).toBe('d')
+    expect(`toRefs() expects a reactive object`).not.toHaveBeenWarned()
   })
 
   test('toRefs reactive array', () => {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -21,7 +21,6 @@ import {
 } from './reactive'
 import type { ComputedRef, WritableComputedRef } from './computed'
 import { ReactiveFlags, TrackOpTypes, TriggerOpTypes } from './constants'
-import { warn } from './warning'
 
 declare const RefSymbol: unique symbol
 export declare const RawSymbol: unique symbol
@@ -362,9 +361,6 @@ type ToRefValue<T extends object, K extends ToRefKey<T>> = K extends keyof T
  */
 /*@__NO_SIDE_EFFECTS__*/
 export function toRefs<T extends object>(object: T): ToRefs<T> {
-  if (__DEV__ && !isProxy(object)) {
-    warn(`toRefs() expects a reactive object but received a plain one.`)
-  }
   const ret: any = isArray(object) ? new Array(object.length) : {}
   for (const key in object) {
     ret[key] = propertyToRef(object, key)


### PR DESCRIPTION
## What changed

- Removed the dev-only warning when `toRefs()` receives a non-proxy object.
- Replaced the old warning expectations with coverage showing plain objects and plain arrays still produce linked property refs without warning.

## Why

- Fix #13171.
- `<script setup>` props rest destructuring is compiled to `createPropsRestProxy()`, which returns a plain object with getters back to the props proxy. Calling `toRefs()` on that object currently emits a false warning even though `toRefs()` can already create property refs for plain objects.
- This matches the direction called out in the issue via `ac43b118975b17d7ce7d9e6886f8806af11bee55` on the vapor branch.

## How tested

- `pnpm test-unit packages/reactivity/__tests__/ref.spec.ts --run`
- `pnpm test-unit packages/reactivity --run`
- `pnpm check`
- `pnpm exec eslint packages/reactivity/src/ref.ts packages/reactivity/__tests__/ref.spec.ts`
- `pnpm exec prettier --check packages/reactivity/src/ref.ts packages/reactivity/__tests__/ref.spec.ts`

## Risk and rollout

- Risk: Low. This removes a dev-only warning and leaves the existing `propertyToRef()` behavior unchanged.
- Rollback: Restore the warning branch and the previous warning expectations.

## Notes for reviewers

- I checked for existing open PRs by `#13171`, `toRefs plain object`, `toRefs plain array`, and the vapor-branch commit title. I only found unrelated type work such as #9701.