### PR TITLE
fix(runtime-vapor): defer mount hooks to owning suspense boundary

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -644,6 +644,7 @@ export {
   performTransitionEnter,
   performTransitionLeave,
   invalidateMount,
+  queuePostRenderEffect,
 } from './renderer'
 /**
  * @internal

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4655,6 +4655,46 @@ describe('vdomInterop', () => {
       await nextTick()
       expect(html()).toContain('<span>resolved</span>')
     })
+
+    test('mounted/activated hooks defer to the owning suspense boundary', async () => {
+      const timeout = (n = 0) => new Promise(r => setTimeout(r, n))
+      const order: string[] = []
+
+      const VaporChild = defineVaporComponent({
+        setup() {
+          onMounted(() => order.push('vapor mounted'))
+          return template('<div>vapor</div>', 1)()
+        },
+      })
+
+      const AsyncSibling = defineComponent({
+        async setup() {
+          await timeout(5)
+          return () => h('span', 'async')
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () =>
+            h(
+              Suspense,
+              { onResolve: () => order.push('suspense resolved') },
+              {
+                default: () =>
+                  h('div', [h(VaporChild as any), h(AsyncSibling)]),
+                fallback: () => h('span', 'loading'),
+              },
+            )
+        },
+      }).render()
+
+      await timeout(20)
+      await nextTick()
+
+      expect(html()).toContain('<div>vapor</div>')
+      expect(order).toEqual(['suspense resolved', 'vapor mounted'])
+    })
   })
 
   describe('VaporSlot vnode vs metadata', () => {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1034,6 +1034,19 @@ export function createPlainElement(
   return el
 }
 
+function queuePostMountEffect(
+  fn: LifecycleHook & {},
+  suspense: SuspenseBoundary | null,
+): void {
+  // while mounting into a pending suspense's hidden container, defer to the
+  // boundary so the hooks run once the resolved branch is in the real tree.
+  if (__FEATURE_SUSPENSE__ && suspense && suspense.pendingBranch) {
+    suspense.effects.push(...fn)
+  } else {
+    queuePostFlushCb(fn)
+  }
+}
+
 export function mountComponent(
   instance: VaporComponentInstance,
   parent: ParentNode,
@@ -1124,13 +1137,13 @@ export function mountComponent(
     // client-only branch switches keep inherited scope ids.
     trackComponentScopeId(instance)
   }
-  if (instance.m) queuePostFlushCb(instance.m!)
+  if (instance.m) queuePostMountEffect(instance.m!, instance.suspense)
   if (
     isKeepAliveEnabled &&
     instance.shapeFlag! & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE &&
     instance.a
   ) {
-    queuePostFlushCb(instance.a!)
+    queuePostMountEffect(instance.a!, instance.suspense)
   }
   instance.isMounted = true
   if (__DEV__) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -32,6 +32,7 @@ import {
   popWarningContext,
   pushWarningContext,
   queuePostFlushCb,
+  queuePostRenderEffect,
   registerHMR,
   resolveComponent,
   setCurrentInstance,
@@ -1034,19 +1035,6 @@ export function createPlainElement(
   return el
 }
 
-function queuePostMountEffect(
-  fn: LifecycleHook & {},
-  suspense: SuspenseBoundary | null,
-): void {
-  // while mounting into a pending suspense's hidden container, defer to the
-  // boundary so the hooks run once the resolved branch is in the real tree.
-  if (__FEATURE_SUSPENSE__ && suspense && suspense.pendingBranch) {
-    suspense.effects.push(...fn)
-  } else {
-    queuePostFlushCb(fn)
-  }
-}
-
 export function mountComponent(
   instance: VaporComponentInstance,
   parent: ParentNode,
@@ -1137,13 +1125,15 @@ export function mountComponent(
     // client-only branch switches keep inherited scope ids.
     trackComponentScopeId(instance)
   }
-  if (instance.m) queuePostMountEffect(instance.m!, instance.suspense)
+  if (instance.m) {
+    queuePostRenderEffect(instance.m!, undefined, instance.suspense)
+  }
   if (
     isKeepAliveEnabled &&
     instance.shapeFlag! & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE &&
     instance.a
   ) {
-    queuePostMountEffect(instance.a!, instance.suspense)
+    queuePostRenderEffect(instance.a!, undefined, instance.suspense)
   }
   instance.isMounted = true
   if (__DEV__) {


### PR DESCRIPTION
one more!

a vapor component mounted into a pending `<Suspense>` runs its `onMounted`/`onActivated` hooks straight away on the next post-flush, while it's still in the boundary's hidden container. VDOM defers these and runs them after the boundary resolves, once the branch is in the real tree, so the two disagree on ordering (and on which branch the hook sees).

as far as I can tell this is because `mountComponent` queues `instance.m`/`instance.a` with `queuePostFlushCb`, which drains immediately, rather than routing them through the owning suspense boundary the way the VDOM renderer's `queuePostRenderEffect` does.

this PR queues them via `queueEffectWithSuspense(fn, undefined, instance.suspense)` under `__FEATURE_SUSPENSE__`, matching what the VDOM renderer does for the same hooks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle hook ordering when vapor components render alongside asynchronous content within Suspense boundaries.
  * Ensured mounted and activated hooks run at the correct time after Suspense resolution.

* **Tests**
  * Added coverage verifying rendered output and lifecycle callback ordering in Suspense scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->