### PR TITLE
fix(runtime-vapor): preserve pending async hydration ranges

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -7064,6 +7064,198 @@ describe('Vapor Mode hydration', () => {
           `)
         })
 
+        test('preserves nested pending SSR range until parent transition leave', async () => {
+          let resolveClient!: () => void
+          let instance!: VaporComponentInstance
+          const data = ref({ show: true })
+          const serverData = ref({ wait: Promise.resolve() })
+          const clientData = ref({
+            wait: new Promise<void>(resolve => {
+              resolveClient = resolve
+            }),
+          })
+          const leaveHtml: string[] = []
+          let finishLeave!: () => void
+          let leavingElement!: Element
+          const transition = {
+            persisted: false,
+            beforeEnter() {},
+            enter() {},
+            leave(el: Element, done: () => void) {
+              leaveHtml.push(el.innerHTML)
+              leavingElement = el
+              finishLeave = done
+            },
+            clone() {
+              return this
+            },
+          }
+          const childCode = `
+            <script vapor>
+              const data = _data
+              await data.value.wait
+            </script>
+            <template><div>async resolved</div></template>
+          `
+          const parentCode = `
+            <script vapor>
+              const components = _components
+            </script>
+            <template><section><components.AsyncChild /></section></template>
+          `
+
+          const serverChild = compileVaporComponent(
+            childCode,
+            serverData,
+            undefined,
+            true,
+          )
+          let Parent = compileVaporComponent(
+            parentCode,
+            serverData,
+            { AsyncChild: serverChild },
+            true,
+          )
+          const App = defineComponent({
+            setup() {
+              return () =>
+                data.value.show
+                  ? h(
+                      runtimeDom.Suspense,
+                      { timeout: 0 },
+                      {
+                        default: () => {
+                          const owner = h(Parent)
+                          owner.transition = transition as any
+                          return owner
+                        },
+                      },
+                    )
+                  : h('p', 'fallback')
+            },
+          })
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(App),
+          )
+
+          const clientChild = compileVaporComponent(childCode, clientData)
+          const setup = clientChild.setup
+          clientChild.setup = (
+            props: any,
+            childInstance: VaporComponentInstance,
+          ) => {
+            instance = childInstance
+            return setup(props, childInstance)
+          }
+          Parent = compileVaporComponent(parentCode, clientData, {
+            AsyncChild: clientChild,
+          })
+
+          const container = document.createElement('div')
+          container.innerHTML = html
+          document.body.appendChild(container)
+          const app = runtimeDom.createSSRApp(App)
+          app.use(runtimeVapor.vaporInteropPlugin)
+          app.mount(container)
+
+          data.value.show = false
+          await nextTick()
+
+          expect(leaveHtml).toEqual(['<div>async resolved</div>'])
+          expect(instance.isUnmounted).toBe(true)
+          expect(instance.scope.active).toBe(false)
+          expect(leavingElement.isConnected).toBe(true)
+          expect(leavingElement.innerHTML).toBe('<div>async resolved</div>')
+
+          finishLeave()
+          expect(leavingElement.isConnected).toBe(false)
+          resolveClient()
+          await new Promise(resolve => setTimeout(resolve))
+        })
+
+        test('removes a pending SSR range through a vapor parent root', async () => {
+          let resolveClient!: () => void
+          let instance!: VaporComponentInstance
+          const data = ref({ show: true })
+          const serverData = ref({ wait: Promise.resolve() })
+          const clientData = ref({
+            wait: new Promise<void>(resolve => {
+              resolveClient = resolve
+            }),
+          })
+          const childCode = `
+            <script vapor>
+              const data = _data
+              await data.value.wait
+            </script>
+            <template><div>async resolved</div></template>
+          `
+          const parentCode = `
+            <script vapor>
+              const components = _components
+            </script>
+            <template><components.AsyncChild /></template>
+          `
+
+          const serverChild = compileVaporComponent(
+            childCode,
+            serverData,
+            undefined,
+            true,
+          )
+          let Parent = compileVaporComponent(
+            parentCode,
+            serverData,
+            { AsyncChild: serverChild },
+            true,
+          )
+          const App = defineComponent({
+            setup() {
+              return () =>
+                data.value.show
+                  ? h(runtimeDom.Suspense, null, {
+                      default: () => h(Parent),
+                    })
+                  : h('p', 'fallback')
+            },
+          })
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(App),
+          )
+
+          const clientChild = compileVaporComponent(childCode, clientData)
+          const setup = clientChild.setup
+          clientChild.setup = (
+            props: any,
+            childInstance: VaporComponentInstance,
+          ) => {
+            instance = childInstance
+            return setup(props, childInstance)
+          }
+          Parent = compileVaporComponent(parentCode, clientData, {
+            AsyncChild: clientChild,
+          })
+
+          const container = document.createElement('div')
+          container.innerHTML = html
+          document.body.appendChild(container)
+          const app = runtimeDom.createSSRApp(App)
+          app.use(runtimeVapor.vaporInteropPlugin)
+          app.mount(container)
+
+          const pendingNodes = normalizeBlock(instance.pendingBlock!)
+          data.value.show = false
+          await nextTick()
+
+          expect(instance.pendingBlock).toBeUndefined()
+          expect(pendingNodes.every(node => !node.isConnected)).toBe(true)
+          expect(container.innerHTML).toBe('<p>fallback</p>')
+
+          resolveClient()
+          await new Promise(resolve => setTimeout(resolve))
+          expect(container.innerHTML).toBe('<p>fallback</p>')
+        })
+
         test.each([
           ['single root', '<span>async</span>', ['<span>async</span>']],
           [

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -42,6 +42,7 @@ import {
   withDeferredHydrationBoundary,
 } from '../src/dom/hydration'
 import { DynamicFragment } from '../src/fragment'
+import { normalizeBlock } from '../src/block'
 
 const formatHtml = (raw: string) => {
   return raw
@@ -51,7 +52,7 @@ const formatHtml = (raw: string) => {
     .replace(/\n{2,}/g, '\n')
 }
 
-const formatNodeList = (nodes: ArrayLike<ChildNode>) => {
+const formatNodeList = (nodes: ArrayLike<Node>) => {
   return Array.from(nodes).map(node => {
     if (node.nodeType === 8) {
       return `<!--${(node as Comment).data}-->`
@@ -6938,6 +6939,7 @@ describe('Vapor Mode hydration', () => {
 
         test('hydrate VDOM Suspense vapor async setup can unmount before resolve', async () => {
           let resolveClient!: () => void
+          let instance!: VaporComponentInstance
           const data = ref({
             showSuspense: true,
             tail: 'tail',
@@ -6950,6 +6952,19 @@ describe('Vapor Mode hydration', () => {
               resolveClient = r
             }),
           })
+          const leaveHtml: string[] = []
+          const transition = {
+            persisted: false,
+            beforeEnter() {},
+            enter() {},
+            leave(el: Element, done: () => void) {
+              leaveHtml.push(el.innerHTML)
+              done()
+            },
+            clone() {
+              return this
+            },
+          }
           const vaporChildCode = `
             <script vapor>
               const data = _data
@@ -6976,7 +6991,11 @@ describe('Vapor Mode hydration', () => {
                       runtimeDom.Suspense,
                       { timeout: 0 },
                       {
-                        default: () => h(VaporChild),
+                        default: () => {
+                          const owner = h('section', [h(VaporChild)])
+                          owner.transition = transition as any
+                          return owner
+                        },
                         fallback: () => h('div', 'pending'),
                       },
                     )
@@ -6991,97 +7010,13 @@ describe('Vapor Mode hydration', () => {
           )
           expect(formatHtml(html)).toMatchInlineSnapshot(`
             "
-            <!--[--><div>async resolved</div><span>tail</span><!--]-->
+            <!--[--><section><div>async resolved</div></section><span>tail</span><!--]-->
             "
           `)
 
           VaporChild = compile(
             vaporChildCode,
             clientData,
-            {},
-            {
-              vapor: true,
-              ssr: false,
-            },
-          )
-
-          const container = document.createElement('div')
-          container.innerHTML = html
-          document.body.appendChild(container)
-
-          const app = runtimeDom.createSSRApp(App)
-          app.use(runtimeVapor.vaporInteropPlugin)
-          app.mount(container)
-          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
-            "
-            <!--[--><div>async resolved</div><span>tail</span><!--]-->
-            "
-          `)
-
-          data.value.showSuspense = false
-          await nextTick()
-          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
-            "
-            <!--[--><p>fallback</p><span>tail</span><!--]-->
-            "
-          `)
-
-          resolveClient()
-          await new Promise(r => setTimeout(r))
-          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
-            "
-            <!--[--><p>fallback</p><span>tail</span><!--]-->
-            "
-          `)
-        })
-
-        test('does not register or insert a CSR placeholder when moving pending hydrated async setup', async () => {
-          let resolveClient!: () => void
-          const childData = ref({ wait: Promise.resolve() })
-          const items = ref(['sync', 'async'])
-          const vaporChildCode = `
-            <script vapor>
-              const data = _data
-              await data.value.wait
-            </script>
-            <template><span>async</span></template>
-          `
-          let VaporChild = compile(
-            vaporChildCode,
-            childData,
-            {},
-            {
-              vapor: true,
-              ssr: true,
-            },
-          )
-          const App = defineComponent({
-            setup() {
-              return () =>
-                h(runtimeDom.Suspense, null, {
-                  default: () =>
-                    h(
-                      'div',
-                      items.value.map(id =>
-                        id === 'async'
-                          ? h(VaporChild, { key: id })
-                          : h('i', { key: id }, 'sync'),
-                      ),
-                    ),
-                })
-            },
-          })
-          const html = await VueServerRenderer.renderToString(
-            runtimeDom.createSSRApp(App),
-          )
-
-          childData.value.wait = new Promise<void>(resolve => {
-            resolveClient = resolve
-          })
-          let instance!: VaporComponentInstance
-          VaporChild = compile(
-            vaporChildCode,
-            childData,
             {},
             {
               vapor: true,
@@ -7097,22 +7032,304 @@ describe('Vapor Mode hydration', () => {
           const container = document.createElement('div')
           container.innerHTML = html
           document.body.appendChild(container)
+
           const app = runtimeDom.createSSRApp(App)
           app.use(runtimeVapor.vaporInteropPlugin)
           app.mount(container)
+          const pendingNodes = normalizeBlock(instance.pendingBlock!)
+          expect(instance.block).toBeNull()
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+            "
+            <!--[--><section><div>async resolved</div></section><span>tail</span><!--]-->
+            "
+          `)
 
-          const registerDep = vi.spyOn(instance.suspense!, 'registerDep')
+          data.value.showSuspense = false
+          await nextTick()
+          expect(leaveHtml).toEqual(['<div>async resolved</div>'])
+          expect(instance.pendingBlock).toBeUndefined()
+          expect(pendingNodes.every(node => !node.isConnected)).toBe(true)
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+            "
+            <!--[--><p>fallback</p><span>tail</span><!--]-->
+            "
+          `)
+
+          resolveClient()
+          await new Promise(r => setTimeout(r))
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+            "
+            <!--[--><p>fallback</p><span>tail</span><!--]-->
+            "
+          `)
+        })
+
+        test.each([
+          ['single root', '<span>async</span>', ['<span>async</span>']],
+          [
+            'multi-root range',
+            '<span>async</span><b>range</b>',
+            ['<!--[-->', '<span>async</span>', '<b>range</b>', '<!--]-->'],
+          ],
+        ] as const)(
+          'moves pending hydrated async setup before resolving (%s)',
+          async (_, childTemplate, expectedPendingNodes) => {
+            let resolveClient!: () => void
+            const childData = ref({ wait: Promise.resolve() })
+            const items = ref(['sync', 'async'])
+            const vaporChildCode = `
+            <script vapor>
+              const data = _data
+              await data.value.wait
+            </script>
+            <template>${childTemplate}</template>
+          `
+            let VaporChild = compile(
+              vaporChildCode,
+              childData,
+              {},
+              {
+                vapor: true,
+                ssr: true,
+              },
+            )
+            const App = defineComponent({
+              setup() {
+                return () =>
+                  h(runtimeDom.Suspense, null, {
+                    default: () =>
+                      h(
+                        'div',
+                        items.value.map(id =>
+                          id === 'async'
+                            ? h(VaporChild, { key: id })
+                            : h('i', { key: id }, 'sync'),
+                        ),
+                      ),
+                  })
+              },
+            })
+            const html = await VueServerRenderer.renderToString(
+              runtimeDom.createSSRApp(App),
+            )
+
+            childData.value.wait = new Promise<void>(resolve => {
+              resolveClient = resolve
+            })
+            let instance!: VaporComponentInstance
+            VaporChild = compile(
+              vaporChildCode,
+              childData,
+              {},
+              {
+                vapor: true,
+                ssr: false,
+              },
+            )
+            const setup = VaporChild.setup
+            VaporChild.setup = (props: any, child: VaporComponentInstance) => {
+              instance = child
+              return setup(props, child)
+            }
+
+            const container = document.createElement('div')
+            container.innerHTML = html
+            document.body.appendChild(container)
+            const app = runtimeDom.createSSRApp(App)
+            app.use(runtimeVapor.vaporInteropPlugin)
+            app.mount(container)
+            const childNodes = container.querySelector('div')!.childNodes
+            const pendingNodes = normalizeBlock(instance.pendingBlock!)
+            const syncNode = childNodes[0]
+            const selfAnchor =
+              pendingNodes[pendingNodes.length - 1].nextSibling!
+            expect(formatNodeList(pendingNodes)).toEqual(expectedPendingNodes)
+            expect(formatNodeList(childNodes)).toEqual([
+              '<i>sync</i>',
+              ...expectedPendingNodes,
+              'text("")',
+            ])
+            expect(instance.block).toBeNull()
+
+            const registerDep = vi.spyOn(instance.suspense!, 'registerDep')
+            try {
+              items.value = ['async', 'sync']
+              await nextTick()
+
+              expect(registerDep).not.toHaveBeenCalled()
+              expect(instance.block).toBeNull()
+              expect(normalizeBlock(instance.pendingBlock!)).toEqual(
+                pendingNodes,
+              )
+              expect(Array.from(childNodes)).toEqual([
+                ...pendingNodes,
+                selfAnchor,
+                syncNode,
+              ])
+
+              resolveClient()
+              await new Promise(resolve => setTimeout(resolve))
+              expect(instance.pendingBlock).toBeUndefined()
+              expect(instance.block).not.toBeNull()
+              expect(Array.from(childNodes)).toEqual([
+                ...pendingNodes,
+                selfAnchor,
+                syncNode,
+              ])
+            } finally {
+              registerDep.mockRestore()
+              app.unmount()
+              resolveClient()
+              await new Promise(resolve => setTimeout(resolve))
+              container.remove()
+            }
+          },
+        )
+
+        test('moves and removes pending hydrated ranges through Vapor v-for', async () => {
+          const serverData = ref({
+            items: [1, 2],
+            wait: Promise.resolve(),
+          })
+          const clientData = ref({
+            items: [1, 2],
+            wait: new Promise<void>(() => {}),
+          })
+          const childCode = `
+            <script vapor>
+              const data = _data
+              const props = defineProps(['id'])
+              await data.value.wait
+            </script>
+            <template>
+              <template v-if="true">
+                <span>{{ props.id }}-one</span>
+                <span>{{ props.id }}-two</span>
+              </template>
+            </template>
+          `
+          const parentCode = `
+            <script vapor>
+              const data = _data
+              const components = _components
+            </script>
+            <template>
+              <div>
+                <components.AsyncChild
+                  v-for="id in data.items"
+                  :key="id"
+                  :id="id"
+                />
+                <i>tail</i>
+              </div>
+            </template>
+          `
+          const serverChild = compileVaporComponent(
+            childCode,
+            serverData,
+            {},
+            true,
+          )
+          let Parent = compileVaporComponent(
+            parentCode,
+            serverData,
+            { AsyncChild: serverChild },
+            true,
+          )
+          const App = defineComponent({
+            setup: () => () =>
+              h(runtimeDom.Suspense, null, {
+                default: () => h(Parent),
+              }),
+          })
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(App),
+          )
+
+          const instances: VaporComponentInstance[] = []
+          const clientChild = compileVaporComponent(childCode, clientData)
+          const setup = clientChild.setup
+          clientChild.setup = (
+            props: any,
+            instance: VaporComponentInstance,
+          ) => {
+            instances.push(instance)
+            return setup(props, instance)
+          }
+          Parent = compileVaporComponent(parentCode, clientData, {
+            AsyncChild: clientChild,
+          })
+
+          const container = document.createElement('div')
+          container.innerHTML = html
+          document.body.appendChild(container)
+          const app = runtimeDom.createSSRApp(App)
+          app.use(runtimeVapor.vaporInteropPlugin)
+
           try {
-            items.value = ['async', 'sync']
+            app.mount(container)
+
+            expect(instances).toHaveLength(2)
+            expect(instances[0].block).toBeNull()
+            expect(instances[1].block).toBeNull()
+            const firstRange = normalizeBlock(instances[0].pendingBlock!)
+            const secondRange = normalizeBlock(instances[1].pendingBlock!)
+            expect(formatNodeList(firstRange)).toEqual([
+              '<!--[-->',
+              '<span>1-one</span>',
+              '<span>1-two</span>',
+              '<!--]-->',
+            ])
+            expect(formatNodeList(secondRange)).toEqual([
+              '<!--[-->',
+              '<span>2-one</span>',
+              '<span>2-two</span>',
+              '<!--]-->',
+            ])
+
+            const parent = container.querySelector('div')!
+            const tail = parent.querySelector('i')!
+            const expectRangesInOrder = (...ranges: Node[][]) => {
+              const nodes: Node[] = Array.from(parent.childNodes)
+              let previousEnd = -1
+              for (const range of ranges) {
+                const start = nodes.indexOf(range[0])
+                expect(start).toBeGreaterThan(previousEnd)
+                expect(nodes.slice(start, start + range.length)).toEqual(range)
+                previousEnd = start + range.length - 1
+              }
+              expect(parent.lastElementChild).toBe(tail)
+            }
+
+            expectRangesInOrder(firstRange, secondRange)
+
+            clientData.value.items = [2, 1]
             await nextTick()
 
-            expect(registerDep).not.toHaveBeenCalled()
-            expect(instance.block).toBeNull()
+            expect(instances).toHaveLength(2)
+            expect(normalizeBlock(instances[0].pendingBlock!)).toEqual(
+              firstRange,
+            )
+            expect(normalizeBlock(instances[1].pendingBlock!)).toEqual(
+              secondRange,
+            )
+            expectRangesInOrder(secondRange, firstRange)
+
+            clientData.value.items = [2]
+            await nextTick()
+            expect(instances[0].pendingBlock).toBeUndefined()
+            expect(firstRange.every(node => node.parentNode === null)).toBe(
+              true,
+            )
+            expect(normalizeBlock(instances[1].pendingBlock!)).toEqual(
+              secondRange,
+            )
+            expectRangesInOrder(secondRange)
+
+            expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+            expect(`Hydration children mismatch`).not.toHaveBeenWarned()
           } finally {
-            registerDep.mockRestore()
             app.unmount()
-            resolveClient()
-            await new Promise(resolve => setTimeout(resolve))
             container.remove()
           }
         })

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -16,6 +16,7 @@ import { isArray, isObject, isString } from '@vue/shared'
 import { createComment, createTextNode } from './dom/node'
 import {
   type Block,
+  getBlockFirstNode,
   insert,
   insertFragment,
   insertNode,
@@ -25,7 +26,7 @@ import {
   removeNode,
 } from './block'
 import { queuePostFlushCb, warn } from '@vue/runtime-dom'
-import { currentInstance, isVaporComponent } from './component'
+import { currentInstance } from './component'
 import {
   type DynamicSlot,
   currentSlotOwner,
@@ -347,7 +348,7 @@ export const createFor = (
               source,
               index,
               index < newLength - 1
-                ? normalizeAnchor(newBlocks[index + 1].nodes)
+                ? getBlockFirstNode(newBlocks[index + 1].nodes)
                 : parentAnchor,
               item,
               key,
@@ -373,9 +374,9 @@ export const createFor = (
             const { index } = action
             if (index < newLength - 1) {
               const nextBlock = newBlocks[index + 1]
-              let anchorNode = normalizeAnchor(nextBlock.prevAnchor!.nodes)
+              let anchorNode = getBlockFirstNode(nextBlock.prevAnchor!.nodes)
               if (!anchorNode.parentNode)
-                anchorNode = normalizeAnchor(nextBlock.nodes)
+                anchorNode = getBlockFirstNode(nextBlock.nodes)
               if ('source' in action) {
                 const { item, key } = action
                 const block = mount(source, index, anchorNode, item, key)
@@ -391,7 +392,7 @@ export const createFor = (
               blocksTail = block
             } else if (action.block.next !== undefined) {
               let anchorNode = anchor
-                ? normalizeAnchor(anchor.nodes)
+                ? getBlockFirstNode(anchor.nodes)
                 : parentAnchor
               if (!anchorNode.parentNode) anchorNode = parentAnchor
               insertForBlock(action.block, anchorNode)
@@ -825,27 +826,6 @@ function getItem(
     return [value, keys[idx], idx]
   } else {
     return [value, idx, undefined]
-  }
-}
-
-function normalizeAnchor(node: Block): Node {
-  if (node instanceof Node) {
-    return node
-  } else if (isArray(node)) {
-    for (let i = 0; i < node.length; i++) {
-      const anchor = normalizeAnchor(node[i])
-      if (anchor) return anchor
-    }
-    return undefined!
-  } else if (isVaporComponent(node)) {
-    return normalizeAnchor(node.block!)
-  } else {
-    const nodes = node.nodes
-    // Empty ForFragment keeps its insertion anchor in `nodes`, even though it
-    // is not a valid content block.
-    return isValidBlock(nodes)
-      ? normalizeAnchor(nodes)
-      : node.anchor || normalizeAnchor(nodes)
   }
 }
 

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -23,6 +23,7 @@ import {
 import { isTeleportEnabled, isTeleportFragment } from './teleport'
 import { isTransitionEnabled } from './transition'
 import { isInteropEnabled } from './vdomInteropState'
+import { isSuspenseEnabled } from './suspense'
 
 export interface VaporTransitionHooks extends TransitionHooks {
   state: TransitionState
@@ -362,11 +363,35 @@ export function normalizeBlock(block: Block): Node[] {
   return nodes
 }
 
+export function getBlockFirstNode(block: Block): Node {
+  if (block instanceof Node) {
+    return block
+  } else if (isArray(block)) {
+    for (let i = 0; i < block.length; i++) {
+      const anchor = getBlockFirstNode(block[i])
+      if (anchor) return anchor
+    }
+    return undefined!
+  } else if (isVaporComponent(block)) {
+    return getBlockFirstNode(getComponentPhysicalBlock(block))
+  } else {
+    const nodes = block.nodes
+    // Empty fragments may keep their insertion anchor in `anchor` or in
+    // `nodes` (ForFragment).
+    return isValidBlock(nodes)
+      ? getBlockFirstNode(nodes)
+      : block.anchor || getBlockFirstNode(nodes)
+  }
+}
+
 export function findBlockBoundary(block: Block): {
   parentNode: Node | null
   nextNode: Node | null
 } {
-  const lastChild = findLastChild(block)!
+  const boundaryBlock = isVaporComponent(block)
+    ? getComponentPhysicalBlock(block)
+    : block
+  const lastChild = findLastChild(boundaryBlock)!
   let { parentNode, nextSibling: nextNode } = lastChild
 
   // if nodes render as a fragment and the current nextNode is fragment
@@ -375,7 +400,7 @@ export function findBlockBoundary(block: Block): {
   if (
     nextNode &&
     isComment(nextNode, ']') &&
-    isFragmentBlock(block) &&
+    isFragmentBlock(boundaryBlock) &&
     !isComment(lastChild, ']') &&
     !(lastChild.nodeType === 3 && !(lastChild as Text).data)
   ) {
@@ -394,18 +419,27 @@ function findLastChild(node: Block): Node | undefined | null {
   } else if (isArray(node)) {
     return findLastChild(node[node.length - 1])
   } else if (isVaporComponent(node)) {
-    return findLastChild(node.block!)
+    return findLastChild(getComponentPhysicalBlock(node))
   } else {
     if (node.anchor) return node.anchor
     return findLastChild(node.nodes!)
   }
 }
 
+// While present, `pendingBlock` is authoritative for physical operations until
+// the initial hydration mount transfers ownership to `block`.
+function getComponentPhysicalBlock(instance: VaporComponentInstance): Block {
+  return (
+    (__FEATURE_SUSPENSE__ && isSuspenseEnabled && instance.pendingBlock) ||
+    instance.block
+  )
+}
+
 export function isFragmentBlock(block: Block): boolean {
   if (isArray(block)) {
     return true
   } else if (isVaporComponent(block)) {
-    return isFragmentBlock(block.block!)
+    return isFragmentBlock(getComponentPhysicalBlock(block))
   } else if (isFragment(block)) {
     return isFragmentBlock(block.nodes)
   }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -420,10 +420,33 @@ export function createComponent(
           // boundary rule above when the delayed setup actually runs.
           wasInOnceSlot ? () => withOnceSlot(setup, false) : setup,
         )
-      } else if (wasInOnceSlot) {
-        withOnceSlot(() => setupComponent(instance, component), false)
       } else {
-        setupComponent(instance, component)
+        if (wasInOnceSlot) {
+          withOnceSlot(() => setupComponent(instance, component), false)
+        } else {
+          setupComponent(instance, component)
+        }
+
+        if (
+          isHydrating &&
+          __FEATURE_SUSPENSE__ &&
+          isSuspenseEnabled &&
+          instance.suspense &&
+          instance.asyncDep
+        ) {
+          // Async setup cannot create `block` yet. Capture the adopted SSR
+          // range for pending move/removal before hydration advances past it.
+          const pendingBlock: Node[] = []
+          let node = hydrationCursor!.start!
+          const hydrationNext = nextLogicalSibling(node)
+          do {
+            pendingBlock.push(node)
+            node = node.nextSibling!
+          } while (node !== hydrationNext)
+          instance.pendingBlock =
+            pendingBlock.length === 1 ? pendingBlock[0] : pendingBlock
+          advanceHydrationNode(pendingBlock[pendingBlock.length - 1])
+        }
       }
     } finally {
       if (__DEV__) {
@@ -643,6 +666,10 @@ export class VaporComponentInstance<
   appContext: GenericAppContext
 
   block: TypeBlock
+  // VDOM can identify adopted SSR DOM with a placeholder VNode. Vapor adopts
+  // raw nodes, so storing them in `block` would make logical consumers treat
+  // them as rendered output. Keep temporary hydration ownership separate.
+  pendingBlock?: Node | Node[]
   scope: EffectScope
 
   rawProps: RawProps
@@ -1052,12 +1079,13 @@ export function mountComponent(
     instance.asyncDep &&
     !instance.asyncResolved
   ) {
-    // Moving a pending instance, including re-entering from KeepAlive, retries
-    // mountComponent. Move its CSR placeholder when present; during hydration,
-    // `instance.block` is still null, but the async dependency must not be
-    // registered again.
+    // Moving a still-pending instance, such as a keyed reorder or KeepAlive
+    // re-entry, retries `mountComponent`. `insert` relocates its already-mounted
+    // DOM without registering the async dependency again.
     if (instance.asyncDepRegistered) {
-      if (instance.block) {
+      if (instance.pendingBlock) {
+        insert(instance.pendingBlock, parent, anchor)
+      } else if (instance.block) {
         insert(instance.block, parent, anchor)
       }
       if (
@@ -1082,10 +1110,6 @@ export function mountComponent(
 
     instance.asyncDepRegistered = true
     const component = instance.type
-    // CSR resolves from the live placeholder, so do not retain its original
-    // DOM location through the unresolved promise.
-    const hydrationParent = hydrating ? parent : undefined
-    const hydrationAnchor = hydrating ? anchor : undefined
     instance.suspense.registerDep(instance, setupResult => {
       // Final suspense retry after async setup resolves. Restore hydrating
       // mode so the last mount does not fall back to fresh DOM insertion.
@@ -1104,24 +1128,26 @@ export function mountComponent(
         }
       }
       try {
+        const pendingBlock = hydrating ? instance.pendingBlock! : instance.block
+        // Use the pending DOM's live boundary because it may have moved while
+        // setup was suspended.
+        const { parentNode, nextNode } = findBlockBoundary(pendingBlock)
         if (hydrating) {
           withDeferredHydrationBoundary(() => {
             handleResult()
-            mountComponent(instance, hydrationParent!, hydrationAnchor)
+            mountComponent(instance, parentNode as ParentNode, nextNode)
             if (instance.deferredHydrationBoundary) {
               instance.deferredHydrationBoundary()
             }
           })
         } else {
-          const placeholder = instance.block as Comment
-          const placeholderParent = placeholder.parentNode as ParentNode
-          const placeholderAnchor = placeholder.nextSibling
           handleResult()
-          mountComponent(instance, placeholderParent, placeholderAnchor)
-          remove(placeholder, placeholderParent)
+          mountComponent(instance, parentNode as ParentNode, nextNode)
+          remove(pendingBlock, parentNode as ParentNode)
         }
       } finally {
         if (hydrating) {
+          instance.pendingBlock = undefined
           instance.deferredHydrationBoundary = undefined
         }
         instance.restoreAsyncContext = undefined
@@ -1189,6 +1215,7 @@ export function unmountComponent(
   instance: VaporComponentInstance,
   parentNode?: ParentNode,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
+  removePendingBlock = true,
 ): void {
   // Skip unmount for kept-alive components - deactivate if called from remove()
   if (
@@ -1235,20 +1262,32 @@ export function unmountComponent(
     instance.isUnmounted = true
   }
 
-  // Callers that own surrounding DOM removal may omit parentNode, so remove
-  // the pending placeholder from its live DOM parent.
-  if (pendingAsyncSetup && instance.block instanceof Comment) {
-    const blockParent = instance.block.parentNode
-    if (blockParent) {
-      remove(instance.block, blockParent)
+  // A pending hydration range may have moved, so remove it from its live parent.
+  // If VDOM owns an enclosing removal, only release `pendingBlock`.
+  if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && pendingAsyncSetup) {
+    if (instance.pendingBlock) {
+      const pendingBlock = instance.pendingBlock
+      if (removePendingBlock) {
+        const { parentNode: blockParent } = findBlockBoundary(pendingBlock)
+        if (blockParent) {
+          remove(pendingBlock, blockParent as ParentNode)
+        }
+      }
+      instance.pendingBlock = undefined
+    } else if (instance.block instanceof Comment) {
+      // CSR placeholders are component-owned, so always detach them from their
+      // live parent even when VDOM owns an enclosing removal.
+      const blockParent = instance.block.parentNode
+      if (blockParent) {
+        remove(instance.block, blockParent)
+      }
     }
   } else if (parentNode) {
-    if (instance.block) {
-      remove(instance.block, parentNode)
-    } else {
-      // TODO: a hydrated async setup component may own SSR DOM before its
-      // block exists. That adopted DOM should be removed on this path.
-    }
+    if (instance.block) remove(instance.block, parentNode)
+  }
+  if (pendingAsyncSetup) {
+    instance.restoreAsyncContext = undefined
+    instance.deferredHydrationBoundary = undefined
   }
 }
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1215,7 +1215,6 @@ export function unmountComponent(
   instance: VaporComponentInstance,
   parentNode?: ParentNode,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
-  removePendingBlock = true,
 ): void {
   // Skip unmount for kept-alive components - deactivate if called from remove()
   if (
@@ -1262,18 +1261,19 @@ export function unmountComponent(
     instance.isUnmounted = true
   }
 
-  // A pending hydration range may have moved, so remove it from its live parent.
-  // If VDOM owns an enclosing removal, only release `pendingBlock`.
   if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && pendingAsyncSetup) {
     if (instance.pendingBlock) {
-      const pendingBlock = instance.pendingBlock
-      if (removePendingBlock) {
+      // Without parentNode this is state-only teardown. Leave the DOM intact
+      // for its enclosing owner, and retain the descriptor in case a
+      // subsequent Vapor block removal needs it.
+      if (parentNode) {
+        const pendingBlock = instance.pendingBlock
         const { parentNode: blockParent } = findBlockBoundary(pendingBlock)
         if (blockParent) {
           remove(pendingBlock, blockParent as ParentNode)
         }
+        instance.pendingBlock = undefined
       }
-      instance.pendingBlock = undefined
     } else if (instance.block instanceof Comment) {
       // CSR placeholders are component-owned, so always detach them from their
       // live parent even when VDOM owns an enclosing removal.

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -568,14 +568,7 @@ export function activate(
   anchor?: Node | null | 0,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
-  move(
-    instance.block,
-    parentNode,
-    anchor,
-    MoveType.ENTER,
-    instance,
-    parentSuspense,
-  )
+  move(instance, parentNode, anchor, MoveType.ENTER, instance, parentSuspense)
 
   queuePostRenderEffect(
     () => {
@@ -603,14 +596,7 @@ export function deactivate(
   invalidateMount(instance.m)
   invalidateMount(instance.a)
 
-  move(
-    instance.block,
-    container,
-    null,
-    MoveType.LEAVE,
-    instance,
-    parentSuspense,
-  )
+  move(instance, container, null, MoveType.LEAVE, instance, parentSuspense)
 
   queuePostRenderEffect(
     () => {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -382,7 +382,11 @@ const vaporInteropImpl: Omit<
           remove(instance.block, blockContainer)
         }
       } else {
-        unmountComponent(instance, container, parentSuspense, doRemove)
+        unmountComponent(instance, container, parentSuspense)
+        if (!doRemove) {
+          // VDOM retains the enclosing range through vnode.el and vnode.anchor.
+          instance.pendingBlock = undefined
+        }
       }
     } else if (vnode.vb) {
       const anchor = vnode.anchor as Node | null

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -382,22 +382,7 @@ const vaporInteropImpl: Omit<
           remove(instance.block, blockContainer)
         }
       } else {
-        // The async Vapor component may not be resolved yet, so block is null.
-        // Hydration still adopted SSR DOM on vnode.el; when this VNode owns
-        // removal, clear the adopted range before the interop anchor.
-        const adoptedNode =
-          vnode.el && vnode.el !== anchor ? (vnode.el as Node) : null
-        unmountComponent(instance, undefined, parentSuspense)
-        if (doRemove && container && adoptedNode) {
-          let cur: Node | null = adoptedNode
-          while (cur && cur !== anchor) {
-            const nextNode: ChildNode | null = cur.nextSibling
-            if (cur.parentNode === container) {
-              remove(cur, container)
-            }
-            cur = nextNode
-          }
-        }
+        unmountComponent(instance, container, parentSuspense, doRemove)
       }
     } else if (vnode.vb) {
       const anchor = vnode.anchor as Node | null
@@ -509,10 +494,16 @@ const vaporInteropImpl: Omit<
   },
 
   move(vnode, container, anchor, moveType, parentSuspense) {
+    const block = vnode.vb || (vnode.component as any)
+    // Resolved Vapor blocks exclude the VDOM-owned opening marker, but a
+    // pending hydration range includes it. Avoid moving `vnode.el` twice.
+    const pendingRangeOwnsFragmentStart =
+      isVaporComponent(block) && !!block.pendingBlock
     if (
       vnode.el &&
       vnode.el !== vnode.anchor &&
-      isComment(vnode.el as Node, '[')
+      isComment(vnode.el as Node, '[') &&
+      !pendingRangeOwnsFragmentStart
     ) {
       move(
         vnode.el as any,
@@ -523,14 +514,7 @@ const vaporInteropImpl: Omit<
         parentSuspense,
       )
     }
-    move(
-      vnode.vb || (vnode.component as any),
-      container,
-      anchor,
-      moveType,
-      undefined,
-      parentSuspense,
-    )
+    move(block, container, anchor, moveType, undefined, parentSuspense)
     move(
       vnode.anchor as any,
       container,
@@ -573,8 +557,8 @@ const vaporInteropImpl: Omit<
       ) as VaporComponentInstance
     })
     if (instance && instance.asyncDep && !instance.asyncResolved) {
-      // mount() cannot expose a block before async setup resolves. Keep the SSR
-      // start node so unmount can remove the adopted range if it is discarded.
+      // `block` stays null until async setup resolves. VDOM still needs
+      // `vnode.el` as the host start node; `pendingBlock` owns the full range.
       vnode.el = node
     }
     return anchor


### PR DESCRIPTION
- track adopted SSR ranges while async setup is pending
- move, resolve, and unmount ranges from their live DOM position
- align Vapor and VDOM interop ownership with regression coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration of asynchronous Vapor components within Suspense boundaries.
  * Prevented pending hydrated content from being moved, duplicated, or left behind during unmounting and resolution.
  * Improved DOM placement when keyed content is inserted or moved.
  * Enhanced KeepAlive activation and deactivation for asynchronous component content.

* **Tests**
  * Expanded coverage for pending hydration ranges, Suspense behavior, transitions, unmounting, and single- or multi-root content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->