### PR TITLE
refactor(runtime-vapor): reduce TransitionGroup bundle size

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -4,10 +4,8 @@ import {
   setBlockKey,
   template,
 } from '../../src'
-import {
-  resolveTransitionBlock,
-  resolveTransitionBlocks,
-} from '../../src/components/Transition'
+import { resolveTransitionBlock } from '../../src/components/Transition'
+import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
 import { nextTick, ref } from 'vue'
 import { compile, makeInteropRender, makeRender } from '../_utils'
 

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -15,6 +15,45 @@ const define = makeRender()
 const timeout = (n = 0) => new Promise(r => setTimeout(r, n))
 
 describe('TransitionGroup', () => {
+  test('registers full transition hooks when Transition is used later', async () => {
+    const group = define({
+      setup() {
+        return createComponent(VaporTransitionGroup)
+      },
+    }).render()
+    group.app.unmount()
+
+    let leaveDone: (() => void) | undefined
+    const data = ref({
+      show: true,
+      onLeave: (_: Element, done: () => void) => {
+        leaveDone = done
+      },
+    })
+    const App = compile(
+      `<template>
+        <Transition mode="out-in" :css="false" @leave="data.onLeave">
+          <div v-if="data.show" key="a">A</div>
+          <div v-else key="b">B</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { host } = define(App as any).render()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(host.textContent).toContain('A')
+    expect(host.textContent).not.toContain('B')
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.textContent).not.toContain('A')
+    expect(host.textContent).toContain('B')
+  })
+
   test('prefixes outer component key for a single transition child', () => {
     const Child = defineVaporComponent({
       setup() {

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -15,45 +15,6 @@ const define = makeRender()
 const timeout = (n = 0) => new Promise(r => setTimeout(r, n))
 
 describe('TransitionGroup', () => {
-  test('registers full transition hooks when Transition is used later', async () => {
-    const group = define({
-      setup() {
-        return createComponent(VaporTransitionGroup)
-      },
-    }).render()
-    group.app.unmount()
-
-    let leaveDone: (() => void) | undefined
-    const data = ref({
-      show: true,
-      onLeave: (_: Element, done: () => void) => {
-        leaveDone = done
-      },
-    })
-    const App = compile(
-      `<template>
-        <Transition mode="out-in" :css="false" @leave="data.onLeave">
-          <div v-if="data.show" key="a">A</div>
-          <div v-else key="b">B</div>
-        </Transition>
-      </template>`,
-      data,
-    )
-    const { host } = define(App as any).render()
-
-    data.value.show = false
-    await nextTick()
-
-    expect(host.textContent).toContain('A')
-    expect(host.textContent).not.toContain('B')
-
-    leaveDone!()
-    await nextTick()
-
-    expect(host.textContent).not.toContain('A')
-    expect(host.textContent).toContain('B')
-  })
-
   test('prefixes outer component key for a single transition child', () => {
     const Child = defineVaporComponent({
       setup() {
@@ -312,5 +273,44 @@ describe('TransitionGroup', () => {
     leaveDone && leaveDone()
     await nextTick()
     expect(host.querySelectorAll('.item').length).toBe(1)
+  })
+
+  test('registers full transition hooks when Transition is used later', async () => {
+    const group = define({
+      setup() {
+        return createComponent(VaporTransitionGroup)
+      },
+    }).render()
+    group.app.unmount()
+
+    let leaveDone: (() => void) | undefined
+    const data = ref({
+      show: true,
+      onLeave: (_: Element, done: () => void) => {
+        leaveDone = done
+      },
+    })
+    const App = compile(
+      `<template>
+        <Transition mode="out-in" :css="false" @leave="data.onLeave">
+          <div v-if="data.show" key="a">A</div>
+          <div v-else key="b">B</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { host } = define(App as any).render()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(host.textContent).toContain('A')
+    expect(host.textContent).not.toContain('B')
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.textContent).not.toContain('A')
+    expect(host.textContent).toContain('B')
   })
 })

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -7,11 +7,9 @@ import {
   type TransitionProps,
   TransitionPropsValidators,
   type TransitionState,
-  type VNode,
   baseResolveTransitionHooks,
   checkTransitionMode,
   currentInstance,
-  getTransitionRawChildren,
   isAsyncWrapper,
   isTemplateNode,
   leaveCbKey,
@@ -33,7 +31,13 @@ import {
   isValidBlock,
   remove,
 } from '../block'
-import { displayName, registerTransitionHooks } from '../transition'
+import {
+  displayName,
+  getInteropTransitionElement,
+  getInteropTransitionType,
+  isVaporTransition,
+  registerTransitionHooks,
+} from '../transition'
 import {
   type FunctionalVaporComponent,
   type VaporComponentInstance,
@@ -43,9 +47,9 @@ import { isArray } from '@vue/shared'
 import { renderEffect } from '../renderEffect'
 import {
   DynamicFragment,
-  ForBlock,
-  ForFragment,
   type VaporFragment,
+  isDynamicFragment,
+  isForFragment,
   isFragment,
   isSlotFragment,
 } from '../fragment'
@@ -63,12 +67,6 @@ export type ResolvedTransitionBlock = (
   | DynamicFragment
 ) &
   TransitionOptions
-
-type ResolveTransitionBlocksOptions = {
-  mode: 'single' | 'group'
-  onFragment?: (frag: VaporFragment) => void
-  onUpdateOwner?: (owner: VaporFragment | VaporComponentInstance) => void
-}
 
 let registered = false
 export const ensureTransitionHooksRegistered = (): void => {
@@ -225,29 +223,22 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
   })
 
 const transitionTypeMap = new WeakMap<ResolvedTransitionBlock, any>()
-const inheritedTransitionKeyMap = new WeakMap<
-  ResolvedTransitionBlock,
-  InheritedTransitionKeyRecord
->()
-
-type InheritedTransitionKeyRecord = {
-  generation: number
-  rawBaseKey: any
-  inheritedKey: string
-}
-
-let transitionKeyGeneration = 0
-let currentTransitionKeyGeneration = 0
 
 function getTransitionType(block: ResolvedTransitionBlock): any {
   const type = transitionTypeMap.get(block)
   if (type !== undefined) return type
   if (block instanceof Element) return block.localName
   if (isInteropEnabled && isFragment(block) && block.vnode) {
-    const children = getTransitionRawChildren([block.vnode])
-    if (children.length === 1) return children[0].type
+    return getInteropTransitionType(block.vnode)
   }
   return block
+}
+
+export function setTransitionType(
+  block: ResolvedTransitionBlock,
+  type: any,
+): void {
+  transitionTypeMap.set(block, type)
 }
 
 function getLeavingNodesForType(
@@ -353,7 +344,7 @@ export function resolveTransitionHooks(
   return hooks
 }
 
-function applyTransitionHooksImpl(
+export function applyTransitionHooksImpl(
   block: Block,
   hooks: VaporTransitionHooks,
 ): VaporTransitionHooks {
@@ -383,7 +374,7 @@ function applyResolvedTransitionHooks(
   // enter/leave hooks for their resolved single child.
   if (
     hooks.applyGroup &&
-    (block instanceof ForFragment ||
+    (isForFragment(block) ||
       isSlotFragment(block) ||
       (isVaporComponent(block) && isSlotFragment(block.block)))
   ) {
@@ -439,7 +430,7 @@ function applyResolvedTransitionHooks(
 
 function isStructuralTransitionFragment(fragment: VaporFragment): boolean {
   return !!(
-    fragment instanceof DynamicFragment &&
+    isDynamicFragment(fragment) &&
     !isSlotFragment(fragment) &&
     fragment.inTransition
   )
@@ -594,106 +585,44 @@ export function resolveTransitionBlock(
   block: Block,
   onFragment?: (frag: VaporFragment) => void,
 ): ResolvedTransitionBlock | undefined {
-  return resolveTransitionChildren(block, { mode: 'single', onFragment })[0]
-}
-
-export function resolveTransitionBlocks(
-  block: Block,
-  onFragment?: (frag: VaporFragment) => void,
-  onUpdateOwner?: (owner: VaporFragment | VaporComponentInstance) => void,
-): ResolvedTransitionBlock[] {
-  return resolveTransitionChildren(block, {
-    mode: 'group',
-    onFragment,
-    onUpdateOwner,
-  })
-}
-
-function resolveTransitionChildren(
-  block: Block,
-  options: ResolveTransitionBlocksOptions,
-): ResolvedTransitionBlock[] {
   const children: ResolvedTransitionBlock[] = []
-  const prevGeneration = currentTransitionKeyGeneration
-  currentTransitionKeyGeneration = ++transitionKeyGeneration
-  try {
-    collectTransitionBlocks(block, options, children)
-    return children
-  } finally {
-    currentTransitionKeyGeneration = prevGeneration
-  }
+  collectTransitionBlocks(block, onFragment, children)
+  return children[0]
 }
 
 function collectTransitionBlocks(
   block: Block,
-  options: ResolveTransitionBlocksOptions,
+  onFragment: ((frag: VaporFragment) => void) | undefined,
   children: ResolvedTransitionBlock[],
 ): void {
   if (block instanceof Node) {
     // transition can only be applied on Element child
     if (block instanceof Element) children.push(block)
   } else if (isVaporComponent(block)) {
-    collectComponentTransitionBlocks(block, options, children)
+    collectComponentTransitionBlocks(block, onFragment, children)
   } else if (isArray(block)) {
-    collectArrayTransitionBlocks(block, options, children)
+    collectArrayTransitionBlocks(block, onFragment, children)
   } else if (isFragment(block)) {
-    collectFragmentTransitionBlocks(block, options, children)
+    collectFragmentTransitionBlocks(block, onFragment, children)
   }
 }
 
 function collectComponentTransitionBlocks(
   block: VaporComponentInstance,
-  options: ResolveTransitionBlocksOptions,
+  onFragment: ((frag: VaporFragment) => void) | undefined,
   children: ResolvedTransitionBlock[],
 ): void {
-  if (options.mode === 'group') {
-    // A normal component child can move when parent-driven props update its
-    // root layout without re-running the surrounding v-for fragment.
-    // When the component root is a slot, the TransitionGroup children are the
-    // slotted blocks, so track the slot fragment instead of the component.
-    const isRootSlot = block.block && isSlotFragment(block.block)
-    if (options.onUpdateOwner && !isRootSlot) options.onUpdateOwner(block)
-
-    const start = children.length
-    collectTransitionBlocks(
-      block.block,
-      isRootSlot
-        ? options
-        : {
-            mode: options.mode,
-            onFragment: options.onFragment,
-          },
-      children,
-    )
-    // Tag the resolved children with the component type so the leaving cache
-    // buckets by component (mirroring single mode's inheritSingleComponentKey
-    // and VDOM's vnode.type bucketing) instead of the shared root tag name.
-    // Otherwise a leaving item cached via this group path under its tag name
-    // can't be matched by a re-entering item — which v-for resolves via the
-    // single path under the component type — so earlyRemove misses and two
-    // same-key instances are left in the DOM. Root-slot children belong to the
-    // parent, so they keep their own resolved type.
-    if (!isRootSlot) {
-      for (let i = start; i < children.length; i++) {
-        transitionTypeMap.set(children[i], block.type)
-      }
-    }
-    inheritTransitionKey(children, start, block.$key)
-    return
-  }
-
   if (isAsyncWrapper(block)) {
     // for unresolved async wrapper, set transition hooks on inner fragment
     if (!block.type.__asyncResolved) {
-      if (options.onFragment)
-        options.onFragment(block.block! as DynamicFragment)
+      if (onFragment) onFragment(block.block! as DynamicFragment)
       return
     }
 
     const start = children.length
     collectTransitionBlocks(
       (block.block! as DynamicFragment).nodes,
-      options,
+      onFragment,
       children,
     )
     inheritSingleComponentKey(children[start], block)
@@ -701,38 +630,23 @@ function collectComponentTransitionBlocks(
   }
 
   // stop searching if encountering nested Transition component
-  if (block.type === VaporTransition) return
+  if (isVaporTransition(block.type)) return
 
   const start = children.length
-  collectTransitionBlocks(block.block, options, children)
+  collectTransitionBlocks(block.block, onFragment, children)
   inheritSingleComponentKey(children[start], block)
 }
 
 function collectArrayTransitionBlocks(
   block: Block[],
-  options: ResolveTransitionBlocksOptions,
+  onFragment: ((frag: VaporFragment) => void) | undefined,
   children: ResolvedTransitionBlock[],
 ): void {
-  if (options.mode === 'group') {
-    for (const c of block) {
-      const start = children.length
-      collectTransitionBlocks(c, options, children)
-      if (c instanceof ForBlock) {
-        const count = children.length - start
-        for (let j = start; j < children.length; j++) {
-          children[j].$key =
-            c.key != null && count > 1 ? `${c.key}:${j - start}` : c.key
-        }
-      }
-    }
-    return
-  }
-
   let hasFound = false
   for (const c of block) {
     if (c instanceof Comment) continue
     const nested: ResolvedTransitionBlock[] = []
-    collectTransitionBlocks(c, options, nested)
+    collectTransitionBlocks(c, onFragment, nested)
     if (__DEV__ && hasFound) {
       // warn more than one non-comment child
       warn(
@@ -749,35 +663,19 @@ function collectArrayTransitionBlocks(
 
 function collectFragmentTransitionBlocks(
   block: VaporFragment,
-  options: ResolveTransitionBlocksOptions,
+  onFragment: ((frag: VaporFragment) => void) | undefined,
   children: ResolvedTransitionBlock[],
 ): void {
-  if (options.mode === 'group') {
-    if (options.onFragment) options.onFragment(block)
-    if (options.onUpdateOwner) options.onUpdateOwner(block)
-    if (isInteropEnabled && block.vnode) {
-      // vdom component
-      children.push(block)
-    } else {
-      const start = children.length
-      collectTransitionBlocks(block.nodes, options, children)
-      inheritTransitionKey(children, start, block.$key)
-    }
-    return
-  }
-
   if (isInteropEnabled && block.vnode) {
     children.push(block)
-    const rawChildren = getTransitionRawChildren([block.vnode])
-    if (rawChildren.length === 1) {
-      transitionTypeMap.set(block, rawChildren[0].type)
-    }
+    const type = getInteropTransitionType(block.vnode)
+    if (type !== undefined) setTransitionType(block, type)
     return
   }
 
   // collect fragments for setting transition hooks
-  if (options.onFragment) options.onFragment(block)
-  collectTransitionBlocks(block.nodes, options, children)
+  if (onFragment) onFragment(block)
+  collectTransitionBlocks(block.nodes, onFragment, children)
 }
 
 function inheritSingleComponentKey(
@@ -795,39 +693,7 @@ function inheritSingleComponentKey(
   if (child.$key == null && block.$key != null) {
     child.$key = block.$key
   }
-  transitionTypeMap.set(child, block.type)
-}
-
-function inheritTransitionKey(
-  children: ResolvedTransitionBlock[],
-  start: number,
-  key: any,
-): void {
-  if (key == null || start === children.length) return
-  for (let i = start; i < children.length; i++) {
-    const child = children[i]
-    let record = inheritedTransitionKeyMap.get(child)
-    let baseKey
-    // Match VDOM parentKey + (child.key ?? index) composition, while reusing
-    // the raw base key across resolutions to avoid repeating prefixes.
-    if (record && record.generation === currentTransitionKeyGeneration) {
-      baseKey = child.$key != null ? child.$key : i - start
-    } else {
-      if (!record || !Object.is(child.$key, record.inheritedKey)) {
-        record = {
-          generation: currentTransitionKeyGeneration,
-          rawBaseKey: child.$key != null ? child.$key : i - start,
-          inheritedKey: '',
-        }
-        inheritedTransitionKeyMap.set(child, record)
-      } else {
-        record.generation = currentTransitionKeyGeneration
-      }
-      baseKey = record.rawBaseKey
-    }
-    record.inheritedKey = String(key) + String(baseKey)
-    child.$key = record.inheritedKey
-  }
+  setTransitionType(child, block.type)
 }
 
 export function setTransitionHooks(
@@ -839,30 +705,6 @@ export function setTransitionHooks(
     if (!block) return
   }
   block.$transition = hooks
-}
-
-export function getVNodeKey(
-  vnode: VNode | undefined,
-): VNode['key'] | undefined {
-  if (!vnode) return
-  const children = getTransitionRawChildren([vnode])
-  return children.length === 1 ? children[0].key : undefined
-}
-
-function getTransitionElementFromVNode(
-  vnode: VNode | undefined,
-): Element | undefined {
-  if (!vnode) return
-  if (vnode.component) {
-    return getTransitionElementFromVNode(vnode.component.subTree)
-  }
-  if (vnode.el instanceof Element) {
-    return vnode.el
-  }
-  const children = getTransitionRawChildren([vnode])
-  if (children.length === 1 && children[0] !== vnode) {
-    return getTransitionElementFromVNode(children[0])
-  }
 }
 
 export function isValidTransitionBlock(
@@ -881,7 +723,7 @@ export function getTransitionElement(
 
   // vdom interop
   if (isInteropEnabled && isFragment(block) && block.vnode) {
-    return getTransitionElementFromVNode(block.vnode)
+    return getInteropTransitionElement(block.vnode)
   }
 }
 

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -229,7 +229,8 @@ function getTransitionType(block: ResolvedTransitionBlock): any {
   if (type !== undefined) return type
   if (block instanceof Element) return block.localName
   if (isInteropEnabled && isFragment(block) && block.vnode) {
-    return getInteropTransitionType(block.vnode)
+    const type = getInteropTransitionType(block.vnode)
+    if (type !== undefined) return type
   }
   return block
 }

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -21,7 +21,7 @@ import {
   vShowHidden,
   warn,
 } from '@vue/runtime-dom'
-import { extend } from '@vue/shared'
+import { extend, isArray } from '@vue/shared'
 import {
   type Block,
   type BlockFn,
@@ -31,26 +31,32 @@ import {
 import { renderEffect } from '../renderEffect'
 import {
   type ResolvedTransitionBlock,
-  ensureTransitionHooksRegistered,
+  applyTransitionHooksImpl,
   getTransitionElement,
   isValidTransitionBlock,
-  resolveTransitionBlocks,
   resolveTransitionHooks,
-  setTransitionHooks,
+  setTransitionType,
 } from './Transition'
-import type {
-  VaporComponentInstance,
-  VaporComponentOptions,
+import {
+  type VaporComponentInstance,
+  type VaporComponentOptions,
+  isVaporComponent,
 } from '../component'
 import { resolveDynamicProps } from '../componentProps'
 import { setForHydrationAnchorResolver } from '../apiCreateFor'
 import { createComment, createElement, createTextNode } from '../dom/node'
-import { DynamicFragment, type VaporFragment, isFragment } from '../fragment'
+import {
+  DynamicFragment,
+  type VaporFragment,
+  isForBlock,
+  isFragment,
+  isSlotFragment,
+} from '../fragment'
 import {
   type DefineVaporComponent,
   defineVaporComponent,
 } from '../apiDefineComponent'
-import { watch } from '@vue/reactivity'
+import { EffectFlags, ReactiveEffect } from '@vue/reactivity'
 import {
   adoptTemplate,
   cleanupHydrationTail,
@@ -60,6 +66,8 @@ import {
   nextLogicalSibling,
   setCurrentHydrationNode,
 } from '../dom/hydration'
+import { isTransitionEnabled, registerTransitionHooks } from '../transition'
+import { isInteropEnabled } from '../vdomInteropState'
 
 const positionMap = new WeakMap<TransitionBlock, DOMRect>()
 const newPositionMap = new WeakMap<TransitionBlock, DOMRect>()
@@ -113,7 +121,7 @@ const decorate = <T extends VaporComponentOptions>(t: T): T => {
   return t
 }
 
-const VaporTransitionGroupImpl = defineVaporComponent({
+const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
   name: 'VaporTransitionGroup',
 
   props: /*@__PURE__*/ extend({}, TransitionPropsValidators, {
@@ -125,8 +133,13 @@ const VaporTransitionGroupImpl = defineVaporComponent({
     // @ts-expect-error
     expose()
 
-    // Register transition hooks on first use
-    ensureTransitionHooksRegistered()
+    if (!isTransitionEnabled) {
+      registerTransitionHooks(
+        applyTransitionHooksImpl,
+        () => false,
+        () => false,
+      )
+    }
 
     const instance = currentInstance as VaporComponentInstance
     const state = useTransitionState()
@@ -304,6 +317,117 @@ export const VaporTransitionGroup: DefineVaporComponent<
   TransitionGroupProps
 > = /*@__PURE__*/ decorate(VaporTransitionGroupImpl)
 
+type InheritedTransitionKeyRecord = {
+  generation: number
+  rawBaseKey: any
+  inheritedKey: string
+}
+
+const inheritedTransitionKeyMap = new WeakMap<
+  ResolvedTransitionBlock,
+  InheritedTransitionKeyRecord
+>()
+let transitionKeyGeneration = 0
+let currentTransitionKeyGeneration = 0
+
+export function resolveTransitionBlocks(
+  block: Block,
+  onFragment?: (frag: VaporFragment) => void,
+  onUpdateOwner?: (owner: TransitionGroupUpdateOwner) => void,
+): ResolvedTransitionBlock[] {
+  const children: ResolvedTransitionBlock[] = []
+  const prevGeneration = currentTransitionKeyGeneration
+  currentTransitionKeyGeneration = ++transitionKeyGeneration
+  try {
+    collectTransitionBlocks(block, children, onFragment, onUpdateOwner)
+    return children
+  } finally {
+    currentTransitionKeyGeneration = prevGeneration
+  }
+}
+
+function collectTransitionBlocks(
+  block: Block,
+  children: ResolvedTransitionBlock[],
+  onFragment?: (frag: VaporFragment) => void,
+  onUpdateOwner?: (owner: TransitionGroupUpdateOwner) => void,
+): void {
+  if (block instanceof Node) {
+    if (block instanceof Element) children.push(block)
+  } else if (isVaporComponent(block)) {
+    const isRootSlot = block.block && isSlotFragment(block.block)
+    if (onUpdateOwner && !isRootSlot) onUpdateOwner(block)
+
+    const start = children.length
+    collectTransitionBlocks(
+      block.block,
+      children,
+      onFragment,
+      isRootSlot ? onUpdateOwner : undefined,
+    )
+    if (!isRootSlot) {
+      for (let i = start; i < children.length; i++) {
+        setTransitionType(children[i], block.type)
+      }
+    }
+    inheritTransitionKey(children, start, block.$key)
+  } else if (isArray(block)) {
+    for (let i = 0; i < block.length; i++) {
+      collectTransitionBlocks(block[i], children, onFragment, onUpdateOwner)
+    }
+  } else if (isFragment(block)) {
+    if (onFragment) onFragment(block)
+    if (onUpdateOwner) onUpdateOwner(block)
+    if (isInteropEnabled && block.vnode) {
+      children.push(block)
+    } else {
+      const start = children.length
+      collectTransitionBlocks(block.nodes, children, onFragment, onUpdateOwner)
+      if (isForBlock(block)) {
+        const count = children.length - start
+        for (let i = start; i < children.length; i++) {
+          children[i].$key =
+            block.key != null && count > 1
+              ? `${block.key}:${i - start}`
+              : block.key
+        }
+      } else {
+        inheritTransitionKey(children, start, block.$key)
+      }
+    }
+  }
+}
+
+function inheritTransitionKey(
+  children: ResolvedTransitionBlock[],
+  start: number,
+  key: any,
+): void {
+  if (key == null || start === children.length) return
+  for (let i = start; i < children.length; i++) {
+    const child = children[i]
+    let record = inheritedTransitionKeyMap.get(child)
+    let baseKey
+    if (record && record.generation === currentTransitionKeyGeneration) {
+      baseKey = child.$key != null ? child.$key : i - start
+    } else {
+      if (!record || !Object.is(child.$key, record.inheritedKey)) {
+        record = {
+          generation: currentTransitionKeyGeneration,
+          rawBaseKey: child.$key != null ? child.$key : i - start,
+          inheritedKey: '',
+        }
+        inheritedTransitionKeyMap.set(child, record)
+      } else {
+        record.generation = currentTransitionKeyGeneration
+      }
+      baseKey = record.rawBaseKey
+    }
+    record.inheritedKey = String(key) + String(baseKey)
+    child.$key = record.inheritedKey
+  }
+}
+
 function applyGroupTransitionHooks(
   block: Block,
   props: TransitionProps,
@@ -321,9 +445,11 @@ function applyGroupTransitionHooks(
     const child = children[i]
     if (isValidTransitionBlock(child)) {
       if (child.$key != null) {
-        setTransitionHooks(
+        child.$transition = resolveTransitionHooks(
           child,
-          resolveTransitionHooks(child, props, state, instance),
+          props,
+          state,
+          instance,
         )
       } else if (__DEV__) {
         warn(`<transition-group> children must be keyed`)
@@ -358,7 +484,7 @@ function trackTransitionGroupUpdate(
     ;(owner.onUpdated ||= []).push(() => updateHooks.updated())
   } else {
     // A component child can update from parent-driven props without re-running
-    // the surrounding v-for fragment. Watch raw props directly instead of
+    // the surrounding v-for fragment. Track raw props directly instead of
     // using component updated hooks, because child-local state updates should
     // not trigger TransitionGroup move bookkeeping. This matches VDOM behavior.
     let isPending = false
@@ -367,25 +493,26 @@ function trackTransitionGroupUpdate(
       updateHooks.updated()
     }
     owner.scope.run(() => {
-      watch(
-        () => {
-          // Dynamic prop sources are resolved as child props, so the getter
-          // must run with the child instance while the watcher itself remains
-          // owned by the child scope for teardown.
-          const prev = setCurrentInstance(owner, owner.scope)
-          try {
-            return resolveDynamicProps(owner.rawProps)
-          } finally {
-            setCurrentInstance(...prev)
-          }
-        },
-        () => {
-          if (isPending) return
-          isPending = true
-          updateHooks.beforeUpdate()
-          queuePostFlushCb(flushUpdated)
-        },
-      )
+      const effect = new ReactiveEffect(() => {
+        // Dynamic prop sources are resolved as child props, so the getter
+        // must run with the child instance while the effect itself remains
+        // owned by the child scope for teardown.
+        const prev = setCurrentInstance(owner, owner.scope)
+        try {
+          resolveDynamicProps(owner.rawProps)
+        } finally {
+          setCurrentInstance(...prev)
+        }
+      })
+      effect.notify = () => {
+        if (effect.flags & EffectFlags.PAUSED || !effect.dirty) return
+        effect.run()
+        if (isPending) return
+        isPending = true
+        updateHooks.beforeUpdate()
+        queuePostFlushCb(flushUpdated)
+      }
+      effect.run()
     })
   }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -690,6 +690,14 @@ export function isDynamicFragment(val: unknown): val is DynamicFragment {
   return !!(val && (val as any).__df)
 }
 
+export function isForFragment(val: unknown): val is ForFragment {
+  return isFragment(val) && typeof (val as ForFragment).onReset === 'function'
+}
+
+export function isForBlock(val: unknown): val is ForBlock {
+  return isFragment(val) && (val as ForBlock).itemRef !== undefined
+}
+
 export function isSlotFragment(val: unknown): val is SlotFragment {
   return isDynamicFragment(val) && !!val.isSlot
 }

--- a/packages/runtime-vapor/src/transition.ts
+++ b/packages/runtime-vapor/src/transition.ts
@@ -1,7 +1,7 @@
-import { getComponentName } from '@vue/runtime-dom'
+import type { VNode } from '@vue/runtime-dom'
 import type { Block, BlockFn } from './block'
 import type { VaporTransitionHooks } from './block'
-import type { VaporComponent } from './component'
+import type { FunctionalVaporComponent, VaporComponent } from './component'
 import type { DynamicFragment } from './fragment'
 
 // Transition hooks registry for tree-shaking
@@ -32,6 +32,12 @@ export let applyTransitionHooks: ApplyTransitionHooksFn
 export let deferBranchUpdateDuringLeave: DeferBranchUpdateDuringLeaveFn
 export let removeBranchWithLeave: RemoveBranchWithLeaveFn
 
+type GetInteropTransitionTypeFn = (vnode: VNode) => VNode['type'] | undefined
+type GetInteropTransitionElementFn = (vnode: VNode) => Element | undefined
+
+export let getInteropTransitionType: GetInteropTransitionTypeFn
+export let getInteropTransitionElement: GetInteropTransitionElementFn
+
 export let isTransitionEnabled = false
 
 export function registerTransitionHooks(
@@ -45,8 +51,16 @@ export function registerTransitionHooks(
   removeBranchWithLeave = removeBranch
 }
 
+export function registerTransitionInterop(
+  getType: GetInteropTransitionTypeFn,
+  getElement: GetInteropTransitionElementFn,
+): void {
+  getInteropTransitionType = getType
+  getInteropTransitionElement = getElement
+}
+
 export const displayName = 'VaporTransition'
 
 export function isVaporTransition(component: VaporComponent): boolean {
-  return getComponentName(component) === displayName
+  return (component as FunctionalVaporComponent).displayName === displayName
 }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -30,6 +30,7 @@ import {
   ensureValidVNode,
   ensureVaporSlotFallback,
   getInheritedScopeIds,
+  getTransitionRawChildren,
   invokeDirectiveHook,
   isEmitListener,
   isKeepAlive,
@@ -139,9 +140,9 @@ import {
 import type { NodeRef } from './apiTemplateRef'
 import {
   ensureTransitionHooksRegistered,
-  getVNodeKey,
   setTransitionHooks as setVaporTransitionHooks,
 } from './components/Transition'
+import { registerTransitionInterop } from './transition'
 import { interopKey, setInteropEnabled } from './vdomInteropState'
 import {
   type KeepAliveInstance,
@@ -162,6 +163,35 @@ import {
 
 const EMPTY_BLOCK = EMPTY_ARR as unknown as Block[]
 const EMPTY_VNODES = EMPTY_ARR as unknown as VNode[]
+
+function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
+  if (!vnode) return
+  const children = getTransitionRawChildren([vnode])
+  return children.length === 1 ? children[0] : undefined
+}
+
+function getInteropTransitionType(vnode: VNode): VNode['type'] | undefined {
+  const child = getRawTransitionChild(vnode)
+  return child && child.type
+}
+
+function getVNodeKey(vnode: VNode | undefined): VNode['key'] | undefined {
+  const child = getRawTransitionChild(vnode)
+  return child && child.key
+}
+
+function getInteropTransitionElement(vnode: VNode): Element | undefined {
+  if (vnode.component) {
+    return getInteropTransitionElement(vnode.component.subTree)
+  }
+  if (vnode.el instanceof Element) {
+    return vnode.el
+  }
+  const child = getRawTransitionChild(vnode)
+  if (child && child !== vnode) {
+    return getInteropTransitionElement(child)
+  }
+}
 
 function filterReservedProps(props: VNode['props']): VNode['props'] {
   const filtered: VNode['props'] = {}
@@ -1703,6 +1733,10 @@ export const vaporInteropPlugin: Plugin = app => {
   if (__FEATURE_SUSPENSE__) {
     enableSuspense()
   }
+  registerTransitionInterop(
+    getInteropTransitionType,
+    getInteropTransitionElement,
+  )
   setInteropEnabled()
   const internals = ensureRenderer().internals
   // Keep the shared base implementation immutable; renderer-bound methods must

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -187,9 +187,9 @@ function getInteropTransitionElement(vnode: VNode): Element | undefined {
   if (vnode.el instanceof Element) {
     return vnode.el
   }
-  const child = getRawTransitionChild(vnode)
-  if (child && child !== vnode) {
-    return getInteropTransitionElement(child)
+  if (vnode.type === Fragment) {
+    const child = getRawTransitionChild(vnode)
+    if (child) return getInteropTransitionElement(child)
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transition and transition-group behavior when transitions are rendered dynamically or nested.
  - Ensured leaving content remains visible until its leave transition completes.
  - Improved transition handling for keyed elements, conditional rendering, and mixed rendering modes.
  - Enhanced compatibility between Vapor and standard VDOM transitions.

- **Tests**
  - Added coverage for delayed transition registration and out-in transition sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->