### PR TITLE
fix(hydration): preserve namespace when patching dynamic props

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -2760,5 +2760,30 @@ describe('SSR hydration', () => {
       expect(el.getAttribute('id')).toBe('client')
       expect(el.getAttribute('value')).toBe('server')
     })
+
+    // #15081
+    test('patches dynamic props as attributes on SVG elements', () => {
+      const { container } = mountWithHydration(
+        `<svg data-allow-mismatch="attribute" viewBox="0 0 12 12"></svg>`,
+        () => (
+          openBlock(),
+          createElementBlock(
+            'svg',
+            {
+              'data-allow-mismatch': 'attribute',
+              viewBox: '0 0 24 24',
+            },
+            null,
+            PatchFlags.PROPS,
+            ['viewBox'],
+          )
+        ),
+      )
+
+      expect(container.firstElementChild!.getAttribute('viewBox')).toBe(
+        '0 0 24 24',
+      )
+      expect(`Failed setting prop "viewBox"`).not.toHaveBeenWarned()
+    })
   })
 })

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -491,6 +491,11 @@ export function createHydrationFunctions(
 
       // props
       if (props) {
+        const namespace = el.namespaceURI!.includes('svg')
+          ? 'svg'
+          : el.namespaceURI!.includes('MathML')
+            ? 'mathml'
+            : undefined
         if (
           __DEV__ ||
           __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__ ||
@@ -520,7 +525,7 @@ export function createHydrationFunctions(
               (isCustomElement && !isReservedProp(key)) ||
               (dynamicProps && dynamicProps.includes(key))
             ) {
-              patchProp(el, key, null, props[key], undefined, parentComponent)
+              patchProp(el, key, null, props[key], namespace, parentComponent)
             }
           }
         } else if (props.onClick) {
@@ -531,7 +536,7 @@ export function createHydrationFunctions(
             'onClick',
             null,
             props.onClick,
-            undefined,
+            namespace,
             parentComponent,
           )
         } else if (patchFlag & PatchFlags.STYLE && isReactive(props.style)) {


### PR DESCRIPTION
close #15081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered hydration for SVG elements.
  * Ensured SVG properties such as `viewBox` are correctly applied as attributes during hydration.
  * Prevented unnecessary hydration warnings for valid SVG attribute mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->