### PR TITLE
fix(runtime-vapor): preserve v-show transition on vdom child

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -724,6 +724,60 @@ describe('vdomInterop', () => {
       expect(html()).toBe('<div style=""></div>')
     })
 
+    test('apply v-show transition to vdom child', async () => {
+      let finishLeave: (() => void) | undefined
+      const onBeforeEnter = vi.fn()
+      const onEnter = vi.fn((_el: Element, done: () => void) => done())
+      const onLeave = vi.fn((_el: Element, done: () => void) => {
+        finishLeave = done
+      })
+      const data = ref({
+        show: true,
+        onBeforeEnter,
+        onEnter,
+        onLeave,
+      })
+      const VDomChild = compile(
+        `<script setup>const text = 'Comp text'</script><template><div>{{ text }}</div></template>`,
+        data,
+        {},
+        { vapor: false },
+      )
+      const App = compile(
+        `<template>
+          <Transition
+            :css="false"
+            @before-enter="data.onBeforeEnter"
+            @enter="data.onEnter"
+            @leave="data.onLeave"
+          >
+            <components.VDomChild v-show="data.show" />
+          </Transition>
+        </template>`,
+        data,
+        { VDomChild },
+      )
+      const { host } = define(App as any).render()
+      document.body.appendChild(host)
+      const el = host.querySelector('div')!
+
+      data.value.show = false
+      await nextTick()
+
+      expect(onLeave).toHaveBeenCalledOnce()
+      expect(el.style.display).toBe('')
+
+      finishLeave!()
+      expect(el.style.display).toBe('none')
+
+      data.value.show = true
+      await nextTick()
+
+      expect(onBeforeEnter).toHaveBeenCalledOnce()
+      expect(onEnter).toHaveBeenCalledOnce()
+      expect(el.style.display).toBe('')
+    })
+
     test('apply v-show to vapor child', async () => {
       const VaporChild = defineVaporComponent({
         setup() {

--- a/packages/runtime-vapor/src/directives/vShow.ts
+++ b/packages/runtime-vapor/src/directives/vShow.ts
@@ -12,7 +12,8 @@ import { isVaporComponent } from '../component'
 import type { Block, TransitionBlock } from '../block'
 import { isArray } from '@vue/shared'
 import { isHydrating } from '../dom/hydration'
-import { isDynamicFragment, isFragment } from '../fragment'
+import { isDynamicFragment, isFragment, isInteropFragment } from '../fragment'
+import { isInteropEnabled } from '../vdomInteropState'
 
 export interface PendingVShow {
   target: Block
@@ -76,16 +77,21 @@ function setDisplay(
   target: Block,
   value: unknown,
   deferEnter = false,
+  transition: TransitionBlock['$transition'] = undefined,
 ): (() => void) | undefined {
   if (isVaporComponent(target)) {
-    return setDisplay(target.block, value, deferEnter)
+    return setDisplay(target.block, value, deferEnter, transition)
   }
   if (isArray(target)) {
     if (target.length === 0) return
-    if (target.length === 1) return setDisplay(target[0], value, deferEnter)
+    if (target.length === 1)
+      return setDisplay(target[0], value, deferEnter, transition)
   }
   if (isFragment(target)) {
-    return setDisplay(target.nodes, value, deferEnter)
+    if (isInteropEnabled && isInteropFragment(target) && target.$transition) {
+      transition = target.$transition
+    }
+    return setDisplay(target.nodes, value, deferEnter, transition)
   }
 
   if (target instanceof Element) {
@@ -95,7 +101,7 @@ function setDisplay(
         el.style.display === 'none' ? '' : el.style.display
     }
 
-    const { $transition } = target as TransitionBlock
+    const { $transition = transition } = target as TransitionBlock
     if ($transition) {
       if (value) {
         $transition.beforeEnter(target)


### PR DESCRIPTION
close #15073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `v-show` transitions when used with virtual DOM fragments.
  * Ensured element visibility and transition hooks remain consistent throughout leave and enter lifecycles.

* **Tests**
  * Added coverage verifying transition hook execution and rendered display changes for `v-show` elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->