### PR TITLE
fix(compiler-sfc): detect pug template import usage

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/importUsageCheck.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/importUsageCheck.spec.ts.snap
@@ -154,6 +154,26 @@ return { get Foo() { return Foo } }
 })"
 `;
 
+exports[`pug template usage 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { MyType, UsedComponent } from './x'
+const msg = 'hi'
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    value: { type: null, required: true }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+
+
+return { msg, get UsedComponent() { return UsedComponent } }
+}
+
+})"
+`;
+
 exports[`spread operator 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 import { Foo, Bar, Baz } from './foo'

--- a/packages/compiler-sfc/__tests__/compileScript/importUsageCheck.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/importUsageCheck.spec.ts
@@ -251,6 +251,25 @@ test('check when has explicit parse options', () => {
   expect(content).toMatch('return { get x() { return x } }')
 })
 
+// #12542
+test('pug template usage', () => {
+  const { content } = compile(`
+<script setup lang="ts">
+import { MyType, UsedComponent } from './x'
+const msg = 'hi'
+defineProps<{ value: MyType }>()
+</script>
+<template lang="pug">
+div
+  UsedComponent
+  span {{ msg }}
+</template>
+  `)
+  expect(content).not.toMatch(`get MyType() { return MyType }`)
+  expect(content).toMatch(`get UsedComponent() { return UsedComponent }`)
+  assertCode(content)
+})
+
 // #11745
 test('shorthand binding w/ kebab-case', () => {
   const { content } = compile(

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -263,8 +263,7 @@ export function compileScript(
       needTemplateUsageCheck &&
       ctx.isTS &&
       sfc.template &&
-      !sfc.template.src &&
-      !sfc.template.lang
+      !sfc.template.src
     ) {
       isUsedInTemplate = isImportUsed(local, sfc)
     }

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -2,14 +2,17 @@ import type { SFCDescriptor } from '../parse'
 import {
   type ExpressionNode,
   NodeTypes,
+  type RootNode,
   type SimpleExpressionNode,
   type TemplateChildNode,
   isSimpleIdentifier,
+  parse as parseTemplate,
   parserOptions,
   walkIdentifiers,
 } from '@vue/compiler-dom'
 import { createCache } from '../cache'
 import { camelize, capitalize, isBuiltInDirective } from '@vue/shared'
+import consolidate from '@vue/consolidate'
 
 /**
  * Check if an import is used in the SFC's template. This is used to determine
@@ -17,12 +20,14 @@ import { camelize, capitalize, isBuiltInDirective } from '@vue/shared'
  * when not using inline mode.
  */
 export function isImportUsed(local: string, sfc: SFCDescriptor): boolean {
-  return resolveTemplateUsedIdentifiers(sfc).has(local)
+  const ids = resolveTemplateUsedIdentifiers(sfc)
+  return ids === undefined || ids.has(local)
 }
 
 const templateAnalysisCache = createCache<{
   usedIds?: Set<string>
   vModelIds: Set<string>
+  isUsageUnknown?: boolean
 }>()
 
 export function resolveTemplateVModelIdentifiers(
@@ -31,8 +36,10 @@ export function resolveTemplateVModelIdentifiers(
   return resolveTemplateAnalysisResult(sfc, false).vModelIds
 }
 
-function resolveTemplateUsedIdentifiers(sfc: SFCDescriptor): Set<string> {
-  return resolveTemplateAnalysisResult(sfc).usedIds!
+function resolveTemplateUsedIdentifiers(
+  sfc: SFCDescriptor,
+): Set<string> | undefined {
+  return resolveTemplateAnalysisResult(sfc).usedIds
 }
 
 function resolveTemplateAnalysisResult(
@@ -42,9 +49,12 @@ function resolveTemplateAnalysisResult(
   usedIds?: Set<string>
   vModelIds: Set<string>
 } {
-  const { content, ast } = sfc.template!
-  const cached = templateAnalysisCache.get(content)
-  if (cached && (!collectUsedIds || cached.usedIds)) {
+  const template = sfc.template!
+  const cacheKey = template.lang
+    ? `${sfc.filename}\n${template.lang}\n${template.content}`
+    : template.content
+  const cached = templateAnalysisCache.get(cacheKey)
+  if (cached && (!collectUsedIds || cached.usedIds || cached.isUsageUnknown)) {
     return cached
   }
 
@@ -52,6 +62,17 @@ function resolveTemplateAnalysisResult(
   // and only collect `vModelIds`.
   const ids = collectUsedIds ? new Set<string>() : undefined
   const vModelIds = new Set<string>()
+  const ast = getTemplateAST(sfc)
+
+  if (!ast) {
+    const result = {
+      usedIds: undefined,
+      vModelIds,
+      isUsageUnknown: collectUsedIds,
+    }
+    templateAnalysisCache.set(cacheKey, result)
+    return result
+  }
 
   ast!.children.forEach(walk)
 
@@ -130,8 +151,61 @@ function resolveTemplateAnalysisResult(
   }
 
   const result = { usedIds: ids, vModelIds }
-  templateAnalysisCache.set(content, result)
+  templateAnalysisCache.set(cacheKey, result)
   return result
+}
+
+interface PreProcessor {
+  render(
+    source: string,
+    options: any,
+    cb: (err: Error | null, res: string) => void,
+  ): void
+}
+
+function getTemplateAST(sfc: SFCDescriptor): RootNode | undefined {
+  const template = sfc.template!
+  if (!template.lang) {
+    return template.ast
+  }
+
+  const preprocessor =
+    !__ESM_BROWSER__ &&
+    !__GLOBAL__ &&
+    (consolidate[template.lang as keyof typeof consolidate] as
+      | PreProcessor
+      | undefined)
+  if (!preprocessor) {
+    return
+  }
+
+  try {
+    return parseTemplate(preprocessTemplate(sfc, preprocessor), {
+      prefixIdentifiers: true,
+    })
+  } catch {
+    return
+  }
+}
+
+function preprocessTemplate(
+  sfc: SFCDescriptor,
+  preprocessor: PreProcessor,
+): string {
+  let res = ''
+  let err: Error | null = null
+  preprocessor.render(
+    sfc.template!.content,
+    { filename: sfc.filename },
+    (_err, _res) => {
+      if (_err) err = _err
+      res = _res
+    },
+  )
+  if (err) {
+    throw err
+  }
+  return res
 }
 
 function extractIdentifiers(ids: Set<string>, node: ExpressionNode) {


### PR DESCRIPTION
## What changed

- Run script setup import usage checks for non-`src` templates even when `template.lang` is set.
- For preprocessable template languages, preprocess the template and parse the generated HTML before reusing the existing identifier walker.
- Keep the old conservative behavior when preprocessing is unavailable or fails, so unknown template languages do not drop imports accidentally.
- Add a regression test for TS `<script setup>` with a Pug template where an imported type is used only in type position.

## Why

- Fixes #12542.
- Pug templates previously skipped precise import usage analysis, so every setup import was treated as template-used.
- That caused type-only TS usage written as a regular import, such as `import { MyType }`, to be returned from setup as a runtime getter and retained as a runtime import.

## How tested

- `pnpm vitest packages/compiler-sfc/__tests__/compileScript/importUsageCheck.spec.ts --run`
- `pnpm vitest packages/compiler-sfc/__tests__ --run`
- `pnpm check`
- `pnpm lint`
- `pnpm prettier --check packages/compiler-sfc/src/compileScript.ts packages/compiler-sfc/src/script/importUsageCheck.ts packages/compiler-sfc/__tests__/compileScript/importUsageCheck.spec.ts --parser typescript`
- `git diff --check`

## Risk and rollout

- Risk: Low to medium. This only changes compiler-sfc import usage detection for non-`src` templates with a `lang`, and unsupported/erroring preprocessors still fall back to the previous conservative behavior.
- Rollback: Revert this commit.

## Notes for reviewers

- The Pug path intentionally preprocesses before walking identifiers, instead of treating all Pug imports as unused, so components actually referenced by the Pug template continue to be returned from setup.