### PR TITLE
fix(runtime-vapor): restore instance context when handling async setup result

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -7,6 +7,7 @@ import {
   createApp,
   createCommentVNode,
   createVNode,
+  currentInstance,
   defineComponent,
   h,
   inject,
@@ -56,6 +57,7 @@ import {
   template,
   txt,
   vaporInteropPlugin,
+  withAsyncContext,
 } from '../src'
 
 const define = makeInteropRender()
@@ -4457,6 +4459,52 @@ describe('vdomInterop', () => {
       expect(
         'resolveComponent can only be used in render() or setup()',
       ).not.toHaveBeenWarned()
+    })
+
+    test('render effects created in render() after async setup are owned by the instance', async () => {
+      const duration = 5
+      const msg = ref('pending')
+      let instanceInRender: any
+
+      const VaporAsyncChild = defineVaporComponent({
+        async setup() {
+          let __temp: any, __restore: any
+          ;(([__temp, __restore] = withAsyncContext(
+            () => new Promise(resolve => setTimeout(resolve, duration)),
+          )),
+            (__temp = await __temp),
+            __restore())
+          return { msg }
+        },
+        render(_ctx: any) {
+          instanceInRender = currentInstance
+          const n = template('<div> </div>')()
+          const x = child(n as any) as any
+          renderEffect(() => setText(x, toDisplayString(_ctx.msg)))
+          return n
+        },
+      })
+
+      const { html } = define({
+        render() {
+          return h(Suspense as any, null, {
+            default: () => h(VaporAsyncChild as any),
+            fallback: () => h('span', 'loading'),
+          })
+        },
+      }).render()
+
+      expect(html()).toContain('<span>loading</span>')
+
+      await new Promise(resolve => setTimeout(resolve, duration + 1))
+      await nextTick()
+
+      expect(html()).toContain('<div>pending</div>')
+      expect(instanceInRender).not.toBe(null)
+
+      msg.value = 'updated'
+      await nextTick()
+      expect(html()).toContain('<div>updated</div>')
     })
 
     test('renders async VDOM child inside VDOM Suspense', async () => {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1053,17 +1053,29 @@ export function mountComponent(
       // mode so the last mount does not fall back to fresh DOM insertion.
       const reset =
         instance.restoreAsyncContext && instance.restoreAsyncContext()
+      // handleSetupResult may invoke the render function, which creates
+      // render effects that must be owned by this instance and its scope.
+      const handleResult = () => {
+        const prevInstance = setCurrentInstance(instance)
+        const prevSub = setActiveSub()
+        try {
+          handleSetupResult(setupResult, component, instance)
+        } finally {
+          setActiveSub(prevSub)
+          setCurrentInstance(...prevInstance)
+        }
+      }
       try {
         if (isHydrating) {
           withDeferredHydrationBoundary(() => {
-            handleSetupResult(setupResult, component, instance)
+            handleResult()
             mountComponent(instance, parent, anchor)
             if (instance.deferredHydrationBoundary) {
               instance.deferredHydrationBoundary()
             }
           })
         } else {
-          handleSetupResult(setupResult, component, instance)
+          handleResult()
           mountComponent(instance, parent, anchor)
         }
       } finally {


### PR DESCRIPTION
this is one of several PRs to fix issues I noticed when testing vapor with Nuxt

when testing v3.6.0-rc.1 Vapor Mode in Nuxt, I consistently hit:
```
[Vue warn]: renderEffect called without active EffectScope or Vapor instance
```
this seems to be because when a vapor component with async setup resolves under a Suspense boundary, `handleSetupResult` is invoked from the `registerDep` callback in `mountComponent`, at which point we've already cleared the current instance

... meaning every effect created in a non-inline component with a render function will warn as above.

this PR wraps `handleSetupResult` in the async re-entry path, matching what `setupComponent` does for the synchronous path.
