### PR TITLE
fix(runtime-vapor): handle custom directives on fragment roots

### DIFF
--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -7,6 +7,9 @@ import {
 } from '../../src'
 import { nextTick, watchEffect } from '@vue/runtime-dom'
 import type { Mock } from 'vitest'
+import { compile, makeRender } from '../_utils'
+
+const define = makeRender()
 
 describe('custom directive', () => {
   it('should work', async () => {
@@ -105,5 +108,86 @@ describe('custom directive', () => {
     expect(
       'Runtime directive used on component with non-element root node',
     ).toHaveBeenWarned()
+  })
+
+  it('should re-apply to dynamic component root', async () => {
+    const teardown = vi.fn()
+    const data = ref({ current: 'div' })
+    const dir: VaporDirective = vi.fn(el => {
+      ;(el as Element).setAttribute('data-custom', '')
+      return teardown
+    })
+    const App = compile(
+      `<template><component :is="data.current" v-custom /></template>`,
+      data,
+    )
+    App.directives = { custom: dir }
+
+    const { host, app } = define(App).render()
+    const first = host.firstElementChild!
+
+    expect(first).toBeInstanceOf(HTMLDivElement)
+    expect(first.getAttribute('data-custom')).toBe('')
+    expect(dir).toHaveBeenCalledOnce()
+    expect(teardown).not.toHaveBeenCalled()
+
+    data.value.current = 'span'
+    await nextTick()
+
+    const second = host.firstElementChild!
+    expect(second).toBeInstanceOf(HTMLSpanElement)
+    expect(second).not.toBe(first)
+    expect(second.getAttribute('data-custom')).toBe('')
+    expect(dir).toHaveBeenCalledTimes(2)
+    expect(teardown).toHaveBeenCalledOnce()
+
+    app.unmount()
+  })
+
+  it('should re-apply when component root element changes', async () => {
+    const teardown = vi.fn()
+    const data = ref({ show: true, value: 'one' })
+    const dir: VaporDirective = vi.fn(el => {
+      watchEffect(() => {
+        ;(el as Element).setAttribute('data-value', data.value.value)
+      })
+      return teardown
+    })
+    const Child = compile(
+      `<template><div v-if="data.show" /><span v-else /></template>`,
+      data,
+    )
+    const App = compile(
+      `<template><components.Child v-custom /></template>`,
+      data,
+      { Child },
+    )
+    App.directives = { custom: dir }
+
+    const { host, app } = define(App).render()
+    const first = host.firstElementChild!
+
+    expect(first).toBeInstanceOf(HTMLDivElement)
+    expect(first.getAttribute('data-value')).toBe('one')
+    expect(dir).toHaveBeenCalledOnce()
+    expect(teardown).not.toHaveBeenCalled()
+
+    data.value.show = false
+    await nextTick()
+
+    const second = host.firstElementChild!
+    expect(second).toBeInstanceOf(HTMLSpanElement)
+    expect(second).not.toBe(first)
+    expect(second.getAttribute('data-value')).toBe('one')
+    expect(dir).toHaveBeenCalledTimes(2)
+    expect(teardown).toHaveBeenCalledOnce()
+
+    data.value.value = 'two'
+    await nextTick()
+
+    expect(first.getAttribute('data-value')).toBe('one')
+    expect(second.getAttribute('data-value')).toBe('two')
+
+    app.unmount()
   })
 })

--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -5,7 +5,7 @@ import {
   defineVaporComponent,
   withVaporDirectives,
 } from '../../src'
-import { nextTick, watchEffect } from '@vue/runtime-dom'
+import { currentInstance, nextTick, watchEffect } from '@vue/runtime-dom'
 import type { Mock } from 'vitest'
 import { compile, makeRender } from '../_utils'
 
@@ -38,7 +38,7 @@ describe('custom directive', () => {
     expect(el.textContent).toBe('2')
 
     scope.stop()
-    expect(teardown).toHaveBeenCalled()
+    expect(teardown).toHaveBeenCalledOnce()
 
     n.value = 3
     await nextTick()
@@ -46,7 +46,7 @@ describe('custom directive', () => {
     expect(el.textContent).toBe('2')
   })
 
-  it('should work on single root component', async () => {
+  it('should apply to a resolved component root synchronously', async () => {
     const teardown = vi.fn()
     const dir: VaporDirective = vi.fn((el, source) => {
       watchEffect(() => {
@@ -71,11 +71,11 @@ describe('custom directive', () => {
     scope.run(() => {
       const instance = createComponent(Child)
       withVaporDirectives(instance, [[dir, source]])
+      expect(dir).toHaveBeenCalledOnce()
       root.appendChild(instance.block as Node)
     })
 
     // Should resolve to the div element inside Child
-    expect(dir).toHaveBeenCalled()
     const el = (dir as unknown as Mock).mock.calls[0][0]
     expect(el).toBeInstanceOf(HTMLDivElement)
     expect(el.textContent).toBe('1')
@@ -85,7 +85,7 @@ describe('custom directive', () => {
     expect(el.textContent).toBe('2')
 
     scope.stop()
-    expect(teardown).toHaveBeenCalled()
+    expect(teardown).toHaveBeenCalledOnce()
   })
 
   it('should warn on multi-root component', () => {
@@ -108,6 +108,7 @@ describe('custom directive', () => {
     expect(
       'Runtime directive used on component with non-element root node',
     ).toHaveBeenWarned()
+    scope.stop()
   })
 
   it('should re-apply to dynamic component root', async () => {
@@ -144,10 +145,12 @@ describe('custom directive', () => {
     app.unmount()
   })
 
-  it('should re-apply when component root element changes', async () => {
+  it('should re-apply with the directive owner when component root changes', async () => {
     const teardown = vi.fn()
     const data = ref({ show: true, value: 'one' })
+    const owners: unknown[] = []
     const dir: VaporDirective = vi.fn(el => {
+      owners.push(currentInstance)
       watchEffect(() => {
         ;(el as Element).setAttribute('data-value', data.value.value)
       })
@@ -165,11 +168,14 @@ describe('custom directive', () => {
     App.directives = { custom: dir }
 
     const { host, app } = define(App).render()
+    const owner = app._instance
     const first = host.firstElementChild!
 
     expect(first).toBeInstanceOf(HTMLDivElement)
     expect(first.getAttribute('data-value')).toBe('one')
     expect(dir).toHaveBeenCalledOnce()
+    expect(owners).toHaveLength(1)
+    expect(owners[0]).toBe(owner)
     expect(teardown).not.toHaveBeenCalled()
 
     data.value.show = false
@@ -180,6 +186,8 @@ describe('custom directive', () => {
     expect(second).not.toBe(first)
     expect(second.getAttribute('data-value')).toBe('one')
     expect(dir).toHaveBeenCalledTimes(2)
+    expect(owners).toHaveLength(2)
+    expect(owners[1]).toBe(owner)
     expect(teardown).toHaveBeenCalledOnce()
 
     data.value.value = 'two'

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -41,6 +41,7 @@ import { VaporSlot } from '../../runtime-core/src/vnode'
 import { compile, makeInteropRender } from './_utils'
 import {
   type VaporComponentInstance,
+  type VaporDirective,
   VaporKeepAlive,
   VaporTeleport,
   applyTextModel,
@@ -830,6 +831,31 @@ describe('vdomInterop', () => {
       show.value = true
       await nextTick()
       expect(root.innerHTML).toBe('<div><div style=""></div></div>')
+    })
+
+    test('apply vapor custom directive to vdom child', () => {
+      const dir: VaporDirective = vi.fn(el => {
+        ;(el as Element).setAttribute('data-custom', '')
+      })
+      const VDomChild = defineComponent({
+        setup() {
+          return () => h('div', 'vdom child')
+        },
+      })
+      const App = compile(
+        `<template><components.VDomChild v-custom /></template>`,
+        ref(null),
+        { VDomChild },
+      )
+      App.directives = { custom: dir }
+
+      const { host } = define(App as any).render()
+      const el = host.firstElementChild!
+
+      expect(el).toBeInstanceOf(HTMLDivElement)
+      expect(el.getAttribute('data-custom')).toBe('')
+      expect(dir).toHaveBeenCalledOnce()
+      expect(dir).toHaveBeenCalledWith(el, undefined, undefined, undefined)
     })
 
     test('apply custom directive to vapor child', async () => {

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -4,6 +4,7 @@ import {
   getRootElement,
   isVaporComponent,
 } from '../component'
+import { type VaporFragment } from 'vue'
 
 // !! vapor directive is different from vdom directives
 export type VaporDirective = (
@@ -26,7 +27,7 @@ type VaporDirectiveArguments = Array<
 >
 
 export function withVaporDirectives(
-  node: Element | VaporComponentInstance,
+  node: Element | VaporComponentInstance | VaporFragment,
   dirs: VaporDirectiveArguments,
 ): void {
   const element = isVaporComponent(node) ? getRootElement(node.block) : node

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -37,8 +37,11 @@ export function withVaporDirectives(
   const trackedFragments = new WeakSet<VaporFragment>()
   let currentElement: Element | null | undefined = null
   let directiveScope: EffectScope | undefined
+  let disposed = false
 
   function applyDirectives() {
+    if (disposed) return
+
     const pending = trackFragments(node)
     const element = getRootElement(node)
     if (!element && pending) return
@@ -108,6 +111,7 @@ export function withVaporDirectives(
 
   if (getCurrentScope()) {
     onScopeDispose(() => {
+      disposed = true
       // To stope the detached scope when the current scope disposes
       if (directiveScope) directiveScope.stop()
     })

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -1,10 +1,14 @@
+import { EffectScope, getCurrentScope } from '@vue/reactivity'
+import { isArray } from '@vue/shared'
 import { type DirectiveModifiers, onScopeDispose, warn } from '@vue/runtime-dom'
+import { type Block, EMPTY_BLOCK } from '../block'
 import {
   type VaporComponentInstance,
   getRootElement,
   isVaporComponent,
 } from '../component'
-import { type VaporFragment } from 'vue'
+import { type VaporFragment, isFragment, isInteropFragment } from '../fragment'
+import { isInteropEnabled } from '../vdomInteropState'
 
 // !! vapor directive is different from vdom directives
 export type VaporDirective = (
@@ -27,24 +31,77 @@ type VaporDirectiveArguments = Array<
 >
 
 export function withVaporDirectives(
-  node: Element | VaporComponentInstance | VaporFragment,
+  node: Block,
   dirs: VaporDirectiveArguments,
 ): void {
-  const element = isVaporComponent(node) ? getRootElement(node.block) : node
-  if (!element) {
-    if (__DEV__) {
-      warn(
-        `Runtime directive used on component with non-element root node. ` +
-          `The directives will not function as intended.`,
-      )
+  const trackedFragments = new WeakSet<VaporFragment>()
+  let currentElement: Element | null | undefined = null
+  let directiveScope: EffectScope | undefined
+
+  function applyDirectives() {
+    const pending = trackFragments(node)
+    const element = getRootElement(node)
+    if (!element && pending) return
+    if (element === currentElement) return
+
+    currentElement = element
+    if (directiveScope) {
+      directiveScope.stop()
+      directiveScope = undefined
     }
-    return
+
+    if (!element) {
+      if (__DEV__) {
+        warn(
+          `Runtime directive used on component with non-element root node. ` +
+            `The directives will not function as intended.`,
+        )
+      }
+      return
+    }
+
+    directiveScope = new EffectScope(true)
+    directiveScope.run(() => {
+      for (const [dir, value, argument, modifiers] of dirs) {
+        if (dir) {
+          const ret = dir(element, value, argument, modifiers)
+          if (ret) onScopeDispose(ret)
+        }
+      }
+    })
   }
 
-  for (const [dir, value, argument, modifiers] of dirs) {
-    if (dir) {
-      const ret = dir(element, value, argument, modifiers)
-      if (ret) onScopeDispose(ret)
+  function trackFragments(block: Block): boolean {
+    if (isVaporComponent(block)) {
+      return trackFragments(block.block)
     }
+    if (isArray(block)) {
+      let pending = false
+      for (const child of block) {
+        pending = trackFragments(child) || pending
+      }
+      return pending
+    }
+    if (!isFragment(block)) return false
+
+    if (!trackedFragments.has(block)) {
+      trackedFragments.add(block)
+      ;(block.onUpdated ||= []).push(applyDirectives)
+    }
+
+    return (
+      (isInteropEnabled &&
+        isInteropFragment(block) &&
+        block.nodes === EMPTY_BLOCK) ||
+      trackFragments(block.nodes)
+    )
   }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (directiveScope) directiveScope.stop()
+    })
+  }
+
+  applyDirectives()
 }

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -42,10 +42,13 @@ export function withVaporDirectives(
     const pending = trackFragments(node)
     const element = getRootElement(node)
     if (!element && pending) return
+    // Only re-apply when the root element changes
     if (element === currentElement) return
 
     currentElement = element
     if (directiveScope) {
+      // The previous root element is no longer directive's target
+      // Dispose effects and cleanup bound to the previous root element
       directiveScope.stop()
       directiveScope = undefined
     }
@@ -60,6 +63,8 @@ export function withVaporDirectives(
       return
     }
 
+    // The fragment makes the root element mutable without disposing the owner scope
+    // So directive effects and cleanup need a replaceable detached scope
     directiveScope = new EffectScope(true)
     directiveScope.run(() => {
       for (const [dir, value, argument, modifiers] of dirs) {
@@ -75,6 +80,7 @@ export function withVaporDirectives(
     if (isVaporComponent(block)) {
       return trackFragments(block.block)
     }
+    // For root-level comments
     if (isArray(block)) {
       let pending = false
       for (const child of block) {
@@ -86,10 +92,13 @@ export function withVaporDirectives(
 
     if (!trackedFragments.has(block)) {
       trackedFragments.add(block)
-      ;(block.onUpdated ||= []).push(applyDirectives)
+      block.onUpdated ||= []
+      // Re-resolve the root element when the fragment updates
+      block.onUpdated.push(applyDirectives)
     }
 
     return (
+      // For VDOM interops, directives cannot resolve the root element until `syncNodes`
       (isInteropEnabled &&
         isInteropFragment(block) &&
         block.nodes === EMPTY_BLOCK) ||
@@ -99,6 +108,7 @@ export function withVaporDirectives(
 
   if (getCurrentScope()) {
     onScopeDispose(() => {
+      // To stope the detached scope when the current scope disposes
       if (directiveScope) directiveScope.stop()
     })
   }

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -1,6 +1,13 @@
-import { EffectScope, getCurrentScope } from '@vue/reactivity'
+import { EffectScope } from '@vue/reactivity'
 import { isArray } from '@vue/shared'
-import { type DirectiveModifiers, onScopeDispose, warn } from '@vue/runtime-dom'
+import {
+  type DirectiveModifiers,
+  currentInstance,
+  onScopeDispose,
+  restoreCurrentInstance,
+  setCurrentInstance,
+  warn,
+} from '@vue/runtime-dom'
 import { type Block, EMPTY_BLOCK } from '../block'
 import {
   type VaporComponentInstance,
@@ -34,6 +41,13 @@ export function withVaporDirectives(
   node: Element | VaporComponentInstance | VaporFragment,
   dirs: VaporDirectiveArguments,
 ): void {
+  // Element targets are stable, so apply synchronously in the current scope
+  if (node instanceof Element) {
+    applyDirectivesToElement(node, dirs)
+    return
+  }
+
+  const instance = currentInstance
   const trackedFragments = new WeakSet<VaporFragment>()
   let currentElement: Element | null | undefined = null
   let directiveScope: EffectScope | undefined
@@ -49,9 +63,9 @@ export function withVaporDirectives(
     if (element === currentElement) return
 
     currentElement = element
+    // The previous root element is no longer directive's target
+    // Dispose effects and cleanup bound to the previous root element
     if (directiveScope) {
-      // The previous root element is no longer directive's target
-      // Dispose effects and cleanup bound to the previous root element
       directiveScope.stop()
       directiveScope = undefined
     }
@@ -69,21 +83,20 @@ export function withVaporDirectives(
     // The fragment makes the root element mutable without disposing the owner scope
     // So directive effects and cleanup need a replaceable detached scope
     directiveScope = new EffectScope(true)
-    directiveScope.run(() => {
-      for (const [dir, value, argument, modifiers] of dirs) {
-        if (dir) {
-          const ret = dir(element, value, argument, modifiers)
-          if (ret) onScopeDispose(ret)
-        }
-      }
-    })
+    // Re-apply in the original directive owner's component context
+    const prev = setCurrentInstance(instance, directiveScope)
+    try {
+      applyDirectivesToElement(element, dirs)
+    } finally {
+      restoreCurrentInstance(prev)
+    }
   }
 
   function trackFragments(block: Block): boolean {
     if (isVaporComponent(block)) {
       return trackFragments(block.block)
     }
-    // For root-level comments
+    // Traverse every child so all nested fragments are tracked
     if (isArray(block)) {
       let pending = false
       for (const child of block) {
@@ -95,9 +108,8 @@ export function withVaporDirectives(
 
     if (!trackedFragments.has(block)) {
       trackedFragments.add(block)
-      block.onUpdated ||= []
       // Re-resolve the root element when the fragment updates
-      block.onUpdated.push(applyDirectives)
+      ;(block.onUpdated ||= []).push(applyDirectives)
     }
 
     return (
@@ -109,13 +121,23 @@ export function withVaporDirectives(
     )
   }
 
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      disposed = true
-      // To stope the detached scope when the current scope disposes
-      if (directiveScope) directiveScope.stop()
-    })
-  }
+  onScopeDispose(() => {
+    disposed = true
+    // Stop the detached scope when the calling scope is disposed
+    if (directiveScope) directiveScope.stop()
+  }, true)
 
   applyDirectives()
+}
+
+function applyDirectivesToElement(
+  element: Element,
+  dirs: VaporDirectiveArguments,
+): void {
+  for (const [dir, value, argument, modifiers] of dirs) {
+    if (dir) {
+      const ret = dir(element, value, argument, modifiers)
+      if (ret) onScopeDispose(ret)
+    }
+  }
 }

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -31,7 +31,7 @@ type VaporDirectiveArguments = Array<
 >
 
 export function withVaporDirectives(
-  node: Block,
+  node: Element | VaporComponentInstance | VaporFragment,
   dirs: VaporDirectiveArguments,
 ): void {
   const trackedFragments = new WeakSet<VaporFragment>()


### PR DESCRIPTION
Close #15157

This PR makes `withVaporDirectives` trace fragment's root-element updates and apply the directive dynamically, to make vapor directive's behavior similar to VDOM's.

🤖 Generated with Codex, reviewed by human.