### PR TITLE
fix(runtime-vapor): validate props for vdom interop

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -333,6 +333,30 @@ describe('vdomInterop', () => {
       expect(html()).toBe('<div class="foo bar"></div>')
     })
 
+    test('should warn on invalid prop when vapor renders vdom component', async () => {
+      const base = ref<unknown>('invalid')
+      const VDomChild = defineComponent({
+        props: {
+          base: Number,
+        },
+        render: () => h('div'),
+      })
+
+      const VaporChild = defineVaporComponent(() =>
+        createComponent(VDomChild as any, {
+          base: () => base.value,
+        }),
+      )
+
+      define(() => h(VaporChild as any)).render()
+
+      expect('type check failed for prop "base"').toHaveBeenWarnedTimes(1)
+
+      base.value = 'still invalid'
+      await nextTick()
+      expect('type check failed for prop "base"').toHaveBeenWarnedTimes(2)
+    })
+
     test('should not pass reserved props into vapor attrs on update', async () => {
       const msg = ref('foo')
       const onVnodeMounted = vi.fn()

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -10,7 +10,9 @@ import {
 } from '@vue/shared'
 import type { VaporComponent, VaporComponentInstance } from './component'
 import {
+  type GenericComponentInstance,
   type NormalizedPropsOptions,
+  type VNode,
   baseNormalizePropsOptions,
   currentInstance,
   isEmitListener,
@@ -488,11 +490,14 @@ export function hasFallthroughAttrs(
 /**
  * dev only
  */
-export function setupPropsValidation(instance: VaporComponentInstance): void {
+export function setupPropsValidation(
+  instance: VaporComponentInstance,
+  warningContext: GenericComponentInstance | VNode = instance,
+): void {
   const rawProps = instance.rawProps
   if (!rawProps) return
   renderEffect(() => {
-    pushWarningContext(instance)
+    pushWarningContext(warningContext)
     validateProps(
       resolveDynamicProps(rawProps),
       instance.props,

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -40,6 +40,7 @@ import {
   onScopeDispose,
   queuePostFlushCb,
   renderSlot,
+  setCurrentInstance,
   setTransitionHooks as setVNodeTransitionHooks,
   shallowReactive,
   shallowRef,
@@ -86,7 +87,11 @@ import {
   isReservedProp,
   isString,
 } from '@vue/shared'
-import { type RawProps, rawPropsProxyHandlers } from './componentProps'
+import {
+  type RawProps,
+  rawPropsProxyHandlers,
+  setupPropsValidation,
+} from './componentProps'
 import type { RawSlots, VaporSlot } from './componentSlots'
 import {
   currentSlotScopeIds,
@@ -1013,6 +1018,15 @@ function createVDOMComponent(
       wrapper.rawSlots === EMPTY_OBJ
         ? EMPTY_OBJ
         : new Proxy(wrapper.rawSlots, vaporSlotsProxyHandler)
+
+    if (__DEV__) {
+      const prev = setCurrentInstance(wrapper, instance.scope)
+      try {
+        setupPropsValidation(wrapper, vnode)
+      } finally {
+        setCurrentInstance(...prev)
+      }
+    }
   }
 
   let rawRef: VNodeNormalizedRef | null = null


### PR DESCRIPTION
The Vapor-to-VDOM interop path bypasses VDOM's normal prop initialization, so invalid props are not validated during mount or reactive updates.

Reproduction: https://github.com/liang-demos/vue-vapor-interop

This PR reuses Vapor's reactive prop validation from the interop initialization hook and keeps the VDOM vnode as the warning context. The validation effect is attached to the VDOM component's scope so it is cleaned up with the component.

🤖 Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prop validation warnings when VDOM components are rendered through Vapor.
  * Warnings now provide the correct component context and remain accurate when reactive prop values change.
  * Added coverage for invalid initial and updated prop values, ensuring warnings are reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->