### PR TITLE
fix: restore warning context after validation errors

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -13,11 +13,13 @@ import {
   inject,
   nextTick,
   nodeOps,
+  popWarningContext,
   provide,
   ref,
   render,
   serializeInner,
   toRefs,
+  warn,
   watch,
 } from '@vue/runtime-test'
 import { render as domRender } from 'vue'
@@ -907,5 +909,72 @@ describe('component props', () => {
     foo.value++
     await nextTick()
     expect(props).not.toHaveProperty('onEvent')
+  })
+
+  test('restores warning context when prop validation throws', () => {
+    const error = new Error('validation failed')
+    const warnHandler = vi.fn()
+    const Comp = defineComponent({
+      props: {
+        foo: {
+          validator() {
+            throw error
+          },
+        },
+      },
+      render() {},
+    })
+    const root = nodeOps.createElement('div')
+    const app = createApp(Comp, { foo: 1 })
+    app.config.warnHandler = warnHandler
+
+    expect(() => app.mount(root)).toThrow(error)
+    warnHandler.mockClear()
+
+    warn('after failed prop validation')
+    popWarningContext()
+
+    expect('[Vue warn]: after failed prop validation').toHaveBeenWarned()
+    expect(warnHandler).not.toHaveBeenCalled()
+  })
+
+  test('restores warning context when prop validation throws on update', async () => {
+    const error = new Error('validation failed')
+    const value = ref(1)
+    const errorHandler = vi.fn()
+    const warnHandler = vi.fn()
+    const Child = defineComponent({
+      props: {
+        foo: {
+          validator(value) {
+            if (value === 2) throw error
+            return true
+          },
+        },
+      },
+      render() {},
+    })
+    const Parent = () => h(Child, { foo: value.value })
+    const root = nodeOps.createElement('div')
+    const app = createApp(Parent)
+    app.config.errorHandler = errorHandler
+    app.config.warnHandler = warnHandler
+    app.mount(root)
+
+    value.value = 2
+    await nextTick()
+    expect(errorHandler).toHaveBeenCalledWith(
+      error,
+      expect.anything(),
+      'component update',
+    )
+    warnHandler.mockClear()
+
+    warn('after failed prop validation update')
+    popWarningContext()
+    popWarningContext()
+
+    expect('[Vue warn]: after failed prop validation update').toHaveBeenWarned()
+    expect(warnHandler).not.toHaveBeenCalled()
   })
 })

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1307,7 +1307,7 @@ function baseCreateRenderer(
     }
   }
 
-  const mountComponent: MountComponentFn = (
+  const mountComponentImpl: MountComponentFn = (
     initialVNode,
     container,
     anchor,
@@ -1333,7 +1333,6 @@ function baseCreateRenderer(
     }
 
     if (__DEV__) {
-      pushWarningContext(initialVNode)
       startMeasure(instance, `mount`)
     }
 
@@ -1418,10 +1417,21 @@ function baseCreateRenderer(
     }
 
     if (__DEV__) {
-      popWarningContext()
       endMeasure(instance, `mount`)
     }
   }
+
+  // keep error-safe warning context cleanup out of the production mount path
+  const mountComponent: MountComponentFn = __DEV__
+    ? (...args) => {
+        pushWarningContext(args[0])
+        try {
+          mountComponentImpl(...args)
+        } finally {
+          popWarningContext()
+        }
+      }
+    : mountComponentImpl
 
   const updateComponent = (n1: VNode, n2: VNode, optimized: boolean) => {
     const instance = (n2.component = n1.component)!
@@ -1435,10 +1445,13 @@ function baseCreateRenderer(
         // since the component's reactive effect for render isn't set-up yet
         if (__DEV__) {
           pushWarningContext(n2)
-        }
-        updateComponentPreRender(instance, n2, optimized)
-        if (__DEV__) {
-          popWarningContext()
+          try {
+            updateComponentPreRender(instance, n2, optimized)
+          } finally {
+            popWarningContext()
+          }
+        } else {
+          updateComponentPreRender(instance, n2, optimized)
         }
         return
       } else {
@@ -1478,6 +1491,19 @@ function baseCreateRenderer(
       this.job.i = instance
 
       if (__DEV__) {
+        // keep the production update effect on the direct call path
+        const componentUpdateFn = this.fn.bind(this)
+        this.fn = () => {
+          if (!instance.isMounted) {
+            return componentUpdateFn()
+          }
+          pushWarningContext(instance.next || instance.vnode)
+          try {
+            componentUpdateFn()
+          } finally {
+            popWarningContext()
+          }
+        }
         this.onTrack = instance.rtc
           ? e => invokeArrayFns(instance.rtc!, e)
           : void 0
@@ -1695,9 +1721,6 @@ function baseCreateRenderer(
         // OR parent calling processComponent (next: VNode)
         let originNext = next
         let vnodeHook: VNodeHook | null | undefined
-        if (__DEV__) {
-          pushWarningContext(next || instance.vnode)
-        }
 
         // Disallow component effect recursion during pre-lifecycle hooks.
         toggleRecurse(instance, false)
@@ -1784,10 +1807,6 @@ function baseCreateRenderer(
 
         if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
           devtoolsComponentUpdated(instance)
-        }
-
-        if (__DEV__) {
-          popWarningContext()
         }
       }
     }

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -4,13 +4,16 @@ import {
   // currentInstance,
   inject,
   nextTick,
+  popWarningContext,
   provide,
   ref,
   toRefs,
+  warn,
   watch,
 } from '@vue/runtime-dom'
 import {
   createComponent,
+  createVaporApp,
   defineVaporComponent,
   renderEffect,
   template,
@@ -850,5 +853,42 @@ describe('component: props', () => {
         title: 'baz',
       })
     })
+  })
+
+  test('restores warning context when prop validation throws', async () => {
+    const error = new Error('validation failed')
+    const value = ref(1)
+    const errorHandler = vi.fn()
+    const warnHandler = vi.fn()
+    const Comp = defineVaporComponent({
+      props: {
+        foo: {
+          validator(value) {
+            if (value === 2) throw error
+            return true
+          },
+        },
+      },
+      setup: () => [],
+    })
+    const app = createVaporApp(Comp, { foo: () => value.value })
+    app.config.errorHandler = errorHandler
+    app.config.warnHandler = warnHandler
+    app.mount(document.createElement('div'))
+
+    value.value = 2
+    await nextTick()
+    expect(errorHandler).toHaveBeenCalledWith(
+      error,
+      expect.anything(),
+      'component update',
+    )
+    warnHandler.mockClear()
+
+    warn('after failed prop validation')
+    popWarningContext()
+
+    expect('[Vue warn]: after failed prop validation').toHaveBeenWarned()
+    expect(warnHandler).not.toHaveBeenCalled()
   })
 })

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -498,12 +498,15 @@ export function setupPropsValidation(
   if (!rawProps) return
   renderEffect(() => {
     pushWarningContext(warningContext)
-    validateProps(
-      resolveDynamicProps(rawProps),
-      instance.props,
-      normalizePropsOptions(instance.type)[0]!,
-    )
-    popWarningContext()
+    try {
+      validateProps(
+        resolveDynamicProps(rawProps),
+        instance.props,
+        normalizePropsOptions(instance.type)[0]!,
+      )
+    } finally {
+      popWarningContext()
+    }
   }, true /* noLifecycle */)
 }
 


### PR DESCRIPTION
Reference: https://github.com/vuejs/core/pull/15111#issuecomment-5018476855 https://github.com/vuejs/core/pull/15111#issuecomment-5018275451 https://github.com/vuejs/core/pull/15111#pullrequestreview-4731851941

The warning context stack is not restored when prop validation throws. This can cause later warnings to be incorrectly attributed to the failed component.

This PR restores the warning context for both VDOM and Vapor prop validation. The original validation error still propagates. The VDOM cleanup is installed only in development builds so production mount and update paths keep their direct call path.

🤖 Generated with Codex
