### PR TITLE
fix(runtime-vapor): preserve pending async component position

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -7035,6 +7035,88 @@ describe('Vapor Mode hydration', () => {
           `)
         })
 
+        test('does not register or insert a CSR placeholder when moving pending hydrated async setup', async () => {
+          let resolveClient!: () => void
+          const childData = ref({ wait: Promise.resolve() })
+          const items = ref(['sync', 'async'])
+          const vaporChildCode = `
+            <script vapor>
+              const data = _data
+              await data.value.wait
+            </script>
+            <template><span>async</span></template>
+          `
+          let VaporChild = compile(
+            vaporChildCode,
+            childData,
+            {},
+            {
+              vapor: true,
+              ssr: true,
+            },
+          )
+          const App = defineComponent({
+            setup() {
+              return () =>
+                h(runtimeDom.Suspense, null, {
+                  default: () =>
+                    h(
+                      'div',
+                      items.value.map(id =>
+                        id === 'async'
+                          ? h(VaporChild, { key: id })
+                          : h('i', { key: id }, 'sync'),
+                      ),
+                    ),
+                })
+            },
+          })
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(App),
+          )
+
+          childData.value.wait = new Promise<void>(resolve => {
+            resolveClient = resolve
+          })
+          let instance!: VaporComponentInstance
+          VaporChild = compile(
+            vaporChildCode,
+            childData,
+            {},
+            {
+              vapor: true,
+              ssr: false,
+            },
+          )
+          const setup = VaporChild.setup
+          VaporChild.setup = (props: any, child: VaporComponentInstance) => {
+            instance = child
+            return setup(props, child)
+          }
+
+          const container = document.createElement('div')
+          container.innerHTML = html
+          document.body.appendChild(container)
+          const app = runtimeDom.createSSRApp(App)
+          app.use(runtimeVapor.vaporInteropPlugin)
+          app.mount(container)
+
+          const registerDep = vi.spyOn(instance.suspense!, 'registerDep')
+          try {
+            items.value = ['async', 'sync']
+            await nextTick()
+
+            expect(registerDep).not.toHaveBeenCalled()
+            expect(instance.block).toBeNull()
+          } finally {
+            registerDep.mockRestore()
+            app.unmount()
+            resolveClient()
+            await new Promise(resolve => setTimeout(resolve))
+            container.remove()
+          }
+        })
+
         test('hydrate VDOM Suspense vapor async multi-root setup should preserve SSR range before resolve', async () => {
           let resolveClient!: () => void
           const serverData = ref({

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -40,6 +40,7 @@ import { VaporDynamicComponentFlags, VaporSlotFlags } from '@vue/shared'
 import { VaporSlot } from '../../runtime-core/src/vnode'
 import { compile, makeInteropRender } from './_utils'
 import {
+  type VaporComponentInstance,
   VaporKeepAlive,
   VaporTeleport,
   applyTextModel,
@@ -4165,6 +4166,286 @@ describe('vdomInterop', () => {
   })
 
   describe('Suspense', () => {
+    function deferred() {
+      let resolve!: () => void
+      const promise = new Promise<void>(r => (resolve = r))
+      return { promise, resolve }
+    }
+
+    async function flushResolution(promise: Promise<void>) {
+      await promise
+      await Promise.resolve()
+      await nextTick()
+      await nextTick()
+    }
+
+    test('preserves source order when an async vapor child precedes a dynamic sibling', async () => {
+      const pending = deferred()
+      const Tail = compile(`<template><i>tail</i></template>`, ref(null))
+      const data = ref({ wait: pending.promise, current: Tail })
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const VaporParent = compile(
+        `<template>
+          <div>
+            <components.AsyncChild />
+            <component :is="data.current" />
+          </div>
+        </template>`,
+        data,
+        { AsyncChild },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+        expect(host.innerHTML).toBe('<p>pending</p>')
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect(host.innerHTML).toBe(
+          '<div><span>async</span><i>tail</i><!--dynamic-component--></div>',
+        )
+      } finally {
+        app.unmount()
+        host.remove()
+      }
+    })
+
+    test('uses the live placeholder after a directive removes the old insertion anchor', async () => {
+      const pending = deferred()
+      const data = ref({ wait: pending.promise })
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const VaporParent = compile(
+        `<template>
+          <div>
+            <components.AsyncChild />
+            <span v-remove>tail</span>
+          </div>
+        </template>`,
+        data,
+        { AsyncChild },
+      )
+      const host = document.createElement('div')
+      const errorHandler = vi.fn()
+      const remove = vi.fn((el: Element) => el.remove())
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+      app.directive('remove', remove)
+      app.config.errorHandler = errorHandler
+
+      try {
+        app.mount(host)
+        expect(host.innerHTML).toBe('<p>pending</p>')
+        expect(remove).toHaveBeenCalledOnce()
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect(errorHandler).not.toHaveBeenCalled()
+        expect(host.innerHTML).toBe('<div><span>async</span></div>')
+      } finally {
+        app.unmount()
+        host.remove()
+      }
+    })
+
+    test('removes a pending async placeholder when its VDOM parent unmounts', async () => {
+      const pending = deferred()
+      const data = ref({ wait: pending.promise })
+      let instance!: VaporComponentInstance
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const setup = AsyncChild.setup
+      AsyncChild.setup = (props: any, child: VaporComponentInstance) => {
+        instance = child
+        return setup(props, child)
+      }
+      const host = document.createElement('div')
+      const errorHandler = vi.fn()
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h('div', [h(AsyncChild)]),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+      app.config.errorHandler = errorHandler
+      let mounted = false
+
+      try {
+        app.mount(host)
+        mounted = true
+        const placeholder = instance.block as Node
+        expect(placeholder).toBeInstanceOf(Comment)
+
+        app.unmount()
+        mounted = false
+
+        expect(placeholder.parentNode).toBeNull()
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+        expect(errorHandler).not.toHaveBeenCalled()
+        expect(host.innerHTML).toBe('')
+      } finally {
+        pending.resolve()
+        if (mounted) app.unmount()
+        host.remove()
+      }
+    })
+
+    test('removes a pending async placeholder disposed through its vapor parent scope', async () => {
+      const pending = deferred()
+      const data = ref({ wait: pending.promise })
+      let instance!: VaporComponentInstance
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const setup = AsyncChild.setup
+      AsyncChild.setup = (props: any, child: VaporComponentInstance) => {
+        instance = child
+        return setup(props, child)
+      }
+      const VaporParent = compile(
+        `<template><div><components.AsyncChild /><i>tail</i></div></template>`,
+        data,
+        { AsyncChild },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+      let mounted = false
+
+      try {
+        app.mount(host)
+        mounted = true
+        const placeholder = instance.block as Node
+        expect(placeholder.parentNode).not.toBeNull()
+
+        app.unmount()
+        mounted = false
+
+        expect(placeholder.parentNode).toBeNull()
+      } finally {
+        if (mounted) app.unmount()
+        pending.resolve()
+        await flushResolution(pending.promise)
+        host.remove()
+      }
+    })
+
+    test('first-mounts a pending async component re-entered from KeepAlive cache', async () => {
+      const pending = deferred()
+      const data = ref({ wait: pending.promise })
+      let instance!: VaporComponentInstance
+      let setupCalls = 0
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const setup = AsyncChild.setup
+      AsyncChild.setup = (props: any, child: VaporComponentInstance) => {
+        setupCalls++
+        instance = child
+        return setup(props, child)
+      }
+      const SyncChild = defineVaporComponent({
+        setup: () => template('<span>sync</span>')(),
+      })
+      const current = shallowRef<any>(SyncChild)
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(VaporKeepAlive, null, {
+            default: () => createDynamicComponent(() => current.value),
+          })
+        },
+      })
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+        current.value = AsyncChild
+        await nextTick()
+        current.value = SyncChild
+        await nextTick()
+        current.value = AsyncChild
+        await nextTick()
+
+        expect(setupCalls).toBe(1)
+        expect(instance.isDeactivated).toBe(false)
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect(instance.isMounted).toBe(true)
+        expect(host.innerHTML).toBe(
+          '<span>async</span><!--dynamic-component-->',
+        )
+      } finally {
+        pending.resolve()
+        app.unmount()
+        host.remove()
+      }
+    })
+
     test('renders vapor async wrapper inside VDOM Suspense', async () => {
       const duration = 5
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -680,6 +680,7 @@ export class VaporComponentInstance<
   suspenseId: number
   asyncDep: Promise<any> | null
   asyncResolved: boolean
+  asyncDepRegistered?: boolean
   restoreAsyncContext?: () => void | (() => void)
   deferredHydrationBoundary?: () => void
 
@@ -1051,7 +1052,40 @@ export function mountComponent(
     instance.asyncDep &&
     !instance.asyncResolved
   ) {
+    // Moving a pending instance, including re-entering from KeepAlive, retries
+    // mountComponent. Move its CSR placeholder when present; during hydration,
+    // `instance.block` is still null, but the async dependency must not be
+    // registered again.
+    if (instance.asyncDepRegistered) {
+      if (instance.block) {
+        insert(instance.block, parent, anchor)
+      }
+      if (
+        isKeepAliveEnabled &&
+        instance.shapeFlag! & ShapeFlags.COMPONENT_KEPT_ALIVE
+      ) {
+        // A cached pending instance still needs its initial mount after setup
+        // resolves. Restore only its active state; KeepAlive activation requires
+        // a mounted block.
+        instance.isDeactivated = false
+      }
+      return
+    }
+
+    const hydrating = isHydrating
+    if (!hydrating) {
+      // Keep a placeholder in the DOM while async setup is pending so
+      // sibling insertion and moves use the component's current position.
+      instance.block = createComment('')
+      insert(instance.block, parent, anchor)
+    }
+
+    instance.asyncDepRegistered = true
     const component = instance.type
+    // CSR resolves from the live placeholder, so do not retain its original
+    // DOM location through the unresolved promise.
+    const hydrationParent = hydrating ? parent : undefined
+    const hydrationAnchor = hydrating ? anchor : undefined
     instance.suspense.registerDep(instance, setupResult => {
       // Final suspense retry after async setup resolves. Restore hydrating
       // mode so the last mount does not fall back to fresh DOM insertion.
@@ -1070,20 +1104,24 @@ export function mountComponent(
         }
       }
       try {
-        if (isHydrating) {
+        if (hydrating) {
           withDeferredHydrationBoundary(() => {
             handleResult()
-            mountComponent(instance, parent, anchor)
+            mountComponent(instance, hydrationParent!, hydrationAnchor)
             if (instance.deferredHydrationBoundary) {
               instance.deferredHydrationBoundary()
             }
           })
         } else {
+          const placeholder = instance.block as Comment
+          const placeholderParent = placeholder.parentNode as ParentNode
+          const placeholderAnchor = placeholder.nextSibling
           handleResult()
-          mountComponent(instance, parent, anchor)
+          mountComponent(instance, placeholderParent, placeholderAnchor)
+          remove(placeholder, placeholderParent)
         }
       } finally {
-        if (isHydrating) {
+        if (hydrating) {
           instance.deferredHydrationBoundary = undefined
         }
         instance.restoreAsyncContext = undefined
@@ -1093,9 +1131,11 @@ export function mountComponent(
     return
   }
 
+  // A pending async component may be cached before its initial mount.
   if (
     isKeepAliveEnabled &&
-    instance.shapeFlag! & ShapeFlags.COMPONENT_KEPT_ALIVE
+    instance.shapeFlag! & ShapeFlags.COMPONENT_KEPT_ALIVE &&
+    instance.isMounted
   ) {
     ;(instance.parent as KeepAliveInstance)!.ctx.activate(
       instance,
@@ -1167,12 +1207,16 @@ export function unmountComponent(
     return
   }
 
+  const pendingAsyncSetup =
+    __FEATURE_SUSPENSE__ && !!instance.asyncDep && !instance.asyncResolved
+
   if (
     !instance.isUnmounted &&
     (instance.isMounted ||
-      // A hydrating async setup component can be unmounted before its block exists.
-      // It still needs normal scope cleanup so a later resolve is ignored.
-      (instance.asyncDep && !instance.asyncResolved))
+      // An async setup component can be unmounted before it finishes mounting.
+      // It still needs normal unmount cleanup and must be marked unmounted so
+      // a later async resolution is ignored.
+      pendingAsyncSetup)
   ) {
     if (__DEV__) {
       unregisterHMR(instance)
@@ -1191,7 +1235,14 @@ export function unmountComponent(
     instance.isUnmounted = true
   }
 
-  if (parentNode) {
+  // Callers that own surrounding DOM removal may omit parentNode, so remove
+  // the pending placeholder from its live DOM parent.
+  if (pendingAsyncSetup && instance.block instanceof Comment) {
+    const blockParent = instance.block.parentNode
+    if (blockParent) {
+      remove(instance.block, blockParent)
+    }
+  } else if (parentNode) {
     if (instance.block) {
       remove(instance.block, parentNode)
     } else {


### PR DESCRIPTION
- use a live comment placeholder while async setup is pending
- avoid duplicate dependency registration during hydration
- clean up pending placeholders during unmount
- preserve first-mount and active state for cached pending components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pending asynchronous components during hydration and Suspense updates.
  * Prevented unnecessary client-rendered placeholders when moving suspended content.
  * Fixed placeholder cleanup when asynchronous components are removed, unmounted, or deactivated.
  * Improved re-entry behavior for cached asynchronous components.
  * Preserved correct content ordering across Vapor and VDOM interoperability scenarios.

* **Tests**
  * Added comprehensive coverage for hydration, Suspense, unmounting, placeholder behavior, and KeepAlive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->