### PR TITLE
fix(compiler-sfc): preserve Pug directive quote escapes (fix #15062)

### DIFF
--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -91,6 +91,33 @@ test('preprocess pug with indents and blank lines', () => {
   )
 })
 
+// #15062
+test('preprocess pug preserves escaped quotes in Vue binding expressions', () => {
+  const { descriptor } = parse(
+    String.raw`
+<script setup>
+const l = (s) => s
+</script>
+<template lang="pug">
+button(:title="l('It\'s')") x
+button(:title='l("It\"s")') y
+</template>
+`,
+    { filename: 'example.vue' },
+  )
+
+  const { content } = compileScript(descriptor, {
+    id: 'x',
+    inlineTemplate: true,
+    templateOptions: {
+      preprocessLang: 'pug',
+    },
+  })
+
+  expect(content).toContain(String.raw`title: l('It\'s')`)
+  expect(content).toContain(String.raw`title: l("It\"s")`)
+})
+
 test('warn missing preprocessor', () => {
   const template = parse(`<template lang="unknownLang">hi</template>\n`, {
     filename: 'example.vue',

--- a/packages/compiler-sfc/src/compileTemplate.ts
+++ b/packages/compiler-sfc/src/compileTemplate.ts
@@ -104,6 +104,104 @@ function preprocess(
   return res
 }
 
+// Pug parses attribute values as JavaScript strings, so redundant quote
+// escapes in Vue directive expressions are removed before Vue sees the HTML.
+// Preserve those escapes in Vue directive attrs so the resulting expression
+// remains valid JavaScript after Pug preprocessing (#15062).
+const pugVueDirectiveExpressionPlugin = {
+  postParse(ast: any) {
+    walkPugAst(ast, node => {
+      const attrs = node.attrs
+      if (Array.isArray(attrs)) {
+        for (const attr of attrs) {
+          if (isVueDirectiveAttr(attr.name) && typeof attr.val === 'string') {
+            attr.val = preservePugQuoteEscapes(attr.val)
+          }
+        }
+      }
+    })
+    return ast
+  },
+}
+
+function resolvePreprocessOptions({
+  preprocessLang,
+  preprocessOptions,
+}: SFCTemplateCompileOptions): any {
+  if (preprocessLang !== 'pug') {
+    return preprocessOptions
+  }
+
+  return {
+    ...preprocessOptions,
+    plugins: [
+      ...(preprocessOptions?.plugins || []),
+      pugVueDirectiveExpressionPlugin,
+    ],
+  }
+}
+
+function walkPugAst(node: any, cb: (node: any) => void): void {
+  if (!node || typeof node !== 'object') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach(child => walkPugAst(child, cb))
+    return
+  }
+
+  cb(node)
+  for (const key in node) {
+    walkPugAst(node[key], cb)
+  }
+}
+
+function isVueDirectiveAttr(name: unknown): boolean {
+  return (
+    typeof name === 'string' &&
+    (name.startsWith('v-') ||
+      name.startsWith(':') ||
+      name.startsWith('@') ||
+      name.startsWith('#'))
+  )
+}
+
+function preservePugQuoteEscapes(value: string): string {
+  const quote = value[0]
+  if ((quote !== `"` && quote !== `'`) || value[value.length - 1] !== quote) {
+    return value
+  }
+
+  const oppositeQuote = quote === `"` ? `'` : `"`
+  const body = value.slice(1, -1)
+  let rewritten = ''
+  let changed = false
+
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i]
+    if (char === `\\`) {
+      let slashCount = 1
+      while (body[i + slashCount] === `\\`) {
+        slashCount++
+      }
+
+      if (body[i + slashCount] === oppositeQuote && slashCount === 1) {
+        rewritten += `\\\\${oppositeQuote}`
+        i += slashCount
+        changed = true
+        continue
+      }
+
+      rewritten += `\\`.repeat(slashCount)
+      i += slashCount - 1
+    } else {
+      rewritten += char
+    }
+  }
+
+  return changed ? `${quote}${rewritten}${quote}` : value
+}
+
 export function compileTemplate(
   options: SFCTemplateCompileOptions,
 ): SFCTemplateCompileResults {
@@ -130,9 +228,11 @@ export function compileTemplate(
     : false
   if (preprocessor) {
     try {
+      const preprocessOptions = resolvePreprocessOptions(options)
       return doCompileTemplate({
         ...options,
-        source: preprocess(options, preprocessor),
+        preprocessOptions,
+        source: preprocess({ ...options, preprocessOptions }, preprocessor),
         ast: undefined, // invalidate AST if template goes through preprocessor
       })
     } catch (e: any) {


### PR DESCRIPTION
## Summary

Fixes #15062.

Pug removes quote escapes inside directive attribute values before Vue compiles the generated template. This preserves those escapes for Vue directive expressions during Pug preprocessing so inline template compilation receives valid JavaScript.

## Test

- `pnpm test-unit packages/compiler-sfc/__tests__/compileTemplate.spec.ts -t "preprocess pug preserves escaped quotes" --run`
- `pnpm test-unit packages/compiler-sfc/__tests__/compileTemplate.spec.ts --run`
- `pnpm test-unit packages/compiler-sfc --run`
- `pnpm exec eslint packages/compiler-sfc/src/compileTemplate.ts packages/compiler-sfc/__tests__/compileTemplate.spec.ts`
- `pnpm exec prettier --check packages/compiler-sfc/src/compileTemplate.ts packages/compiler-sfc/__tests__/compileTemplate.spec.ts`
- `pnpm check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pug template compilation to preserve escaped single and double quotes in Vue binding expressions.
  * Improved reliability when compiling templates with quoted directive attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->