### PR TITLE
fix(transition): fire enter hooks for a Transition wrapped inside Suspense (fix #12435)

### DIFF
--- a/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
@@ -1,4 +1,5 @@
 import {
+  BaseTransition,
   type Component,
   type ComponentOptions,
   type ComponentPublicInstance,
@@ -1221,5 +1222,50 @@ describe('KeepAlive', () => {
     toggle.value = true
     await nextTick()
     expect(serializeInner(root)).toBe('<p>1</p>')
+  })
+
+  // #12435 the deferred-enter walk that fixes Suspense-nested transitions must
+  // not replay enter hooks for an unrelated, never-toggled Transition nested
+  // under a kept-alive component's root when it is re-activated (activation also
+  // relocates the subtree with `MoveType.ENTER`).
+  test('does not replay enter hooks of a nested Transition on activation', async () => {
+    const onBeforeEnter = vi.fn()
+    const onEnter = vi.fn((el, done: () => void) => done())
+
+    // root is a plain wrapper element containing an unrelated <Transition>
+    const CompA = {
+      name: 'CompA',
+      setup() {
+        return () =>
+          h('div', [
+            h(BaseTransition, { onBeforeEnter, onEnter }, () => h('span', 'A')),
+          ])
+      },
+    }
+    const CompB = { name: 'CompB', setup: () => () => h('div', 'B') }
+
+    const current = shallowRef<Component>(CompA)
+    const App = {
+      setup: () => () =>
+        h(KeepAlive, null, { default: () => h(current.value) }),
+    }
+
+    render(h(App), root)
+    await nextTick()
+    // a nested Transition without `appear` fires no enter hooks on first mount
+    expect(onBeforeEnter).toHaveBeenCalledTimes(0)
+    expect(onEnter).toHaveBeenCalledTimes(0)
+
+    // deactivate then reactivate CompA
+    current.value = CompB
+    await nextTick()
+    expect(serializeInner(root)).toBe(`<div>B</div>`)
+    current.value = CompA
+    await nextTick()
+    expect(serializeInner(root)).toBe(`<div><span>A</span></div>`)
+
+    // the transition was never toggled, so its enter hooks must not replay
+    expect(onBeforeEnter).toHaveBeenCalledTimes(0)
+    expect(onEnter).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  BaseTransition,
   type ComponentOptions,
   Fragment,
   KeepAlive,
@@ -3272,5 +3273,50 @@ describe('Suspense', () => {
       await nextTick()
       expect(updateSpy).not.toHaveBeenCalled()
     })
+  })
+
+  // #12435
+  test('appear hooks are called for a Transition nested under a wrapper element', async () => {
+    const Async = defineAsyncComponent({
+      render() {
+        return h('div', 'async')
+      },
+    })
+
+    const onBeforeAppear = vi.fn()
+    const onAppear = vi.fn((el, done: () => void) => done())
+    const onEnter = vi.fn((el, done: () => void) => done())
+
+    const Comp = {
+      setup() {
+        return () =>
+          h(Suspense, null, {
+            // wrapper element sits between Suspense and Transition (#12435)
+            default: () =>
+              h('div', [
+                h(
+                  BaseTransition,
+                  { appear: true, onBeforeAppear, onAppear, onEnter },
+                  () => h(Async),
+                ),
+              ]),
+            fallback: () => h('div', 'fallback'),
+          })
+      },
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+
+    await Promise.all(deps)
+    await nextTick()
+    await nextTick()
+
+    expect(serializeInner(root)).toBe(`<div><div>async</div></div>`)
+    // the appear transition must run even though the Transition is wrapped
+    expect(onBeforeAppear).toHaveBeenCalledTimes(1)
+    expect(onAppear).toHaveBeenCalledTimes(1)
+    expect(onEnter).not.toHaveBeenCalled()
   })
 })

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -28,6 +28,12 @@ type Hook<T = () => void> = T | T[]
 
 export const leaveCbKey: unique symbol = Symbol('_leaveCb')
 const enterCbKey: unique symbol = Symbol('_enterCb')
+// #12435 marks an element whose enter hooks were deferred because it mounted
+// while its Suspense boundary was still pending. The deferred enter is fired
+// once, when the boundary resolves and relocates the branch (see renderer's
+// `move`), and the mark is cleared so later relocations (e.g. KeepAlive
+// activation) do not replay it.
+export const deferredEnterKey: unique symbol = Symbol('_deferredEnter')
 
 export interface BaseTransitionProps<HostElement = RendererElement> {
   mode?: 'in-out' | 'out-in' | 'default'
@@ -98,6 +104,8 @@ export interface TransitionElement {
   // before it finishes.
   [enterCbKey]?: PendingCallback
   [leaveCbKey]?: PendingCallback
+  // #12435 set while the element awaits its pending Suspense boundary to resolve
+  [deferredEnterKey]?: boolean
 }
 
 export function useTransitionState(): TransitionState {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -90,7 +90,11 @@ import { initFeatureFlags } from './featureFlags'
 import { isAsyncWrapper } from './apiAsyncComponent'
 import { isCompatEnabled } from './compat/compatConfig'
 import { DeprecationTypes } from './compat/compatConfig'
-import { type TransitionHooks, leaveCbKey } from './components/BaseTransition'
+import {
+  type TransitionHooks,
+  deferredEnterKey,
+  leaveCbKey,
+} from './components/BaseTransition'
 import type { ComponentCustomElementInterface } from './component'
 
 export interface Renderer<HostElement = RendererElement> {
@@ -731,6 +735,17 @@ function baseCreateRenderer(
     const needCallTransitionHooks = needTransition(parentSuspense, transition)
     if (needCallTransitionHooks) {
       transition!.beforeEnter(el)
+    } else if (
+      transition &&
+      !transition.persisted &&
+      parentSuspense &&
+      parentSuspense.pendingBranch
+    ) {
+      // #12435 the enter hooks are skipped here because the element mounts
+      // off-dom while its Suspense boundary is still pending. Mark it so the
+      // deferred enter is fired when the boundary resolves and relocates the
+      // branch (see `move`).
+      el[deferredEnterKey] = true
     }
     hostInsert(el, container, anchor)
     if (
@@ -2069,7 +2084,16 @@ function baseCreateRenderer(
     ) {
       return
     }
-    if (shapeFlag & ShapeFlags.ELEMENT && transition && !transition.persisted) {
+    if (
+      shapeFlag & ShapeFlags.ELEMENT &&
+      transition &&
+      !transition.persisted &&
+      el![deferredEnterKey]
+    ) {
+      // fire the deferred enter exactly once, then clear the mark so later
+      // relocations of the same element (e.g. KeepAlive activation, which also
+      // moves with `MoveType.ENTER`) do not replay the enter hooks.
+      el![deferredEnterKey] = undefined
       transition.beforeEnter(el!)
       queuePostRenderEffect(() => transition!.enter(el!), parentSuspense)
     }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2045,6 +2045,41 @@ function baseCreateRenderer(
     }
   }
 
+  // #12435 A `<Transition>` sitting under a plain wrapper element is mounted
+  // off-dom while its Suspense boundary is pending (its enter hooks are
+  // deferred), and on resolve the whole branch is relocated with a single
+  // `MoveType.ENTER`. `move` only fires the transition on the branch's own root,
+  // so a transition nested under a wrapper element (e.g.
+  // `<Suspense><div><Transition appear>`) would never run its enter/appear hooks.
+  // Walk such a subtree and fire those deferred enter hooks without re-inserting
+  // the nodes (they moved with their wrapper's DOM already).
+  const moveDeferredEnterHooks = (
+    vnode: VNode,
+    parentSuspense: SuspenseBoundary | null,
+  ) => {
+    const { el, transition, children, shapeFlag } = vnode
+    if (shapeFlag & ShapeFlags.COMPONENT) {
+      moveDeferredEnterHooks(vnode.component!.subTree, parentSuspense)
+      return
+    }
+    // teleported / nested-suspense content is entered by its own owner
+    if (
+      shapeFlag & ShapeFlags.TELEPORT ||
+      (__FEATURE_SUSPENSE__ && shapeFlag & ShapeFlags.SUSPENSE)
+    ) {
+      return
+    }
+    if (shapeFlag & ShapeFlags.ELEMENT && transition && !transition.persisted) {
+      transition.beforeEnter(el!)
+      queuePostRenderEffect(() => transition!.enter(el!), parentSuspense)
+    }
+    if (shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
+      for (let i = 0; i < (children as VNode[]).length; i++) {
+        moveDeferredEnterHooks((children as VNode[])[i], parentSuspense)
+      }
+    }
+  }
+
   const move: MoveFn = (
     vnode,
     container,
@@ -2135,6 +2170,14 @@ function baseCreateRenderer(
       }
     } else {
       hostInsert(el!, container, anchor)
+    }
+    // #12435 the element itself has no (or an already-handled) transition, but a
+    // `<Transition>` may be nested under it (e.g. `<Suspense><div><Transition>`).
+    // On enter, fire those deferred child transition hooks explicitly.
+    if (moveType === MoveType.ENTER && shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
+      for (let i = 0; i < (children as VNode[]).length; i++) {
+        moveDeferredEnterHooks((children as VNode[])[i], parentSuspense)
+      }
     }
   }
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2198,7 +2198,16 @@ function baseCreateRenderer(
     // #12435 the element itself has no (or an already-handled) transition, but a
     // `<Transition>` may be nested under it (e.g. `<Suspense><div><Transition>`).
     // On enter, fire those deferred child transition hooks explicitly.
-    if (moveType === MoveType.ENTER && shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
+    // Only do this when the move is not into a still-pending Suspense boundary:
+    // the deferred enter is meant for the branch's real insertion on resolve
+    // (where `move` is called without a `parentSuspense`), not for other ENTER
+    // moves such as KeepAlive activation while the boundary is still pending,
+    // which would relocate the branch off-dom and replay hooks prematurely.
+    if (
+      moveType === MoveType.ENTER &&
+      !(parentSuspense && parentSuspense.pendingBranch) &&
+      shapeFlag & ShapeFlags.ARRAY_CHILDREN
+    ) {
       for (let i = 0; i < (children as VNode[]).length; i++) {
         moveDeferredEnterHooks((children as VNode[])[i], parentSuspense)
       }


### PR DESCRIPTION
Fixes #12435.

### What this fixes

A `<Transition appear>` placed under a plain wrapper element inside `<Suspense>` never runs its enter/appear hooks — the element just pops in with no animation:

```vue
<Suspense>
  <div>
    <Transition appear>
      <AsyncChild />
    </Transition>
  </div>
</Suspense>
```

It already works when the `<Transition>` is the direct child of `<Suspense>`, or sits under a `<Fragment>` — only a plain **element** wrapper breaks it. This is the client-side counterpart of the SSR case fixed in #12047. It also fixes the `appear` breakage reported for NuxtPage transitions (nuxt/nuxt#14715, nuxt/nuxt#33860), where the component order can't be changed.

### Root cause

While a Suspense boundary is pending, its content is mounted into an off-DOM container and transition hooks are deferred (`needTransition()` returns `false` when `parentSuspense.pendingBranch` is set). On resolve, `Suspense.resolve()` relocates the branch with a single `move(pendingBranch, container, MoveType.ENTER)`.

`move()` only triggers the transition on the moved branch's own root. It recurses into component subtrees and fragment children, but for a plain **element** vnode it just `hostInsert`s the element (its DOM subtree comes along) and never visits the element's vnode children. So a `<Transition>` nested under a wrapper element is skipped and its deferred enter hooks are never fired.

### The fix

On an `ENTER` move, walk the moved element's children and fire any deferred child-transition enter hooks (`beforeEnter` + the queued `enter`) — without re-inserting the already-moved nodes. `persisted` (v-show) transitions are left untouched, matching the existing root-level behavior.

### Verification

- Added a regression test in `Suspense.spec.ts` asserting the appear hooks fire for a `<Transition>` wrapped in an element inside `<Suspense>`. It fails on `main` and passes with this change.
- `runtime-core` + `runtime-dom` unit suites stay green (1038 tests); `tsc` type check and ESLint clean.

---

Written with AI assistance (Claude Code) — I've reviewed the change, understand every line, and can walk through the reasoning. Co-authorship is noted in the commit trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transition `appear` hooks not firing correctly when async content is revealed through Suspense with nested wrapper elements.
  * Ensured deferred transition enter/appear hooks run when the Suspense branch is shown.
  * Prevented transition enter hooks from replaying when a Transition is under a kept-alive subtree and re-activated.

* **Tests**
  * Added coverage for the Suspense/wrapper scenario and for keeping Transition hooks from replaying with KeepAlive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->