### PR TITLE
fix(compiler-vapor): avoid helper and cache variable name collisions

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -30,6 +30,53 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: v-for > avoids cache variable collision with an existing runtime helper 1`] = `
+"import { setInsertionState as _setInsertionState, createSelector as _createSelector, child as _child, txt as _txt, setProp as _setProp, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, setClassName as _setClassName, createFor as _createFor, template as _template } from 'vue';
+const t0 = _template("<button><span> ")
+const t1 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n4 = t1()
+  _setInsertionState(n4, null, 0)
+  const _selector0 = _createSelector(() => _ctx.selected)
+  const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
+    const n3 = t0()
+    const n2 = _child(n3)
+    const x2 = _txt(n2)
+    let _child1
+    _renderEffect(() => {
+      _child1 = _for_item0.value
+      _setProp(n3, "disabled", _child1.disabled)
+      _setText(x2, _toDisplayString(_child1.label))
+    })
+    _selector0(_child1.key, () => {
+      _setClassName(n3, (_child1.key === _ctx.selected ? 1 : 0), "selected")
+    })
+    return n3
+  }, (child) => (child.key), 9 /* FAST_REMOVE, IS_SINGLE_NODE */)
+  n0.onReset(_selector0.reset)
+  return n4
+}"
+`;
+
+exports[`compiler: v-for > avoids runtime helper collision with an existing cache variable 1`] = `
+"import { setProp as _setProp1, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n0 = _createFor(() => (_ctx.items), (_for_item0) => {
+    const n2 = t0()
+    _renderEffect(() => {
+      const _setProp = _for_item0.value
+      _setProp1(n2, "id", _setProp.id)
+      _setProp1(n2, "title", _setProp.title)
+    })
+    return n2
+  }, undefined, 8 /* IS_SINGLE_NODE */)
+  return n0
+}"
+`;
+
 exports[`compiler: v-for > basic v-for 1`] = `
 "import { txt as _txt, createInvoker as _createInvoker, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, delegateEvents as _delegateEvents, template as _template } from 'vue';
 const t0 = _template("<div> ")

--- a/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
@@ -565,4 +565,38 @@ describe('compiler: v-for', () => {
       type: IRNodeTypes.KEY,
     })
   })
+
+  test('avoids cache variable collision with an existing runtime helper', () => {
+    const { code } = compileWithVFor(`
+      <div>
+        <button
+          v-for="child in items"
+          :key="child.key"
+          :disabled="child.disabled"
+          :class="{ selected: child.key === selected }"
+        >
+          <span>{{ child.label }}</span>
+        </button>
+      </div>
+    `)
+
+    expect(code).matchSnapshot()
+    expect(code).toContain('child as _child')
+    expect(code).toContain('const n2 = _child(n3)')
+    expect(code).toContain('let _child1')
+    expect(code).toContain('_child1 = _for_item0.value')
+    expect(code).toContain('_selector0(_child1.key')
+  })
+
+  test('avoids runtime helper collision with an existing cache variable', () => {
+    const { code } = compileWithVFor(
+      `<div v-for="setProp in items" :id="setProp.id" :title="setProp.title" />`,
+    )
+
+    expect(code).matchSnapshot()
+    expect(code).toContain('setProp as _setProp1')
+    expect(code).toContain('const _setProp = _for_item0.value')
+    expect(code).toContain('_setProp1(n2, "id", _setProp.id)')
+    expect(code).toContain('_setProp1(n2, "title", _setProp.title)')
+  })
 })

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -52,22 +52,9 @@ export class CodegenContext {
     }
 
     const base = `_${helperNameAliases[name] || name}`
-    if (this.isHelperNameAvailable(base)) {
-      this.helpers.set(name, base)
-      return base
-    }
-
-    const map = this.nextIdMap.get(base)
-    let next = 1
-    while (true) {
-      // start from 1 because "base" (no suffix) is already taken.
-      const alias = `${base}${getNextId(map, next)}`
-      if (this.isHelperNameAvailable(alias)) {
-        this.helpers.set(name, alias)
-        return alias
-      }
-      next++
-    }
+    const alias = this.findAvailableName(base, this.generatedLocalNames)
+    this.helpers.set(name, alias)
+    return alias
   }
 
   delegates: Set<string> = new Set<string>()
@@ -141,12 +128,34 @@ export class CodegenContext {
   private templateVars: Map<number, string> = new Map()
   private nextIdMap: Map<string, Map<number, number>> = new Map()
   private lastIdMap: Map<string, number> = new Map()
-  private isHelperNameAvailable(name: string): boolean {
-    if (this.bindingNames.has(name)) return false
+  private generatedLocalNames: Set<string> = new Set()
+
+  getUniqueLocalName(base: string, scopeNames: Set<string>): string {
+    const name = this.findAvailableName(base, scopeNames)
+    scopeNames.add(name)
+    this.generatedLocalNames.add(name)
+    return name
+  }
+
+  private isNameAvailable(name: string, reservedNames: Set<string>): boolean {
+    if (this.bindingNames.has(name) || reservedNames.has(name)) return false
     for (const alias of this.helpers.values()) {
       if (alias === name) return false
     }
     return true
+  }
+
+  private findAvailableName(base: string, reservedNames: Set<string>): string {
+    if (this.isNameAvailable(base, reservedNames)) return base
+
+    const map = this.nextIdMap.get(base)
+    let next = 1
+    while (true) {
+      const id = getNextId(map, next)
+      const name = `${base}${id}`
+      if (this.isNameAvailable(name, reservedNames)) return name
+      next = id + 1
+    }
   }
 
   private lastTIndex: number = -1

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -943,8 +943,10 @@ function genDeclarations(
   // process identifiers first as expressions may rely on them
   declarations.forEach(({ name, isIdentifier, value }) => {
     if (isIdentifier) {
-      const varName = (ids[name] = `_${name}`)
-      varNames.add(varName)
+      const varName = (ids[name] = context.getUniqueLocalName(
+        `_${name}`,
+        varNames,
+      ))
       if (shouldDeclare) {
         push(`const `)
       }
@@ -955,8 +957,7 @@ function genDeclarations(
   // process expressions
   declarations.forEach(({ name, isIdentifier, value }) => {
     if (!isIdentifier) {
-      const varName = `_${name}`
-      varNames.add(varName)
+      const varName = context.getUniqueLocalName(`_${name}`, varNames)
       if (shouldDeclare) {
         push(`const `)
       }


### PR DESCRIPTION
close #15118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated code to prevent naming collisions between template variables and compiler-generated helpers or cache variables.
  * Ensured generated property updates and selectors reference the correct uniquely named variables.

* **Tests**
  * Added coverage for naming collisions involving runtime helpers and property-setting variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->