### PR TITLE
build: configuration improvements

### DIFF
--- a/scripts/create-rolldown-config.js
+++ b/scripts/create-rolldown-config.js
@@ -193,6 +193,9 @@ export function createConfigsForPackage({
         __TEST__: `false`,
         // this is only used during Vue's internal e2e-tests
         __E2E_TEST__: String(e2eTest),
+        __DEV__: isBundlerESMBuild
+          ? `!!(process.env.NODE_ENV !== 'production')`
+          : String(!isProductionBuild),
         // If the build is expected to run directly in the browser (global / esm builds)
         __BROWSER__: String(isBrowserBuild),
         __GLOBAL__: String(isGlobalBuild),
@@ -219,11 +222,6 @@ export function createConfigsForPackage({
           : `false`,
       }
 
-      if (!isBundlerESMBuild) {
-        // hard coded dev/prod builds
-        defines.__DEV__ = String(!isProductionBuild)
-      }
-
       // allow inline overrides like
       //__RUNTIME_COMPILE__=true pnpm build runtime-core
       Object.keys(defines).forEach(key => {
@@ -242,13 +240,6 @@ export function createConfigsForPackage({
     function resolveReplace() {
       /** @type {Record<string, string>} */
       const replacements = { ...enumDefines }
-
-      if (isBundlerESMBuild) {
-        Object.assign(replacements, {
-          // preserve to be handled by bundlers
-          __DEV__: `!!(process.env.NODE_ENV !== 'production')`,
-        })
-      }
 
       // for compiler-sfc browser build inlined deps
       if (isBrowserESMBuild && name === 'compiler-sfc') {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -21,7 +21,7 @@ import { parseArgs } from 'node:util'
 let versionUpdated = false
 
 const { prompt } = enquirer
-const currentVersion = createRequire(import.meta.url)('../package.json').version
+let currentVersion = createRequire(import.meta.url)('../package.json').version
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const { values: args, positionals } = parseArgs({
@@ -358,9 +358,11 @@ async function getBranch() {
  * @param {(pkgName: string) => string} getNewPackageName
  */
 function updateVersions(version, getNewPackageName = keepThePackageName) {
-  // 1. update root package.json
+  // 1. update currentVersion
+  currentVersion = version
+  // 2. update root package.json
   updatePackage(path.resolve(__dirname, '..'), version, getNewPackageName)
-  // 2. update all packages
+  // 3. update all packages
   packages.forEach(p =>
     updatePackage(getPkgRoot(p), version, getNewPackageName),
   )


### PR DESCRIPTION
本次修改基于 v3.6.0-beta.17，改动点：

- `scripts/create-rolldown-config.js`：3.6.0 已基于 oxc，其 `define` 已兼容模板字符串的赋值，可以不用再写两套 `__DEV__ `宏的替换分别在 `resolveDefine` 和 `resolveReplace` 中去维护。
- `scripts/release.js`：版本更新时需要同步 `currentVersion` 变量，否则 `publishOnly` 方法执行时容易出错 —— 先执行了 `updateVersions(targetVersion)` 且未更新 `currentVersion` 变量，后续执行 `await publishPackages(currentVersion)` 会导致其使用的版本号（`currentVersion`）是未经修改的。