### PR TITLE
fix(ssr): keep component v-show out of attrs

### DIFF
--- a/packages/compiler-ssr/__tests__/ssrVShow.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVShow.spec.ts
@@ -134,4 +134,30 @@ describe('ssr: v-show', () => {
       }"
     `)
   })
+
+  test('on component', () => {
+    expect(compile(`<foo v-show="foo"/>`).code).toMatchInlineSnapshot(`
+      "const { resolveComponent: _resolveComponent } = require("vue")
+      const { ssrRenderComponent: _ssrRenderComponent } = require("vue/server-renderer")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs) {
+        const _component_foo = _resolveComponent("foo")
+
+        _push(_ssrRenderComponent(_component_foo, _attrs, null, _parent, undefined, {
+          style: (_ctx.foo) ? null : { display: "none" }
+        }))
+      }"
+    `)
+    expect(compile(`<component :is="foo" v-show="foo"/>`).code)
+      .toMatchInlineSnapshot(`
+        "const { resolveDynamicComponent: _resolveDynamicComponent, createVNode: _createVNode } = require("vue")
+        const { ssrRenderVNode: _ssrRenderVNode } = require("vue/server-renderer")
+
+        return function ssrRender(_ctx, _push, _parent, _attrs) {
+          _ssrRenderVNode(_push, _createVNode(_resolveDynamicComponent(_ctx.foo), _attrs, null), _parent, undefined, {
+            style: (_ctx.foo) ? null : { display: "none" }
+          })
+        }"
+      `)
+  })
 })

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -30,6 +30,7 @@ import {
   createCallExpression,
   createFunctionExpression,
   createIfStatement,
+  createObjectExpression,
   createReturnStatement,
   createRoot,
   createSimpleExpression,
@@ -61,6 +62,7 @@ import {
   ssrProcessTransition,
   ssrTransformTransition,
 } from './ssrTransformTransition'
+import { ssrTransformShow } from './ssrVShow'
 
 // We need to construct the slot functions in the 1st pass to ensure proper
 // scope tracking, but the children of each slot cannot be processed until
@@ -81,6 +83,7 @@ const componentTypeMap = new WeakMap<
   ComponentNode,
   string | symbol | CallExpression
 >()
+const rootAttrsMap = new WeakMap<ComponentNode, JSChildNode>()
 
 // ssr component transform is done in two phases:
 // In phase 1. we use `buildSlot` to analyze the children of the component into
@@ -122,6 +125,18 @@ export const ssrTransformComponent: NodeTransform = (node, context) => {
   const clonedNode = clone(node)
 
   return function ssrPostTransformComponent() {
+    const vShowIndex = node.props.findIndex(
+      p => p.type === NodeTypes.DIRECTIVE && p.name === 'show',
+    )
+    if (vShowIndex !== -1) {
+      const vShow = node.props[vShowIndex] as DirectiveNode
+      node.props.splice(vShowIndex, 1)
+      rootAttrsMap.set(
+        node,
+        createObjectExpression(ssrTransformShow(vShow, node, context).props),
+      )
+    }
+
     // Using the cloned node, build the normal VNode-based branches (for
     // fallback in case the child is render-fn based). Store them in an array
     // for later use.
@@ -253,6 +268,13 @@ export function ssrProcessComponent(
     // component is inside a slot, inherit slot scope Id
     if (context.withSlotScopeId) {
       node.ssrCodegenNode.arguments.push(`_scopeId`)
+    }
+    const rootAttrs = rootAttrsMap.get(node)
+    if (rootAttrs) {
+      if (!context.withSlotScopeId) {
+        node.ssrCodegenNode.arguments.push(`undefined`)
+      }
+      node.ssrCodegenNode.arguments.push(rootAttrs)
     }
 
     if (typeof component === 'string') {

--- a/packages/server-renderer/__tests__/ssrDirectives.spec.ts
+++ b/packages/server-renderer/__tests__/ssrDirectives.spec.ts
@@ -2,6 +2,7 @@ import { renderToString } from '../src/renderToString'
 import {
   createApp,
   h,
+  markRaw,
   mergeProps,
   ref,
   resolveDirective,
@@ -65,6 +66,31 @@ describe('ssr: directives', () => {
           }),
         ),
       ).toBe(`<div style="color:red;font-size:12;display:none;"></div>`)
+    })
+
+    // #12503
+    test('component with inheritAttrs false and manual attrs binding', async () => {
+      const Child = {
+        inheritAttrs: false,
+        template: `<div><div v-bind="$attrs">child</div></div>`,
+      }
+      expect(
+        await renderToString(
+          createApp({
+            data: () => ({ show: false }),
+            components: { Child },
+            template: `<Child v-show="show" />`,
+          }),
+        ),
+      ).toBe(`<div style="display:none;"><div>child</div></div>`)
+      expect(
+        await renderToString(
+          createApp({
+            data: () => ({ show: false, child: markRaw(Child) }),
+            template: `<component :is="child" v-show="show" />`,
+          }),
+        ),
+      ).toBe(`<div style="display:none;"><div>child</div></div>`)
     })
   })
 

--- a/packages/server-renderer/src/helpers/ssrRenderComponent.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderComponent.ts
@@ -13,10 +13,12 @@ export function ssrRenderComponent(
   children: Slots | SSRSlots | null = null,
   parentComponent: ComponentInternalInstance | null = null,
   slotScopeId?: string,
+  rootAttrs?: Props,
 ): SSRBuffer | Promise<SSRBuffer> {
   return renderComponentVNode(
     createVNode(comp, props, children),
     parentComponent,
     slotScopeId,
+    rootAttrs,
   )
 }

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -93,6 +93,7 @@ export function renderComponentVNode(
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null = null,
   slotScopeId?: string,
+  rootAttrs?: Props,
 ): SSRBuffer | Promise<SSRBuffer> {
   const instance = (vnode.component = createComponentInstance(
     vnode,
@@ -117,15 +118,18 @@ export function renderComponentVNode(
       })
       // Note: error display is already done by the wrapped lifecycle hook function.
       .catch(NOOP)
-    return p.then(() => renderComponentSubTree(instance, slotScopeId))
+    return p.then(() =>
+      renderComponentSubTree(instance, slotScopeId, rootAttrs),
+    )
   } else {
-    return renderComponentSubTree(instance, slotScopeId)
+    return renderComponentSubTree(instance, slotScopeId, rootAttrs)
   }
 }
 
 function renderComponentSubTree(
   instance: ComponentInternalInstance,
   slotScopeId?: string,
+  rootAttrs?: Props,
 ): SSRBuffer | Promise<SSRBuffer> {
   if (__DEV__) pushWarningContext(instance.vnode)
   const comp = instance.type as Component
@@ -141,7 +145,13 @@ function renderComponentSubTree(
         }
       }
     }
-    renderVNode(push, (instance.subTree = root), instance, slotScopeId)
+    renderVNode(
+      push,
+      (instance.subTree = root),
+      instance,
+      slotScopeId,
+      rootAttrs,
+    )
   } else {
     if (
       (!instance.render || instance.render === NOOP) &&
@@ -158,6 +168,9 @@ function renderComponentSubTree(
       // resolve fallthrough attrs
       let attrs = instance.inheritAttrs !== false ? instance.attrs : undefined
       let hasCloned = false
+      if (rootAttrs) {
+        attrs = attrs ? mergeProps(attrs, rootAttrs) : rootAttrs
+      }
 
       let cur = instance
       while (true) {
@@ -210,6 +223,7 @@ function renderComponentSubTree(
         (instance.subTree = renderComponentRoot(instance)),
         instance,
         slotScopeId,
+        rootAttrs,
       )
     } else {
       const componentName = comp.name || comp.__file || `<Anonymous>`
@@ -226,6 +240,7 @@ export function renderVNode(
   vnode: VNode,
   parentComponent: ComponentInternalInstance,
   slotScopeId?: string,
+  rootAttrs?: Props,
 ): void {
   const { type, shapeFlag, children, dirs, props } = vnode
   if (dirs) {
@@ -262,9 +277,11 @@ export function renderVNode(
       break
     default:
       if (shapeFlag & ShapeFlags.ELEMENT) {
-        renderElementVNode(push, vnode, parentComponent, slotScopeId)
+        renderElementVNode(push, vnode, parentComponent, slotScopeId, rootAttrs)
       } else if (shapeFlag & ShapeFlags.COMPONENT) {
-        push(renderComponentVNode(vnode, parentComponent, slotScopeId))
+        push(
+          renderComponentVNode(vnode, parentComponent, slotScopeId, rootAttrs),
+        )
       } else if (shapeFlag & ShapeFlags.TELEPORT) {
         renderTeleportVNode(push, vnode, parentComponent, slotScopeId)
       } else if (shapeFlag & ShapeFlags.SUSPENSE) {
@@ -295,9 +312,13 @@ function renderElementVNode(
   vnode: VNode,
   parentComponent: ComponentInternalInstance,
   slotScopeId?: string,
+  rootAttrs?: Props,
 ) {
   const tag = vnode.type as string
   let { props, children, shapeFlag, scopeId } = vnode
+  if (rootAttrs) {
+    props = props ? mergeProps(props, rootAttrs) : rootAttrs
+  }
   let openTag = `<${tag}`
 
   if (props) {


### PR DESCRIPTION
## What changed

- Treat SSR `v-show` on components as root-only attrs instead of normal component props.
- Add optional `rootAttrs` plumbing through `ssrRenderComponent` / `ssrRenderVNode` so SSR can apply those attrs to the rendered root without adding them to `instance.attrs` / `$attrs`.
- Cover both static component and dynamic component SSR codegen paths.
- Add a regression test for `inheritAttrs: false` plus manual `v-bind=$attrs` forwarding.

## Why

- Fixes #12503.
- Previously, SSR compiled component `v-show` into a `style` prop on the component vnode.
- That made the synthetic `display:none` style visible through `$attrs`, so components that manually forwarded `$attrs` rendered hidden inner elements that the client-side `v-show` directive does not manage.

## How tested

- `pnpm vitest packages/compiler-ssr/__tests__/ssrVShow.spec.ts packages/server-renderer/__tests__/ssrDirectives.spec.ts --run`
- `pnpm vitest packages/compiler-ssr/__tests__ packages/server-renderer/__tests__ --run`
- `pnpm check`
- `pnpm lint`
- `pnpm prettier --check packages/compiler-ssr/src/transforms/ssrTransformComponent.ts packages/compiler-ssr/__tests__/ssrVShow.spec.ts packages/server-renderer/src/render.ts packages/server-renderer/src/helpers/ssrRenderComponent.ts packages/server-renderer/__tests__/ssrDirectives.spec.ts --parser typescript`
- `git diff --check`

## Risk and rollout

- Risk: Medium-low. The change is limited to SSR component `v-show` handling and an optional internal helper parameter. It preserves normal fallthrough attrs and keeps unsupported/non-`v-show` directive behavior unchanged.
- Rollback: Revert this commit.

## Notes for reviewers

- I checked open and closed PRs for `#12503`, `v-show inheritAttrs attrs SSR`, and related keywords before opening this; I did not find an existing PR covering it.
- The root-only attrs are intentionally merged into the SSR root render path, not into component props, so `$attrs` continues to represent user-provided attrs.