### PR TITLE
fix(reactivity): handle effect removal during scope stop

### DIFF
--- a/packages/reactivity/__tests__/effectScope.spec.ts
+++ b/packages/reactivity/__tests__/effectScope.spec.ts
@@ -435,4 +435,40 @@ describe('reactivity/effect/scope', () => {
     expect(rs.value.stage).toBe(1)
     expect(renderCount).toBe(5)
   })
+
+  it('should stop child scopes when cleanup stops a sibling scope', () => {
+    const parent = effectScope()
+    let sibling!: EffectScope
+
+    parent.run(() => {
+      effectScope().run(() => {
+        onScopeDispose(() => sibling.stop())
+      })
+      sibling = effectScope()
+    })
+
+    expect(() => parent.stop()).not.toThrow()
+    expect(sibling.active).toBe(false)
+  })
+
+  it('should resume effects when a watcher stops a sibling watcher', () => {
+    const count = ref(0)
+    const scope = effectScope()
+    let stopSecond = () => {}
+    const firstSpy = vi.fn(() => stopSecond())
+    const secondSpy = vi.fn()
+
+    scope.run(() => {
+      watch(count, firstSpy, { flush: 'sync' })
+      stopSecond = watch(count, secondSpy, { flush: 'sync' })
+    })
+
+    scope.pause()
+    count.value++
+
+    expect(() => scope.resume()).not.toThrow()
+    expect(firstSpy).toHaveBeenCalledTimes(1)
+    expect(secondSpy).not.toHaveBeenCalled()
+    expect(scope.effects).toHaveLength(1)
+  })
 })

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -95,8 +95,9 @@ export class EffectScope {
             scopes[i].resume()
           }
         }
-        for (i = 0, l = this.effects.length; i < l; i++) {
-          this.effects[i].resume()
+        const effects = this.effects.slice()
+        for (i = 0, l = effects.length; i < l; i++) {
+          effects[i].resume()
         }
       }
     }

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -70,8 +70,9 @@ export class EffectScope {
       this._isPaused = true
       let i, l
       if (this.scopes) {
-        for (i = 0, l = this.scopes.length; i < l; i++) {
-          this.scopes[i].pause()
+        const scopes = this.scopes.slice()
+        for (i = 0, l = scopes.length; i < l; i++) {
+          scopes[i].pause()
         }
       }
       for (i = 0, l = this.effects.length; i < l; i++) {
@@ -89,8 +90,9 @@ export class EffectScope {
         this._isPaused = false
         let i, l
         if (this.scopes) {
-          for (i = 0, l = this.scopes.length; i < l; i++) {
-            this.scopes[i].resume()
+          const scopes = this.scopes.slice()
+          for (i = 0, l = scopes.length; i < l; i++) {
+            scopes[i].resume()
           }
         }
         for (i = 0, l = this.effects.length; i < l; i++) {
@@ -171,8 +173,9 @@ export class EffectScope {
       this.cleanups.length = 0
 
       if (this.scopes) {
-        for (i = 0, l = this.scopes.length; i < l; i++) {
-          this.scopes[i].stop(true)
+        const scopes = this.scopes.slice()
+        for (i = 0, l = scopes.length; i < l; i++) {
+          scopes[i].stop(true)
         }
         this.scopes.length = 0
       }


### PR DESCRIPTION
### Description
This PR fixes a runtime crash in EffectScope (TypeError: Cannot read properties of undefined).

### Cause
When a parent scope stops, pauses, or resumes, it iterates over this.scopes using a cached length. If a child's cleanup callback (onScopeDispose) stops a sibling scope, the sibling removes itself from parent.scopes dynamically. This shrinks the array, causing the parent loop to access an out-of-bounds index (undefined) and crash.

### Fix
We now create a shallow copy of this.scopes using .slice() before iterating in pause(), resume(), and stop() methods. This ensures that any dynamic array mutations during traversal do not break the loop.

fixes  #15083 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `EffectScope` lifecycle handling so pausing, resuming, and stopping remain reliable even if child scopes or watchers are added/removed during the process.
  * Added test coverage for scenarios involving sibling scope/watcher cleanup while scopes are paused or being resumed, preventing errors and ensuring correct inactive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->