### PR TITLE
fix(compiler-sfc): avoid dropping template-only imports in SSR pass

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -811,6 +811,21 @@ return { ref }
 }"
 `;
 
+exports[`SFC compile <script setup> > imports > should re-parse the template when its AST is already transformed 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { transformedMsg } from './transformedMsg'
+        
+export default /*@__PURE__*/_defineComponent({
+  setup(__props, { expose: __expose }) {
+  __expose();
+
+        
+return { get transformedMsg() { return transformedMsg } }
+}
+
+})"
+`;
+
 exports[`SFC compile <script setup> > imports > should support module string names syntax 1`] = `
 "
       

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -7,6 +7,7 @@ import {
   mockId,
 } from './utils'
 import { type RawSourceMap, SourceMapConsumer } from 'source-map-js'
+import { compileScript, compileTemplate, parse } from '../src'
 
 vi.mock('../src/warn', () => ({
   warn: vi.fn(),
@@ -343,6 +344,27 @@ describe('SFC compile <script setup>', () => {
         `import { useCssVars as _useCssVars, unref as _unref } from 'vue'`,
       )
       expect(content).toMatch(`import { useCssVars, ref } from 'vue'`)
+    })
+
+    test('should re-parse the template when its AST is already transformed', () => {
+      const { descriptor } = parse(`
+        <script setup lang="ts">
+        import { transformedMsg } from './transformedMsg'
+        </script>
+        <template><p>{{ transformedMsg }}</p></template>
+        `)
+      compileTemplate({
+        filename: 'example.vue',
+        id: mockId,
+        source: descriptor.template!.content,
+        ast: descriptor.template!.ast,
+      })
+      expect(descriptor.template!.ast!.transformed).toBe(true)
+      const { content } = compileScript(descriptor, { id: mockId })
+      expect(content).toMatch(
+        `return { get transformedMsg() { return transformedMsg } }`,
+      )
+      assertCode(content)
     })
 
     test('import dedupe between <script> and <script setup>', () => {

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -5,6 +5,7 @@ import {
   type SimpleExpressionNode,
   type TemplateChildNode,
   isSimpleIdentifier,
+  parse,
   parserOptions,
   walkIdentifiers,
 } from '@vue/compiler-dom'
@@ -53,7 +54,11 @@ function resolveTemplateAnalysisResult(
   const ids = collectUsedIds ? new Set<string>() : undefined
   const vModelIds = new Set<string>()
 
-  ast!.children.forEach(walk)
+  const root = ast?.transformed
+    ? parse(content, { prefixIdentifiers: true })
+    : ast
+
+  root!.children.forEach(walk)
 
   function walk(node: TemplateChildNode) {
     switch (node.type) {

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -55,7 +55,10 @@ function resolveTemplateAnalysisResult(
   const vModelIds = new Set<string>()
 
   const root = ast?.transformed
-    ? parse(content, { prefixIdentifiers: true })
+    ? parse(content, {
+        prefixIdentifiers: true,
+        onError: () => {} // ignore errors since they were already reported by the SFC parser
+      })
     : ast
 
   root!.children.forEach(walk)


### PR DESCRIPTION
Closes #15126 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of SFC templates that have already been transformed during compilation.
  - Correctly analyzes template-used imports and `v-model` targets in these scenarios, preventing missing or incorrect generated bindings.

- **Tests**
  - Added new coverage to ensure script output is generated correctly when the template AST is pre-transformed.
  - Verified expected properties (including exposed template values) remain accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->