### PR TITLE
fix(hydration): pass namespace when patching dynamic props

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -2763,6 +2763,42 @@ describe('SSR hydration', () => {
       }
     })
 
+    test('force patch foreignObject dynamic props with correct namespace when hydrating', () => {
+      __DEV__ = false
+      try {
+        const container = document.createElement('div')
+        container.innerHTML =
+          '<svg><foreignObject width="24"></foreignObject></svg>'
+        const el = container.querySelector('foreignObject')!
+        expect(el.namespaceURI).toContain('svg')
+        // jsdom doesn't implement SVGForeignObjectElement.width.
+        Object.defineProperty(el, 'width', {
+          configurable: true,
+          get: () => 24,
+        })
+
+        createSSRApp({
+          render: () => (
+            openBlock(),
+            createElementBlock('svg', null, [
+              (openBlock(),
+              createElementBlock(
+                'foreignObject',
+                { width: 48 },
+                null,
+                PatchFlags.PROPS,
+                ['width'],
+              )),
+            ])
+          ),
+        }).mount(container)
+
+        expect(el.getAttribute('width')).toBe('48')
+      } finally {
+        __DEV__ = true
+      }
+    })
+
     test('only patches declared dynamic props when hydrating', () => {
       const { container } = mountWithHydration(
         `<div data-allow-mismatch="attribute" id="server" value="server"></div>`,

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -2739,6 +2739,30 @@ describe('SSR hydration', () => {
       }
     })
 
+    test('force patch svg dynamic props with correct namespace when hydrating', () => {
+      __DEV__ = false
+      try {
+        const { container } = mountWithHydration(
+          `<svg width="24" height="24" viewBox="0 0 24 24"></svg>`,
+          () =>
+            createElementVNode(
+              'svg',
+              { width: 48, height: 48, viewBox: '0 0 48 48' },
+              null,
+              PatchFlags.PROPS,
+              ['width', 'height', 'viewBox'],
+            ),
+        )
+        const el = container.firstChild as Element
+        expect(el.namespaceURI).toContain('svg')
+        expect(el.getAttribute('width')).toBe('48')
+        expect(el.getAttribute('height')).toBe('48')
+        expect(el.getAttribute('viewBox')).toBe('0 0 48 48')
+      } finally {
+        __DEV__ = true
+      }
+    })
+
     test('only patches declared dynamic props when hydrating', () => {
       const { container } = mountWithHydration(
         `<div data-allow-mismatch="attribute" id="server" value="server"></div>`,

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -500,6 +500,10 @@ export function createHydrationFunctions(
           patchFlag & (PatchFlags.FULL_PROPS | PatchFlags.NEED_HYDRATION)
         ) {
           const isCustomElement = el.tagName.includes('-')
+          // pass the element's namespace so that e.g. readonly SVG/MathML props
+          // (width/height/viewBox) are patched as attributes rather than as
+          // DOM properties, which would throw.
+          const namespace = getContainerType(el)
           for (const key in props) {
             // check hydration mismatch
             if (
@@ -520,7 +524,7 @@ export function createHydrationFunctions(
               (isCustomElement && !isReservedProp(key)) ||
               (dynamicProps && dynamicProps.includes(key))
             ) {
-              patchProp(el, key, null, props[key], undefined, parentComponent)
+              patchProp(el, key, null, props[key], namespace, parentComponent)
             }
           }
         } else if (props.onClick) {

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -500,10 +500,11 @@ export function createHydrationFunctions(
           patchFlag & (PatchFlags.FULL_PROPS | PatchFlags.NEED_HYDRATION)
         ) {
           const isCustomElement = el.tagName.includes('-')
-          // pass the element's namespace so that e.g. readonly SVG/MathML props
-          // (width/height/viewBox) are patched as attributes rather than as
-          // DOM properties, which would throw.
-          const namespace = getContainerType(el)
+          const namespace = el.namespaceURI!.includes('svg')
+            ? 'svg'
+            : el.namespaceURI!.includes('MathML')
+              ? 'mathml'
+              : undefined
           for (const key in props) {
             // check hydration mismatch
             if (


### PR DESCRIPTION
close #15081
close #15050

During hydration, dynamic props are force-patched, but `hydrateElement` calls `patchProp(el, key, null, prop [key], undefined, parentComponent)` - the `namespace` argument is `undefined`. runtime-dom's `patchProp` derives `isSVG` from that namespace, so SVG/MathML elements are treated as HTML and read-only props (`width`, `height`, `viewBox`, …) are set as DOM properties, which throws:

> [Vue warn]: Failed setting prop "viewBox" on `<svg>`: value 0 0 24 24 is invalid.
> TypeError: Cannot set property viewBox of #`<SVGSVGElement>` which has only a getter

This forwards the element's namespace via the existing `getContainerType(el)` helper (already used for children hydration in the same file), so these props are patched via `setAttribute`, matching the normal client render path.

Regression range: 3.5.35 is unaffected (dynamic-prop force patch did not exist); 3.5.39 is broken.

### Testing

Added a regression test in `hydration.spec.ts` that hydrates an `<svg>` with dynamic `width`/`height`/`viewBox` and asserts they are applied as attributes. The full `runtime-core` test suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hydration of namespaced elements (including SVG and nested foreignObject) so dynamically declared props correctly update the server-rendered DOM attributes (e.g., dimensions and viewBox).
  * Improved hydration patching by using the host element’s namespace to apply props with the correct attribute/property behavior.

* **Tests**
  * Added hydration regression tests covering mismatch handling for the “force patch” path on SVG elements and foreignObject.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->