### PR TITLE
fix(types): avoid intersecting large unions for loose required props

### DIFF
--- a/packages-private/dts-test/setupHelpers.test-d.ts
+++ b/packages-private/dts-test/setupHelpers.test-d.ts
@@ -43,6 +43,16 @@ describe('defineProps w/ never prop', () => {
   expectType<number>(props.bar)
 })
 
+describe('defineProps w/ large union prop', () => {
+  type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+  type Icon = `${Digit}${Digit}${Digit}` | { name: string }
+
+  const props = defineProps<{
+    icon?: Icon
+  }>()
+  expectType<Icon | undefined>(props.icon)
+})
+
 describe('defineProps w/ generics', () => {
   function test<T extends boolean>() {
     const props = defineProps<{ foo: T; bar: string; x?: boolean }>()

--- a/packages/shared/src/typeUtils.ts
+++ b/packages/shared/src/typeUtils.ts
@@ -7,7 +7,9 @@ export type UnionToIntersection<U> = (
   : never
 
 // make keys required but keep undefined values
-export type LooseRequired<T> = { [P in keyof (T & Required<T>)]: T[P] }
+export type LooseRequired<T> = {
+  [P in keyof (T & { [P in keyof T]-?: unknown })]: T[P]
+}
 
 // If the type T accepts type "any", output type Y, otherwise output type N.
 // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360


### PR DESCRIPTION
fix #10514

---

*This pull request was created with assistance from a code agent.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript type handling for optional properties and complex union types.
  - Preserved accurate prop value types while ensuring required property checks behave consistently.

- **Tests**
  - Added coverage for large union-based props, including template-literal and object type variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->