### PR TITLE
fix(runtime-core,runtime-vapor): restore undefined effect scope after `setCurrentInstance`

### DIFF
--- a/packages/runtime-core/src/apiLifecycle.ts
+++ b/packages/runtime-core/src/apiLifecycle.ts
@@ -2,6 +2,7 @@ import {
   type GenericComponentInstance,
   currentInstance,
   isInSSRComponentSetup,
+  restoreCurrentInstance,
   setCurrentInstance,
 } from './component'
 import type { ComponentPublicInstance } from './componentPublicInstance'
@@ -37,7 +38,7 @@ export function injectHook(
         try {
           return callWithAsyncErrorHandling(hook, target, type, args)
         } finally {
-          setCurrentInstance(...prev)
+          restoreCurrentInstance(prev)
           setActiveSub(prevSub)
         }
       })

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -16,6 +16,7 @@ import {
   type GenericComponentInstance,
   currentInstance,
   isInSSRComponentSetup,
+  restoreCurrentInstance,
   setCurrentInstance,
 } from './component'
 import { callWithAsyncErrorHandling } from './errorHandling'
@@ -297,7 +298,7 @@ export function instanceWatch(
   }
   const prev = setCurrentInstance(this)
   const res = doWatch(getter, cb.bind(publicThis), options)
-  setCurrentInstance(...prev)
+  restoreCurrentInstance(prev)
   return res
 }
 

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -94,6 +94,7 @@ import { markAsyncBoundary } from './helpers/useId'
 import { isAsyncWrapper } from './apiAsyncComponent'
 import type { RendererElement } from './renderer'
 import {
+  restoreCurrentInstance,
   setCurrentInstance,
   setInSSRSetupState,
 } from './componentCurrentInstance'
@@ -954,7 +955,7 @@ function setupStatefulComponent(
     )
     const isAsyncSetup = isPromise(setupResult)
     setActiveSub(prevSub)
-    setCurrentInstance(...prev)
+    restoreCurrentInstance(prev)
 
     if ((isAsyncSetup || instance.sp) && !isAsyncWrapper(instance)) {
       // async setup / serverPrefetch, mark as async boundary for useId()
@@ -1143,7 +1144,7 @@ export function finishComponentSetup(
       applyOptions(instance)
     } finally {
       setActiveSub(prevSub)
-      setCurrentInstance(...prevInstance)
+      restoreCurrentInstance(prevInstance)
     }
   }
 

--- a/packages/runtime-core/src/componentCurrentInstance.ts
+++ b/packages/runtime-core/src/componentCurrentInstance.ts
@@ -92,6 +92,19 @@ export const setCurrentInstance = (
   }
 }
 
+/**
+ * Restores a snapshot returned by {@link setCurrentInstance}. Unlike calling
+ * `setCurrentInstance(...prev)`, an `undefined` saved scope is restored
+ * verbatim instead of re-triggering the `instance.scope` default.
+ * @internal
+ */
+export const restoreCurrentInstance = (
+  prev: [GenericComponentInstance | null, EffectScope | undefined],
+): void => {
+  setCurrentScope(prev[1])
+  simpleSetCurrentInstance(prev[0])
+}
+
 const internalOptions = ['ce', 'type', 'uid'] as const
 
 /**

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -32,6 +32,7 @@ import {
   type ConcreteComponent,
   type Data,
   type GenericComponentInstance,
+  restoreCurrentInstance,
   setCurrentInstance,
 } from './component'
 import { isEmitListener } from './componentEmits'
@@ -533,7 +534,7 @@ function baseResolveDefault(
       : null,
     props,
   )
-  setCurrentInstance(...prev)
+  restoreCurrentInstance(prev)
   return value
 }
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -562,6 +562,7 @@ export {
  */
 export {
   currentInstance,
+  restoreCurrentInstance,
   setCurrentInstance,
   simpleSetCurrentInstance,
 } from './componentCurrentInstance'

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -24,6 +24,7 @@ import {
   effectScope,
   nextTick,
   ref,
+  restoreCurrentInstance,
   setCurrentInstance,
   svgNS,
   xlinkNS,
@@ -40,7 +41,7 @@ let removeComponentInstance = NOOP
 beforeEach(() => {
   const instance = new VaporComponentInstance({}, {}, null)
   const prev = setCurrentInstance(instance)
-  removeComponentInstance = () => setCurrentInstance(...prev)
+  removeComponentInstance = () => restoreCurrentInstance(prev)
 })
 afterEach(() => {
   removeComponentInstance()

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -10,6 +10,7 @@ import {
   createVNode,
   currentInstance,
   defineComponent,
+  getCurrentScope,
   h,
   inject,
   nextTick,
@@ -4654,6 +4655,69 @@ describe('vdomInterop', () => {
 
       await nextTick()
       expect(html()).toContain('<span>resolved</span>')
+    })
+  })
+
+  describe('current scope', () => {
+    test('does not leak active scope after mounting sync-setup vapor child', () => {
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return template('<div>vapor</div>')()
+        },
+      })
+
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () => h(VaporChild as any),
+      })
+      app.use(vaporInteropPlugin)
+      app.mount(host)
+
+      expect(getCurrentScope()).toBeUndefined()
+    })
+
+    test('vapor component mounted via Suspense branch swap is not unmounted on resolve', async () => {
+      const unmounted = vi.fn()
+
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return template('<span>sync vapor</span>')()
+        },
+      })
+
+      const Page1 = defineComponent({
+        setup() {
+          return () => h('div', [h(VaporChild as any)])
+        },
+      })
+
+      const VaporPage2 = defineVaporComponent({
+        async setup() {
+          onUnmounted(unmounted)
+          return template('<div>page 2</div>')()
+        },
+      })
+
+      const current = shallowRef<any>(Page1)
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(current.value),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+      app.mount(host)
+      await nextTick()
+      expect(host.innerHTML).toContain('sync vapor')
+
+      current.value = VaporPage2
+      await nextTick()
+      await new Promise(resolve => setTimeout(resolve))
+      await nextTick()
+
+      expect(host.innerHTML).toContain('page 2')
+      expect(unmounted).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -7,6 +7,7 @@ import {
   handleError,
   markAsyncBoundary,
   performAsyncHydrate,
+  restoreCurrentInstance,
   setCurrentInstance,
   useAsyncComponentState,
 } from '@vue/runtime-dom'
@@ -230,6 +231,6 @@ function createInnerComp(
       parent.appContext,
     )
   } finally {
-    setCurrentInstance(...prevInstance)
+    restoreCurrentInstance(prevInstance)
   }
 }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1062,7 +1062,7 @@ export function mountComponent(
           handleSetupResult(setupResult, component, instance)
         } finally {
           setActiveSub(prevSub)
-          setCurrentInstance(...prevInstance)
+          restoreCurrentInstance(prevInstance)
         }
       }
       try {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -34,6 +34,7 @@ import {
   queuePostFlushCb,
   registerHMR,
   resolveComponent,
+  restoreCurrentInstance,
   setCurrentInstance,
   setCurrentRenderingInstance,
   startMeasure,
@@ -531,7 +532,7 @@ export function setupComponent(
   }
 
   setActiveSub(prevSub)
-  setCurrentInstance(...prevInstance)
+  restoreCurrentInstance(prevInstance)
 }
 
 export let isApplyingFallthroughProps = false

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -19,6 +19,7 @@ import {
   popWarningContext,
   pushWarningContext,
   resolvePropValue,
+  restoreCurrentInstance,
   setCurrentInstance,
   validateProps,
   warn,
@@ -61,15 +62,22 @@ export function resolveFunctionSource<T>(
   // where source was defined.
   const parent = currentInstance && currentInstance.parent
   if (parent) {
-    source._cache = computed(oldValue => {
-      const prev = setCurrentInstance(parent)
-      try {
-        return stabilizeDynamicSourceValue(oldValue, source())
-      } finally {
-        setCurrentInstance(...prev)
-      }
-    })
-    onScopeDispose(() => (source._cache = undefined))
+    // create the computed in the parent's context so it is collected by the
+    // parent's scope rather than whatever scope happens to be active here
+    const prev = setCurrentInstance(parent)
+    try {
+      source._cache = computed(oldValue => {
+        const prevInner = setCurrentInstance(parent)
+        try {
+          return stabilizeDynamicSourceValue(oldValue, source())
+        } finally {
+          restoreCurrentInstance(prevInner)
+        }
+      })
+      onScopeDispose(() => (source._cache = undefined))
+    } finally {
+      restoreCurrentInstance(prev)
+    }
     return source._cache.value
   }
 
@@ -462,7 +470,7 @@ function resolveDefault(
 ) {
   const prev = setCurrentInstance(instance)
   const res = factory.call(null, instance.props)
-  setCurrentInstance(...prev)
+  restoreCurrentInstance(prev)
   return res
 }
 

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -13,6 +13,7 @@ import {
   logMismatchError,
   queuePostFlushCb,
   resolveTeleportTarget,
+  restoreCurrentInstance,
   setCurrentInstance,
   warn,
 } from '@vue/runtime-dom'
@@ -157,7 +158,7 @@ export class TeleportFragment extends RenderContextFragment {
       )
       this.bindChildren(this.nodes)
     } finally {
-      setCurrentInstance(...prevInstance)
+      restoreCurrentInstance(prevInstance)
     }
   }
 

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -16,6 +16,7 @@ import {
   onBeforeMount,
   queuePostFlushCb,
   resolveTransitionProps,
+  restoreCurrentInstance,
   setCurrentInstance,
   useTransitionState,
   vShowOriginalDisplay,
@@ -563,7 +564,7 @@ function removeBranchWithLeaveImpl(
           frag.renderBranch(render, transition, parent, key, noScope, true)
         }
       } finally {
-        setCurrentInstance(...prevInstance)
+        restoreCurrentInstance(prevInstance)
       }
     })
     if (mode === 'out-in') {

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -16,6 +16,7 @@ import {
   onUpdated,
   queuePostFlushCb,
   resolveTransitionProps,
+  restoreCurrentInstance,
   setCurrentInstance,
   useTransitionState,
   vShowHidden,
@@ -501,7 +502,7 @@ function trackTransitionGroupUpdate(
         try {
           resolveDynamicProps(owner.rawProps)
         } finally {
-          setCurrentInstance(...prev)
+          restoreCurrentInstance(prev)
         }
       })
       effect.notify = () => {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -17,6 +17,7 @@ import {
   type VNode,
   currentInstance,
   queuePostFlushCb,
+  restoreCurrentInstance,
   setCurrentInstance,
 } from '@vue/runtime-dom'
 import type { VaporComponentInstance } from './component'
@@ -143,7 +144,7 @@ export function runWithRenderCtx<R>(
   try {
     return runWithFragmentCtxOnly(fragment, fn)
   } finally {
-    setCurrentInstance(...prevInstance)
+    restoreCurrentInstance(prevInstance)
   }
 }
 

--- a/packages/runtime-vapor/src/hmr.ts
+++ b/packages/runtime-vapor/src/hmr.ts
@@ -1,6 +1,7 @@
 import {
   popWarningContext,
   pushWarningContext,
+  restoreCurrentInstance,
   setCurrentInstance,
 } from '@vue/runtime-dom'
 import { findBlockBoundary, insert, remove } from './block'
@@ -27,7 +28,7 @@ export function hmrRerender(instance: VaporComponentInstance): void {
     devRender(instance)
   } finally {
     popWarningContext()
-    setCurrentInstance(...prev)
+    restoreCurrentInstance(prev)
   }
   insert(instance.block, parent, anchor)
 }
@@ -62,7 +63,7 @@ export function hmrReload(
       instance.appContext,
     )
   } finally {
-    setCurrentInstance(...prev)
+    restoreCurrentInstance(prev)
   }
   mountComponent(newInstance, parent, anchor)
 

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -6,6 +6,7 @@ import {
   endMeasure,
   queueJob,
   queuePostFlushCb,
+  restoreCurrentInstance,
   setCurrentInstance,
   startMeasure,
   warn,
@@ -96,7 +97,7 @@ export class RenderEffect extends ReactiveEffect {
         this.render()
       }
     } finally {
-      setCurrentInstance(...prev)
+      restoreCurrentInstance(prev)
       if (__DEV__ && instance) {
         endMeasure(instance, `renderEffect`)
       }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -42,6 +42,7 @@ import {
   onScopeDispose,
   queuePostFlushCb,
   renderSlot,
+  restoreCurrentInstance,
   setCurrentInstance,
   setTransitionHooks as setVNodeTransitionHooks,
   shallowReactive,
@@ -1079,7 +1080,7 @@ function createVDOMComponent(
       try {
         setupPropsValidation(wrapper, vnode)
       } finally {
-        setCurrentInstance(...prev)
+        restoreCurrentInstance(prev)
       }
     }
   }


### PR DESCRIPTION
on the first client-side navigation from a vdom page to a vapor page through a Suspense boundary, the vapor page mounts and is then immediately unmounted when `Suspense.resolve()` tears down the old branch, leaving the page frozen (its watchers are dead)

this PR adds a `restoreCurrentInstance` helper that restores the saved tuple verbatim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restoration of component context and effect scopes after lifecycle hooks, setup, watchers, transitions, and rendering operations.
  - Prevented stale active scopes from persisting after synchronous Vapor component mounts.
  - Improved Suspense behavior when switching between synchronous and asynchronous Vapor components.

- **Tests**
  - Added coverage for scope cleanup and Suspense component lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->