### PR TITLE
fix(compiler-core): treat empty custom directive value as no expression

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -745,6 +745,75 @@ describe('compiler: element transform', () => {
     })
   })
 
+  // #6283
+  test('empty directive value is treated as no expression', () => {
+    // empty value with an arg -> `void 0` placeholder keeps the arg's position
+    expect(
+      parseWithElementTransform(`<div v-foo:bar="" />`).node,
+    ).toMatchObject({
+      directives: {
+        type: NodeTypes.JS_ARRAY_EXPRESSION,
+        elements: [
+          {
+            type: NodeTypes.JS_ARRAY_EXPRESSION,
+            elements: [
+              `_directive_foo`,
+              `void 0`,
+              {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: `bar`,
+                isStatic: true,
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    // a whitespace-only value is also treated as empty
+    expect(
+      parseWithElementTransform(`<div v-foo:bar="  " />`).node,
+    ).toMatchObject({
+      directives: {
+        elements: [
+          {
+            elements: [
+              `_directive_foo`,
+              `void 0`,
+              { type: NodeTypes.SIMPLE_EXPRESSION, content: `bar` },
+            ],
+          },
+        ],
+      },
+    })
+
+    // empty value with modifiers but no arg -> two `void 0` placeholders
+    expect(
+      parseWithElementTransform(`<div v-foo.mod="" />`).node,
+    ).toMatchObject({
+      directives: {
+        elements: [
+          {
+            elements: [
+              `_directive_foo`,
+              `void 0`,
+              `void 0`,
+              {
+                type: NodeTypes.JS_OBJECT_EXPRESSION,
+                properties: [
+                  {
+                    key: { content: `mod`, isStatic: true },
+                    value: { content: `true` },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   test(`props merging: event handlers`, () => {
     const { node } = parseWithElementTransform(
       `<div @click.foo="a" @click.bar="b" />`,

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -896,16 +896,25 @@ export function buildDirectiveArgs(
     }
   }
   const { loc } = dir
-  if (dir.exp) dirArgs.push(dir.exp)
+  // An empty directive value (e.g. `v-my-dir=""`) parses to an empty expression.
+  // Treat it as absent so it is not emitted as an argument, which would otherwise
+  // produce invalid code in the SSR output (a hole in a function call argument list).
+  const exp =
+    dir.exp &&
+    (dir.exp.type !== NodeTypes.SIMPLE_EXPRESSION ||
+      dir.exp.content.trim() !== '')
+      ? dir.exp
+      : undefined
+  if (exp) dirArgs.push(exp)
   if (dir.arg) {
-    if (!dir.exp) {
+    if (!exp) {
       dirArgs.push(`void 0`)
     }
     dirArgs.push(dir.arg)
   }
   if (Object.keys(dir.modifiers).length) {
     if (!dir.arg) {
-      if (!dir.exp) {
+      if (!exp) {
         dirArgs.push(`void 0`)
       }
       dirArgs.push(`void 0`)

--- a/packages/compiler-ssr/__tests__/ssrElement.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrElement.spec.ts
@@ -312,6 +312,18 @@ describe('ssr: element', () => {
       `)
     })
 
+    // #6283 an empty directive value must not emit an empty argument, which
+    // would generate a syntax error in the SSR output
+    test('custom dir with empty value', () => {
+      expect(getCompiledString(`<div v-xxx:x="" />`)).toMatchInlineSnapshot(`
+        "\`<div\${
+            _ssrRenderAttrs(_temp0 = _ssrGetDirectiveProps(_ctx, _directive_xxx, void 0, "x"))
+          }>\${
+            ("textContent" in _temp0) ? _ssrInterpolate(_temp0.textContent) : _temp0.innerHTML ?? ''
+          }</div>\`"
+      `)
+    })
+
     test('custom dir with normal attrs', () => {
       expect(getCompiledString(`<div class="foo" v-xxx />`))
         .toMatchInlineSnapshot(`


### PR DESCRIPTION
### Description

Fixes #6283.

An empty custom directive value (e.g. `<span v-my-dir:foo="">`) parses to an empty `SimpleExpression` (`content === ''`), which is truthy. `buildDirectiveArgs` therefore treated it as a real expression and pushed it as a directive argument.

On the SSR codegen path this produced a **hole in a function call argument list**, which is a syntax error:

```js
_ssrGetDirectiveProps(_ctx, _directive_custom_directive, , "foo")
//                                                       ^ SyntaxError
```

(On the client path the same case landed in an array — `[_dir, , "foo"]` — where a hole is legal but sparse, so it never surfaced. This matches @LinusBorg's note on the issue that "the SSR ones need a fix".)

### Fix

In `buildDirectiveArgs`, normalize an empty (whitespace-only) expression to `undefined` so the existing `void 0` placeholder machinery is used, exactly as for a valueless directive:

```js
_ssrGetDirectiveProps(_ctx, _directive_custom_directive, void 0, "foo") // valid
```

The runtime behavior is unchanged: `withDirectives` reads the argument by destructuring, so both a hole and `void 0` yield `binding.value === undefined`. The change also tidies the client-side sparse array into an explicit `void 0`.

### Tests

- `compiler-ssr`: `<div v-xxx:x="" />` now compiles to valid `void 0` output (would previously emit the invalid hole).
- `compiler-core`: empty value with an arg, a whitespace-only value, and an empty value with modifiers but no arg all fall back to the `void 0` placeholder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directive compilation so empty or whitespace-only values no longer produce invalid argument positions.
  * Improved handling of directives with modifiers and no value to preserve expected argument order.
  * Updated server-side rendering output to avoid emitting empty directive arguments for custom directives.
* **Tests**
  * Added coverage for directive transform and SSR behavior to verify the corrected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->