### PR TITLE
fix(runtime-vapor): defer post-render effects to vdom suspense boundaries

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -199,8 +199,18 @@ export interface VaporInteropInterface {
     onBeforeUpdate?: () => void,
     onVnodeBeforeUpdate?: () => void,
   ): void
-  unmount(vnode: VNode, doRemove?: boolean): void
-  move(vnode: VNode, container: any, anchor: any, moveType: MoveType): void
+  unmount(
+    vnode: VNode,
+    doRemove: boolean | undefined,
+    parentSuspense: SuspenseBoundary | null,
+  ): void
+  move(
+    vnode: VNode,
+    container: any,
+    anchor: any,
+    moveType: MoveType,
+    parentSuspense: SuspenseBoundary | null,
+  ): void
   slot(
     n1: VNode | null,
     n2: VNode,
@@ -230,8 +240,13 @@ export interface VaporInteropInterface {
     container: any,
     anchor: any,
     parentComponent: ComponentInternalInstance,
+    parentSuspense: SuspenseBoundary | null,
   ): void
-  deactivate(vnode: VNode, container: any): void
+  deactivate(
+    vnode: VNode,
+    container: any,
+    parentSuspense: SuspenseBoundary | null,
+  ): void
   setTransitionHooks(
     component: ComponentInternalInstance,
     transition: TransitionHooks,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1209,6 +1209,7 @@ function baseCreateRenderer(
             container,
             anchor,
             parentComponent!,
+            parentSuspense,
           )
         } else {
           const vnodeBeforeMountHook =
@@ -2268,6 +2269,7 @@ function baseCreateRenderer(
         container,
         anchor,
         moveType,
+        parentSuspense,
       )
       return
     }
@@ -2413,6 +2415,7 @@ function baseCreateRenderer(
         getVaporInterface(parentComponent!, vnode).deactivate(
           vnode,
           (parentComponent!.ctx as KeepAliveContext).getStorageContainer(),
+          parentSuspense,
         )
       } else {
         ;(parentComponent!.ctx as KeepAliveContext).deactivate(vnode)
@@ -2437,7 +2440,11 @@ function baseCreateRenderer(
         if (dirs) {
           invokeDirectiveHook(vnode, null, parentComponent, 'beforeUnmount')
         }
-        getVaporInterface(parentComponent, vnode).unmount(vnode, doRemove)
+        getVaporInterface(parentComponent, vnode).unmount(
+          vnode,
+          doRemove,
+          parentSuspense,
+        )
         if (
           (shouldInvokeVnodeHook &&
             (vnodeHook = props && props.onVnodeUnmounted)) ||
@@ -2505,7 +2512,11 @@ function baseCreateRenderer(
       }
 
       if (type === VaporSlot) {
-        getVaporInterface(parentComponent, vnode).unmount(vnode, doRemove)
+        getVaporInterface(parentComponent, vnode).unmount(
+          vnode,
+          doRemove,
+          parentSuspense,
+        )
         return
       }
 

--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -1,5 +1,33 @@
-import { nextTick, reactive } from 'vue'
-import { compile, runtimeDom, runtimeVapor } from '../_utils'
+import {
+  KeepAlive,
+  Suspense,
+  createApp,
+  createSSRApp,
+  defineComponent,
+  h,
+  nextTick,
+  onActivated,
+  onDeactivated,
+  onMounted,
+  onUnmounted,
+  onUpdated,
+  reactive,
+  ref,
+} from '@vue/runtime-dom'
+import {
+  VaporKeepAlive,
+  VaporTeleport,
+  VaporTransitionGroup,
+  createComponent,
+  createDynamicComponent,
+  createFor,
+  createTemplateRefSetter,
+  defineVaporComponent,
+  renderEffect,
+  template,
+  vaporInteropPlugin,
+} from '../../src'
+import { VueServerRenderer, compile, runtimeDom, runtimeVapor } from '../_utils'
 
 describe.todo('VaporSuspense', () => {})
 
@@ -244,5 +272,600 @@ describe('vdom interop', () => {
     await Promise.all(data.deps)
     await nextTick()
     expect(container.innerHTML).toBe(`<!--v-if-->`)
+  })
+})
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>(r => (resolve = r))
+  return { promise, resolve }
+}
+
+async function flushResolution(promise: Promise<void>) {
+  await promise
+  await Promise.resolve()
+  await nextTick()
+  await nextTick()
+}
+
+describe('effects in pending branches', () => {
+  test('updated hook waits for the branch to resolve', async () => {
+    const asyncSetup = deferred()
+    const value = ref(0)
+    const order: string[] = []
+    const VaporChild = defineVaporComponent({
+      setup() {
+        const el = template('<div></div>')() as Element
+        onMounted(() => order.push('mounted'))
+        onUpdated(() => order.push('updated'))
+        renderEffect(() => (el.textContent = String(value.value)))
+        return el
+      },
+    })
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(
+          Suspense,
+          { onResolve: () => order.push('resolved') },
+          {
+            default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+            fallback: () => h('span', 'loading'),
+          },
+        ),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    value.value++
+    await nextTick()
+    expect(order).toEqual([])
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(order).toEqual(['resolved', 'mounted', 'updated'])
+    app.unmount()
+  })
+
+  test('non-null template ref waits for the branch to resolve', async () => {
+    const asyncSetup = deferred()
+    const elementRef = ref<Element | null>(null)
+    const VaporChild = defineVaporComponent({
+      setup() {
+        const el = template('<div>vapor</div>')() as Element
+        createTemplateRefSetter()(el, elementRef)
+        return el
+      },
+    })
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(elementRef.value).toBe(null)
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(elementRef.value).toBeInstanceOf(HTMLDivElement)
+    app.unmount()
+  })
+
+  test('slotted template ref uses the rendering suspense boundary', async () => {
+    const asyncSetup = deferred()
+    const elementRef = ref<Element | null>(null)
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const VDomHost = defineComponent({
+      setup(_, { slots }) {
+        return () =>
+          h(Suspense, null, {
+            default: () => h('div', [slots.default!(), h(AsyncSibling)]),
+            fallback: () => h('span', 'loading'),
+          })
+      },
+    })
+    const VaporOwner = defineVaporComponent({
+      setup() {
+        const setRef = createTemplateRefSetter()
+        return createComponent(VDomHost as any, null, {
+          default: () => {
+            const el = template('<div>slotted</div>')() as Element
+            setRef(el, elementRef)
+            return el
+          },
+        })
+      },
+    })
+    const host = document.createElement('div')
+    const app = createApp({ render: () => h(VaporOwner as any) })
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(elementRef.value).toBe(null)
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(elementRef.value).toBeInstanceOf(HTMLDivElement)
+    app.unmount()
+  })
+
+  test('teleport target mount waits for the branch to resolve', async () => {
+    const asyncSetup = deferred()
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createComponent(
+          VaporTeleport,
+          { to: () => target },
+          { default: () => template('<div>teleported</div>')() },
+        )
+      },
+    })
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(target.textContent).toBe('')
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(target.textContent).toBe('teleported')
+    app.unmount()
+    target.remove()
+  })
+
+  test('slotted teleport uses the rendering suspense boundary', async () => {
+    const asyncSetup = deferred()
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const VDomHost = defineComponent({
+      setup(_, { slots }) {
+        return () =>
+          h(Suspense, null, {
+            default: () => h('div', [slots.default!(), h(AsyncSibling)]),
+            fallback: () => h('span', 'loading'),
+          })
+      },
+    })
+    const VaporOwner = defineVaporComponent({
+      setup() {
+        return createComponent(VDomHost as any, null, {
+          default: () =>
+            createComponent(
+              VaporTeleport,
+              { to: () => target },
+              { default: () => template('<div>teleported</div>')() },
+            ),
+        })
+      },
+    })
+    const host = document.createElement('div')
+    const app = createApp({ render: () => h(VaporOwner as any) })
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(target.textContent).toBe('')
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(target.textContent).toBe('teleported')
+    app.unmount()
+    target.remove()
+  })
+
+  test('unmounted hook waits when a child is removed from the pending branch', async () => {
+    const asyncSetup = deferred()
+    const show = ref(true)
+    const order: string[] = []
+    const VaporChild = defineVaporComponent({
+      setup() {
+        onMounted(() => order.push('mounted'))
+        onUnmounted(() => order.push('unmounted'))
+        return template('<div>vapor</div>')()
+      },
+    })
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(
+          Suspense,
+          { onResolve: () => order.push('resolved') },
+          {
+            default: () =>
+              h('div', [
+                show.value ? h(VaporChild as any) : h('span', 'gone'),
+                h(AsyncSibling),
+              ]),
+            fallback: () => h('span', 'loading'),
+          },
+        ),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    show.value = false
+    await nextTick()
+    expect(order).toEqual([])
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(order).toEqual(['resolved', 'unmounted'])
+    app.unmount()
+  })
+
+  test.each(['vdom', 'vapor'] as const)(
+    '%s unmounted hook runs when the whole pending boundary is removed',
+    async kind => {
+      const asyncSetup = deferred()
+      const showBoundary = ref(true)
+      const order: string[] = []
+      const Child =
+        kind === 'vdom'
+          ? defineComponent({
+              setup() {
+                onUnmounted(() => order.push('unmounted'))
+                return () => h('div', 'vdom')
+              },
+            })
+          : defineVaporComponent({
+              setup() {
+                onUnmounted(() => order.push('unmounted'))
+                return template('<div>vapor</div>')()
+              },
+            })
+      const AsyncSibling = defineComponent({
+        async setup() {
+          await asyncSetup.promise
+          return () => h('span', 'async')
+        },
+      })
+      const Root = defineComponent({
+        setup: () => () =>
+          showBoundary.value
+            ? h(Suspense, null, {
+                default: () => h('div', [h(Child as any), h(AsyncSibling)]),
+                fallback: () => h('span', 'loading'),
+              })
+            : h('span', 'gone'),
+      })
+      const host = document.createElement('div')
+      const app = createApp(Root)
+      app.use(vaporInteropPlugin)
+      app.mount(host)
+
+      await nextTick()
+      showBoundary.value = false
+      await nextTick()
+      expect(order).toEqual(['unmounted'])
+      app.unmount()
+    },
+  )
+
+  test('keep-alive lifecycle and vnode hooks wait for the branch to resolve', async () => {
+    const asyncSetup = deferred()
+    const current = ref<'A' | 'B'>('A')
+    const order: string[] = []
+    const makeChild = (name: string) =>
+      defineVaporComponent({
+        name,
+        setup() {
+          onMounted(() => order.push(`${name} mounted`))
+          onActivated(() => order.push(`${name} activated`))
+          onDeactivated(() => order.push(`${name} deactivated`))
+          return template(`<div>${name}</div>`)()
+        },
+      })
+    const A = makeChild('A')
+    const B = makeChild('B')
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () => {
+        const Child = current.value === 'A' ? A : B
+        return h(
+          Suspense,
+          { onResolve: () => order.push('resolved') },
+          {
+            default: () =>
+              h('div', [
+                h(KeepAlive, null, {
+                  default: () =>
+                    h(Child as any, {
+                      onVnodeMounted: () => order.push('vnode mounted'),
+                      onVnodeUnmounted: () => order.push('vnode unmounted'),
+                    }),
+                }),
+                h(AsyncSibling),
+              ]),
+            fallback: () => h('span', 'loading'),
+          },
+        )
+      },
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    current.value = 'B'
+    await nextTick()
+    expect(order).toEqual([])
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(order[0]).toBe('resolved')
+    app.unmount()
+  })
+
+  test.each(['vdom', 'vapor'] as const)(
+    '%s current keep-alive entry deactivates after the branch resolves',
+    async kind => {
+      const asyncSetup = deferred()
+      const showKeepAlive = ref(true)
+      const order: string[] = []
+      const VDomChild = defineComponent({
+        setup() {
+          onDeactivated(() => order.push('deactivated'))
+          return () => h('div', 'vdom')
+        },
+      })
+      const VaporChild = defineVaporComponent({
+        setup() {
+          onDeactivated(() => order.push('deactivated'))
+          return template('<div>vapor</div>')()
+        },
+      })
+      const VaporTree = defineVaporComponent({
+        setup() {
+          return createComponent(VaporKeepAlive, null, {
+            default: () => createDynamicComponent(() => VaporChild),
+          })
+        },
+      })
+      const AsyncSibling = defineComponent({
+        async setup() {
+          await asyncSetup.promise
+          return () => h('span', 'async')
+        },
+      })
+      const Root = defineComponent({
+        setup: () => () =>
+          h(Suspense, null, {
+            default: () =>
+              h('div', [
+                showKeepAlive.value
+                  ? kind === 'vdom'
+                    ? h(KeepAlive, null, { default: () => h(VDomChild) })
+                    : h(VaporTree as any)
+                  : h('span', 'gone'),
+                h(AsyncSibling),
+              ]),
+            fallback: () => h('span', 'loading'),
+          }),
+      })
+      const host = document.createElement('div')
+      const app = createApp(Root)
+      app.use(vaporInteropPlugin)
+      app.mount(host)
+
+      await nextTick()
+      showKeepAlive.value = false
+      await nextTick()
+      expect(order).toEqual([])
+
+      asyncSetup.resolve()
+      await flushResolution(asyncSetup.promise)
+      expect(order).toEqual(['deactivated'])
+      app.unmount()
+    },
+  )
+
+  test('initial v-show appear enter waits for the branch to resolve', async () => {
+    const asyncSetup = deferred()
+    const calls: string[] = []
+    const data = ref({
+      show: true,
+      onBeforeAppear: () => calls.push('before appear'),
+      onAppear: () => calls.push('appear'),
+    })
+    const VaporChild = compile(
+      `<template>
+        <Transition
+          appear
+          :css="false"
+          @before-appear="data.onBeforeAppear"
+          @appear="data.onAppear"
+        >
+          <div v-show="data.show">vapor</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(calls).toEqual(['before appear'])
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(calls).toEqual(['before appear', 'appear'])
+    app.unmount()
+  })
+
+  test('transition-group move processing waits for the branch to resolve', async () => {
+    const asyncSetup = deferred()
+    const items = ref([1, 2])
+    let first!: any
+    const VaporChild = defineVaporComponent({
+      setup() {
+        const list = createFor(
+          () => items.value,
+          item => {
+            const el = template('<div></div>')()
+            el.textContent = String(item.value)
+            return el
+          },
+          item => item,
+        )
+        first = (list.nodes as any)[0][0].nodes
+        return createComponent(VaporTransitionGroup, null, {
+          default: () => list,
+        })
+      },
+    })
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    items.value = [2, 1]
+    await nextTick()
+    expect(first.$transition.disabled).toBe(true)
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(first.$transition.disabled).toBe(false)
+    app.unmount()
+  })
+
+  test('hydrated transition appear enter waits for the branch to resolve', async () => {
+    const asyncSetup = deferred()
+    const calls: string[] = []
+    const data = ref({
+      onBeforeAppear: () => calls.push('before appear'),
+      onAppear: () => calls.push('appear'),
+    })
+    const source = `<template>
+      <Transition
+        appear
+        :css="false"
+        @before-appear="data.onBeforeAppear"
+        @appear="data.onAppear"
+      >
+        <div>vapor</div>
+      </Transition>
+    </template>`
+    const ServerVaporChild = compile(source, data, {}, { ssr: true })
+    const ClientVaporChild = compile(source, data)
+    let isClient = false
+    const AsyncSibling = defineComponent({
+      async setup() {
+        if (isClient) await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const createRoot = (VaporChild: any) =>
+      defineComponent({
+        setup: () => () =>
+          h(Suspense, null, {
+            default: () => h('div', [h(VaporChild), h(AsyncSibling)]),
+            fallback: () => h('span', 'loading'),
+          }),
+      })
+
+    const html = await VueServerRenderer.renderToString(
+      createSSRApp(createRoot(ServerVaporChild)),
+    )
+    const host = document.createElement('div')
+    host.innerHTML = html
+    isClient = true
+    const app = createSSRApp(createRoot(ClientVaporChild))
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(calls).toEqual(['before appear'])
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(calls).toEqual(['before appear', 'appear'])
+    app.unmount()
   })
 })

--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -414,6 +414,60 @@ describe('effects in pending branches', () => {
     app.unmount()
   })
 
+  test('dynamic VDOM component ref uses the rendering suspense boundary', async () => {
+    const asyncSetup = deferred()
+    const useSecondRef = ref(false)
+    const firstRef = ref<unknown>(null)
+    const secondRef = ref<unknown>(null)
+    const VDomChild = defineComponent({
+      setup: () => () => h('div', 'child'),
+    })
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const VDomHost = defineComponent({
+      setup(_, { slots }) {
+        return () =>
+          h(Suspense, null, {
+            default: () => h('div', [slots.default!(), h(AsyncSibling)]),
+            fallback: () => h('span', 'loading'),
+          })
+      },
+    })
+    const VaporOwner = defineVaporComponent({
+      setup() {
+        const child = createComponent(VDomChild as any)
+        const setRef = createTemplateRefSetter()
+        renderEffect(() =>
+          setRef(child, useSecondRef.value ? secondRef : firstRef),
+        )
+        return createComponent(VDomHost as any, null, {
+          default: () => child,
+        })
+      },
+    })
+    const host = document.createElement('div')
+    const app = createApp({ render: () => h(VaporOwner as any) })
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(firstRef.value === null).toBe(true)
+
+    useSecondRef.value = true
+    await nextTick()
+    expect(secondRef.value === null).toBe(true)
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(firstRef.value === null).toBe(true)
+    expect(secondRef.value === null).toBe(false)
+    app.unmount()
+  })
+
   test('teleport target mount waits for the branch to resolve', async () => {
     const asyncSetup = deferred()
     const target = document.createElement('div')

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -8,12 +8,13 @@ import {
 import {
   ErrorCodes,
   type SchedulerJob,
+  type SuspenseBoundary,
   callWithErrorHandling,
   createCanSetSetupRefChecker,
   isAsyncWrapper,
   isTemplateRefKey,
   knownTemplateRefs,
-  queuePostFlushCb,
+  queuePostRenderEffect,
   warn,
 } from '@vue/runtime-dom'
 import {
@@ -40,6 +41,7 @@ import {
   unsetRef,
 } from './refCleanup'
 import { renderEffect } from './renderEffect'
+import { parentSuspense } from './suspense'
 
 export type NodeRef =
   | string
@@ -59,6 +61,7 @@ export type setRefFn = (
 ) => NodeRef | undefined
 
 interface TemplateRefState {
+  suspense: SuspenseBoundary | null
   oldRef?: NodeRef
   oldRefKey?: string
   ref: NodeRef
@@ -94,7 +97,7 @@ export function createTemplateRefSetter(): setRefFn {
   return (el, ref, refFor, refKey) => {
     let state = stateMap.get(el)
     if (!state) {
-      stateMap.set(el, (state = { ref }))
+      stateMap.set(el, (state = { ref, suspense: parentSuspense }))
     }
     return setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
   }
@@ -106,7 +109,7 @@ function createSingleTemplateRefSetter(): setRefFn {
 
   return (el, ref, refFor, refKey) => {
     if (!state) {
-      state = { ref }
+      state = { ref, suspense: parentSuspense }
     }
     return setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
   }
@@ -135,6 +138,7 @@ function setTemplateRefWithState(
       if (isVaporComponent(el) && el.isDeactivated) return
       state.oldRef = setRef(
         instance,
+        state.suspense,
         el,
         state.ref,
         state.oldRef,
@@ -148,6 +152,7 @@ function setTemplateRefWithState(
 
   const oldRef = setRef(
     instance,
+    state.suspense,
     el,
     ref,
     state.oldRef,
@@ -167,14 +172,15 @@ export function setStaticTemplateRef(
   refKey?: string,
 ): NodeRef | undefined {
   const instance = currentInstance as VaporComponentInstance
-  const oldRef = setRef(instance, el, ref, undefined, refFor, refKey)
+  const suspense = parentSuspense
+  const oldRef = setRef(instance, suspense, el, ref, undefined, refFor, refKey)
   const frag = getTemplateRefUpdateFragment(el)
   if (frag) {
     // Static refs do not need old-ref tracking, but async/dynamic component
     // targets still need to re-apply the same ref after their fragment updates.
     ;(frag.onUpdated ||= []).push(() => {
       if (isVaporComponent(el) && el.isDeactivated) return
-      setRef(instance, el, ref, oldRef, refFor, refKey)
+      setRef(instance, suspense, el, ref, oldRef, refFor, refKey)
     })
   }
   return oldRef
@@ -195,6 +201,7 @@ export function setTemplateRefBinding(
  */
 function setRef(
   instance: VaporComponentInstance,
+  suspense: SuspenseBoundary | null,
   el: RefEl,
   ref: NodeRef,
   oldRef?: NodeRef,
@@ -355,7 +362,7 @@ function setRef(
           if (cleanup.job === job) cleanup.job = undefined
         }
         cleanup.job = job
-        queuePostFlushCb(job, -1)
+        queuePostRenderEffect(job, -1, suspense)
       } else {
         doSet()
       }

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -171,8 +171,8 @@ export function insertFragment(
     block.insert(
       parent,
       anchor,
-      (block as TransitionBlock).$transition,
       parentSuspense,
+      (block as TransitionBlock).$transition,
     )
   } else {
     insert(block.nodes, parent, anchor, parentSuspense)
@@ -263,8 +263,8 @@ export function move(
       block.insert(
         parent,
         anchor,
-        (block as TransitionBlock).$transition,
         parentSuspense,
+        (block as TransitionBlock).$transition,
       )
     } else {
       move(

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -115,7 +115,7 @@ export function insert(
   if (isVaporComponent(block)) {
     anchor = anchor === 0 ? parent.$fc || _child(parent) : anchor
     if (block.isMounted && !block.isDeactivated) {
-      insert(block.block!, parent, anchor)
+      insert(block.block!, parent, anchor, parentSuspense)
     } else {
       mountComponent(block, parent, anchor)
     }
@@ -168,7 +168,12 @@ export function insertFragment(
     anchor = block.anchor
   }
   if (block.insert) {
-    block.insert(parent, anchor, (block as TransitionBlock).$transition)
+    block.insert(
+      parent,
+      anchor,
+      (block as TransitionBlock).$transition,
+      parentSuspense,
+    )
   } else {
     insert(block.nodes, parent, anchor, parentSuspense)
   }
@@ -255,7 +260,12 @@ export function move(
     }
     // fragment
     if (block.insert) {
-      block.insert(parent, anchor, (block as TransitionBlock).$transition)
+      block.insert(
+        parent,
+        anchor,
+        (block as TransitionBlock).$transition,
+        parentSuspense,
+      )
     } else {
       move(
         block.nodes,

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -31,7 +31,6 @@ import {
   nextUid,
   popWarningContext,
   pushWarningContext,
-  queuePostFlushCb,
   queuePostRenderEffect,
   registerHMR,
   resolveComponent,
@@ -340,7 +339,9 @@ export function createComponent(
         once,
       )
       if (!isHydrating) {
-        if (_insertionParent) insert(frag, _insertionParent, _insertionAnchor)
+        if (_insertionParent) {
+          insert(frag, _insertionParent, _insertionAnchor, parentSuspense)
+        }
       } else {
         frag.hydrate()
       }
@@ -356,7 +357,9 @@ export function createComponent(
         onScopeDispose(() => frag.dispose(), true)
       }
       if (!isHydrating) {
-        if (_insertionParent) insert(frag, _insertionParent, _insertionAnchor)
+        if (_insertionParent) {
+          insert(frag, _insertionParent, _insertionAnchor, parentSuspense)
+        }
       } else {
         frag.hydrate()
       }
@@ -1145,6 +1148,7 @@ export function mountComponent(
 export function unmountComponent(
   instance: VaporComponentInstance,
   parentNode?: ParentNode,
+  parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
   // Skip unmount for kept-alive components - deactivate if called from remove()
   if (
@@ -1155,7 +1159,10 @@ export function unmountComponent(
     (instance.parent as KeepAliveInstance).ctx
   ) {
     if (parentNode) {
-      ;(instance.parent as KeepAliveInstance)!.ctx.deactivate(instance)
+      ;(instance.parent as KeepAliveInstance)!.ctx.deactivate(
+        instance,
+        parentSuspense,
+      )
     }
     return
   }
@@ -1179,7 +1186,7 @@ export function unmountComponent(
     instance.scope.stop()
 
     if (instance.um) {
-      queuePostFlushCb(instance.um!)
+      queuePostRenderEffect(instance.um!, undefined, parentSuspense)
     }
     instance.isUnmounted = true
   }

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -4,6 +4,7 @@ import {
   type GenericComponentInstance,
   type KeepAliveProps,
   MoveType,
+  type SuspenseBoundary,
   type VNode,
   currentInstance,
   devtoolsComponentAdded,
@@ -15,7 +16,7 @@ import {
   onBeforeUnmount,
   onMounted,
   onUpdated,
-  queuePostFlushCb,
+  queuePostRenderEffect,
   resetShapeFlag,
   warn,
   watch,
@@ -54,8 +55,12 @@ export interface KeepAliveInstance extends VaporComponentInstance {
       instance: VaporComponentInstance,
       parentNode: ParentNode,
       anchor?: Node | null | 0,
+      parentSuspense?: SuspenseBoundary | null,
     ) => void
-    deactivate: (instance: VaporComponentInstance) => void
+    deactivate: (
+      instance: VaporComponentInstance,
+      parentSuspense?: SuspenseBoundary | null,
+    ) => void
     getCachedComponent: (
       comp: VaporComponent | VNode['type'] | VNode,
       key?: any,
@@ -312,7 +317,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
         const instance = getInstanceFromCache(cached)
         if (instance) {
           const da = instance.da
-          da && queuePostFlushCb(da)
+          da && queuePostRenderEffect(da, undefined, keepAliveInstance.suspense)
         }
       }
 
@@ -349,13 +354,13 @@ const VaporKeepAliveImpl = defineVaporComponent({
         }
         return cache.get(key ?? currentCacheKey ?? comp)
       },
-      activate: (instance, parentNode, anchor) => {
+      activate: (instance, parentNode, anchor, parentSuspense) => {
         current = instance
-        activate(instance, parentNode, anchor)
+        activate(instance, parentNode, anchor, parentSuspense)
       },
-      deactivate: instance => {
+      deactivate: (instance, parentSuspense) => {
         current = undefined
-        deactivate(instance, storageContainer)
+        deactivate(instance, storageContainer, parentSuspense)
       },
       acquireBranchScope(key) {
         return deleteScope(key)
@@ -561,13 +566,25 @@ export function activate(
   instance: VaporComponentInstance,
   parentNode: ParentNode,
   anchor?: Node | null | 0,
+  parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
-  move(instance.block, parentNode, anchor, MoveType.ENTER, instance)
+  move(
+    instance.block,
+    parentNode,
+    anchor,
+    MoveType.ENTER,
+    instance,
+    parentSuspense,
+  )
 
-  queuePostFlushCb(() => {
-    instance.isDeactivated = false
-    if (instance.a) invokeArrayFns(instance.a)
-  })
+  queuePostRenderEffect(
+    () => {
+      instance.isDeactivated = false
+      if (instance.a) invokeArrayFns(instance.a)
+    },
+    undefined,
+    parentSuspense,
+  )
 
   if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
     devtoolsComponentAdded(instance)
@@ -577,6 +594,7 @@ export function activate(
 export function deactivate(
   instance: VaporComponentInstance,
   container: ParentNode,
+  parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
   // Clear refs before deactivation, matching VDOM core's unmount path
   // which calls setRef(null) before the deactivation check.
@@ -585,12 +603,23 @@ export function deactivate(
   invalidateMount(instance.m)
   invalidateMount(instance.a)
 
-  move(instance.block, container, null, MoveType.LEAVE, instance)
+  move(
+    instance.block,
+    container,
+    null,
+    MoveType.LEAVE,
+    instance,
+    parentSuspense,
+  )
 
-  queuePostFlushCb(() => {
-    if (instance.da) invokeArrayFns(instance.da)
-    instance.isDeactivated = true
-  })
+  queuePostRenderEffect(
+    () => {
+      if (instance.da) invokeArrayFns(instance.da)
+      instance.isDeactivated = true
+    },
+    undefined,
+    parentSuspense,
+  )
 
   if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
     devtoolsComponentAdded(instance)

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -5,13 +5,15 @@ import {
   MoveType,
   type SchedulerJob,
   SchedulerJobFlags,
+  type SuspenseBoundary,
   type TeleportProps,
   type TeleportTargetElement,
+  type TransitionHooks,
   isMismatchAllowed,
   isTeleportDeferred,
   isTeleportDisabled,
   logMismatchError,
-  queuePostFlushCb,
+  queuePostRenderEffect,
   resolveTeleportTarget,
   restoreCurrentInstance,
   setCurrentInstance,
@@ -96,6 +98,7 @@ export class TeleportFragment extends RenderContextFragment {
   }
 
   private mountToTargetJob?: SchedulerJob
+  private parentSuspense?: SuspenseBoundary | null
 
   constructor(props: LooseRawProps, slots?: RawSlots | null) {
     super([])
@@ -297,7 +300,11 @@ export class TeleportFragment extends RenderContextFragment {
         }
       }
     }
-    queuePostFlushCb(this.mountToTargetJob)
+    queuePostRenderEffect(
+      this.mountToTargetJob,
+      undefined,
+      this.parentSuspense || null,
+    )
   }
 
   private mountToTarget(): void {
@@ -350,8 +357,15 @@ export class TeleportFragment extends RenderContextFragment {
     }
   }
 
-  insert = (container: ParentNode, anchor: Node | null): void => {
+  insert = (
+    container: ParentNode,
+    anchor: Node | null,
+    _transition?: TransitionHooks,
+    parentSuspense?: SuspenseBoundary | null,
+  ): void => {
     if (isHydrating) return
+
+    this.parentSuspense = parentSuspense
 
     const wasMountedInTarget =
       this.mountState.location === TeleportMountLocation.Target

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -8,7 +8,6 @@ import {
   type SuspenseBoundary,
   type TeleportProps,
   type TeleportTargetElement,
-  type TransitionHooks,
   isMismatchAllowed,
   isTeleportDeferred,
   isTeleportDisabled,
@@ -360,7 +359,6 @@ export class TeleportFragment extends RenderContextFragment {
   insert = (
     container: ParentNode,
     anchor: Node | null,
-    _transition?: TransitionHooks,
     parentSuspense?: SuspenseBoundary | null,
   ): void => {
     if (isHydrating) return

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -1,6 +1,7 @@
 import {
   type BaseTransitionProps,
   type GenericComponentInstance,
+  type SuspenseBoundary,
   type TransitionElement,
   type TransitionHooks,
   type TransitionHooksContext,
@@ -14,7 +15,7 @@ import {
   isTemplateNode,
   leaveCbKey,
   onBeforeMount,
-  queuePostFlushCb,
+  queuePostRenderEffect,
   resolveTransitionProps,
   restoreCurrentInstance,
   setCurrentInstance,
@@ -81,7 +82,7 @@ export const ensureTransitionHooksRegistered = (): void => {
   }
 }
 
-const hydrateTransitionImpl = () => {
+const hydrateTransitionImpl = (suspense: SuspenseBoundary | null) => {
   if (!currentHydrationNode || !isTemplateNode(currentHydrationNode)) return
   // replace <template> node with inner child
   const { content, parentNode } = currentHydrationNode
@@ -115,7 +116,11 @@ const hydrateTransitionImpl = () => {
       return (hooks: TransitionHooks) => {
         hooks.beforeEnter(transitionEl)
         transitionEl.style.display = originalDisplay
-        queuePostFlushCb(() => hooks.enter(transitionEl))
+        queuePostRenderEffect(
+          () => hooks.enter(transitionEl),
+          undefined,
+          suspense,
+        )
       }
     }
   }
@@ -136,9 +141,11 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
     // Register transition hooks on first use
     ensureTransitionHooksRegistered()
 
-    const performAppear = isHydrating ? hydrateTransitionImpl() : undefined
-    const state = useTransitionState()
     const instance = currentInstance! as VaporComponentInstance
+    const performAppear = isHydrating
+      ? hydrateTransitionImpl(instance.suspense)
+      : undefined
+    const state = useTransitionState()
     const { mode } = props
     __DEV__ && checkTransitionMode(mode)
 
@@ -781,7 +788,11 @@ function applyPendingVShows(
     pendingVShows.length = 0
     if (enterCbs) {
       const cbs = enterCbs
-      queuePostFlushCb(() => cbs.forEach(cb => cb()), -1)
+      queuePostRenderEffect(
+        () => cbs.forEach(cb => cb()),
+        -1,
+        hooks.instance.suspense,
+      )
     }
   })
 }

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -15,6 +15,7 @@ import {
   onBeforeUpdate,
   onUpdated,
   queuePostFlushCb,
+  queuePostRenderEffect,
   resolveTransitionProps,
   restoreCurrentInstance,
   setCurrentInstance,
@@ -234,7 +235,7 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
     const updated = () => {
       if (!isUpdatePending || isUpdatedPending) return
       isUpdatedPending = true
-      queuePostFlushCb(flushUpdated)
+      queuePostRenderEffect(flushUpdated, undefined, instance.suspense)
     }
 
     onBeforeUpdate(beforeUpdate)

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -13,6 +13,7 @@ import {
 } from './block'
 import {
   type GenericComponentInstance,
+  type SuspenseBoundary,
   type TransitionHooks,
   type VNode,
   currentInstance,
@@ -84,6 +85,7 @@ export class VaporFragment<
     parent: ParentNode,
     anchor: Node | null,
     transitionHooks?: TransitionHooks,
+    parentSuspense?: SuspenseBoundary | null,
   ) => void
   remove?: (parent?: ParentNode, transitionHooks?: TransitionHooks) => void
   hydrate?(...args: any[]): void
@@ -473,7 +475,8 @@ export class SlotFragment
   constructor(private readonly notifyParentBoundary: boolean = false) {
     super(isHydrating || __DEV__ ? 'slot' : undefined, false, false, false)
     if (!isHydrating) {
-      this.insert = (parent, anchor) => this.insertSlot(parent, anchor)
+      this.insert = (parent, anchor, _transition, parentSuspense) =>
+        this.insertSlot(parent, anchor, parentSuspense)
     }
     this.remove = parent => this.removeSlot(parent)
   }
@@ -493,9 +496,13 @@ export class SlotFragment
     })
   }
 
-  private insertSlot(parent: ParentNode, anchor: Node | null): void {
+  private insertSlot(
+    parent: ParentNode,
+    anchor: Node | null,
+    parentSuspense?: SuspenseBoundary | null,
+  ): void {
     this.disposed = false
-    insert(this.nodes, parent, anchor)
+    insert(this.nodes, parent, anchor, parentSuspense)
   }
 
   private removeSlot(parent?: ParentNode): void {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -84,8 +84,8 @@ export class VaporFragment<
   insert?: (
     parent: ParentNode,
     anchor: Node | null,
-    transitionHooks?: TransitionHooks,
     parentSuspense?: SuspenseBoundary | null,
+    transitionHooks?: TransitionHooks,
   ) => void
   remove?: (parent?: ParentNode, transitionHooks?: TransitionHooks) => void
   hydrate?(...args: any[]): void
@@ -475,7 +475,7 @@ export class SlotFragment
   constructor(private readonly notifyParentBoundary: boolean = false) {
     super(isHydrating || __DEV__ ? 'slot' : undefined, false, false, false)
     if (!isHydrating) {
-      this.insert = (parent, anchor, _transition, parentSuspense) =>
+      this.insert = (parent, anchor, parentSuspense) =>
         this.insertSlot(parent, anchor, parentSuspense)
     }
     this.remove = parent => this.removeSlot(parent)

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -5,7 +5,7 @@ import {
   currentInstance,
   endMeasure,
   queueJob,
-  queuePostFlushCb,
+  queuePostRenderEffect,
   restoreCurrentInstance,
   setCurrentInstance,
   startMeasure,
@@ -92,7 +92,7 @@ export class RenderEffect extends ReactiveEffect {
             instance.u && invokeArrayFns(instance.u)
           }
         }
-        queuePostFlushCb(updateJob)
+        queuePostRenderEffect(updateJob, undefined, instance.suspense)
       } else {
         this.render()
       }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1045,7 +1045,7 @@ function createVDOMComponent(
   rawSlots?: LooseRawSlots | null,
   once?: boolean,
 ): VaporFragment {
-  const suspense =
+  let suspense =
     currentParentSuspense || (parentComponent && parentComponent.suspense)
   const useBridge = shouldUseRendererBridge(component)
   const comp = useBridge ? ensureRendererBridge(component) : component
@@ -1176,8 +1176,8 @@ function createVDOMComponent(
 
   frag.insert = (parentNode, anchor, parentSuspense, transition) => {
     if (isHydrating) return
-    const operationSuspense =
-      parentSuspense === undefined ? suspense : parentSuspense
+    if (parentSuspense !== undefined) suspense = parentSuspense
+    const operationSuspense = suspense
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
       vdomActivate(
         vnode,
@@ -1244,7 +1244,7 @@ function createVDOMComponent(
 
     if (isMounted) {
       if (rawRef) {
-        vdomSetRef(rawRef, oldRawRef, null, vnode)
+        vdomSetRef(rawRef, oldRawRef, suspense, vnode)
       } else if (oldRawRef) {
         vdomSetRef(oldRawRef, null, null, vnode, true)
       }
@@ -1765,7 +1765,7 @@ function renderVDOMSlot(
               if (prevRendered) {
                 removeRenderedContent(prevRendered, currentParentNode!)
               }
-              insert(slotContent, currentParentNode!, currentAnchor)
+              insert(slotContent, currentParentNode!, currentAnchor, suspense)
               setRenderedContent(slotContent, slotContentValid)
               finishContentUpdate()
               return

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -41,6 +41,7 @@ import {
   normalizeVNode,
   onScopeDispose,
   queuePostFlushCb,
+  queuePostRenderEffect,
   renderSlot,
   restoreCurrentInstance,
   setCurrentInstance,
@@ -362,14 +363,14 @@ const vaporInteropImpl: Omit<
     }
   },
 
-  unmount(vnode, doRemove) {
+  unmount(vnode, doRemove, parentSuspense) {
     const container = doRemove ? vnode.anchor!.parentNode : undefined
     const instance = vnode.component as any as VaporComponentInstance
     let slotStartAnchor: Node | null = null
     if (instance) {
       const anchor = vnode.anchor as Node | null
       if (instance.block) {
-        unmountComponent(instance, container)
+        unmountComponent(instance, container, parentSuspense)
         if (!doRemove) {
           // When the surrounding VDOM fragment owns DOM removal, we still need
           // to dispose the vapor-returned block tree so nested interop state
@@ -386,7 +387,7 @@ const vaporInteropImpl: Omit<
         // removal, clear the adopted range before the interop anchor.
         const adoptedNode =
           vnode.el && vnode.el !== anchor ? (vnode.el as Node) : null
-        unmountComponent(instance)
+        unmountComponent(instance, undefined, parentSuspense)
         if (doRemove && container && adoptedNode) {
           let cur: Node | null = adoptedNode
           while (cur && cur !== anchor) {
@@ -454,7 +455,7 @@ const vaporInteropImpl: Omit<
         (isFragment(slotBlock) ? slotBlock.anchor : undefined) ||
         createTextNode()
       insert((n2.el = n2.anchor = selfAnchor), container, anchor)
-      insert((n2.vb = slotBlock), container, selfAnchor)
+      insert((n2.vb = slotBlock), container, selfAnchor, parentSuspense)
     } else {
       // update
       // slot function changed (e.g. dynamic slots from _createForSlots),
@@ -493,7 +494,7 @@ const vaporInteropImpl: Omit<
         }
         insert((n2.anchor = newAnchor), parent, insertAnchor)
         n2.el = rangeStartAnchor || newAnchor
-        insert((n2.vb = slotBlock), parent, newAnchor)
+        insert((n2.vb = slotBlock), parent, newAnchor, parentSuspense)
       } else {
         const vs1 = n1.vs!
         const vs2 = n2.vs!
@@ -507,16 +508,37 @@ const vaporInteropImpl: Omit<
     }
   },
 
-  move(vnode, container, anchor, moveType) {
+  move(vnode, container, anchor, moveType, parentSuspense) {
     if (
       vnode.el &&
       vnode.el !== vnode.anchor &&
       isComment(vnode.el as Node, '[')
     ) {
-      move(vnode.el as any, container, anchor, moveType)
+      move(
+        vnode.el as any,
+        container,
+        anchor,
+        moveType,
+        undefined,
+        parentSuspense,
+      )
     }
-    move(vnode.vb || (vnode.component as any), container, anchor, moveType)
-    move(vnode.anchor as any, container, anchor, moveType)
+    move(
+      vnode.vb || (vnode.component as any),
+      container,
+      anchor,
+      moveType,
+      undefined,
+      parentSuspense,
+    )
+    move(
+      vnode.anchor as any,
+      container,
+      anchor,
+      moveType,
+      undefined,
+      parentSuspense,
+    )
   },
 
   hydrate(
@@ -609,7 +631,7 @@ const vaporInteropImpl: Omit<
     setVaporTransitionHooks(component as any, hooks as VaporTransitionHooks)
   },
 
-  activate(vnode, container, anchor, parentComponent) {
+  activate(vnode, container, anchor, parentComponent, parentSuspense) {
     const cached = (parentComponent.ctx as KeepAliveContext).getCachedComponent(
       vnode,
     )
@@ -651,53 +673,67 @@ const vaporInteropImpl: Omit<
       }
       queuePostFlushCb(() => {
         syncVNodeEl(vnode, instance)
-        if (vnode.dirs) {
-          invokeDirectiveHook(vnode, cached, parentComponent, 'updated')
-        }
-        const vnodeUpdatedHook = vnode.props && vnode.props.onVnodeUpdated
-        if (vnodeUpdatedHook) {
-          callWithAsyncErrorHandling(
-            vnodeUpdatedHook,
-            parentComponent,
-            ErrorCodes.VNODE_HOOK,
-            [vnode, cached],
-          )
-        }
         if (!instance.isUpdating) {
           vnodeHookState.skipVnodeHooks = false
         }
       })
+      queuePostRenderEffect(
+        () => {
+          if (vnode.dirs) {
+            invokeDirectiveHook(vnode, cached, parentComponent, 'updated')
+          }
+          const vnodeUpdatedHook = vnode.props && vnode.props.onVnodeUpdated
+          if (vnodeUpdatedHook) {
+            callWithAsyncErrorHandling(
+              vnodeUpdatedHook,
+              parentComponent,
+              ErrorCodes.VNODE_HOOK,
+              [vnode, cached],
+            )
+          }
+        },
+        undefined,
+        parentSuspense,
+      )
     }
-    activate(instance, container, anchor)
+    activate(instance, container, anchor, parentSuspense)
     insert(vnode.anchor as any, container, anchor)
     const vnodeMountedHook = vnode.props && vnode.props.onVnodeMounted
     if (vnodeMountedHook) {
-      queuePostFlushCb(() => {
-        callWithAsyncErrorHandling(
-          vnodeMountedHook,
-          parentComponent,
-          ErrorCodes.VNODE_HOOK,
-          [vnode],
-        )
-      })
+      queuePostRenderEffect(
+        () => {
+          callWithAsyncErrorHandling(
+            vnodeMountedHook,
+            parentComponent,
+            ErrorCodes.VNODE_HOOK,
+            [vnode],
+          )
+        },
+        undefined,
+        parentSuspense,
+      )
     }
   },
 
-  deactivate(vnode, container) {
+  deactivate(vnode, container, parentSuspense) {
     const instance = vnode.component as any as VaporComponentInstance
-    deactivate(instance, container)
+    deactivate(instance, container, parentSuspense)
     insert(vnode.anchor as any, container)
-    queuePostFlushCb(() => {
-      const vnodeHook = vnode.props && vnode.props.onVnodeUnmounted
-      if (vnodeHook) {
-        callWithAsyncErrorHandling(
-          vnodeHook,
-          instance.parent,
-          ErrorCodes.VNODE_HOOK,
-          [vnode],
-        )
-      }
-    })
+    queuePostRenderEffect(
+      () => {
+        const vnodeHook = vnode.props && vnode.props.onVnodeUnmounted
+        if (vnodeHook) {
+          callWithAsyncErrorHandling(
+            vnodeHook,
+            instance.parent,
+            ErrorCodes.VNODE_HOOK,
+            [vnode],
+          )
+        }
+      },
+      undefined,
+      parentSuspense,
+    )
   },
 }
 
@@ -940,11 +976,13 @@ function mountVNode(
     syncNodes()
   }
 
-  frag.insert = (parentNode, anchor, transition) => {
+  frag.insert = (parentNode, anchor, transition, parentSuspense) => {
     if (isHydrating) return
+    const operationSuspense =
+      parentSuspense === undefined ? suspense : parentSuspense
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
       if ((vnode.type as any).__vapor) {
-        activate(vnode.component as any, parentNode, anchor)
+        activate(vnode.component as any, parentNode, anchor, operationSuspense)
       } else {
         vdomActivate(
           vnode,
@@ -952,7 +990,7 @@ function mountVNode(
           anchor,
           internals,
           parentComponent as any,
-          null,
+          operationSuspense,
           undefined,
           false,
         )
@@ -969,7 +1007,7 @@ function mountVNode(
           parentNode,
           anchor,
           parentComponent as any,
-          suspense,
+          operationSuspense,
           undefined, // namespace
           vnode.slotScopeIds,
         )
@@ -983,6 +1021,7 @@ function mountVNode(
           anchor,
           MoveType.REORDER,
           parentComponent as any,
+          operationSuspense,
         )
       }
       simpleSetCurrentInstance(prev)
@@ -1135,8 +1174,10 @@ function createVDOMComponent(
   vnode.scopeId = getCurrentScopeId() || null
   vnode.slotScopeIds = currentSlotScopeIds
 
-  frag.insert = (parentNode, anchor, transition) => {
+  frag.insert = (parentNode, anchor, transition, parentSuspense) => {
     if (isHydrating) return
+    const operationSuspense =
+      parentSuspense === undefined ? suspense : parentSuspense
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
       vdomActivate(
         vnode,
@@ -1144,7 +1185,7 @@ function createVDOMComponent(
         anchor,
         internals,
         parentComponent as any,
-        null,
+        operationSuspense,
         undefined,
         false,
       )
@@ -1158,12 +1199,12 @@ function createVDOMComponent(
           parentNode,
           anchor,
           parentComponent as any,
-          suspense,
+          operationSuspense,
           undefined,
           false,
         )
         // set ref
-        if (rawRef) vdomSetRef(rawRef, null, null, vnode)
+        if (rawRef) vdomSetRef(rawRef, null, operationSuspense, vnode)
         isMounted = true
       } else {
         // move
@@ -1173,6 +1214,7 @@ function createVDOMComponent(
           anchor,
           MoveType.REORDER,
           parentComponent as any,
+          operationSuspense,
         )
       }
       simpleSetCurrentInstance(prev)
@@ -1384,7 +1426,7 @@ function renderVDOMSlot(
   once?: boolean,
   slotRoot?: boolean,
 ): VaporFragment {
-  const suspense = currentParentSuspense || parentComponent.suspense
+  let suspense = currentParentSuspense || parentComponent.suspense
   const frag = createInteropFragment()
   // `isBlockValid` below reports VDOM-side validity (`contentState.valid`), not
   // `isValidBlock(frag.nodes)`: `frag.nodes` tracks the active fallback when one
@@ -1524,8 +1566,9 @@ function renderVDOMSlot(
     }
   }
 
-  frag.insert = (parentNode, anchor) => {
+  frag.insert = (parentNode, anchor, _transition, parentSuspense) => {
     if (isHydrating) return
+    if (parentSuspense !== undefined) suspense = parentSuspense
     currentParentNode = parentNode
     currentAnchor = anchor
 
@@ -1541,10 +1584,11 @@ function renderVDOMSlot(
           anchor,
           MoveType.REORDER,
           parentComponent as any,
+          suspense,
         )
       } else if (contentState.rendered) {
         // move vapor content
-        insert(contentState.rendered, parentNode, anchor)
+        insert(contentState.rendered, parentNode, anchor, suspense)
       }
 
       insertActiveSlotFallback(slotResolutionState)
@@ -2131,13 +2175,13 @@ function renderVaporSlot(
 
       slotResolutionState.pendingRecheck = false
       slotResolutionState.pendingRecheckForce = false
-      frag.insert = (parentNode, anchor) => {
+      frag.insert = (parentNode, anchor, _transition, parentSuspense) => {
         currentParentNode = parentNode
         currentAnchor = anchor
         if (slotResolutionState.activeFallback) {
           insertActiveSlotFallback(slotResolutionState)
         } else {
-          insert(frag.nodes, parentNode, anchor)
+          insert(frag.nodes, parentNode, anchor, parentSuspense)
         }
       }
       frag.remove = parentNode => {
@@ -2280,7 +2324,7 @@ function createVNodeChildrenFragment(
   render: () => VNode[],
   parentComponent: ComponentInternalInstance | null,
 ): VaporFragment {
-  const suspense =
+  let suspense =
     currentParentSuspense || (parentComponent && parentComponent.suspense)
   const frag = createInteropFragment()
   let contentValid = false
@@ -2452,8 +2496,9 @@ function createVNodeChildrenFragment(
     startRenderEffect()
   }
 
-  frag.insert = (parentNode, anchor) => {
+  frag.insert = (parentNode, anchor, _transition, parentSuspense) => {
     if (isHydrating) return
+    if (parentSuspense !== undefined) suspense = parentSuspense
     currentParentNode = parentNode
     currentAnchor = anchor
     if (!isMounted) {
@@ -2489,6 +2534,7 @@ function createVNodeChildrenFragment(
           anchor,
           MoveType.REORDER,
           parentComponent as any,
+          suspense,
         )
       })
     }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -976,7 +976,7 @@ function mountVNode(
     syncNodes()
   }
 
-  frag.insert = (parentNode, anchor, transition, parentSuspense) => {
+  frag.insert = (parentNode, anchor, parentSuspense, transition) => {
     if (isHydrating) return
     const operationSuspense =
       parentSuspense === undefined ? suspense : parentSuspense
@@ -1174,7 +1174,7 @@ function createVDOMComponent(
   vnode.scopeId = getCurrentScopeId() || null
   vnode.slotScopeIds = currentSlotScopeIds
 
-  frag.insert = (parentNode, anchor, transition, parentSuspense) => {
+  frag.insert = (parentNode, anchor, parentSuspense, transition) => {
     if (isHydrating) return
     const operationSuspense =
       parentSuspense === undefined ? suspense : parentSuspense
@@ -1566,7 +1566,7 @@ function renderVDOMSlot(
     }
   }
 
-  frag.insert = (parentNode, anchor, _transition, parentSuspense) => {
+  frag.insert = (parentNode, anchor, parentSuspense) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
     currentParentNode = parentNode
@@ -2175,7 +2175,7 @@ function renderVaporSlot(
 
       slotResolutionState.pendingRecheck = false
       slotResolutionState.pendingRecheckForce = false
-      frag.insert = (parentNode, anchor, _transition, parentSuspense) => {
+      frag.insert = (parentNode, anchor, parentSuspense) => {
         currentParentNode = parentNode
         currentAnchor = anchor
         if (slotResolutionState.activeFallback) {
@@ -2496,7 +2496,7 @@ function createVNodeChildrenFragment(
     startRenderEffect()
   }
 
-  frag.insert = (parentNode, anchor, _transition, parentSuspense) => {
+  frag.insert = (parentNode, anchor, parentSuspense) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
     currentParentNode = parentNode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Suspense integration across Vapor rendering, including mounting, unmounting, moving, hydration, and deferred updates.
  * Corrected lifecycle timing when Suspense branches are pending, including template refs, transitions, teleports, KeepAlive, and transition groups.
  * Improved behavior when pending Suspense content is removed, resolved, deactivated, or reactivated, with correct scheduling for vnode/ref and lifecycle callbacks.

* **Tests**
  * Added/expanded coverage for lifecycle hooks, refs, teleports, KeepAlive, transitions, hydration, and unmounting during pending Suspense states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->