### PR TITLE
fix(runtime-vapor): preserve functional component root bindings

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -348,10 +348,13 @@ export function filterSingleRoot(
   return singleRoot
 }
 
+export const isFunctionalFallthroughKey = (key: string): boolean =>
+  key === 'class' || key === 'style' || isOn(key)
+
 export const getFunctionalFallthrough = (attrs: Data): Data | undefined => {
   let res: Data | undefined
   for (const key in attrs) {
-    if (key === 'class' || key === 'style' || isOn(key)) {
+    if (isFunctionalFallthroughKey(key)) {
       ;(res || (res = {}))[key] = attrs[key]
     }
   }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -697,6 +697,7 @@ export type { GenericComponent } from './component'
 export {
   warnExtraneousAttributes,
   getFunctionalFallthrough,
+  isFunctionalFallthroughKey,
   shouldUpdateComponent,
 } from './componentRenderUtils'
 

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -125,6 +125,29 @@ describe('attribute fallthrough', () => {
     expect(node.style.fontWeight).toBe('bold')
   })
 
+  it('should preserve root bindings excluded from functional fallthrough', async () => {
+    const title = ref('one')
+    const { component: Child } = define((props: any) => {
+      const n0 = template('<div></div>', 1)() as Element
+      renderEffect(() => setProp(n0, 'title', `child:${props.title}`))
+      return n0
+    })
+
+    const { host } = define({
+      setup() {
+        return createComponent(Child, {
+          title: () => title.value,
+        })
+      },
+    }).render()
+
+    expect(host.innerHTML).toBe('<div title="child:one"></div>')
+
+    title.value = 'two'
+    await nextTick()
+    expect(host.innerHTML).toBe('<div title="child:two"></div>')
+  })
+
   it('should only allow whitelisted fallthrough on functional component dynamic root branch', async () => {
     const show = ref(false)
     const parentClass = ref('c0')

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -541,6 +541,15 @@ export function setupComponent(
 
 export let isApplyingFallthroughProps = false
 
+export function shouldUseFunctionalFallthrough(
+  component: VaporComponent,
+): boolean {
+  return (
+    isFunction(component) &&
+    !(isTransitionEnabled && isVaporTransition(component))
+  )
+}
+
 export function applyFallthroughProps(
   el: Element,
   attrs: Record<string, any>,
@@ -1360,11 +1369,9 @@ function handleSetupResult(
     component.inheritAttrs !== false &&
     Object.keys(instance.attrs).length
   ) {
-    const getFallthroughAttrs =
-      isFunction(component) &&
-      !(isTransitionEnabled ? isVaporTransition(component) : false)
-        ? () => getFunctionalFallthrough(instance.attrs)
-        : () => instance.attrs
+    const getFallthroughAttrs = shouldUseFunctionalFallthrough(component)
+      ? () => getFunctionalFallthrough(instance.attrs)
+      : () => instance.attrs
     // attach attrs to the root element, or to root dynamic fragments so they
     // can be (re-)applied during each branch update
     applyFallthroughAttrs(instance.block, instance, getFallthroughAttrs)

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -22,6 +22,7 @@ import {
   MismatchTypes,
   currentInstance,
   getAttributeMismatch,
+  isFunctionalFallthroughKey,
   isMapEqual,
   isMismatchAllowed,
   isSetEqual,
@@ -45,6 +46,7 @@ import {
   type VaporComponentInstance,
   isApplyingFallthroughProps,
   isVaporComponent,
+  shouldUseFunctionalFallthrough,
 } from '../component'
 import {
   isHydrating,
@@ -71,7 +73,9 @@ const shouldSkipFallthroughKey = (el: TargetElement, key: string) => {
     el.$root &&
     instance.hasFallthrough &&
     instance.type.inheritAttrs !== false &&
-    key in instance.attrs
+    key in instance.attrs &&
+    (!shouldUseFunctionalFallthrough(instance.type) ||
+      isFunctionalFallthroughKey(key))
   )
 }
 


### PR DESCRIPTION

Closes #15148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed attribute inheritance for functional components so parent-provided root bindings, such as `title`, remain applied and update correctly.
  - Improved handling of inherited `class`, `style`, and event listener attributes.
  - Ensured functional component attributes are applied consistently while preserving expected behavior for transition components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->