### PR TITLE
fix(runtime-core): avoid duplicate useTemplateRef prod crash (fix #12754)

### DIFF
--- a/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts
@@ -85,6 +85,31 @@ describe('useTemplateRef', () => {
     expect(`useTemplateRef('foo') already exists.`).toHaveBeenWarned()
   })
 
+  // #12754
+  test('should not throw on duplicate useTemplateRef (compiled in prod mode)', () => {
+    __DEV__ = false
+    try {
+      let foo: ShallowRef
+      let duplicate: ShallowRef
+      const Comp = {
+        setup() {
+          foo = useTemplateRef('foo')
+          duplicate = useTemplateRef('foo')
+        },
+        render() {
+          return h('div', { ref: 'foo' })
+        },
+      }
+      const root = nodeOps.createElement('div')
+
+      expect(() => render(h(Comp), root)).not.toThrow()
+      expect(foo!.value).toBe(root.children[0])
+      expect(duplicate!.value).toBe(null)
+    } finally {
+      __DEV__ = true
+    }
+  })
+
   // #11795
   test('should not attempt to set when variable name is same as key', () => {
     let tRef: ShallowRef

--- a/packages/runtime-core/src/helpers/useTemplateRef.ts
+++ b/packages/runtime-core/src/helpers/useTemplateRef.ts
@@ -14,8 +14,10 @@ export function useTemplateRef<T = unknown, Keys extends string = string>(
   const r = shallowRef(null)
   if (i) {
     const refs = i.refs === EMPTY_OBJ ? (i.refs = {}) : i.refs
-    if (__DEV__ && isTemplateRefKey(refs, key)) {
-      warn(`useTemplateRef('${key}') already exists.`)
+    if (isTemplateRefKey(refs, key)) {
+      if (__DEV__) {
+        warn(`useTemplateRef('${key}') already exists.`)
+      }
     } else {
       Object.defineProperty(refs, key, {
         enumerable: true,


### PR DESCRIPTION
﻿## What changed

- Run the duplicate `useTemplateRef()` key check in production as well as development.
- Keep the existing development warning for duplicate template ref keys.
- Add a production-mode regression test for calling `useTemplateRef()` twice with the same key.

## Why

- Fixes #12754.
- In development, duplicate `useTemplateRef('foo')` calls are detected and the second `Object.defineProperty()` is skipped.
- In production, that check was compiled away, so the second call tried to redefine the non-configurable `refs.foo` property and aborted setup with `Cannot redefine property`.

## How tested

- `pnpm vitest packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts --run --testNamePattern "duplicate useTemplateRef"`
- `pnpm vitest packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts --run`
- `pnpm vitest packages/runtime-core/__tests__ --run`
- `pnpm check`
- `pnpm lint`
- `pnpm prettier --check packages/runtime-core/src/helpers/useTemplateRef.ts packages/runtime-core/__tests__/helpers/useTemplateRef.spec.ts --parser typescript`
- `git diff --check`

## Risk and rollout

- Risk: Low. This keeps the existing dev behavior and only prevents production from attempting the duplicate property definition.
- Rollback: Revert this commit.

## Notes for reviewers

- I checked open and closed PRs for `#12754`, duplicate `useTemplateRef`, and `Cannot redefine property` before opening this; I did not find an existing PR covering it.
- The second returned ref remains disconnected, matching the current dev behavior; this PR only removes the dev/prod crash difference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate template references from overwriting existing references in production builds.
  * Duplicate template-reference declarations now remain safely ignored, while development builds continue to provide a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->