### PR TITLE
fix(server-renderer): remove package dependency cycle

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -25,6 +25,7 @@ import {
   openBlock,
   reactive,
   ref,
+  registerRuntimeCompiler,
   renderSlot,
   useCssVars,
   vModelCheckbox,
@@ -32,13 +33,28 @@ import {
   withCtx,
   withDirectives,
 } from '@vue/runtime-dom'
+import * as runtimeDom from '@vue/runtime-dom'
 import type { HMRRuntime } from '../src/hmr'
+import type { InternalRenderFunction } from '../src/component'
 import { type SSRContext, renderToString } from '@vue/server-renderer'
+import { type CompilerOptions, compile } from '@vue/compiler-dom'
 import { PatchFlags, normalizeStyle } from '@vue/shared'
 import { vShowOriginalDisplay } from '../../runtime-dom/src/directives/vShow'
 
 declare var __VUE_HMR_RUNTIME__: HMRRuntime
 const { createRecord, reload } = __VUE_HMR_RUNTIME__
+
+registerRuntimeCompiler(compileToFunction)
+
+function compileToFunction(template: string, options?: CompilerOptions) {
+  const { code } = compile(
+    template,
+    Object.assign({ hoistStatic: true }, options),
+  )
+  const render = new Function('Vue', code)(runtimeDom) as InternalRenderFunction
+  render._rc = true
+  return render
+}
 
 function mountWithHydration(html: string, render: () => any) {
   const container = document.createElement('div')

--- a/packages/server-renderer/package.json
+++ b/packages/server-renderer/package.json
@@ -45,11 +45,9 @@
     "url": "https://github.com/vuejs/core/issues"
   },
   "homepage": "https://github.com/vuejs/core/tree/main/packages/server-renderer#readme",
-  "peerDependencies": {
-    "vue": "workspace:*"
-  },
   "dependencies": {
     "@vue/shared": "workspace:*",
-    "@vue/compiler-ssr": "workspace:*"
+    "@vue/compiler-ssr": "workspace:*",
+    "@vue/runtime-dom": "workspace:*"
   }
 }

--- a/packages/server-renderer/src/helpers/ssrCompile.ts
+++ b/packages/server-renderer/src/helpers/ssrCompile.ts
@@ -2,13 +2,13 @@ import {
   type ComponentInternalInstance,
   type ComponentOptions,
   warn,
-} from 'vue'
+} from '@vue/runtime-dom'
 import { compile } from '@vue/compiler-ssr'
 import { NO, extend, generateCodeFrame, isFunction } from '@vue/shared'
 import type { CompilerError, CompilerOptions } from '@vue/compiler-core'
 import type { PushFn } from '../render'
 
-import * as Vue from 'vue'
+import * as Vue from '@vue/runtime-dom'
 import * as helpers from '../internal'
 
 type SSRRenderFunction = (

--- a/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
+++ b/packages/server-renderer/src/helpers/ssrGetDirectiveProps.ts
@@ -1,4 +1,8 @@
-import { type ComponentPublicInstance, type Directive, ssrUtils } from 'vue'
+import {
+  type ComponentPublicInstance,
+  type Directive,
+  ssrUtils,
+} from '@vue/runtime-dom'
 
 export function ssrGetDirectiveProps(
   instance: ComponentPublicInstance,

--- a/packages/server-renderer/src/helpers/ssrRenderComponent.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderComponent.ts
@@ -3,7 +3,7 @@ import {
   type ComponentInternalInstance,
   type Slots,
   createVNode,
-} from 'vue'
+} from '@vue/runtime-dom'
 import { type Props, type SSRBuffer, renderComponentVNode } from '../render'
 import type { SSRSlots } from './ssrRenderSlot'
 

--- a/packages/server-renderer/src/helpers/ssrRenderList.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderList.ts
@@ -1,5 +1,5 @@
 import { isArray, isObject, isString } from '@vue/shared'
-import { warn } from '@vue/runtime-core'
+import { warn } from '@vue/runtime-dom'
 
 export function ssrRenderList(
   source: unknown,

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -1,4 +1,8 @@
-import { type ComponentInternalInstance, type Slots, ssrUtils } from 'vue'
+import {
+  type ComponentInternalInstance,
+  type Slots,
+  ssrUtils,
+} from '@vue/runtime-dom'
 import {
   type Props,
   type PushFn,

--- a/packages/server-renderer/src/helpers/ssrRenderTeleport.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderTeleport.ts
@@ -1,4 +1,4 @@
-import { type ComponentInternalInstance, ssrContextKey } from 'vue'
+import { type ComponentInternalInstance, ssrContextKey } from '@vue/runtime-dom'
 import { isArray, isPromise } from '@vue/shared'
 import {
   type PushFn,

--- a/packages/server-renderer/src/index.ts
+++ b/packages/server-renderer/src/index.ts
@@ -1,4 +1,4 @@
-import { initDirectivesForSSR } from 'vue'
+import { initDirectivesForSSR } from '@vue/runtime-dom'
 initDirectivesForSSR()
 
 // public

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -13,7 +13,7 @@ import {
   mergeProps,
   ssrUtils,
   warn,
-} from 'vue'
+} from '@vue/runtime-dom'
 import {
   NOOP,
   ShapeFlags,

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -5,7 +5,7 @@ import {
   createVNode,
   ssrContextKey,
   ssrUtils,
-} from 'vue'
+} from '@vue/runtime-dom'
 import { isPromise, isString } from '@vue/shared'
 import { type SSRBuffer, type SSRContext, renderComponentVNode } from './render'
 import type { Readable, Writable } from 'node:stream'

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -5,7 +5,7 @@ import {
   createVNode,
   ssrContextKey,
   ssrUtils,
-} from 'vue'
+} from '@vue/runtime-dom'
 import { isPromise, isString } from '@vue/shared'
 import { type SSRBuffer, type SSRContext, renderComponentVNode } from './render'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,12 +406,12 @@ importers:
       '@vue/compiler-ssr':
         specifier: workspace:*
         version: link:../compiler-ssr
+      '@vue/runtime-dom':
+        specifier: workspace:*
+        version: link:../runtime-dom
       '@vue/shared':
         specifier: workspace:*
         version: link:../shared
-      vue:
-        specifier: workspace:*
-        version: link:../vue
 
   packages/shared: {}
 


### PR DESCRIPTION
There was a cyclic dependency in the project:

```
vue -> @vue/server-renderer -> vue (peer)
```

You can find this warning in every CI job during `pnpm install`:
```
[WARN] There are cyclic workspace dependencies: /home/runner/work/core/core/packages/server-renderer, /home/runner/work/core/core/packages/vue
```

But actually everything `@vue/server-renderer` needs from `vue` can be imported from `@vue/runtime-dom` instead. So this PR rewrites these imports and resolves the cyclic dependency problem.

Also edited `hydration.spec.ts` because the tests there implicitly relied on the registered runtime compiler in the `vue` package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering compatibility by consistently using the runtime DOM package across SSR rendering paths and helpers.
  * Updated renderer dependency declarations to align with the runtime modules used during SSR, improving resolution consistency.
* **Tests**
  * Enhanced SSR hydration test setup to register the runtime compiler so hydration scenarios reflect real compilation behavior more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->