### PR TITLE
chore(sfc-playground): limit displayed pre-release versions

### DIFF
--- a/packages-private/sfc-playground/src/VersionSelect.vue
+++ b/packages-private/sfc-playground/src/VersionSelect.vue
@@ -86,11 +86,19 @@ onMounted(() => {
 
     <ul class="versions" :class="{ expanded }">
       <li v-if="!versions"><a>loading versions...</a></li>
-      <li v-for="(ver, index) of versions" class="versions-item" :class="{
-        active: ver === version || (version === 'latest' && index === 0),
-      }">
+      <li
+        v-for="(ver, index) of versions"
+        class="versions-item"
+        :class="{
+          active: ver === version || (version === 'latest' && index === 0),
+        }"
+      >
         <a @click="setVersion(ver)">v{{ ver }}</a>
-        <button title="Copy Version" class="version-copy" @click="copyVersion(`v${ver}`)">
+        <button
+          title="Copy Version"
+          class="version-copy"
+          @click="copyVersion(`v${ver}`)"
+        >
           <Copy />
         </button>
       </li>

--- a/packages-private/sfc-playground/src/VersionSelect.vue
+++ b/packages-private/sfc-playground/src/VersionSelect.vue
@@ -25,20 +25,23 @@ async function fetchVersions(): Promise<string[]> {
   const { versions } = (await res.json()) as { versions: string[] }
 
   if (props.pkg === 'vue') {
-    // if the latest version is a pre-release, list all current pre-releases
-    // otherwise filter out pre-releases
+    // If the latest Vue version is a pre-release, include up to 10 of the
+    // current pre-releases so stable releases still have room in the list.
+    // Once a stable release is reached, skip all older pre-releases.
     let isInPreRelease = versions[0].includes('-')
+    let preReleaseCount = 0
     const filteredVersions: string[] = []
     for (const v of versions) {
       if (v.includes('-')) {
-        if (isInPreRelease) {
+        if (isInPreRelease && preReleaseCount < 10) {
           filteredVersions.push(v)
+          preReleaseCount++
         }
       } else {
         filteredVersions.push(v)
         isInPreRelease = false
       }
-      if (filteredVersions.length >= 30 || v === '3.0.10') {
+      if (filteredVersions.length >= 30) {
         break
       }
     }
@@ -83,19 +86,11 @@ onMounted(() => {
 
     <ul class="versions" :class="{ expanded }">
       <li v-if="!versions"><a>loading versions...</a></li>
-      <li
-        v-for="(ver, index) of versions"
-        class="versions-item"
-        :class="{
-          active: ver === version || (version === 'latest' && index === 0),
-        }"
-      >
+      <li v-for="(ver, index) of versions" class="versions-item" :class="{
+        active: ver === version || (version === 'latest' && index === 0),
+      }">
         <a @click="setVersion(ver)">v{{ ver }}</a>
-        <button
-          title="Copy Version"
-          class="version-copy"
-          @click="copyVersion(`v${ver}`)"
-        >
+        <button title="Copy Version" class="version-copy" @click="copyVersion(`v${ver}`)">
           <Copy />
         </button>
       </li>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version list filtering in the Vue playground.
  * Pre-release versions are now limited to 10 entries while preserving up to 30 total versions, including stable releases.
  * Removed an outdated version-specific stopping rule to ensure more consistent version lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->