### PR TITLE
fix(vapor): handle v-if and v-show on transition roots

### DIFF
--- a/packages/compiler-dom/src/transforms/Transition.ts
+++ b/packages/compiler-dom/src/transforms/Transition.ts
@@ -5,6 +5,7 @@ import {
   type IfBranchNode,
   type NodeTransform,
   NodeTypes,
+  findDir,
   isCommentOrWhitespace,
 } from '@vue/compiler-core'
 import { TRANSITION } from '../runtimeHelpers'
@@ -47,7 +48,7 @@ export function postTransformTransition(
     // check if it's a single child w/ v-show
     // if yes, inject "persisted: true" to the transition props
     const child = node.children[0]
-    if (child.type === NodeTypes.ELEMENT) {
+    if (child.type === NodeTypes.ELEMENT && !findDir(child, 'if')) {
       for (const p of child.props) {
         if (p.type === NodeTypes.DIRECTIVE && p.name === 'show') {
           node.props.push({

--- a/packages/compiler-vapor/__tests__/transforms/TransformTransition.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/TransformTransition.spec.ts
@@ -268,6 +268,16 @@ describe('compiler: transition', () => {
     ).toMatchSnapshot()
   })
 
+  test('does not inject persisted when v-if owns a v-show child', () => {
+    const { code } = compileWithElementTransform(
+      `<Transition><div v-if="show" v-show="true" /></Transition>`,
+    )
+
+    expect(code).toContain('_createIf')
+    expect(code).toContain('_applyVShow')
+    expect(code).not.toContain('persisted')
+  })
+
   test('the v-if/else-if/else branches in Transition should ignore comments', () => {
     const { code } = compile(
       `

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -317,6 +317,65 @@ describe('Transition', () => {
     expect(calls).toEqual([false, true])
   })
 
+  test('v-if should own enter and leave when its root also has v-show', async () => {
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      show: true,
+      onEnter,
+      onLeave,
+    })
+    const App = compile(
+      `<template>
+        <Transition
+          :css="false"
+          @enter="data.onEnter"
+          @leave="data.onLeave"
+        >
+          <div v-if="data.show" v-show="true">foo</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { host } = define(App as any).render()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('div')).toBeNull()
+
+    data.value.show = true
+    await nextTick()
+
+    expect(onEnter).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('div')?.textContent).toBe('foo')
+  })
+
+  test('appear should not persist a v-show root owned by v-if', async () => {
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      show: true,
+      onLeave,
+    })
+    const App = compile(
+      `<template>
+        <Transition appear :css="false" @leave="data.onLeave">
+          <div v-if="data.show" v-show="true">foo</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { host } = define(App as any).render()
+
+    await nextTick()
+    data.value.show = false
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('div')).toBeNull()
+  })
+
   test('direct slot child with initial hidden v-show should not trigger appear hooks', async () => {
     const { data, onBeforeAppear, onAppear } = createAppearTestState(false)
     const Child = compile(`<template><slot /></template>`, data)

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -615,6 +615,45 @@ describe('Transition', () => {
     leaveDone && leaveDone()
   })
 
+  test('does not carry persisted into a structural v-if root', async () => {
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      branch: true,
+      show: true,
+      visible: true,
+      onLeave,
+    })
+    const Child = compile(`<template><slot /></template>`, data)
+    const App = compile(
+      `<template>
+        <Transition appear :css="false" @leave="data.onLeave">
+          <template #default v-if="data.branch">
+            <components.Child>
+              <div v-show="data.show">foo</div>
+            </components.Child>
+          </template>
+          <template #default v-else>
+            <div v-if="data.visible" v-show="true">bar</div>
+          </template>
+        </Transition>
+      </template>`,
+      data,
+      { Child },
+    )
+    const { host } = define(App as any).render()
+    await nextTick()
+
+    data.value.branch = false
+    await nextTick()
+    expect(host.querySelector('div')?.textContent).toBe('bar')
+    onLeave.mockClear()
+
+    data.value.visible = false
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')).toBeNull()
+  })
+
   test('does not early-remove across mixed number/string keys of equal value', async () => {
     let leaveDone: (() => void) | undefined
     const data = ref<any>({

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -174,10 +174,15 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
           shouldCaptureVShow && !isMounted,
           () => frag.update(slots.default),
         )
+        let hasStructuralRoot = false
+        const root = resolveTransitionBlock(frag.nodes, fragment => {
+          hasStructuralRoot ||= isStructuralTransitionFragment(fragment)
+        })
         applyPendingVShows(
           frag.$transition!,
-          resolveTransitionBlock(frag.nodes),
+          root,
           pendingVShows,
+          hasStructuralRoot,
         )
         if (!isMounted && shouldPerformAppear) performAppear(frag.$transition!)
         isMounted = true
@@ -205,14 +210,14 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
     // re-resolve. Reusing appliedHooks preserves runtime state (persisted /
     // delayedLeave) across re-resolves.
     renderEffect(() => {
-      const { hooks, root } = applyResolvedTransitionHooks(
+      const { hooks, root, hasStructuralRoot } = applyResolvedTransitionHooks(
         children,
         appliedHooks,
       )
       appliedHooks = hooks
       if (!isMounted) {
         isMounted = true
-        applyPendingVShows(hooks, root, pendingVShows)
+        applyPendingVShows(hooks, root, pendingVShows, hasStructuralRoot)
         if (shouldPerformAppear) performAppear(hooks)
       }
     })
@@ -361,6 +366,7 @@ function applyResolvedTransitionHooks(
 ): {
   hooks: VaporTransitionHooks
   root?: ResolvedTransitionBlock
+  hasStructuralRoot: boolean
 } {
   // filter out comment nodes
   if (isArray(block)) {
@@ -368,7 +374,7 @@ function applyResolvedTransitionHooks(
     if (block.length === 1) {
       block = block[0]
     } else if (block.length === 0) {
-      return { hooks }
+      return { hooks, hasStructuralRoot: false }
     }
   }
 
@@ -382,11 +388,15 @@ function applyResolvedTransitionHooks(
       (isVaporComponent(block) && isSlotFragment(block.block)))
   ) {
     hooks.applyGroup(block, hooks.props, hooks.state, hooks.instance)
-    return { hooks }
+    return { hooks, hasStructuralRoot: false }
   }
 
   const fragments: VaporFragment[] = []
-  const child = resolveTransitionBlock(block, frag => fragments.push(frag))
+  let hasStructuralRoot = false
+  const child = resolveTransitionBlock(block, fragment => {
+    fragments.push(fragment)
+    hasStructuralRoot ||= isStructuralTransitionFragment(fragment)
+  })
   if (!child) {
     // set transition hooks on fragments for later use
     fragments.forEach(f => (f.$transition = hooks))
@@ -394,7 +404,7 @@ function applyResolvedTransitionHooks(
     if (__DEV__ && fragments.length === 0) {
       warn('Transition component has no valid child element')
     }
-    return { hooks }
+    return { hooks, hasStructuralRoot }
   }
 
   const { props, instance, state, delayedLeave } = hooks
@@ -422,7 +432,16 @@ function applyResolvedTransitionHooks(
   return {
     hooks: resolvedHooks,
     root: child,
+    hasStructuralRoot,
   }
+}
+
+function isStructuralTransitionFragment(fragment: VaporFragment): boolean {
+  return !!(
+    fragment instanceof DynamicFragment &&
+    !isSlotFragment(fragment) &&
+    fragment.inTransition
+  )
 }
 
 function applyTransitionLeaveHooksImpl(
@@ -886,6 +905,7 @@ function applyPendingVShows(
   hooks: VaporTransitionHooks,
   root: ResolvedTransitionBlock | undefined,
   pendingVShows: PendingVShow[] | undefined,
+  hasStructuralRoot: boolean,
 ): void {
   if (!pendingVShows) return
 
@@ -895,11 +915,12 @@ function applyPendingVShows(
     // deferred v-show target resolves to the same transition root.
     hooks.persisted =
       hooks.persisted ||
-      pendingVShows.some(
-        pending =>
-          pending.target === root ||
-          resolveTransitionBlock(pending.target) === root,
-      )
+      (!hasStructuralRoot &&
+        pendingVShows.some(
+          pending =>
+            pending.target === root ||
+            resolveTransitionBlock(pending.target) === root,
+        ))
   }
 
   onBeforeMount(() => {

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -418,13 +418,14 @@ function applyResolvedTransitionHooks(
   // Dynamic slot / branch swaps replace the active hook object. The previously
   // derived persisted state (slot/component-root v-show, detected only at mount
   // via applyPendingVShows) must carry forward when the new root is *also* a
-  // v-show root, but must NOT leak onto a non-v-show root — otherwise that
-  // root's structural removal would wrongly skip its leave animation. Gating
-  // the carry-forward on the current root's v-show marker keeps the latch tied
-  // to the live root; mount/non-appear paths are untouched because they never
-  // have a latched `hooks.persisted` to carry.
+  // v-show root, but must NOT leak onto a structural root — otherwise that
+  // root's removal would wrongly skip its leave animation. Gating the
+  // carry-forward on both the current root's v-show marker and its ownership
+  // keeps the latch tied to the live root; mount/non-appear paths are untouched
+  // because they never have a latched `hooks.persisted` to carry.
   resolvedHooks.persisted =
-    resolvedHooks.persisted || (hooks.persisted && hasVShowMarker(child))
+    resolvedHooks.persisted ||
+    (!hasStructuralRoot && hooks.persisted && hasVShowMarker(child))
   resolvedHooks.delayedLeave = delayedLeave
   child.$transition = resolvedHooks
   fragments.forEach(f => (f.$transition = resolvedHooks))


### PR DESCRIPTION
close #15068

Avoid marking a Transition as persisted when v-if owns the insertion and removal of a root that also uses v-show.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Transition behavior when `v-if` and `v-show` are combined, preventing persisted `v-show` state from carrying over incorrectly.
  * Ensured elements are properly removed and restored while transition enter and leave hooks run only once.
  * Corrected transition behavior across conditional branches, including transitions using `appear`.

* **Tests**
  * Added coverage for conditional rendering and visibility directives used together within transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->