### PR TITLE
fix(runtime-core): restore SSR setup state when handling async setup result

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -894,7 +894,12 @@ function setupStatefulComponent(
         // return the promise so server-renderer can wait on it
         return setupResult
           .then((resolvedResult: unknown) => {
-            handleSetupResult(instance, resolvedResult, isSSR)
+            setInSSRSetupState(true)
+            try {
+              handleSetupResult(instance, resolvedResult, isSSR)
+            } finally {
+              setInSSRSetupState(false)
+            }
           })
           .catch(e => {
             handleError(e, instance, ErrorCodes.SETUP_FUNCTION)

--- a/packages/server-renderer/__tests__/ssrWatch.spec.ts
+++ b/packages/server-renderer/__tests__/ssrWatch.spec.ts
@@ -130,6 +130,35 @@ describe('ssr: watch', () => {
     expect(msg).toBe('start')
   })
 
+  // #15113
+  test('options-api watchers should not be created for async setup components', async () => {
+    const open = ref(true)
+    const spy = vi.fn()
+
+    const App = defineComponent({
+      setup: () => Promise.resolve({}),
+      computed: {
+        isOpen() {
+          return open.value
+        },
+      },
+      watch: {
+        isOpen: spy,
+      },
+      render() {
+        return h('div', String(this.isOpen))
+      },
+    })
+
+    const html = await renderToString(createSSRApp(App))
+    expect(html).toBe('<div>true</div>')
+
+    // mutating the state after the request is done should not trigger the watcher
+    open.value = false
+    await nextTick()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
   test('should not run non-immediate watchers registered after async context restore', async () => {
     const text = ref('start')
     let beforeAwaitTriggered = false
@@ -339,6 +368,46 @@ describe.skipIf(!global.gc)('ssr: watch gc', () => {
 
       expect(html).toContain('Component A false')
       expect(html).toContain('Component B false')
+    }
+
+    for (let i = 0; i < 10; i++) {
+      await renderOnce()
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await gc()
+    }
+
+    expect(weakRefs.filter(ref => ref.deref()).length).toBe(0)
+  })
+
+  // #15113
+  test('options-api should not retain apps with async setup + watcher on global state', async () => {
+    const weakRefs: { deref(): unknown | undefined }[] = []
+
+    const open = ref(true)
+
+    const App = defineComponent({
+      setup: () => Promise.resolve({}),
+      computed: {
+        isOpen() {
+          return open.value
+        },
+      },
+      watch: {
+        isOpen() {},
+      },
+      render() {
+        return h('div', String(this.isOpen))
+      },
+    })
+
+    async function renderOnce() {
+      const app = createSSRApp(App)
+      // @ts-expect-error ES2021 API
+      weakRefs.push(new WeakRef(app))
+      const html = await renderToString(app)
+      expect(html).toBe('<div>true</div>')
     }
 
     for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
fix https://github.com/vuejs/core/issues/15113

this should fix a problem where regular watchers were being created on the server for Options API components with `async setup()`

and also a potential memory leak since SSR never unmounts and such a watcher is never stopped... if it depends on request-outliving state, it retains the whole component instance and through it the whole app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering reliability for components using asynchronous setup.
  * Prevented watchers from being created or retained unexpectedly during server-side rendering.
  * Reduced potential memory retention after repeated server-rendered requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->