### PR TITLE
fix(runtime-vapor): contain setup errors in prod

### DIFF
--- a/packages/runtime-vapor/__tests__/errorHandling.spec.ts
+++ b/packages/runtime-vapor/__tests__/errorHandling.spec.ts
@@ -941,40 +941,44 @@ describe('error handling', () => {
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
-  test('component can be updated and unmounted after setup error', async () => {
-    const err = new Error('foo')
-    const fn = vi.fn()
-    const toggle = ref(true)
+  test('component can be updated and unmounted after setup error in production', async () => {
+    __DEV__ = false
+    try {
+      const err = new Error('foo')
+      const fn = vi.fn()
+      const toggle = ref(true)
 
-    const Child = defineVaporComponent({
-      setup() {
-        throw err
-      },
-    })
+      const Child = defineVaporComponent({
+        setup() {
+          throw err
+        },
+      })
 
-    const Comp: VaporComponent = {
-      setup() {
-        onErrorCaptured((err, instance, info) => {
-          fn(err, info)
-          return false
-        })
-        return createIf(
-          () => toggle.value,
-          () => createComponent(Child),
-          () => template('<div>fallback</div>')(),
-        )
-      },
+      const Comp: VaporComponent = {
+        setup() {
+          onErrorCaptured(err => {
+            fn(err)
+            return false
+          })
+          return createIf(
+            () => toggle.value,
+            () => createComponent(Child),
+            () => template('<div>fallback</div>')(),
+          )
+        },
+      }
+
+      const { app, html } = define(Comp).render()
+      expect(fn).toHaveBeenCalledWith(err)
+
+      toggle.value = false
+      await nextTick()
+      expect(html()).toContain('fallback')
+
+      expect(() => app.unmount()).not.toThrow()
+    } finally {
+      __DEV__ = true
     }
-
-    const { app, html } = define(Comp).render()
-    expect(fn).toHaveBeenCalledWith(err, 'setup function')
-
-    toggle.value = false
-    await nextTick()
-    expect(html()).toContain('fallback')
-
-    expect(() => app.unmount()).not.toThrow()
-    expect(`returned non-block value`).toHaveBeenWarned()
   })
 
   // native event handler handling should be tested in respective renderers

--- a/packages/runtime-vapor/__tests__/errorHandling.spec.ts
+++ b/packages/runtime-vapor/__tests__/errorHandling.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@vue/runtime-dom'
 import {
   createComponent,
+  createIf,
   createInvoker,
   createSlot,
   createTemplateRefSetter,
@@ -938,6 +939,42 @@ describe('error handling', () => {
     await nextTick()
     expect(handler).toHaveBeenCalledWith(error, {}, 'render function')
     expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('component can be updated and unmounted after setup error', async () => {
+    const err = new Error('foo')
+    const fn = vi.fn()
+    const toggle = ref(true)
+
+    const Child = defineVaporComponent({
+      setup() {
+        throw err
+      },
+    })
+
+    const Comp: VaporComponent = {
+      setup() {
+        onErrorCaptured((err, instance, info) => {
+          fn(err, info)
+          return false
+        })
+        return createIf(
+          () => toggle.value,
+          () => createComponent(Child),
+          () => template('<div>fallback</div>')(),
+        )
+      },
+    }
+
+    const { app, html } = define(Comp).render()
+    expect(fn).toHaveBeenCalledWith(err, 'setup function')
+
+    toggle.value = false
+    await nextTick()
+    expect(html()).toContain('fallback')
+
+    expect(() => app.unmount()).not.toThrow()
+    expect(`returned non-block value`).toHaveBeenWarned()
   })
 
   // native event handler handling should be tested in respective renderers

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -15,6 +15,7 @@ import {
   onBeforeMount,
   onBeforeUpdate,
   onDeactivated,
+  onErrorCaptured,
   onMounted,
   onUnmounted,
   onUpdated,
@@ -4756,6 +4757,47 @@ describe('vdomInterop', () => {
         'component updated',
         'vnode updated',
       ])
+    })
+  })
+
+  describe('error handling', () => {
+    test('vdom parent captures error thrown in vapor child setup', async () => {
+      const err = new Error('foo')
+      const fn = vi.fn()
+      const show = ref(false)
+
+      const VaporChild = defineVaporComponent({
+        setup() {
+          throw err
+        },
+      })
+
+      const Parent = defineComponent({
+        setup() {
+          onErrorCaptured((err, instance, info) => {
+            fn(err, info)
+            return false
+          })
+          return () => (show.value ? h(VaporChild as any) : h('div', 'ok'))
+        },
+      })
+
+      const root = document.createElement('div')
+      const app = createApp(Parent)
+      app.use(vaporInteropPlugin)
+      app.mount(root)
+      expect(root.innerHTML).toBe('<div>ok</div>')
+
+      show.value = true
+      await nextTick()
+      expect(fn).toHaveBeenCalledWith(err, 'setup function')
+
+      show.value = false
+      await nextTick()
+      expect(root.innerHTML).toBe('<div>ok</div>')
+
+      expect(() => app.unmount()).not.toThrow()
+      expect(`returned non-block value`).toHaveBeenWarned()
     })
   })
 })

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1244,34 +1244,34 @@ function handleSetupResult(
     pushWarningContext(instance)
   }
 
-  if (__DEV__ && !isBlock(setupResult)) {
+  if (!isBlock(setupResult)) {
     if (isFunction(component)) {
-      warn(`Functional vapor component must return a block directly.`)
+      if (__DEV__) {
+        warn(`Functional vapor component must return a block directly.`)
+      }
       instance.block = []
     } else if (!component.render) {
-      warn(
-        `Vapor component setup() returned non-block value, and has no render function.`,
-      )
-      instance.block = []
-    } else {
-      if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
-        instance.devtoolsRawSetupState = setupResult
-      }
-      instance.setupState = proxyRefs(setupResult)
       if (__DEV__) {
-        instance.setupState = createDevSetupStateProxy(instance)
+        warn(
+          `Vapor component setup() returned non-block value, and has no render function.`,
+        )
       }
+      // setup either threw or returned a non-block value: fall back to an
+      // empty block so mount / unmount can proceed and the error can
+      // propagate to parent error boundaries
+      instance.block = []
+    } else if (__DEV__) {
+      instance.devtoolsRawSetupState = setupResult
+      instance.setupState = proxyRefs(setupResult)
+      instance.setupState = createDevSetupStateProxy(instance)
       devRender(instance)
+    } else {
+      // component has a render function but no setup function
+      // (typically components with only a template and no state)
+      instance.block = callRender(component.render, instance, setupResult) || []
     }
   } else {
-    // component has a render function but no setup function
-    // (typically components with only a template and no state)
-    if (setupResult === EMPTY_OBJ && component.render) {
-      instance.block = callRender(component.render, instance, setupResult)
-    } else {
-      // in prod result can only be block
-      instance.block = setupResult as Block
-    }
+    instance.block = setupResult as Block
   }
 
   // single root, inherit attrs

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -552,15 +552,14 @@ export function applyFallthroughProps(
  * dev only
  */
 function createDevSetupStateProxy(
-  instance: VaporComponentInstance,
+  setupState: Record<string, any>,
 ): Record<string, any> {
-  const { setupState } = instance
-  return new Proxy(setupState!, {
+  return new Proxy(setupState, {
     get(target, key: string | symbol, receiver) {
       if (
         isString(key) &&
         !key.startsWith('__v') &&
-        !hasOwn(toRaw(setupState)!, key)
+        !hasOwn(toRaw(setupState), key)
       ) {
         warn(
           `Property ${JSON.stringify(key)} was accessed during render ` +
@@ -1260,15 +1259,19 @@ function handleSetupResult(
       // empty block so mount / unmount can proceed and the error can
       // propagate to parent error boundaries
       instance.block = []
-    } else if (__DEV__) {
-      instance.devtoolsRawSetupState = setupResult
-      instance.setupState = proxyRefs(setupResult)
-      instance.setupState = createDevSetupStateProxy(instance)
-      devRender(instance)
     } else {
-      // component has a render function but no setup function
-      // (typically components with only a template and no state)
-      instance.block = callRender(component.render, instance, setupResult) || []
+      if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
+        instance.devtoolsRawSetupState = setupResult
+      }
+      if (__DEV__) {
+        instance.setupState = createDevSetupStateProxy(proxyRefs(setupResult))
+        devRender(instance)
+      } else {
+        // component has a render function but no setup function
+        // (typically components with only a template and no state)
+        instance.block =
+          callRender(component.render, instance, setupResult) || []
+      }
     }
   } else {
     instance.block = setupResult as Block


### PR DESCRIPTION
this is one of several PRs to fix issues I noticed when testing vapor with Nuxt

a vapor component that throws synchronously in setup inside a parent using `onErrorCaptured` (`<NuxtErrorBoundary>`) works fine in dev, but production builds crash with:

```
TypeError: Cannot read properties of undefined (reading 'anchor')
```

during mount (and `reading 'onRemove'` on unmount), tearing down the tree the boundary was supposed to keep alive. same behaviour with a pure-vapor parent, so it's not interop-specific.

this seems to be because the non-block fallback in `handleSetupResult` is behind a `__DEV__` guard, so in prod a thrown setup leaves `instance.block` as `EMPTY_OBJ` and the next block traversal crashes

this PR shares that fallback with prod (keeping the warnings and `devRender` path dev-only), matching what the dev branch already does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when component setup fails, allowing captured errors to render fallback content.
  * Prevented unmounting from throwing after a setup error.
  * Improved stability when switching between failing components and fallback content.
  * Ensured components continue rendering correctly in production when setup returns non-renderable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->