### PR TITLE
fix(runtime-vapor): support setup state in production

### DIFF
--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -565,6 +565,36 @@ describe('component', () => {
     }
   })
 
+  test('should mount a component with setup state and a render function in production mode', async () => {
+    __DEV__ = false
+    try {
+      const message = ref('hello')
+      const { component: Child } = define({
+        setup() {
+          return { message }
+        },
+        render(ctx: { message: string }) {
+          const n0 = template('<div></div>')()
+          renderEffect(() => setElementText(n0, ctx.message))
+          return n0
+        },
+      })
+
+      const { host } = define({
+        setup() {
+          return createComponent(Child)
+        },
+      }).render()
+
+      expect(host.innerHTML).toBe('<div>hello</div>')
+      message.value = 'updated'
+      await nextTick()
+      expect(host.innerHTML).toBe('<div>updated</div>')
+    } finally {
+      __DEV__ = true
+    }
+  })
+
   test('should pass slot args to template-only component render in production mode', () => {
     __DEV__ = false
     try {

--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -1387,6 +1387,28 @@ describe('api: template ref', () => {
     }
   })
 
+  test('should update a string template ref in production mode', () => {
+    __DEV__ = false
+    try {
+      let el: ReturnType<typeof ref>
+      const { host } = define({
+        setup() {
+          el = ref(null)
+          return { el }
+        },
+        render() {
+          const n0 = template('<div></div>')() as Element
+          createTemplateRefSetter()(n0, 'el')
+          return n0
+        },
+      }).render()
+
+      expect(el!.value).toBe(host.children[0])
+    } finally {
+      __DEV__ = true
+    }
+  })
+
   it('should not register duplicate onScopeDispose callbacks for dynamic function refs', async () => {
     const fn1 = vi.fn()
     const fn2 = vi.fn()

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -18,7 +18,6 @@ import {
 } from '@vue/runtime-dom'
 import {
   EMPTY_OBJ,
-  NO,
   NOOP,
   isArray,
   isFunction,
@@ -204,7 +203,7 @@ function setRef(
 ): NodeRef | undefined {
   if (!instance || instance.isUnmounted) return
 
-  const setupState: any = __DEV__ ? instance.setupState || {} : null
+  const setupState: any = instance.setupState || {}
   const refValue = getRefValue(el)
 
   // vdom interop
@@ -224,9 +223,7 @@ function setRef(
   const refs =
     instance.refs === EMPTY_OBJ ? (instance.refs = {}) : instance.refs
 
-  const canSetSetupRef = __DEV__
-    ? createCanSetSetupRefChecker(setupState, refs)
-    : NO
+  const canSetSetupRef = createCanSetSetupRefChecker(setupState, refs)
 
   const canSetRef = (ref: NodeRef, key?: string) => {
     if (__DEV__ && knownTemplateRefs.has(ref as any)) {
@@ -243,7 +240,7 @@ function setRef(
     invalidatePendingRef(el)
     if (isString(oldRef)) {
       refs[oldRef] = null
-      if (__DEV__ && canSetSetupRef(oldRef)) {
+      if (canSetSetupRef(oldRef)) {
         setupState[oldRef] = null
       }
     } else if (isRef(oldRef)) {
@@ -294,7 +291,7 @@ function setRef(
           if (refValue == null) return
 
           existing = _isString
-            ? __DEV__ && canSetSetupRef(ref)
+            ? canSetSetupRef(ref)
               ? setupState[ref]
               : refs[ref]
             : canSetRef(ref) || !refKey
@@ -305,7 +302,7 @@ function setRef(
             existing = [refValue]
             if (_isString) {
               refs[ref] = existing
-              if (__DEV__ && canSetSetupRef(ref)) {
+              if (canSetSetupRef(ref)) {
                 setupState[ref] = refs[ref]
                 // if setupState[ref] is a reactivity ref,
                 // the existing will also become reactivity too
@@ -321,7 +318,7 @@ function setRef(
           }
         } else if (_isString) {
           refs[ref] = refValue
-          if (__DEV__ && canSetSetupRef(ref)) {
+          if (canSetSetupRef(ref)) {
             setupState[ref] = refValue
           }
         } else if (_isRef) {
@@ -339,7 +336,7 @@ function setRef(
           }
         } else if (_isString) {
           refs[ref] = null
-          if (__DEV__ && canSetSetupRef(ref)) {
+          if (canSetSetupRef(ref)) {
             setupState[ref] = null
           }
         } else if (_isRef) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1244,24 +1244,30 @@ function handleSetupResult(
     pushWarningContext(instance)
   }
 
-  if (__DEV__ && !isBlock(setupResult)) {
+  if (!isBlock(setupResult) && !isFunction(component) && component.render) {
+    if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
+      instance.devtoolsRawSetupState = setupResult
+    }
+    instance.setupState = proxyRefs(setupResult)
+    if (__DEV__) {
+      instance.setupState = createDevSetupStateProxy(instance)
+      devRender(instance)
+    } else {
+      instance.block = callRender(
+        component.render,
+        instance,
+        instance.setupState!,
+      )
+    }
+  } else if (__DEV__ && !isBlock(setupResult)) {
     if (isFunction(component)) {
       warn(`Functional vapor component must return a block directly.`)
       instance.block = []
-    } else if (!component.render) {
+    } else {
       warn(
         `Vapor component setup() returned non-block value, and has no render function.`,
       )
       instance.block = []
-    } else {
-      if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
-        instance.devtoolsRawSetupState = setupResult
-      }
-      instance.setupState = proxyRefs(setupResult)
-      if (__DEV__) {
-        instance.setupState = createDevSetupStateProxy(instance)
-      }
-      devRender(instance)
     }
   } else {
     // component has a render function but no setup function


### PR DESCRIPTION
## Summary

- render non-block setup results through the component render function in production
- synchronize string template refs with setup state outside development builds
- add production-only Vapor regressions for both paths

## Root cause

The runtime kept `setupState` initialization and string template-ref writes behind development-only branches. In production, a non-inline component that returned setup state together with a render function was treated as a block, while string refs did not update their corresponding setup bindings.

Fixes #15099.

## Validation

- `corepack pnpm@11.13.0 test -- --project unit-jsdom packages/runtime-vapor`
- `corepack pnpm@11.13.0 check`
- `corepack pnpm@11.13.0 lint -- packages/runtime-vapor/src/component.ts packages/runtime-vapor/src/apiTemplateRef.ts packages/runtime-vapor/__tests__/component.spec.ts packages/runtime-vapor/__tests__/dom/templateRef.spec.ts`
- `corepack pnpm@11.13.0 format-check -- packages/runtime-vapor/src/component.ts packages/runtime-vapor/src/apiTemplateRef.ts packages/runtime-vapor/__tests__/component.spec.ts packages/runtime-vapor/__tests__/dom/templateRef.spec.ts`
- `corepack pnpm@11.13.0 build runtime-vapor -f esm-bundler`
- `git diff --check`
