### PR TITLE
Revert "fix(runtime-core): pause tracking when invoking function refs"

### DIFF
--- a/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
+++ b/packages/runtime-core/__tests__/rendererTemplateRef.spec.ts
@@ -111,26 +111,6 @@ describe('api: template refs', () => {
     expect(fn2.mock.calls[0][0]).toBe(root.children[0])
   })
 
-  it('function ref should not track dependencies read by callback', async () => {
-    const root = nodeOps.createElement('div')
-    const visible = ref(new Set<number>())
-    const fn = vi.fn((el: any) => {
-      if (!el || visible.value.has(0)) {
-        return
-      }
-      visible.value = new Set([0])
-    })
-
-    const Comp = defineComponent(() => () => h('div', { ref: fn }))
-
-    render(h(Comp), root)
-    expect(fn).toHaveBeenCalledTimes(1)
-    expect(visible.value.has(0)).toBe(true)
-
-    await nextTick()
-    expect(fn).toHaveBeenCalledTimes(1)
-  })
-
   it('function ref unmount', async () => {
     const root = nodeOps.createElement('div')
     const fn = vi.fn()

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -17,7 +17,7 @@ import {
 } from '@vue/shared'
 import { isAsyncWrapper } from './apiAsyncComponent'
 import { warn } from './warning'
-import { isRef, pauseTracking, resetTracking, toRaw } from '@vue/reactivity'
+import { isRef, toRaw } from '@vue/reactivity'
 import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 import { type SchedulerJob, SchedulerJobFlags } from './scheduler'
 import { queuePostRenderEffect } from './renderer'
@@ -136,12 +136,7 @@ export function setRef(
   }
 
   if (isFunction(ref)) {
-    pauseTracking()
-    try {
-      callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [value, refs])
-    } finally {
-      resetTracking()
-    }
+    callWithErrorHandling(ref, owner, ErrorCodes.FUNCTION_REF, [value, refs])
   } else {
     const _isString = isString(ref)
     const _isRef = isRef(ref)


### PR DESCRIPTION
close #15039
close #15041

Reverts #14985 and restores dependency tracking inside function template refs.
As Evan clarified in [#4084](https://github.com/vuejs/core/issues/4084#issuecomment-877428419) and [#4646](https://github.com/vuejs/core/issues/4646#issuecomment-924907118), this is intentional behavior: function refs may run on each render, and their dependencies should be tracked because reactive state may determine which ref receives the value.
#14985 caused #15039, while #15041 introduced downstream regressions in radix-vue. Reverting is the smallest compatibility-preserving fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated function-based template refs to preserve dependency tracking during callback execution.
  * Removed outdated test coverage for the previous tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->