### PR TITLE
fix(compiler-sfc): handle transformed template AST after cache invalidation

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -7,6 +7,8 @@ import {
   mockId,
 } from './utils'
 import { type RawSourceMap, SourceMapConsumer } from 'source-map-js'
+import { compileScript, compileTemplate, parse } from '../src'
+import { templateAnalysisCache } from '../src/script/importUsageCheck'
 
 vi.mock('../src/warn', () => ({
   warn: vi.fn(),
@@ -343,6 +345,43 @@ describe('SFC compile <script setup>', () => {
         `import { useCssVars as _useCssVars, unref as _unref } from 'vue'`,
       )
       expect(content).toMatch(`import { useCssVars, ref } from 'vue'`)
+    })
+
+    test('should re-analyze a transformed template after cache invalidation', () => {
+      const delimiters: [string, string] = ['[[', ']]']
+      const { descriptor } = parse(
+        `
+        <script setup lang="ts">
+        import { cachedMsg } from './cachedMsg'
+        </script>
+        <template><p>[[ cachedMsg ]]</p></template>
+        `,
+        { templateParseOptions: { delimiters } },
+      )
+
+      const templateOptions = { compilerOptions: { delimiters } }
+      compileScript(descriptor, { id: mockId, templateOptions })
+      expect(templateAnalysisCache.has(descriptor.template!.content)).toBe(true)
+
+      compileTemplate({
+        filename: 'example.vue',
+        id: mockId,
+        source: descriptor.template!.content,
+        ast: descriptor.template!.ast,
+        compilerOptions: { delimiters },
+      })
+      expect(descriptor.template!.ast!.transformed).toBe(true)
+
+      templateAnalysisCache.clear()
+      expect(templateAnalysisCache.has(descriptor.template!.content)).toBe(
+        false,
+      )
+
+      const { content } = compileScript(descriptor, {
+        id: mockId,
+        templateOptions,
+      })
+      expect(content).toMatch(`return { get cachedMsg() { return cachedMsg } }`)
     })
 
     test('import dedupe between <script> and <script setup>', () => {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -266,7 +266,7 @@ export function compileScript(
       !sfc.template.src &&
       !sfc.template.lang
     ) {
-      isUsedInTemplate = isImportUsed(local, sfc)
+      isUsedInTemplate = isImportUsed(local, sfc, options.templateOptions)
     }
 
     ctx.userImports[local] = {
@@ -769,7 +769,10 @@ export function compileScript(
   // which requires a SETUP_LET binding (getter + setter) to keep script state in sync.
   // In inline mode, it generates `foo = $event`, which also requires `let`.
   if (sfc.template && !sfc.template.src && sfc.template.ast) {
-    const vModelIds = resolveTemplateVModelIdentifiers(sfc)
+    const vModelIds = resolveTemplateVModelIdentifiers(
+      sfc,
+      options.templateOptions,
+    )
     if (vModelIds.size) {
       const toDemote = new Set<string>()
       for (const id of vModelIds) {

--- a/packages/compiler-sfc/src/compileTemplate.ts
+++ b/packages/compiler-sfc/src/compileTemplate.ts
@@ -1,14 +1,11 @@
-import {
-  type CodegenResult,
-  type CompilerError,
-  type CompilerOptions,
-  type ElementNode,
-  type NodeTransform,
-  NodeTypes,
-  type ParserOptions,
-  type RawSourceMap,
-  type RootNode,
-  createRoot,
+import type {
+  CodegenResult,
+  CompilerError,
+  CompilerOptions,
+  NodeTransform,
+  ParserOptions,
+  RawSourceMap,
+  RootNode,
 } from '@vue/compiler-core'
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map-js'
 import {
@@ -28,6 +25,7 @@ import * as CompilerSSR from '@vue/compiler-ssr'
 import consolidate from '@vue/consolidate'
 import { warnOnce } from './warn'
 import { genCssVarsFromList } from './style/cssVars'
+import { resolveTemplateAST } from './template/resolveTemplateAST'
 
 export interface TemplateCompiler {
   compile(source: string | RootNode, options: CompilerOptions): CodegenResult
@@ -211,21 +209,12 @@ function doCompileTemplate({
     inAST = undefined
   }
 
-  if (inAST?.transformed) {
-    // If input AST has already been transformed, then it cannot be reused.
-    // We need to parse a fresh one. Can't just use `source` here since we need
-    // the AST location info to be relative to the entire SFC.
-    const newAST = (ssr ? CompilerDOM : compiler).parse(inAST.source, {
-      prefixIdentifiers: true,
-      ...compilerOptions,
-      parseMode: 'sfc',
-      onError: e => errors.push(e),
-    })
-    const template = newAST.children.find(
-      node => node.type === NodeTypes.ELEMENT && node.tag === 'template',
-    ) as ElementNode
-    inAST = createRoot(template.children, inAST.source)
-  }
+  inAST = resolveTemplateAST(inAST, {
+    compiler,
+    compilerOptions,
+    ssr,
+    onError: e => errors.push(e),
+  })
 
   let { code, ast, preamble, map } = compiler.compile(inAST || source, {
     mode: 'module',

--- a/packages/compiler-sfc/src/script/importUsageCheck.ts
+++ b/packages/compiler-sfc/src/script/importUsageCheck.ts
@@ -1,4 +1,5 @@
 import type { SFCDescriptor } from '../parse'
+import type { SFCTemplateCompileOptions } from '../compileTemplate'
 import {
   type ExpressionNode,
   NodeTypes,
@@ -8,36 +9,57 @@ import {
   parserOptions,
   walkIdentifiers,
 } from '@vue/compiler-dom'
+import type { LRUCache } from 'lru-cache'
 import { createCache } from '../cache'
 import { camelize, capitalize, isBuiltInDirective } from '@vue/shared'
+import { resolveTemplateAST } from '../template/resolveTemplateAST'
+
+type TemplateOptions = Pick<
+  SFCTemplateCompileOptions,
+  'compiler' | 'compilerOptions' | 'ssr'
+>
 
 /**
  * Check if an import is used in the SFC's template. This is used to determine
  * the properties that should be included in the object returned from setup()
  * when not using inline mode.
  */
-export function isImportUsed(local: string, sfc: SFCDescriptor): boolean {
-  return resolveTemplateUsedIdentifiers(sfc).has(local)
+export function isImportUsed(
+  local: string,
+  sfc: SFCDescriptor,
+  options?: TemplateOptions,
+): boolean {
+  return resolveTemplateUsedIdentifiers(sfc, options).has(local)
 }
 
-const templateAnalysisCache = createCache<{
+type TemplateAnalysisResult = {
   usedIds?: Set<string>
   vModelIds: Set<string>
-}>()
+}
+
+export const templateAnalysisCache:
+  | Map<string, TemplateAnalysisResult>
+  | LRUCache<string, TemplateAnalysisResult> =
+  createCache<TemplateAnalysisResult>()
 
 export function resolveTemplateVModelIdentifiers(
   sfc: SFCDescriptor,
+  options?: TemplateOptions,
 ): Set<string> {
-  return resolveTemplateAnalysisResult(sfc, false).vModelIds
+  return resolveTemplateAnalysisResult(sfc, false, options).vModelIds
 }
 
-function resolveTemplateUsedIdentifiers(sfc: SFCDescriptor): Set<string> {
-  return resolveTemplateAnalysisResult(sfc).usedIds!
+function resolveTemplateUsedIdentifiers(
+  sfc: SFCDescriptor,
+  options?: TemplateOptions,
+): Set<string> {
+  return resolveTemplateAnalysisResult(sfc, true, options).usedIds!
 }
 
 function resolveTemplateAnalysisResult(
   sfc: SFCDescriptor,
   collectUsedIds = true,
+  options?: TemplateOptions,
 ): {
   usedIds?: Set<string>
   vModelIds: Set<string>
@@ -53,7 +75,15 @@ function resolveTemplateAnalysisResult(
   const ids = collectUsedIds ? new Set<string>() : undefined
   const vModelIds = new Set<string>()
 
-  ast!.children.forEach(walk)
+  const root = resolveTemplateAST(ast, {
+    compiler: options?.compiler,
+    compilerOptions: options?.compilerOptions,
+    ssr: options?.ssr,
+    // ignore errors since they were already reported by the SFC parser
+    onError: () => {},
+  })
+
+  root!.children.forEach(walk)
 
   function walk(node: TemplateChildNode) {
     switch (node.type) {

--- a/packages/compiler-sfc/src/template/resolveTemplateAST.ts
+++ b/packages/compiler-sfc/src/template/resolveTemplateAST.ts
@@ -1,0 +1,40 @@
+import {
+  type CompilerError,
+  type ElementNode,
+  NodeTypes,
+  type ParserOptions,
+  type RootNode,
+  createRoot,
+} from '@vue/compiler-core'
+import * as CompilerDOM from '@vue/compiler-dom'
+
+interface TemplateParser {
+  parse(template: string, options: ParserOptions): RootNode
+}
+
+export function resolveTemplateAST(
+  inAST: RootNode | undefined,
+  options: {
+    compiler?: TemplateParser
+    compilerOptions?: ParserOptions
+    ssr?: boolean
+    onError: (error: CompilerError) => void
+  },
+): RootNode | undefined {
+  if (!inAST?.transformed) {
+    return inAST
+  }
+
+  // Parse the full SFC source to preserve template locations relative to it.
+  const { compiler = CompilerDOM, compilerOptions, ssr, onError } = options
+  const newAST = (ssr ? CompilerDOM : compiler).parse(inAST.source, {
+    prefixIdentifiers: true,
+    ...compilerOptions,
+    parseMode: 'sfc',
+    onError,
+  })
+  const template = newAST.children.find(
+    node => node.type === NodeTypes.ELEMENT && node.tag === 'template',
+  ) as ElementNode
+  return createRoot(template.children, inAST.source)
+}


### PR DESCRIPTION
Template usage analysis normally reuses its cached result. Once that cache entry is evicted, a later compileScript() call recomputes the result from the descriptor's template AST.

If compileTemplate() has already transformed that AST, walking it again can miss template-only imports and v-model identifiers, notably during a later SSR pass.

Reparse transformed template ASTs before analysis, preserving the configured compiler, compiler options, SSR mode, and SFC-relative source locations.

Closes #15126 
Closes #15128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved template analysis when custom compiler options, delimiters, or SSR settings are used.
  - Corrected import-usage and `v-model` detection based on configured template options.
  - Ensured templates are correctly re-analyzed after the analysis cache is cleared.

- **Tests**
  - Added coverage verifying template analysis cache invalidation and regenerated script accessors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->