### PR TITLE
fix(runtime-core): skip lazy hydration for detached roots

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1193,7 +1193,7 @@ describe('SSR hydration', () => {
   })
 
   // #15091
-  test('skip lazy hydration when the SSR root is detached', async () => {
+  async function assertSkipLazyHydration(detached: 'root' | 'ancestor') {
     let observer!: IntersectionObserver
     let observerCallback!: IntersectionObserverCallback
     const originalIntersectionObserver = globalThis.IntersectionObserver
@@ -1216,11 +1216,17 @@ describe('SSR hydration', () => {
       const container = document.createElement('div')
 
       container.innerHTML = await renderToString(h(App))
+      document.body.appendChild(container)
       Comp.mockClear()
       createSSRApp(App).mount(container)
 
       const el = container.firstElementChild!
-      el.remove()
+      if (detached === 'root') {
+        el.remove()
+      } else {
+        container.remove()
+      }
+      expect(el.isConnected).toBe(false)
 
       expect(() =>
         observerCallback(
@@ -1232,7 +1238,12 @@ describe('SSR hydration', () => {
     } finally {
       globalThis.IntersectionObserver = originalIntersectionObserver
     }
-  })
+  }
+
+  test.each(['root', 'ancestor'] as const)(
+    'skip lazy hydration when the SSR %s is detached',
+    assertSkipLazyHydration,
+  )
 
   test('update async wrapper before resolve', async () => {
     const Comp = {

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -19,6 +19,7 @@ import {
   defineAsyncComponent,
   defineComponent,
   h,
+  hydrateOnVisible,
   nextTick,
   onMounted,
   onServerPrefetch,
@@ -1189,6 +1190,48 @@ describe('SSR hydration', () => {
     // should be hydrated now
     triggerEvent('click', container.querySelector('button')!)
     expect(spy).toHaveBeenCalled()
+  })
+
+  // #15091
+  test('skip lazy hydration when the SSR root is detached', async () => {
+    let observer!: IntersectionObserver
+    let observerCallback!: IntersectionObserverCallback
+    const originalIntersectionObserver = globalThis.IntersectionObserver
+    globalThis.IntersectionObserver = class {
+      constructor(callback: IntersectionObserverCallback) {
+        observer = this as any
+        observerCallback = callback
+      }
+      disconnect() {}
+      observe() {}
+    } as any
+
+    try {
+      const Comp = vi.fn(() => h('p', 'hello'))
+      const AsyncComp = defineAsyncComponent({
+        loader: () => Promise.resolve(Comp),
+        hydrate: hydrateOnVisible(),
+      })
+      const App = () => h(AsyncComp)
+      const container = document.createElement('div')
+
+      container.innerHTML = await renderToString(h(App))
+      Comp.mockClear()
+      createSSRApp(App).mount(container)
+
+      const el = container.firstElementChild!
+      el.remove()
+
+      expect(() =>
+        observerCallback(
+          [{ isIntersecting: true, target: el } as IntersectionObserverEntry],
+          observer,
+        ),
+      ).not.toThrow()
+      expect(Comp).not.toHaveBeenCalled()
+    } finally {
+      globalThis.IntersectionObserver = originalIntersectionObserver
+    }
   })
 
   test('update async wrapper before resolve', async () => {

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -136,6 +136,7 @@ export function defineAsyncComponent<
           }
           return
         }
+        if (!el.parentNode) return
         hydrate()
       }
       const doHydrate = hydrateStrategy

--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -123,6 +123,7 @@ export function defineAsyncComponent<
     __asyncLoader: load,
 
     __asyncHydrate(el, instance, hydrate) {
+      const wasConnected = el.isConnected
       let patched = false
       ;(instance.bu || (instance.bu = [])).push(() => (patched = true))
       const performHydrate = () => {
@@ -136,7 +137,7 @@ export function defineAsyncComponent<
           }
           return
         }
-        if (!el.parentNode) return
+        if (!el.parentNode || (wasConnected && !el.isConnected)) return
         hydrate()
       }
       const doHydrate = hydrateStrategy


### PR DESCRIPTION
close #15091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lazy hydration reliability by skipping hydration when the target element is not connected (e.g., removed before hydration starts).
  * Prevented unnecessary async component loading and avoided errors for detached SSR content.

* **Tests**
  * Added an SSR regression coverage for lazy hydration when visibility observers fire after detaching either the root or an ancestor container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->