### PR TITLE
fix(reactivity): reset computed dirty flag and globalVersion on getter error

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -1150,4 +1150,29 @@ describe('reactivity/computed', () => {
     const t2 = performance.now()
     expect(t2 - t1).toBeLessThan(process.env.CI ? 100 : 30)
   })
+
+  it('should re-throw on repeated reads after getter error', () => {
+    const c = computed(() => {
+      throw new Error('fail')
+    })
+
+    expect(() => c.value).toThrow('fail')
+    expect(() => c.value).toThrow('fail')
+  })
+
+  it('should recover after getter error when condition clears', () => {
+    let shouldThrow = true
+    const c = computed(() => {
+      if (shouldThrow) {
+        throw new Error('fail')
+      }
+      return 42
+    })
+
+    expect(() => c.value).toThrow('fail')
+    expect(() => c.value).toThrow('fail')
+
+    shouldThrow = false
+    expect(c.value).toBe(42)
+  })
 })

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -419,6 +419,8 @@ export function refreshComputed(computed: ComputedRefImpl): undefined {
       dep.version++
     }
   } catch (err) {
+    computed.flags |= EffectFlags.DIRTY
+    computed.globalVersion = -1
     dep.version++
     throw err
   } finally {


### PR DESCRIPTION
This PR fixes a bug where a computed property returns a cached undefined (or stale value) instead of re-throwing or re-evaluating after its getter throws an error.

### Cause
During evaluation inside refreshComputed, the DIRTY flag is cleared and the globalVersion cache key is updated *before* the getter function runs. If the getter throws an error, these flags are never restored or invalidated, leaving the computed property in an "evaluated" state with a stale cached value.

### fix
We now restore the DIRTY flag and invalidate globalVersion in the catch block of refreshComputed. This ensures that subsequent reads will trigger a re-evaluation instead of silently returning the cached undefined.

fixes #15101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved computed values’ error handling so failures are consistently re-thrown on repeated reads.
  * Computed values can now recover and return updated results after the underlying error condition is resolved.

* **Tests**
  * Added coverage for repeated errors and successful recovery after a computed getter failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->