### PR TITLE
fix(types): preserve defineModel inference with factory defaults

### DIFF
--- a/packages-private/dts-test/setupHelpers.test-d.ts
+++ b/packages-private/dts-test/setupHelpers.test-d.ts
@@ -1,4 +1,5 @@
 import {
+  type PropType,
   type Ref,
   type Slots,
   type VNode,
@@ -421,6 +422,18 @@ describe('defineModel', () => {
   const countDefault = defineModel<number>('count', { default: 1 })
   expectType<Ref<number>>(countDefault)
 
+  const inferredNamedArrayDefault = defineModel('items', {
+    type: Array as PropType<string[]>,
+    default: () => [],
+  })
+  expectType<Ref<string[]>>(inferredNamedArrayDefault)
+
+  const inferredArrayDefault = defineModel({
+    type: Array as PropType<string[]>,
+    default: () => [],
+  })
+  expectType<Ref<string[]>>(inferredArrayDefault)
+
   const arrayDefault = defineModel<number[]>({ default: () => [] })
   expectType<Ref<number[]>>(arrayDefault)
 
@@ -468,6 +481,11 @@ describe('defineModel', () => {
 
   // @ts-expect-error type / default mismatch
   defineModel<string>({ default: 123 })
+  // @ts-expect-error runtime type / default mismatch
+  defineModel('items', {
+    type: Array as PropType<string[]>,
+    default: () => [1],
+  })
   // @ts-expect-error raw array defaults must use a factory
   defineModel<number[]>({ default: [] })
   // @ts-expect-error raw object defaults must use a factory

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -309,8 +309,8 @@ type DefineModelDefault<T> = InferDefault<Data, T>
  * ```
  */
 export function defineModel<T, M extends PropertyKey = string, G = T, S = T>(
-  options: ({ default: DefineModelDefault<T> } | { required: true }) &
-    DefineModelRuntimeOptions<T, G, S>,
+  options: DefineModelRuntimeOptions<T, G, S> &
+    ({ default: DefineModelDefault<T> } | { required: true }),
 ): ModelRef<T, M, G, S>
 
 export function defineModel<T, M extends PropertyKey = string, G = T, S = T>(
@@ -319,8 +319,8 @@ export function defineModel<T, M extends PropertyKey = string, G = T, S = T>(
 
 export function defineModel<T, M extends PropertyKey = string, G = T, S = T>(
   name: string,
-  options: ({ default: DefineModelDefault<T> } | { required: true }) &
-    DefineModelRuntimeOptions<T, G, S>,
+  options: DefineModelRuntimeOptions<T, G, S> &
+    ({ default: DefineModelDefault<T> } | { required: true }),
 ): ModelRef<T, M, G, S>
 
 export function defineModel<T, M extends PropertyKey = string, G = T, S = T>(


### PR DESCRIPTION
close #15096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type inference for `defineModel` array defaults.
  * Added validation for mismatched default values, helping surface configuration errors during development.
* **Tests**
  * Expanded type coverage for named and object-based `defineModel` declarations, including required and default-value scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->