### PR TITLE
chore: allow `@parcel/watcher` builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ catalog:
   '@vitejs/plugin-vue': ^6.0.8
 
 allowBuilds:
+  '@parcel/watcher': true
   '@swc/core': true
   'esbuild': true
   'puppeteer': true


### PR DESCRIPTION
## Summary

- allow `@parcel/watcher` install scripts through `pnpm-workspace.yaml`
- keep the lockfile reproducible instead of manually removing the optional dependency

---

*This pull request was created with assistance from a code agent.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to support building the Parcel watcher package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->