### PR TITLE
fix(runtime-vapor): update logical child cache after hydration mutations

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4690,6 +4690,37 @@ describe('Vapor Mode hydration', () => {
       await nextTick()
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`"<!---->"`)
     })
+
+    test('transition appear should not break following component hydration', async () => {
+      const data = ref('initial')
+      const { container, html } = await testHydration(
+        `<template>
+          <div>
+            <Transition :css="false" appear>
+              <p>{{ data }}</p>
+            </Transition>
+            <components.Second />
+          </div>
+        </template>`,
+        {
+          Second: `<template><i>{{ data }}</i></template>`,
+        },
+        data,
+      )
+
+      expect(html).toBe(
+        '<div><template><p>initial</p></template><i>initial</i></div>',
+      )
+      expect(container.innerHTML).toBe(
+        '<div><p style="">initial</p><i>initial</i></div>',
+      )
+
+      data.value = 'updated'
+      await nextTick()
+      expect(container.innerHTML).toBe(
+        '<div><p style="">updated</p><i>updated</i></div>',
+      )
+    })
   })
 
   describe('transition-group', () => {
@@ -7792,6 +7823,65 @@ describe('mismatch handling', () => {
     expect(container.innerHTML).toBe('<ins id="foo">x</ins>')
     expect(`Hydration node mismatch`).toHaveBeenWarned()
   })
+  test('element mismatch should not break following component hydration', async () => {
+    const data = ref('initial')
+    const appCode = `<template>
+      <div>
+        <components.First />
+        <components.Second />
+      </div>
+    </template>`
+
+    const ssrComponents: Record<string, any> = {}
+    ssrComponents.First = compile(
+      `<template><span>{{ data }}</span></template>`,
+      data,
+      ssrComponents,
+      { vapor: true, ssr: true },
+    )
+    ssrComponents.Second = compile(
+      `<template><i>{{ data }}</i></template>`,
+      data,
+      ssrComponents,
+      { vapor: true, ssr: true },
+    )
+    const serverComp = compile(appCode, data, ssrComponents, {
+      vapor: true,
+      ssr: true,
+    })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    const clientComponents: Record<string, any> = {}
+    clientComponents.First = compile(
+      `<template><p>{{ data }}</p></template>`,
+      data,
+      clientComponents,
+      { vapor: true },
+    )
+    clientComponents.Second = compile(
+      `<template><i>{{ data }}</i></template>`,
+      data,
+      clientComponents,
+      { vapor: true },
+    )
+    const clientComp = compile(appCode, data, clientComponents, {
+      vapor: true,
+    })
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    createVaporSSRApp(clientComp).mount(container)
+
+    expect(container.innerHTML).toBe('<div><p>initial</p><i>initial</i></div>')
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+
+    data.value = 'updated'
+    await nextTick()
+    expect(container.innerHTML).toBe('<div><p>updated</p><i>updated</i></div>')
+  })
   test('static text content mismatch should warn', async () => {
     const { container } = await mountWithHydration(`server text`, `client text`)
     expect(container.textContent).toBe('client text')
@@ -7927,6 +8017,50 @@ describe('mismatch handling', () => {
     )
 
     const { container } = await mountWithHydration(html, code, clientData)
+
+    expect(container.innerHTML).toBe('<div><!--if--><i>tail</i></div>')
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+
+    clientData.value.show = true
+    clientData.value.tail = 'tail updated'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<div><span>shown</span><!--if--><i>tail updated</i></div>',
+    )
+  })
+  test('v-if empty branch should not break following component hydration', async () => {
+    const code = `
+      <div>
+        <span v-if="data.show">shown</span>
+        <components.Second />
+      </div>
+    `
+    const ssrData = ref({ show: true, tail: 'tail' })
+    const ssrComponents = {
+      Second: compileVaporComponent(
+        `<i>{{ data.tail }}</i>`,
+        ssrData,
+        undefined,
+        true,
+      ),
+    }
+    const SSRComp = compileVaporComponent(code, ssrData, ssrComponents, true)
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(SSRComp),
+    )
+    expect(html).toBe('<div><span>shown</span><i>tail</i></div>')
+
+    const clientData = ref({ show: false, tail: 'tail' })
+    const clientComponents = {
+      Second: compileVaporComponent(`<i>{{ data.tail }}</i>`, clientData),
+    }
+    const { container } = await mountWithHydration(
+      html,
+      code,
+      clientData,
+      clientComponents,
+    )
 
     expect(container.innerHTML).toBe('<div><!--if--><i>tail</i></div>')
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()
@@ -9999,6 +10133,56 @@ describe('VDOM interop', () => {
     await nextTick()
     expect(container.innerHTML).toBe(
       '<!--[--><!--dynamic-component--><span>tail-updated</span><!--]-->',
+    )
+  })
+
+  test('hydrate null dynamic component should not break following component hydration', async () => {
+    const code = `<div>
+      <component :is="data.show ? 'p' : null">{{ data.msg }}</component>
+      <components.Second />
+    </div>`
+    const ssrData = ref({ show: true, msg: 'initial' })
+    const ssrComponents = {
+      Second: compileVaporComponent(
+        `<i>{{ data.msg }}</i>`,
+        ssrData,
+        undefined,
+        true,
+      ),
+    }
+    const SSRComp = compileVaporComponent(code, ssrData, ssrComponents, true)
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(SSRComp),
+    )
+    expect(html).toBe('<div><p>initial</p><i>initial</i></div>')
+
+    const clientData = ref({ show: false, msg: 'initial' })
+    const clientComponents = {
+      Second: compileVaporComponent(`<i>{{ data.msg }}</i>`, clientData),
+    }
+    const { container } = await mountWithHydration(
+      html,
+      code,
+      clientData,
+      clientComponents,
+    )
+
+    expect(container.innerHTML).toBe(
+      '<div><!--dynamic-component--><i>initial</i></div>',
+    )
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+
+    clientData.value.msg = 'updated'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<div><!--dynamic-component--><i>updated</i></div>',
+    )
+
+    clientData.value.show = true
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<div><p>updated</p><!--dynamic-component--><i>updated</i></div>',
     )
   })
 

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -60,6 +60,7 @@ import {
   isHydrating,
   setCurrentHydrationNode,
 } from '../dom/hydration'
+import { updateLastLocatedLogicalChild } from '../dom/node'
 import { type PendingVShow, setCurrentPendingVShows } from '../directives/vShow'
 import { isInteropEnabled } from '../vdomInteropState'
 
@@ -85,7 +86,8 @@ export const ensureTransitionHooksRegistered = (): void => {
 const hydrateTransitionImpl = (suspense: SuspenseBoundary | null) => {
   if (!currentHydrationNode || !isTemplateNode(currentHydrationNode)) return
   // replace <template> node with inner child
-  const { content, parentNode } = currentHydrationNode
+  const templateNode = currentHydrationNode
+  const { content, parentNode } = templateNode
   const { firstChild } = content
   if (firstChild) {
     let transitionEl: Element | undefined
@@ -102,8 +104,9 @@ const hydrateTransitionImpl = (suspense: SuspenseBoundary | null) => {
       }
     }
 
-    parentNode!.insertBefore(content, currentHydrationNode)
-    parentNode!.removeChild(currentHydrationNode)
+    parentNode!.insertBefore(content, templateNode)
+    parentNode!.removeChild(templateNode)
+    updateLastLocatedLogicalChild(parentNode!, templateNode, firstChild)
     setCurrentHydrationNode(firstChild)
 
     if (

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -19,6 +19,7 @@ import {
   createComment,
   createTextNode,
   parentNode as getParentNode,
+  updateLastLocatedLogicalChild,
 } from './node'
 import { EMPTY_BLOCK, findBlockBoundary, isValidBlock } from '../block'
 import type { DynamicFragment } from '../fragment'
@@ -522,6 +523,17 @@ export function executeAnchorPlan(
       }
       case 'create-cleanup': {
         frag.nodes = EMPTY_BLOCK
+        // The runtime anchor is inserted later. Until then, advance the cache
+        // to the surviving next sibling, or clear it when cleanup reaches the tail.
+        const cleanupParent = getParentNode(plan.cleanupStart)
+        if (cleanupParent) {
+          updateLastLocatedLogicalChild(
+            cleanupParent,
+            plan.cleanupStart,
+            plan.cleanupUntil,
+            1,
+          )
+        }
         if (plan.cleanupUntil) {
           exitHydrationBoundary = enterHydrationBoundary(plan.cleanupUntil)
         } else {

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -20,6 +20,7 @@ import {
   createTextNode,
   locateChildByLogicalIndex,
   parentNode,
+  updateLastLocatedLogicalChild,
 } from './node'
 import { remove } from '../block'
 
@@ -363,10 +364,12 @@ function handleMismatch(
 
   // fast path for text nodes
   if (template[0] !== '<') {
-    return container.insertBefore(
-      markRecreatedNode(createTextNode(template)),
-      next,
-    )
+    const newNode = markRecreatedNode(createTextNode(template))
+    container.insertBefore(newNode, next)
+    if (!shouldPreserveAnchor) {
+      updateLastLocatedLogicalChild(container, node, newNode)
+    }
+    return newNode
   }
 
   // element node
@@ -398,6 +401,9 @@ function handleMismatch(
     }
   }
   container.insertBefore(newNode, next)
+  if (!shouldPreserveAnchor) {
+    updateLastLocatedLogicalChild(container, node, newNode)
+  }
   return newNode
 }
 

--- a/packages/runtime-vapor/src/dom/node.ts
+++ b/packages/runtime-vapor/src/dom/node.ts
@@ -109,3 +109,20 @@ export function locateChildByLogicalIndex(
 
   return null
 }
+
+// Hydration mismatch recovery and other DOM mutations can replace or remove
+// the cached node. Transfer `$llc` only when it still points to that node.
+export function updateLastLocatedLogicalChild(
+  parent: ParentNode,
+  from: Node,
+  to: Node | null,
+  logicalIndexOffset = 0,
+): void {
+  const insertionParent = parent as InsertionParent
+  if (insertionParent.$llc === from) {
+    if (to) {
+      ;(to as ChildItem).$idx = (from as ChildItem).$idx + logicalIndexOffset
+    }
+    insertionParent.$llc = to
+  }
+}


### PR DESCRIPTION
- transfer the last located logical child when mismatch recovery replaces nodes
- maintain the cache during Transition template unwrapping and fragment cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hydration recovery when server-rendered content differs from the client.
  - Fixed issues where transitions, empty conditional branches, dynamic components, or mismatched elements could disrupt hydration of subsequent sibling components.
  - Ensured affected components continue to update correctly after hydration mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->