### PR TITLE
fix(runtime-vapor): hydrate vapor components in deferred vdom hydration via interop

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -663,6 +663,7 @@ export {
   isValidHtmlOrSvgAttribute,
   getAttributeMismatch,
   isHydrating,
+  isHydratingEnabled,
   logMismatchError,
 } from './hydration'
 /**

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -6648,6 +6648,99 @@ describe('Vapor Mode hydration', () => {
       `)
     })
 
+    test('hydrate vapor component inside VDOM async component resolved after hydration (interop)', async () => {
+      const data = ref({
+        spy: vi.fn(),
+      })
+
+      const compCode = `<button @click="data.spy">hello!</button>`
+      const SSRComp = compileVaporComponent(compCode, data, undefined, true)
+      const SSRAsyncComp = defineAsyncComponent(() => Promise.resolve(SSRComp))
+      const SSRApp = defineComponent({
+        render: () => h('div', [h(SSRAsyncComp)]),
+      })
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+      expect(html).toMatchInlineSnapshot(`"<div><button>hello!</button></div>"`)
+
+      let clientResolve: any
+      const AsyncComp = defineAsyncComponent(
+        () =>
+          new Promise(r => {
+            clientResolve = r
+          }),
+      )
+      const App = defineComponent({
+        render: () => h('div', [h(AsyncComp)]),
+      })
+
+      const Comp = compileVaporComponent(compCode, data)
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const app = runtimeDom.createSSRApp(App)
+      app.use(runtimeVapor.vaporInteropPlugin)
+      app.mount(container)
+
+      triggerEvent('click', container.querySelector('button')!)
+      expect(data.value.spy).not.toHaveBeenCalled()
+
+      clientResolve(Comp)
+      await new Promise(r => setTimeout(r))
+
+      triggerEvent('click', container.querySelector('button')!)
+      expect(data.value.spy).toHaveBeenCalledTimes(1)
+    })
+
+    test('hydrate vapor component inside VDOM async component with lazy hydration strategy (interop)', async () => {
+      const data = ref({
+        spy: vi.fn(),
+      })
+
+      const compCode = `<button @click="data.spy">hello!</button>`
+      const SSRComp = compileVaporComponent(compCode, data, undefined, true)
+      const SSRAsyncComp = defineAsyncComponent(() => Promise.resolve(SSRComp))
+      const SSRApp = defineComponent({
+        render: () => h('div', [h(SSRAsyncComp)]),
+      })
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+
+      const Comp = compileVaporComponent(compCode, data)
+      let doHydrate: (() => void) | undefined
+      const AsyncComp = defineAsyncComponent({
+        loader: () => Promise.resolve(Comp) as any,
+        hydrate(hydrate) {
+          doHydrate = hydrate
+          return () => {}
+        },
+      })
+      const App = defineComponent({
+        render: () => h('div', [h(AsyncComp)]),
+      })
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const app = runtimeDom.createSSRApp(App)
+      app.use(runtimeVapor.vaporInteropPlugin)
+      app.mount(container)
+      await new Promise(r => setTimeout(r))
+
+      triggerEvent('click', container.querySelector('button')!)
+      expect(data.value.spy).not.toHaveBeenCalled()
+
+      expect(doHydrate).toBeDefined()
+      doHydrate!()
+      await new Promise(r => setTimeout(r))
+
+      triggerEvent('click', container.querySelector('button')!)
+      expect(data.value.spy).toHaveBeenCalledTimes(1)
+    })
+
     describe('suspense', () => {
       describe('VDOM suspense', () => {
         test('hydrate VDOM Suspense vapor async setup updates empty v-for before trailing sibling', async () => {

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -2,6 +2,7 @@ import {
   MismatchTypes,
   isMismatchAllowed,
   isHydrating as isVdomHydrating,
+  isHydratingEnabled as isVdomHydratingEnabled,
   logMismatchError,
   warn,
 } from '@vue/runtime-dom'
@@ -34,7 +35,9 @@ export let currentHydrationNode: Node | null = null
 
 export let isHydrating = false
 function setIsHydrating(value: boolean) {
-  if (!isHydratingEnabled && !isVdomHydrating) return false
+  if (!isHydratingEnabled && !isVdomHydrating && !isVdomHydratingEnabled) {
+    return false
+  }
   try {
     return isHydrating
   } finally {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -109,11 +109,9 @@ import {
   currentHydrationNode,
   isComment,
   isHydrating,
-  isHydratingEnabled,
   isHydrationAnchor,
   locateEndAnchor,
   setCurrentHydrationNode,
-  setIsHydratingEnabled,
   hydrateNode as vaporHydrateNode,
 } from './dom/hydration'
 import {
@@ -212,19 +210,6 @@ function filterReservedProps(props: VNode['props']): VNode['props'] {
 }
 
 // mounting vapor components and slots in vdom
-// Deferred hydration (async chunks, lazy hydration strategies) runs after
-// vapor's hydration gate has been reset, so scope-enable it for the duration
-// of the interop hydrate call.
-function withVaporHydrationEnabled<T>(fn: () => T): T {
-  const prev = isHydratingEnabled
-  if (!prev) setIsHydratingEnabled(true)
-  try {
-    return fn()
-  } finally {
-    if (!prev) setIsHydratingEnabled(false)
-  }
-}
-
 const vaporInteropImpl: Omit<
   VaporInteropInterface,
   'vdomMount' | 'vdomUnmount' | 'vdomSlot' | 'vdomMountVNode'
@@ -545,18 +530,16 @@ const vaporInteropImpl: Omit<
       return node
     }
     let instance: VaporComponentInstance | undefined
-    withVaporHydrationEnabled(() => {
-      vaporHydrateNode(node, () => {
-        instance = this.mount(
-          vnode,
-          container,
-          anchor,
-          parentComponent,
-          parentSuspense,
-          onBeforeMount,
-          onVnodeBeforeMount,
-        ) as VaporComponentInstance
-      })
+    vaporHydrateNode(node, () => {
+      instance = this.mount(
+        vnode,
+        container,
+        anchor,
+        parentComponent,
+        parentSuspense,
+        onBeforeMount,
+        onVnodeBeforeMount,
+      ) as VaporComponentInstance
     })
     if (instance && instance.asyncDep && !instance.asyncResolved) {
       // mount() cannot expose a block before async setup resolves. Keep the SSR
@@ -570,27 +553,25 @@ const vaporInteropImpl: Omit<
     if (!isHydrating && !isVdomHydrating && !isVdomHydratingEnabled) {
       return node
     }
-    withVaporHydrationEnabled(() => {
-      vaporHydrateNode(node, () => {
-        vnode.vb = renderVaporSlot(vnode, parentComponent, parentSuspense)
-        const anchor =
-          isFragment(vnode.vb) && vnode.vb.anchor
-            ? vnode.vb.anchor
-            : currentHydrationNode!
-        // VDOM SSR wraps slot output in fragment anchors. Keep that range on the
-        // VaporSlot vnode so enabled Teleport removal can dispose both anchors.
-        if (isComment(node, '[') && isComment(anchor, ']')) {
-          vnode.el = node
-          vnode.anchor = anchor
-        } else {
-          vnode.anchor = vnode.el = anchor
-        }
-        if (__DEV__ && !vnode.anchor) {
-          throw new Error(
-            `Failed to locate slot anchor. this is likely a Vue internal bug.`,
-          )
-        }
-      })
+    vaporHydrateNode(node, () => {
+      vnode.vb = renderVaporSlot(vnode, parentComponent, parentSuspense)
+      const anchor =
+        isFragment(vnode.vb) && vnode.vb.anchor
+          ? vnode.vb.anchor
+          : currentHydrationNode!
+      // VDOM SSR wraps slot output in fragment anchors. Keep that range on the
+      // VaporSlot vnode so enabled Teleport removal can dispose both anchors.
+      if (isComment(node, '[') && isComment(anchor, ']')) {
+        vnode.el = node
+        vnode.anchor = anchor
+      } else {
+        vnode.anchor = vnode.el = anchor
+      }
+      if (__DEV__ && !vnode.anchor) {
+        throw new Error(
+          `Failed to locate slot anchor. this is likely a Vue internal bug.`,
+        )
+      }
     })
     // For fragment-wrapped slot content (`<!--[-->...<!--]-->`), return the
     // node after the end anchor to avoid hydrateChildren() treating `<!--]-->`

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -36,6 +36,7 @@ import {
   isKeepAlive,
   isVNode,
   isHydrating as isVdomHydrating,
+  isHydratingEnabled as isVdomHydratingEnabled,
   normalizeRef,
   normalizeVNode,
   onScopeDispose,
@@ -108,9 +109,11 @@ import {
   currentHydrationNode,
   isComment,
   isHydrating,
+  isHydratingEnabled,
   isHydrationAnchor,
   locateEndAnchor,
   setCurrentHydrationNode,
+  setIsHydratingEnabled,
   hydrateNode as vaporHydrateNode,
 } from './dom/hydration'
 import {
@@ -209,6 +212,19 @@ function filterReservedProps(props: VNode['props']): VNode['props'] {
 }
 
 // mounting vapor components and slots in vdom
+// Deferred hydration (async chunks, lazy hydration strategies) runs after
+// vapor's hydration gate has been reset, so scope-enable it for the duration
+// of the interop hydrate call.
+function withVaporHydrationEnabled<T>(fn: () => T): T {
+  const prev = isHydratingEnabled
+  if (!prev) setIsHydratingEnabled(true)
+  try {
+    return fn()
+  } finally {
+    if (!prev) setIsHydratingEnabled(false)
+  }
+}
+
 const vaporInteropImpl: Omit<
   VaporInteropInterface,
   'vdomMount' | 'vdomUnmount' | 'vdomSlot' | 'vdomMountVNode'
@@ -519,22 +535,28 @@ const vaporInteropImpl: Omit<
     onBeforeMount,
     onVnodeBeforeMount,
   ) {
-    // Check both vapor's isHydrating (for createVaporSSRApp) and
-    // VDOM's isVdomHydrating (for createSSRApp).
-    // In CSR (createApp/createVaporApp + vaporInteropPlugin), both are false,
+    // Check vapor's isHydrating (for createVaporSSRApp) and VDOM's
+    // isVdomHydrating (for createSSRApp). isVdomHydratingEnabled covers
+    // deferred hydration (async chunks, lazy hydration strategies), which
+    // runs after the root hydration pass has reset isVdomHydrating.
+    // In CSR (createApp/createVaporApp + vaporInteropPlugin), all are false,
     // so this logic is tree-shaken.
-    if (!isHydrating && !isVdomHydrating) return node
+    if (!isHydrating && !isVdomHydrating && !isVdomHydratingEnabled) {
+      return node
+    }
     let instance: VaporComponentInstance | undefined
-    vaporHydrateNode(node, () => {
-      instance = this.mount(
-        vnode,
-        container,
-        anchor,
-        parentComponent,
-        parentSuspense,
-        onBeforeMount,
-        onVnodeBeforeMount,
-      ) as VaporComponentInstance
+    withVaporHydrationEnabled(() => {
+      vaporHydrateNode(node, () => {
+        instance = this.mount(
+          vnode,
+          container,
+          anchor,
+          parentComponent,
+          parentSuspense,
+          onBeforeMount,
+          onVnodeBeforeMount,
+        ) as VaporComponentInstance
+      })
     })
     if (instance && instance.asyncDep && !instance.asyncResolved) {
       // mount() cannot expose a block before async setup resolves. Keep the SSR
@@ -545,26 +567,30 @@ const vaporInteropImpl: Omit<
   },
 
   hydrateSlot(vnode, node, parentComponent, parentSuspense) {
-    if (!isHydrating && !isVdomHydrating) return node
-    vaporHydrateNode(node, () => {
-      vnode.vb = renderVaporSlot(vnode, parentComponent, parentSuspense)
-      const anchor =
-        isFragment(vnode.vb) && vnode.vb.anchor
-          ? vnode.vb.anchor
-          : currentHydrationNode!
-      // VDOM SSR wraps slot output in fragment anchors. Keep that range on the
-      // VaporSlot vnode so enabled Teleport removal can dispose both anchors.
-      if (isComment(node, '[') && isComment(anchor, ']')) {
-        vnode.el = node
-        vnode.anchor = anchor
-      } else {
-        vnode.anchor = vnode.el = anchor
-      }
-      if (__DEV__ && !vnode.anchor) {
-        throw new Error(
-          `Failed to locate slot anchor. this is likely a Vue internal bug.`,
-        )
-      }
+    if (!isHydrating && !isVdomHydrating && !isVdomHydratingEnabled) {
+      return node
+    }
+    withVaporHydrationEnabled(() => {
+      vaporHydrateNode(node, () => {
+        vnode.vb = renderVaporSlot(vnode, parentComponent, parentSuspense)
+        const anchor =
+          isFragment(vnode.vb) && vnode.vb.anchor
+            ? vnode.vb.anchor
+            : currentHydrationNode!
+        // VDOM SSR wraps slot output in fragment anchors. Keep that range on the
+        // VaporSlot vnode so enabled Teleport removal can dispose both anchors.
+        if (isComment(node, '[') && isComment(anchor, ']')) {
+          vnode.el = node
+          vnode.anchor = anchor
+        } else {
+          vnode.anchor = vnode.el = anchor
+        }
+        if (__DEV__ && !vnode.anchor) {
+          throw new Error(
+            `Failed to locate slot anchor. this is likely a Vue internal bug.`,
+          )
+        }
+      })
     })
     // For fragment-wrapped slot content (`<!--[-->...<!--]-->`), return the
     // node after the end anchor to avoid hydrateChildren() treating `<!--]-->`


### PR DESCRIPTION
this is one of several PRs to fix issues I noticed when testing vapor with Nuxt

a vapor component wrapped in a VDOM `defineAsyncComponent` (with interop) SSRs fine but never hydrates on the client: with a lazy strategy like `hydrateOnVisible()` it stays inert after the trigger fires, and with a plain async loader it silently never attaches event handlers when the chunk resolves after the hydration pass. no errors either way.

this seems to be because `vaporInteropImpl.hydrate` / `hydrateSlot` bail when neither `isHydrating` nor `isVdomHydrating` is set, and deferred hydration (`__asyncHydrate` -> `hydrateSubTree`) runs after the root hydration pass has reset both flags... meaning any vapor component whose hydration is deferred past that pass is skipped entirely.

this PR also accepts the persistent `isHydratingEnabled` flag (set once by `createSSRApp`) and scope-enables vapor's own hydration gate for the duration of the call, matching how pure-VDOM children hydrate unconditionally from `hydrateSubTree`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hydration coordination between Vapor and VDOM components.
  - Prevented event handlers from activating before deferred or asynchronous hydration is complete.
  - Ensured lazy hydration correctly activates interactions after hydration is explicitly triggered.

- **Tests**
  - Added coverage for eager and lazy hydration scenarios involving asynchronous components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->