### PR TITLE
fix(scheduler): avoid stack overflow when flushing very large post cb arrays

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -321,6 +321,26 @@ describe('scheduler', () => {
       expect(called).toBe(1000000)
     })
 
+    it('should not overflow the call stack when merging a very large cb array into an active flush', async () => {
+      // same as above, but the large array is queued while a post flush is
+      // already in progress, exercising the merge into activePostFlushCbs
+      // inside a nested flushPostFlushCbs call
+      let called = 0
+      const cbs: SchedulerJob[] = []
+      for (let i = 0; i < 1000000; i++) {
+        cbs.push(() => {
+          called++
+        })
+      }
+
+      queuePostFlushCb(() => {
+        queuePostFlushCb(cbs)
+        flushPostFlushCbs()
+      })
+      await nextTick()
+      expect(called).toBe(1000000)
+    })
+
     it('should dedupe queued postFlushCb', async () => {
       const calls: string[] = []
       const cb1 = () => {

--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -303,6 +303,24 @@ describe('scheduler', () => {
       expect(calls).toEqual(['cb1', 'cb2', 'cb3'])
     })
 
+    it('should not overflow the call stack with a very large cb array', async () => {
+      // a suspense boundary can buffer an unbounded number of post effects
+      // while pending (e.g. a large tree re-rendering under it) and flush them
+      // all at once on resolve - spreading such an array into push() throws
+      // RangeError: Maximum call stack size exceeded
+      let called = 0
+      const cbs: SchedulerJob[] = []
+      for (let i = 0; i < 1000000; i++) {
+        cbs.push(() => {
+          called++
+        })
+      }
+
+      queuePostFlushCb(cbs)
+      await nextTick()
+      expect(called).toBe(1000000)
+    })
+
     it('should dedupe queued postFlushCb', async () => {
       const calls: string[] = []
       const cb1 = () => {

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -616,8 +616,11 @@ function createSuspenseBoundary(
       while (parent) {
         if (parent.pendingBranch) {
           // found a pending parent suspense, merge buffered post jobs
-          // into that parent
-          parent.effects.push(...effects)
+          // into that parent. loop instead of spread to avoid a call stack
+          // overflow when many effects were buffered while pending
+          for (let i = 0; i < effects.length; i++) {
+            parent.effects.push(effects[i])
+          }
           hasUnresolvedAncestor = true
           break
         }

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -616,8 +616,7 @@ function createSuspenseBoundary(
       while (parent) {
         if (parent.pendingBranch) {
           // found a pending parent suspense, merge buffered post jobs
-          // into that parent. loop instead of spread to avoid a call stack
-          // overflow when many effects were buffered while pending
+          // into that parent
           for (let i = 0; i < effects.length; i++) {
             parent.effects.push(effects[i])
           }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -184,8 +184,6 @@ export function flushPostFlushCbs(seen?: CountMap): void {
 
     // #1947 already has active queue, nested flushPostFlushCbs call
     if (activePostFlushCbs) {
-      // loop instead of spread to avoid a call stack overflow when the
-      // deduped array is very large
       for (let i = 0; i < deduped.length; i++) {
         activePostFlushCbs.push(deduped[i])
       }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -133,8 +133,13 @@ export function queuePostFlushCb(cb: SchedulerJobs): void {
   } else {
     // if cb is an array, it is a component lifecycle hook which can only be
     // triggered by a job, which is already deduped in the main queue, so
-    // we can skip duplicate check here to improve perf
-    pendingPostFlushCbs.push(...cb)
+    // we can skip duplicate check here to improve perf.
+    // use a loop instead of `push(...cb)`: the array can be arbitrarily large
+    // (e.g. effects buffered by a suspense boundary) and spreading it would
+    // overflow the call stack (#15142)
+    for (let i = 0; i < cb.length; i++) {
+      pendingPostFlushCbs.push(cb[i])
+    }
   }
   queueFlush()
 }
@@ -179,7 +184,11 @@ export function flushPostFlushCbs(seen?: CountMap): void {
 
     // #1947 already has active queue, nested flushPostFlushCbs call
     if (activePostFlushCbs) {
-      activePostFlushCbs.push(...deduped)
+      // loop instead of spread to avoid a call stack overflow when the
+      // deduped array is very large
+      for (let i = 0; i < deduped.length; i++) {
+        activePostFlushCbs.push(deduped[i])
+      }
       return
     }
 


### PR DESCRIPTION
close #15142

When a suspense boundary stays pending while a large component tree under it keeps re-rendering (e.g. an app navigating away from a page with ~1000 mounted components that update on a timer), the buffered `suspense.effects` array can grow to hundreds of thousands of entries. Flushing it on resolve via `pendingPostFlushCbs.push(...cb)` spreads the whole array into a single call, which throws `RangeError: Maximum call stack size exceeded` and leaves the scheduler permanently wedged (blank page, app unusable until a hard reload).

Playground reproduction (crashes on latest): https://play.vuejs.org/#eNp9VMuO4zYQ/JWCcrCE0VhKkL14JQGDRQ65BIOZALkIWNBSyyJMk1ySkmAYAvYj8g35sP2SgJRszz6wJ5PN7nJ3VbUu0ZPW23GgaBcVtjFcO1hyg65qyU9aGYcLDHUpWuq4pCd7ls0HddJKknSY0Rl1wmYcaHMreFHTGt5mL2raLo+1zDIwCeYR0PRctHA9czgSaQvXE4rXwWqSlipoki2XB3TKgKGjCZYaJVubBhzBjwQGzQ6Eph/kEXvy6UKxllq0g/G31+cnSDbyA3NcyVo2SlqHV6GmD+Hvyx8OFdcSiBOUlT8AkiY8G3XilmJDVomRUFa4LK/wdP3NT6QGF4cqrEnxBY5OWjBHO2yKlo/V29mXVovMxzeYkxS/53meLKhzktYyqW89O94cUXohYp+SZZh6LiiwZlfSwO2VtjSQCkOPhmRLgQyfuucHOEO0EM9tQLKOC4GTGqSjFoPPB3eIV46PTO6ZxF4x02LQLXMejUYy51WT5Noll47MyARKT8qf621lJfDl59iOTAz08ODvvEN8j6HCr3meoBHEzK38iprUck7xLn9Di1GTRYknY9h56y0XXyBIHly/w295nmNOEX9MwUMHPKllkS0mrzxIcdUnKH1336JBUOwqcnF3TXYPeqePj50yZR0ZcBkaqiPsjnT2IX/045V15H/q6Fa86L6er23gl44JsWfNsQqCXy6L8POML5//xcS4u+3E3UlfPv9XZF9Pkr0Z5au3KI3WjfzZvk/MNX0Kp16o+2bFr8xro7S9LdCzv8VLtzv8NZz2ZDAn37g34MWhMsXGBzfJ+l0g1vSePOyHriNjYb3BmIBW1j12YrA9qOuocd7jZvEh3ZcggGhm/DfpB/uA+NNAA/0REP7hrr/yk9TSsxkLcuAokb8HR4F378EfHpLFs4GN4NIUq5XnFBeErnbY+BY3Ydr55/6ymklYdxZU1lHLrRbsvINUkuqoumtdZD7xO+Xm/wFAmvDh

This PR replaces the unbounded spread pushes with plain loops in the three places where the pushed array is not bounded by a single component's hook count:

- `queuePostFlushCb` — receives the whole buffered `suspense.effects` array on resolve
- `flushPostFlushCbs` — nested-flush merge of `deduped` into `activePostFlushCbs`
- `Suspense` resolve — merge of `effects` into a pending parent's buffer

The regression test flushes a 1,000,000-entry cb array through `queuePostFlushCb`; it throws `RangeError` before this change and passes after.

Found debugging a production Nuxt app where every SPA navigation away from a large kanban board crashed to a white screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler reliability when enqueueing and flushing very large batches of post-flush callbacks.
  * Prevented potential call stack overflows when nested post-flush operations process large callback queues.
  * Improved Suspense behavior when transferring buffered effects to a pending parent suspense under heavy load.
* **Tests**
  * Added stress coverage to verify callback execution remains correct with batches up to one million callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->