### PR TITLE
fix(runtime-vapor): sync transition hooks on interop update

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -5069,6 +5069,45 @@ describe('vdomInterop', () => {
       expect(html()).toContain('vdom')
       expect(html()).not.toContain('vapor')
     })
+
+    test('uses latest transition hooks when a vapor root branch switches', async () => {
+      const data = ref({ show: true })
+      const useSecondHook = ref(false)
+      const firstLeave = vi.fn((_el: Element, done: () => void) => done())
+      const secondLeave = vi.fn((_el: Element, done: () => void) => done())
+      const VaporChild = compile(
+        `<template>
+          <div v-if="data.show">first</div>
+          <div v-else>second</div>
+        </template>`,
+        data,
+      )
+      const { html } = define({
+        setup() {
+          return () =>
+            h(
+              Transition,
+              {
+                css: false,
+                onLeave: useSecondHook.value ? secondLeave : firstLeave,
+              },
+              { default: () => h(VaporChild as any) },
+            )
+        },
+      }).render()
+
+      expect(html()).toContain('first')
+
+      useSecondHook.value = true
+      await nextTick()
+
+      data.value.show = false
+      await nextTick()
+
+      expect(firstLeave).not.toHaveBeenCalled()
+      expect(secondLeave).toHaveBeenCalledTimes(1)
+      expect(html()).toContain('second')
+    })
   })
 
   describe('error handling', () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -5012,6 +5012,63 @@ describe('vdomInterop', () => {
       expect(html()).not.toContain('vapor')
       expect(html()).toContain('vdom')
     })
+
+    test('out-in + suspense: leaving vapor branch completes after hooks re-clone', async () => {
+      const hooks = makeHooks()
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return template('<div>vapor</div>', 1)()
+        },
+      })
+      const VdomChild = { setup: () => () => h('div', 'vdom') }
+      const current = shallowRef<any>(VaporChild)
+      const tick = ref(0)
+      const { host, html } = define({
+        setup() {
+          return () => {
+            // reading tick makes a bump re-render the tree, which re-clones the
+            // transition hooks onto the branch vnode (mirrors an intervening
+            // parent render during an async page's resolve window in Nuxt).
+            void tick.value
+            return h(
+              Transition,
+              {
+                mode: 'out-in',
+                css: false,
+                onLeave: hooks.onLeave,
+                onEnter: hooks.onEnter,
+              },
+              {
+                default: () =>
+                  h(Suspense, null, {
+                    default: () =>
+                      h(current.value, {
+                        key: current.value === VaporChild ? 'a' : 'b',
+                      }),
+                  }),
+              },
+            )
+          }
+        },
+      }).render()
+      document.body.appendChild(host)
+
+      await timeout(10)
+      expect(html()).toContain('vapor')
+
+      tick.value++
+      await nextTick()
+
+      current.value = VdomChild
+      await timeout(10)
+      expect(hooks.onLeave).toHaveBeenCalledTimes(1)
+      expect(html()).toContain('vapor')
+
+      hooks.finishLeave()
+      await timeout(10)
+      expect(html()).toContain('vdom')
+      expect(html()).not.toContain('vapor')
+    })
   })
 
   describe('error handling', () => {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -341,6 +341,10 @@ const vaporInteropImpl: Omit<
         }
       }
       vnodeHookState.skipVnodeHooks = true
+      if (n2.transition && instance.block) {
+        ensureTransitionHooksRegistered()
+        setVaporTransitionHooks(instance, n2.transition as VaporTransitionHooks)
+      }
       instance.rawPropsRef!.value = filterReservedProps(n2.props)
       instance.rawSlotsRef!.value = normalizeInteropSlots(n2.children)
       queuePostFlushCb(() => {
@@ -364,19 +368,6 @@ const vaporInteropImpl: Omit<
     if (instance) {
       const anchor = vnode.anchor as Node | null
       if (instance.block) {
-        // The block's transition hooks are applied at mount time, but a later
-        // re-clone (e.g. Suspense's setTransitionHooks assigns a fresh clone to
-        // the branch vnode without reaching the vapor block) leaves the block
-        // pointing at a stale hooks object. Re-sync here so the leaving block
-        // runs the current hooks, whose afterLeave is what Suspense relies on
-        // to move in the next out-in branch.
-        if (vnode.transition) {
-          ensureTransitionHooksRegistered()
-          setVaporTransitionHooks(
-            instance,
-            vnode.transition as VaporTransitionHooks,
-          )
-        }
         unmountComponent(instance, container)
         if (!doRemove) {
           // When the surrounding VDOM fragment owns DOM removal, we still need

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -364,6 +364,19 @@ const vaporInteropImpl: Omit<
     if (instance) {
       const anchor = vnode.anchor as Node | null
       if (instance.block) {
+        // The block's transition hooks are applied at mount time, but a later
+        // re-clone (e.g. Suspense's setTransitionHooks assigns a fresh clone to
+        // the branch vnode without reaching the vapor block) leaves the block
+        // pointing at a stale hooks object. Re-sync here so the leaving block
+        // runs the current hooks, whose afterLeave is what Suspense relies on
+        // to move in the next out-in branch.
+        if (vnode.transition) {
+          ensureTransitionHooksRegistered()
+          setVaporTransitionHooks(
+            instance,
+            vnode.transition as VaporTransitionHooks,
+          )
+        }
         unmountComponent(instance, container)
         if (!doRemove) {
           // When the surrounding VDOM fragment owns DOM removal, we still need


### PR DESCRIPTION
another one 🤦 

navigating away from a vapor page under `<Transition mode="out-in">` (in Nuxt, `NuxtPage` with an out-in page transition, which also wraps the page in `<Suspense>`) deadlocks: the old page is removed but the incoming branch never mounts, and `afterLeave` never runs.

I think this is because a vapor block's transition hooks are applied once at mount, but `setTransitionHooks` assigns a fresh `hooks.clone(...)` to a `Suspense` vnode's `ssContent.transition` without propagating it to the vapor block. `Suspense.resolve` then hangs `afterLeave` (which moves in the next out-in branch) on that new clone while the leaving block still holds the stale object, so completing the leave never fires it. it only becomes a problem when something re-clones between mount and leave, e.g. a parent render during an async page's resolve window, which is why the existing tests pass but it hangs on Nuxt.

this PR re-applies the current `vnode.transition` to the block in the interop `unmount`, mirroring the `setVaporTransitionHooks` the interop already does at mount.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transition handling when switching between Vapor and VDOM content.
  * Ensured the latest transition leave hooks are applied during updates.
  * Improved out-in transitions so old content is removed correctly before new content appears.

* **Tests**
  * Added coverage for Vapor-to-VDOM transitions and updated leave-hook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->