### PR TITLE
fix(runtime-vapor): support vdom slot content in Transition

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -523,6 +523,7 @@ export function prepareTransitionSwitch(
   state: TransitionState,
   instance: GenericComponentInstance,
   resumeAfterLeave: () => void,
+  delayedLeaveSource?: TransitionHooks,
 ): VNode | undefined {
   if (state.isLeaving) {
     return emptyPlaceholder(next)
@@ -538,13 +539,17 @@ export function prepareTransitionSwitch(
     state,
     instance,
     // #11061: keep enter hooks in sync when the incoming VNode is cloned.
-    hooks => (enterHooks = hooks),
+    hooks => {
+      forwardDelayedLeave(hooks, delayedLeaveSource)
+      enterHooks = hooks
+    },
   )
+  forwardDelayedLeave(enterHooks, delayedLeaveSource)
   if (nextInner.type !== Comment) {
     setTransitionHooks(nextInner, enterHooks)
   }
 
-  let previousInner = previous && getInnerChild(previous)
+  const previousInner = previous && getInnerChild(previous)
   if (
     previous &&
     previousInner &&
@@ -553,56 +558,146 @@ export function prepareTransitionSwitch(
     (!previous.component ||
       recursiveGetSubtree(previous.component).type !== Comment)
   ) {
-    // update old tree's hooks in case of dynamic transition
-    const leavingHooks = resolveTransitionHooks(
+    const leavingHooks = prepareLeavingTransitionHooks(
       previousInner,
       props,
       state,
       instance,
     )
-    setTransitionHooks(previousInner, leavingHooks)
-
-    // switching between different views
-    if (props.mode === 'out-in' && nextInner.type !== Comment) {
-      state.isLeaving = true
-      leavingHooks.afterLeave = () => {
-        state.isLeaving = false
-        resumeAfterLeave()
-        delete leavingHooks.afterLeave
-        previousInner = undefined
-      }
+    if (
+      nextInner.type !== Comment &&
+      applyTransitionModeSwitch(
+        previousInner,
+        leavingHooks,
+        () => enterHooks,
+        props,
+        state,
+        resumeAfterLeave,
+      )
+    ) {
       return emptyPlaceholder(next)
-    } else if (props.mode === 'in-out' && nextInner.type !== Comment) {
-      leavingHooks.delayLeave = (
-        el: TransitionElement,
-        earlyRemove,
-        delayedLeave,
-      ) => {
-        const leavingVNodesCache = getLeavingNodesForType(state, previousInner!)
-        leavingVNodesCache[String(previousInner!.key)] = previousInner!
-        // early removal callback
-        el[leaveCbKey] = () => {
-          earlyRemove()
-          el[leaveCbKey] = undefined
-          delete enterHooks.delayedLeave
-          previousInner = undefined
-        }
-        enterHooks.delayedLeave = () => {
-          delayedLeave()
-          delete enterHooks.delayedLeave
-          previousInner = undefined
-        }
-      }
-      return next
     }
   }
-
-  // avoid retaining the previous tree through enterHooks' clone callback
-  previousInner = undefined
   return next
 }
 
-export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks): void {
+function forwardDelayedLeave(
+  hooks: TransitionHooks,
+  source: TransitionHooks | undefined,
+): void {
+  const delayedLeave = source && source.delayedLeave
+  if (!delayedLeave) return
+
+  hooks.delayedLeave = () => {
+    if (source.delayedLeave === delayedLeave) {
+      delayedLeave()
+    }
+    delete hooks.delayedLeave
+  }
+}
+
+/**
+ * Prepares an outgoing VNode when the incoming branch belongs to another
+ * renderer. Returns true when out-in must defer the incoming branch.
+ *
+ * @internal
+ */
+export function prepareTransitionLeave(
+  previous: VNode,
+  enterHooks: TransitionHooks | undefined,
+  props: BaseTransitionProps<any>,
+  state: TransitionState,
+  instance: GenericComponentInstance,
+  resumeAfterLeave: () => void,
+): boolean {
+  const previousInner = getInnerChild(previous)
+  if (
+    !previousInner ||
+    previousInner.type === Comment ||
+    (previous.component &&
+      recursiveGetSubtree(previous.component).type === Comment)
+  ) {
+    return false
+  }
+
+  return applyTransitionModeSwitch(
+    previousInner,
+    prepareLeavingTransitionHooks(previousInner, props, state, instance),
+    enterHooks ? () => enterHooks : undefined,
+    props,
+    state,
+    resumeAfterLeave,
+  )
+}
+
+function prepareLeavingTransitionHooks(
+  previousInner: VNode,
+  props: BaseTransitionProps<any>,
+  state: TransitionState,
+  instance: GenericComponentInstance,
+): TransitionHooks {
+  // update old tree's hooks in case of dynamic transition
+  const leavingHooks = resolveTransitionHooks(
+    previousInner,
+    props,
+    state,
+    instance,
+  )
+  return setTransitionHooks(previousInner, leavingHooks)
+}
+
+function applyTransitionModeSwitch(
+  leavingVNode: VNode,
+  leavingHooks: TransitionHooks,
+  getEnterHooks: (() => TransitionHooks | undefined) | undefined,
+  props: BaseTransitionProps<any>,
+  state: TransitionState,
+  resumeAfterLeave: () => void,
+): boolean {
+  if (props.mode === 'out-in') {
+    state.isLeaving = true
+    leavingHooks.afterLeave = () => {
+      state.isLeaving = false
+      resumeAfterLeave()
+      delete leavingHooks.afterLeave
+    }
+    return true
+  } else if (props.mode === 'in-out' && getEnterHooks) {
+    let delayedLeavingVNode: VNode | undefined = leavingVNode
+    leavingHooks.delayLeave = (
+      el: TransitionElement,
+      earlyRemove,
+      delayedLeave,
+    ) => {
+      const enterHooks = getEnterHooks()
+      if (!enterHooks) {
+        delayedLeave()
+        return
+      }
+      const vnode = delayedLeavingVNode!
+      const leavingVNodesCache = getLeavingNodesForType(state, vnode)
+      leavingVNodesCache[String(vnode.key)] = vnode
+      // early removal callback
+      el[leaveCbKey] = () => {
+        earlyRemove()
+        el[leaveCbKey] = undefined
+        delete enterHooks.delayedLeave
+        delayedLeavingVNode = undefined
+      }
+      enterHooks.delayedLeave = () => {
+        delayedLeave()
+        delete enterHooks.delayedLeave
+        delayedLeavingVNode = undefined
+      }
+    }
+  }
+  return false
+}
+
+export function setTransitionHooks(
+  vnode: VNode,
+  hooks: TransitionHooks,
+): TransitionHooks {
   if (vnode.shapeFlag & ShapeFlags.COMPONENT && vnode.component) {
     vnode.transition = hooks
     if (isVaporComponent(vnode.type as ConcreteComponent)) {
@@ -611,14 +706,22 @@ export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks): void {
         hooks,
       )
     } else {
-      setTransitionHooks(vnode.component.subTree, hooks)
+      return setTransitionHooks(vnode.component.subTree, hooks)
     }
   } else if (__FEATURE_SUSPENSE__ && vnode.shapeFlag & ShapeFlags.SUSPENSE) {
-    vnode.ssContent!.transition = hooks.clone(vnode.ssContent!)
-    vnode.ssFallback!.transition = hooks.clone(vnode.ssFallback!)
+    const contentHooks = (vnode.ssContent!.transition = hooks.clone(
+      vnode.ssContent!,
+    ))
+    const fallbackHooks = (vnode.ssFallback!.transition = hooks.clone(
+      vnode.ssFallback!,
+    ))
+    return vnode.suspense && vnode.suspense.activeBranch === vnode.ssFallback
+      ? fallbackHooks
+      : contentHooks
   } else {
     vnode.transition = hooks
   }
+  return hooks
 }
 
 export function getTransitionRawChildren(

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -160,6 +160,13 @@ const BaseTransitionImpl: ComponentOptions = {
   setup(props: BaseTransitionProps, { slots }: SetupContext) {
     const instance = getCurrentInstance()!
     const state = useTransitionState()
+    const resumeAfterLeave = () => {
+      // #6835
+      // it also needs to be updated when active is undefined
+      if (!(instance.job.flags! & SchedulerJobFlags.DISPOSED)) {
+        instance.update()
+      }
+    }
 
     return () => {
       const child = resolveTransitionChild(
@@ -177,80 +184,14 @@ const BaseTransitionImpl: ComponentOptions = {
       // check mode
       checkTransitionMode(mode)
 
-      if (state.isLeaving) {
-        return emptyPlaceholder(child)
-      }
-
-      const prepared = prepareTransition(child, rawProps, state, instance)
-      if (!prepared) {
-        return emptyPlaceholder(child)
-      }
-      const { inner: innerChild } = prepared
-
-      let oldInnerChild = instance.subTree && getInnerChild(instance.subTree)
-
-      // handle mode
-      if (
-        oldInnerChild &&
-        oldInnerChild.type !== Comment &&
-        !isSameVNodeType(oldInnerChild, innerChild) &&
-        recursiveGetSubtree(instance).type !== Comment
-      ) {
-        let leavingHooks = resolveTransitionHooks(
-          oldInnerChild,
-          rawProps,
-          state,
-          instance,
-        )
-        // update old tree's hooks in case of dynamic transition
-        setTransitionHooks(oldInnerChild, leavingHooks)
-        // switching between different views
-        if (mode === 'out-in' && innerChild.type !== Comment) {
-          state.isLeaving = true
-          // return placeholder node and queue update when leave finishes
-          leavingHooks.afterLeave = () => {
-            state.isLeaving = false
-            // #6835
-            // it also needs to be updated when active is undefined
-            if (!(instance.job.flags! & SchedulerJobFlags.DISPOSED)) {
-              instance.update()
-            }
-            delete leavingHooks.afterLeave
-            oldInnerChild = undefined
-          }
-          return emptyPlaceholder(child)
-        } else if (mode === 'in-out' && innerChild.type !== Comment) {
-          leavingHooks.delayLeave = (
-            el: TransitionElement,
-            earlyRemove,
-            delayedLeave,
-          ) => {
-            const leavingVNodesCache = getLeavingNodesForType(
-              state,
-              oldInnerChild!,
-            )
-            leavingVNodesCache[String(oldInnerChild!.key)] = oldInnerChild!
-            // early removal callback
-            el[leaveCbKey] = () => {
-              earlyRemove()
-              el[leaveCbKey] = undefined
-              delete prepared.hooks.delayedLeave
-              oldInnerChild = undefined
-            }
-            prepared.hooks.delayedLeave = () => {
-              delayedLeave()
-              delete prepared.hooks.delayedLeave
-              oldInnerChild = undefined
-            }
-          }
-        } else {
-          oldInnerChild = undefined
-        }
-      } else if (oldInnerChild) {
-        oldInnerChild = undefined
-      }
-
-      return child
+      return prepareTransitionSwitch(
+        instance.subTree,
+        child,
+        rawProps,
+        state,
+        instance,
+        resumeAfterLeave,
+      )
     }
   },
 }
@@ -571,7 +512,7 @@ export function resolveTransitionChild(
       : undefined
 }
 
-export function prepareTransition(
+function prepareTransition(
   vnode: VNode,
   props: BaseTransitionProps<any>,
   state: TransitionState,
@@ -599,16 +540,73 @@ export function prepareTransition(
   return prepared
 }
 
-export function hasTransitionChildChanged(
-  vnode: VNode,
-  nextInner: VNode,
-): boolean {
-  const inner = getInnerChild(vnode)
-  return !!(
-    inner &&
-    inner.type !== Comment &&
-    !isSameVNodeType(inner, nextInner)
-  )
+/**
+ * @internal
+ */
+export function prepareTransitionSwitch(
+  previous: VNode | null | undefined,
+  next: VNode,
+  props: BaseTransitionProps<any>,
+  state: TransitionState,
+  instance: GenericComponentInstance,
+  resumeAfterLeave: () => void,
+): VNode | undefined {
+  if (state.isLeaving) {
+    return emptyPlaceholder(next)
+  }
+
+  const prepared = prepareTransition(next, props, state, instance)
+  if (!prepared) {
+    return emptyPlaceholder(next)
+  }
+
+  let previousInner = previous && getInnerChild(previous)
+  if (
+    previous &&
+    previousInner &&
+    previousInner.type !== Comment &&
+    !isSameVNodeType(previousInner, prepared.inner) &&
+    (!previous.component ||
+      recursiveGetSubtree(previous.component).type !== Comment)
+  ) {
+    // update old tree's hooks in case of dynamic transition
+    const leaving = prepareTransition(previous, props, state, instance)!
+
+    // switching between different views
+    if (props.mode === 'out-in' && prepared.inner.type !== Comment) {
+      state.isLeaving = true
+      leaving.hooks.afterLeave = () => {
+        state.isLeaving = false
+        resumeAfterLeave()
+        delete leaving.hooks.afterLeave
+        previousInner = undefined
+      }
+      return emptyPlaceholder(next)
+    } else if (props.mode === 'in-out' && prepared.inner.type !== Comment) {
+      leaving.hooks.delayLeave = (
+        el: TransitionElement,
+        earlyRemove,
+        delayedLeave,
+      ) => {
+        const leavingVNodesCache = getLeavingNodesForType(state, previousInner!)
+        leavingVNodesCache[String(previousInner!.key)] = previousInner!
+        // early removal callback
+        el[leaveCbKey] = () => {
+          earlyRemove()
+          el[leaveCbKey] = undefined
+          delete prepared.hooks.delayedLeave
+          previousInner = undefined
+        }
+        prepared.hooks.delayedLeave = () => {
+          delayedLeave()
+          delete prepared.hooks.delayedLeave
+          previousInner = undefined
+        }
+      }
+    }
+  }
+
+  return next
 }
 
 export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks): void {

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -19,7 +19,7 @@ import { warn } from '../warning'
 import { isKeepAlive } from './KeepAlive'
 import { toRaw } from '@vue/reactivity'
 import { ErrorCodes, callWithAsyncErrorHandling } from '../errorHandling'
-import { PatchFlags, ShapeFlags, isArray, isFunction } from '@vue/shared'
+import { NOOP, PatchFlags, ShapeFlags, isArray, isFunction } from '@vue/shared'
 import { onBeforeUnmount, onMounted } from '../apiLifecycle'
 import { isTeleport } from './Teleport'
 import {
@@ -160,13 +160,7 @@ const BaseTransitionImpl: ComponentOptions = {
   setup(props: BaseTransitionProps, { slots }: SetupContext) {
     const instance = getCurrentInstance()!
     const state = useTransitionState()
-    const resumeAfterLeave = () => {
-      // #6835
-      // it also needs to be updated when active is undefined
-      if (!(instance.job.flags! & SchedulerJobFlags.DISPOSED)) {
-        instance.update()
-      }
-    }
+    let resumeAfterLeave: (() => void) | undefined
 
     return () => {
       const child = resolveTransitionChild(
@@ -190,7 +184,14 @@ const BaseTransitionImpl: ComponentOptions = {
         rawProps,
         state,
         instance,
-        resumeAfterLeave,
+        mode === 'out-in'
+          ? (resumeAfterLeave ||= () => {
+              // #6835: update even when the active branch is undefined.
+              if (!(instance.job.flags! & SchedulerJobFlags.DISPOSED)) {
+                instance.update()
+              }
+            })
+          : NOOP,
       )
     }
   },
@@ -512,34 +513,6 @@ export function resolveTransitionChild(
       : undefined
 }
 
-function prepareTransition(
-  vnode: VNode,
-  props: BaseTransitionProps<any>,
-  state: TransitionState,
-  instance: GenericComponentInstance,
-): { inner: VNode; hooks: TransitionHooks } | undefined {
-  // in the case of <transition><keep-alive/></transition>, we need to
-  // compare the type of the kept-alive children.
-  const inner = getInnerChild(vnode)
-  if (!inner) {
-    return
-  }
-  let prepared: { inner: VNode; hooks: TransitionHooks }
-  const hooks = resolveTransitionHooks(
-    inner,
-    props,
-    state,
-    instance,
-    // #11061, keep the returned hooks fresh after clone
-    cloned => (prepared.hooks = cloned),
-  )
-  prepared = { inner, hooks }
-  if (inner.type !== Comment) {
-    setTransitionHooks(inner, hooks)
-  }
-  return prepared
-}
-
 /**
  * @internal
  */
@@ -555,9 +528,20 @@ export function prepareTransitionSwitch(
     return emptyPlaceholder(next)
   }
 
-  const prepared = prepareTransition(next, props, state, instance)
-  if (!prepared) {
+  const nextInner = getInnerChild(next)
+  if (!nextInner) {
     return emptyPlaceholder(next)
+  }
+  let enterHooks = resolveTransitionHooks(
+    nextInner,
+    props,
+    state,
+    instance,
+    // #11061: keep enter hooks in sync when the incoming VNode is cloned.
+    hooks => (enterHooks = hooks),
+  )
+  if (nextInner.type !== Comment) {
+    setTransitionHooks(nextInner, enterHooks)
   }
 
   let previousInner = previous && getInnerChild(previous)
@@ -565,25 +549,31 @@ export function prepareTransitionSwitch(
     previous &&
     previousInner &&
     previousInner.type !== Comment &&
-    !isSameVNodeType(previousInner, prepared.inner) &&
+    !isSameVNodeType(previousInner, nextInner) &&
     (!previous.component ||
       recursiveGetSubtree(previous.component).type !== Comment)
   ) {
     // update old tree's hooks in case of dynamic transition
-    const leaving = prepareTransition(previous, props, state, instance)!
+    const leavingHooks = resolveTransitionHooks(
+      previousInner,
+      props,
+      state,
+      instance,
+    )
+    setTransitionHooks(previousInner, leavingHooks)
 
     // switching between different views
-    if (props.mode === 'out-in' && prepared.inner.type !== Comment) {
+    if (props.mode === 'out-in' && nextInner.type !== Comment) {
       state.isLeaving = true
-      leaving.hooks.afterLeave = () => {
+      leavingHooks.afterLeave = () => {
         state.isLeaving = false
         resumeAfterLeave()
-        delete leaving.hooks.afterLeave
+        delete leavingHooks.afterLeave
         previousInner = undefined
       }
       return emptyPlaceholder(next)
-    } else if (props.mode === 'in-out' && prepared.inner.type !== Comment) {
-      leaving.hooks.delayLeave = (
+    } else if (props.mode === 'in-out' && nextInner.type !== Comment) {
+      leavingHooks.delayLeave = (
         el: TransitionElement,
         earlyRemove,
         delayedLeave,
@@ -594,12 +584,12 @@ export function prepareTransitionSwitch(
         el[leaveCbKey] = () => {
           earlyRemove()
           el[leaveCbKey] = undefined
-          delete prepared.hooks.delayedLeave
+          delete enterHooks.delayedLeave
           previousInner = undefined
         }
-        prepared.hooks.delayedLeave = () => {
+        enterHooks.delayedLeave = () => {
           delayedLeave()
-          delete prepared.hooks.delayedLeave
+          delete enterHooks.delayedLeave
           previousInner = undefined
         }
       }

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -181,7 +181,7 @@ const BaseTransitionImpl: ComponentOptions = {
         return emptyPlaceholder(child)
       }
 
-      const prepared = prepareTransitionBranch(child, rawProps, state, instance)
+      const prepared = prepareTransition(child, rawProps, state, instance)
       if (!prepared) {
         return emptyPlaceholder(child)
       }
@@ -571,15 +571,15 @@ export function resolveTransitionChild(
       : undefined
 }
 
-export function prepareTransitionBranch(
-  branch: VNode,
+export function prepareTransition(
+  vnode: VNode,
   props: BaseTransitionProps<any>,
   state: TransitionState,
   instance: GenericComponentInstance,
 ): { inner: VNode; hooks: TransitionHooks } | undefined {
   // in the case of <transition><keep-alive/></transition>, we need to
   // compare the type of the kept-alive children.
-  const inner = getInnerChild(branch)
+  const inner = getInnerChild(vnode)
   if (!inner) {
     return
   }

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -599,6 +599,18 @@ export function prepareTransition(
   return prepared
 }
 
+export function hasTransitionChildChanged(
+  vnode: VNode,
+  nextInner: VNode,
+): boolean {
+  const inner = getInnerChild(vnode)
+  return !!(
+    inner &&
+    inner.type !== Comment &&
+    !isSameVNodeType(inner, nextInner)
+  )
+}
+
 export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks): void {
   if (vnode.shapeFlag & ShapeFlags.COMPONENT && vnode.component) {
     vnode.transition = hooks

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -162,16 +162,10 @@ const BaseTransitionImpl: ComponentOptions = {
     const state = useTransitionState()
 
     return () => {
-      const children =
-        slots.default && getTransitionRawChildren(slots.default(), true)
-      const child =
-        children && children.length
-          ? findNonCommentChild(children)
-          : // Keep explicit default-slot conditionals on the same transition path
-            // as regular v-if branches, which render a comment placeholder.
-            instance.subTree
-            ? createCommentVNode()
-            : undefined
+      const child = resolveTransitionChild(
+        slots.default && slots.default(),
+        !!instance.subTree,
+      )
       if (!child) {
         return
       }
@@ -187,24 +181,14 @@ const BaseTransitionImpl: ComponentOptions = {
         return emptyPlaceholder(child)
       }
 
-      // in the case of <transition><keep-alive/></transition>, we need to
-      // compare the type of the kept-alive children.
-      const innerChild = getInnerChild(child)
-      if (!innerChild) {
-        return emptyPlaceholder(child)
-      }
-
-      let enterHooks = resolveTransitionHooks(
-        innerChild,
+      const { inner: innerChild, hooks: enterHooks } = prepareTransitionBranch(
+        child,
         rawProps,
         state,
         instance,
-        // #11061, ensure enterHooks is fresh after clone
-        hooks => (enterHooks = hooks),
       )
-
-      if (innerChild.type !== Comment) {
-        setTransitionHooks(innerChild, enterHooks)
+      if (!innerChild || !enterHooks) {
+        return emptyPlaceholder(child)
       }
 
       let oldInnerChild = instance.subTree && getInnerChild(instance.subTree)
@@ -575,6 +559,50 @@ function getInnerChild(vnode: VNode): VNode | undefined {
       return (children as any).default()
     }
   }
+}
+
+export function resolveTransitionChild(
+  children: VNode[] | undefined,
+  renderEmpty: boolean = false,
+): VNode | undefined {
+  const branches = children && getTransitionRawChildren(children, true)
+  return branches && branches.length
+    ? findNonCommentChild(branches)
+    : renderEmpty
+      ? // Keep explicit default-slot conditionals on the same transition path
+        // as regular v-if branches, which render a comment placeholder.
+        createCommentVNode()
+      : undefined
+}
+
+export function prepareTransitionBranch(
+  branch: VNode,
+  props: BaseTransitionProps<any>,
+  state: TransitionState,
+  instance: GenericComponentInstance,
+): {
+  inner?: VNode
+  hooks?: TransitionHooks
+} {
+  // in the case of <transition><keep-alive/></transition>, we need to
+  // compare the type of the kept-alive children.
+  const inner = getInnerChild(branch)
+  if (!inner) {
+    return {}
+  }
+  let hooks: TransitionHooks
+  hooks = resolveTransitionHooks(
+    inner,
+    props,
+    state,
+    instance,
+    // #11061, ensure enterHooks is fresh after clone
+    cloned => (hooks = cloned),
+  )
+  if (inner.type !== Comment) {
+    setTransitionHooks(inner, hooks)
+  }
+  return { inner, hooks }
 }
 
 export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks): void {

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -540,15 +540,20 @@ export function prepareTransitionSwitch(
     instance,
     // #11061: keep enter hooks in sync when the incoming VNode is cloned.
     hooks => {
-      forwardDelayedLeave(hooks, delayedLeaveSource)
+      if (delayedLeaveSource) {
+        forwardDelayedLeave(hooks, delayedLeaveSource)
+      }
       enterHooks = hooks
     },
   )
-  forwardDelayedLeave(enterHooks, delayedLeaveSource)
+  if (delayedLeaveSource) {
+    forwardDelayedLeave(enterHooks, delayedLeaveSource)
+  }
   if (nextInner.type !== Comment) {
     setTransitionHooks(nextInner, enterHooks)
   }
 
+  const mode = props.mode
   const previousInner = previous && getInnerChild(previous)
   if (
     previous &&
@@ -566,10 +571,11 @@ export function prepareTransitionSwitch(
     )
     if (
       nextInner.type !== Comment &&
+      (mode === 'out-in' || mode === 'in-out') &&
       applyTransitionModeSwitch(
         previousInner,
         leavingHooks,
-        () => enterHooks,
+        mode === 'in-out' ? () => enterHooks : undefined,
         props,
         state,
         resumeAfterLeave,

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -181,15 +181,11 @@ const BaseTransitionImpl: ComponentOptions = {
         return emptyPlaceholder(child)
       }
 
-      const { inner: innerChild, hooks: enterHooks } = prepareTransitionBranch(
-        child,
-        rawProps,
-        state,
-        instance,
-      )
-      if (!innerChild || !enterHooks) {
+      const prepared = prepareTransitionBranch(child, rawProps, state, instance)
+      if (!prepared) {
         return emptyPlaceholder(child)
       }
+      const { inner: innerChild } = prepared
 
       let oldInnerChild = instance.subTree && getInnerChild(instance.subTree)
 
@@ -238,12 +234,12 @@ const BaseTransitionImpl: ComponentOptions = {
             el[leaveCbKey] = () => {
               earlyRemove()
               el[leaveCbKey] = undefined
-              delete enterHooks.delayedLeave
+              delete prepared.hooks.delayedLeave
               oldInnerChild = undefined
             }
-            enterHooks.delayedLeave = () => {
+            prepared.hooks.delayedLeave = () => {
               delayedLeave()
-              delete enterHooks.delayedLeave
+              delete prepared.hooks.delayedLeave
               oldInnerChild = undefined
             }
           }
@@ -580,29 +576,27 @@ export function prepareTransitionBranch(
   props: BaseTransitionProps<any>,
   state: TransitionState,
   instance: GenericComponentInstance,
-): {
-  inner?: VNode
-  hooks?: TransitionHooks
-} {
+): { inner: VNode; hooks: TransitionHooks } | undefined {
   // in the case of <transition><keep-alive/></transition>, we need to
   // compare the type of the kept-alive children.
   const inner = getInnerChild(branch)
   if (!inner) {
-    return {}
+    return
   }
-  let hooks: TransitionHooks
-  hooks = resolveTransitionHooks(
+  let prepared: { inner: VNode; hooks: TransitionHooks }
+  const hooks = resolveTransitionHooks(
     inner,
     props,
     state,
     instance,
-    // #11061, ensure enterHooks is fresh after clone
-    cloned => (hooks = cloned),
+    // #11061, keep the returned hooks fresh after clone
+    cloned => (prepared.hooks = cloned),
   )
+  prepared = { inner, hooks }
   if (inner.type !== Comment) {
     setTransitionHooks(inner, hooks)
   }
-  return { inner, hooks }
+  return prepared
 }
 
 export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks): void {

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -593,9 +593,12 @@ export function prepareTransitionSwitch(
           previousInner = undefined
         }
       }
+      return next
     }
   }
 
+  // avoid retaining the previous tree through enterHooks' clone callback
+  previousInner = undefined
   return next
 }
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -684,6 +684,8 @@ export {
   baseResolveTransitionHooks,
   checkTransitionMode,
   leaveCbKey,
+  prepareTransitionBranch,
+  resolveTransitionChild,
 } from './components/BaseTransition'
 
 /**

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -684,6 +684,7 @@ export {
   baseResolveTransitionHooks,
   checkTransitionMode,
   leaveCbKey,
+  prepareTransitionLeave,
   prepareTransitionSwitch,
   resolveTransitionChild,
 } from './components/BaseTransition'

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -683,6 +683,7 @@ export { isTemplateNode } from './hydration'
 export {
   baseResolveTransitionHooks,
   checkTransitionMode,
+  hasTransitionChildChanged,
   leaveCbKey,
   prepareTransition,
   resolveTransitionChild,

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -684,7 +684,7 @@ export {
   baseResolveTransitionHooks,
   checkTransitionMode,
   leaveCbKey,
-  prepareTransitionBranch,
+  prepareTransition,
   resolveTransitionChild,
 } from './components/BaseTransition'
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -683,9 +683,8 @@ export { isTemplateNode } from './hydration'
 export {
   baseResolveTransitionHooks,
   checkTransitionMode,
-  hasTransitionChildChanged,
   leaveCbKey,
-  prepareTransition,
+  prepareTransitionSwitch,
   resolveTransitionChild,
 } from './components/BaseTransition'
 

--- a/packages/runtime-vapor/__tests__/_utils.ts
+++ b/packages/runtime-vapor/__tests__/_utils.ts
@@ -102,6 +102,7 @@ export interface InteropRenderContext {
     props?: RawProps,
     container?: string | ParentNode,
   ) => InteropRenderContext
+  app: App
   host: HTMLElement
   html: () => string
 }
@@ -137,6 +138,7 @@ export function makeInteropRender(): (comp: Component) => InteropRenderContext {
     }
 
     const res = () => ({
+      app,
       host,
       mount,
       render,

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -124,6 +124,7 @@ function createTestSlotResolutionState(options: {
   state = {
     boundary,
     activeFallback: null,
+    fallbackInserted: false,
     pendingRecheck: false,
     pendingRecheckForce: false,
     isRenderingFallback: false,
@@ -765,6 +766,7 @@ describe('component: slots', () => {
       state = {
         boundary,
         activeFallback: null,
+        fallbackInserted: false,
         pendingRecheck: false,
         pendingRecheckForce: false,
         isRenderingFallback: false,
@@ -810,6 +812,7 @@ describe('component: slots', () => {
       state = {
         boundary,
         activeFallback: null,
+        fallbackInserted: false,
         pendingRecheck: false,
         pendingRecheckForce: false,
         isRenderingFallback: false,

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -6,7 +6,16 @@ import {
 } from '../../src'
 import { resolveTransitionBlock } from '../../src/components/Transition'
 import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
-import { Fragment, Transition, defineComponent, h, nextTick, ref } from 'vue'
+import {
+  Fragment,
+  type Ref,
+  Transition,
+  type VNode,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+} from 'vue'
 import { compile, makeInteropRender, makeRender } from '../_utils'
 
 const define = makeRender()
@@ -30,6 +39,44 @@ function createAppearTestState(
     onBeforeAppear,
     onAppear,
   }
+}
+
+interface InteropSlotTransitionTestData {
+  show: boolean
+  onEnter: (el: Element, done: () => void) => void
+  onLeave: (el: Element, done: () => void) => void
+}
+
+function renderInteropSlotFallbackTransition<
+  T extends InteropSlotTransitionTestData,
+>(
+  mode: 'out-in' | 'in-out',
+  data: Ref<T>,
+  renderContent: () => VNode = () => h('span', { class: 'content' }, 'content'),
+  fallback: string = '<div class="fallback">fallback</div>',
+) {
+  const Child = compile(
+    `<template>
+      <Transition
+        mode="${mode}"
+        :css="false"
+        @enter="data.onEnter"
+        @leave="data.onLeave"
+      >
+        <slot>${fallback}</slot>
+      </Transition>
+    </template>`,
+    data,
+  )
+  const App = defineComponent({
+    setup() {
+      return () =>
+        h(Child, null, {
+          default: () => (data.value.show ? renderContent() : []),
+        })
+    },
+  })
+  return defineInterop(App).render()
 }
 
 describe('Transition', () => {
@@ -683,46 +730,286 @@ describe('Transition', () => {
     leaveDone && leaveDone()
   })
 
-  test('interop slot fallback should participate in out-in transition swaps', async () => {
+  test('vdom slot content should wait for fallback leave in out-in mode', async () => {
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
     const data = ref({
       show: false,
-      fallback: 'fallback',
-      msg: 'slot',
+      onEnter,
+      onLeave,
     })
-    const Child = compile(
-      `<template>
-        <Transition mode="out-in">
-          <slot>
-            <div>{{ data.fallback }}</div>
-          </slot>
-        </Transition>
-      </template>`,
-      data,
-    )
-    const App = compile(
-      `<template>
-        <components.Child>
-          <template #default v-if="data.show">
-            <span>{{ data.msg }}</span>
-          </template>
-        </components.Child>
-      </template>`,
-      data,
-      { Child },
-      { vapor: false },
-    )
-    const { host } = defineInterop(App as any).render()
+    const { host } = renderInteropSlotFallbackTransition('out-in', data)
 
-    expect(host.innerHTML).toContain('<div>fallback</div>')
+    expect(host.querySelector('.fallback')).not.toBeNull()
 
     data.value.show = true
     await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+    expect(host.querySelector('.content')).toBeNull()
+
+    leaveDone!()
     await nextTick()
 
-    expect(host.innerHTML).toContain(
-      '<span class="v-enter-from v-enter-active">slot</span>',
+    expect(host.querySelector('.fallback')).toBeNull()
+    expect(host.querySelector('.content')).not.toBeNull()
+    expect(onEnter).toHaveBeenCalledOnce()
+  })
+
+  test('slot fallback should wait for vdom content leave in out-in mode', async () => {
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: true,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition('out-in', data)
+
+    expect(host.querySelector('.content')).not.toBeNull()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.content')).not.toBeNull()
+    expect(host.querySelector('.fallback')).toBeNull()
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('.content')).toBeNull()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+    expect(onEnter).toHaveBeenCalledOnce()
+  })
+
+  test('slot fallback should wait for vdom content enter in in-out mode', async () => {
+    let enterDone: (() => void) | undefined
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => {
+      enterDone = done
+    })
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: false,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition('in-out', data)
+
+    data.value.show = true
+    await nextTick()
+
+    expect(onEnter).toHaveBeenCalledOnce()
+    expect(onLeave).not.toHaveBeenCalled()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+    expect(host.querySelector('.content')).not.toBeNull()
+
+    enterDone!()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+
+    leaveDone!()
+    expect(host.querySelector('.fallback')).toBeNull()
+    expect(host.querySelector('.content')).not.toBeNull()
+  })
+
+  test('vdom slot content should wait for fallback enter in in-out mode', async () => {
+    let enterDone: (() => void) | undefined
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => {
+      enterDone = done
+    })
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: true,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition('in-out', data)
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onEnter).toHaveBeenCalledOnce()
+    expect(onLeave).not.toHaveBeenCalled()
+    expect(host.querySelector('.content')).not.toBeNull()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+
+    enterDone!()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.content')).not.toBeNull()
+
+    leaveDone!()
+    expect(host.querySelector('.content')).toBeNull()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+  })
+
+  test('out-in should not wait for an invalid slot fallback', async () => {
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn()
+    const data = ref({
+      show: false,
+      fallbackVisible: false,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition(
+      'out-in',
+      data,
+      undefined,
+      '<div v-if="data.fallbackVisible" class="fallback">fallback</div>',
     )
-    expect(host.innerHTML).not.toContain('<div>fallback</div>')
+
+    data.value.show = true
+    await nextTick()
+
+    expect(host.querySelector('.fallback')).toBeNull()
+    expect(host.querySelector('.content')).not.toBeNull()
+    expect(onLeave).not.toHaveBeenCalled()
+    expect(onEnter).toHaveBeenCalledOnce()
+  })
+
+  test('in-out should not delay vdom leave for an invalid slot fallback', async () => {
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: true,
+      fallbackVisible: false,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition(
+      'in-out',
+      data,
+      undefined,
+      '<div v-if="data.fallbackVisible" class="fallback">fallback</div>',
+    )
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onEnter).not.toHaveBeenCalled()
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.content')).not.toBeNull()
+
+    leaveDone!()
+    expect(host.querySelector('.content')).toBeNull()
+  })
+
+  test('in-out should handle switching back to vdom before fallback enter finishes', async () => {
+    let fallbackEnterDone: (() => void) | undefined
+    let contentEnterDone: (() => void) | undefined
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((el: Element, done: () => void) => {
+      if (el.classList.contains('fallback')) {
+        fallbackEnterDone = done
+      } else {
+        contentEnterDone = done
+      }
+    })
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: true,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition('in-out', data)
+
+    data.value.show = false
+    await nextTick()
+
+    expect(fallbackEnterDone).toBeDefined()
+    expect(onLeave).not.toHaveBeenCalled()
+
+    data.value.show = true
+    await nextTick()
+
+    expect(contentEnterDone).toBeDefined()
+    expect(onLeave).not.toHaveBeenCalled()
+
+    contentEnterDone!()
+    expect(onLeave).toHaveBeenCalledOnce()
+
+    leaveDone!()
+    expect(host.querySelector('.fallback')).toBeNull()
+    expect(host.querySelectorAll('.content')).toHaveLength(1)
+  })
+
+  test('out-in fallback switch should render the latest vdom slot content', async () => {
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: false,
+      tag: 'span',
+      text: 'A',
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition('out-in', data, () =>
+      h(data.value.tag, { class: 'content' }, data.value.text),
+    )
+
+    data.value.show = true
+    await nextTick()
+
+    data.value.show = false
+    await nextTick()
+
+    data.value.tag = 'p'
+    data.value.text = 'B'
+    data.value.show = true
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.content')).toBeNull()
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('span')).toBeNull()
+    expect(host.querySelector('p.content')?.textContent).toBe('B')
+    expect(onEnter).toHaveBeenCalledOnce()
+  })
+
+  test('out-in fallback switch should handle synchronous leave completion', async () => {
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      show: false,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition('out-in', data)
+
+    data.value.show = true
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.fallback')).toBeNull()
+    expect(host.querySelector('.content')).not.toBeNull()
+    expect(onEnter).toHaveBeenCalledOnce()
   })
 
   test('does not treat inherited VDOM transition hooks as Vapor state', async () => {

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -55,6 +55,7 @@ function renderInteropSlotFallbackTransition<
   data: Ref<T>,
   renderContent: () => VNode = () => h('span', { class: 'content' }, 'content'),
   fallback: string = '<div class="fallback">fallback</div>',
+  removeSlotWhenHidden = false,
 ) {
   const Child = compile(
     `<template>
@@ -72,9 +73,15 @@ function renderInteropSlotFallbackTransition<
   const App = defineComponent({
     setup() {
       return () =>
-        h(Child, null, {
-          default: () => (data.value.show ? renderContent() : []),
-        })
+        h(
+          Child,
+          null,
+          removeSlotWhenHidden && !data.value.show
+            ? undefined
+            : {
+                default: () => (data.value.show ? renderContent() : []),
+              },
+        )
     },
   })
   return defineInterop(App).render()
@@ -791,6 +798,40 @@ describe('Transition', () => {
     expect(onEnter).toHaveBeenCalledOnce()
   })
 
+  test('removed vdom slot should respect out-in mode', async () => {
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: true,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition(
+      'out-in',
+      data,
+      undefined,
+      undefined,
+      true,
+    )
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.content')).not.toBeNull()
+    expect(host.querySelector('.fallback')).toBeNull()
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('.content')).toBeNull()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+    expect(onEnter).toHaveBeenCalledOnce()
+  })
+
   test('unmounts a leaving fallback during an out-in switch', async () => {
     let leaveDone: (() => void) | undefined
     const data = ref({
@@ -968,6 +1009,46 @@ describe('Transition', () => {
       onLeave,
     })
     const { host } = renderInteropSlotFallbackTransition('in-out', data)
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onEnter).toHaveBeenCalledOnce()
+    expect(onLeave).not.toHaveBeenCalled()
+    expect(host.querySelector('.content')).not.toBeNull()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+
+    enterDone!()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('.content')).not.toBeNull()
+
+    leaveDone!()
+    expect(host.querySelector('.content')).toBeNull()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+  })
+
+  test('removed vdom slot should respect in-out mode', async () => {
+    let enterDone: (() => void) | undefined
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => {
+      enterDone = done
+    })
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: true,
+      onEnter,
+      onLeave,
+    })
+    const { host } = renderInteropSlotFallbackTransition(
+      'in-out',
+      data,
+      undefined,
+      undefined,
+      true,
+    )
 
     data.value.show = false
     await nextTick()

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src'
 import { resolveTransitionBlock } from '../../src/components/Transition'
 import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
-import { nextTick, ref } from 'vue'
+import { Fragment, defineComponent, h, nextTick, ref } from 'vue'
 import { compile, makeInteropRender, makeRender } from '../_utils'
 
 const define = makeRender()
@@ -723,6 +723,115 @@ describe('Transition', () => {
       '<span class="v-enter-from v-enter-active">slot</span>',
     )
     expect(host.innerHTML).not.toContain('<div>fallback</div>')
+  })
+
+  test('vdom slot content should participate in leave transition', async () => {
+    const data = ref({
+      show: true,
+    })
+    const Child = compile(
+      `<template>
+        <Transition name="fade">
+          <slot />
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <div v-if="data.show">slot</div>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+      { vapor: false },
+    )
+    const { host } = defineInterop(App as any).render()
+
+    expect(host.innerHTML).toContain('<div>slot</div>')
+
+    data.value.show = false
+    await nextTick()
+
+    expect(host.innerHTML).toContain(
+      '<div class="fade-leave-from fade-leave-active">slot</div>',
+    )
+  })
+
+  test('vdom slot content should participate in enter transition', async () => {
+    const data = ref({
+      show: false,
+    })
+    const Child = compile(
+      `<template>
+        <Transition name="fade">
+          <slot />
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <div v-if="data.show">slot</div>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+      { vapor: false },
+    )
+    const { host } = defineInterop(App as any).render()
+
+    expect(host.querySelector('div')).toBeNull()
+
+    data.value.show = true
+    await nextTick()
+
+    expect(host.innerHTML).toContain(
+      '<div class="fade-enter-from fade-enter-active">slot</div>',
+    )
+  })
+
+  test('vdom slot fragment keys should control transition child identity', async () => {
+    const key = ref('a')
+    const Child = compile(
+      `<template>
+        <Transition name="fade">
+          <slot />
+        </Transition>
+      </template>`,
+      key,
+    )
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(Child, null, {
+            default: () => [
+              h(Fragment, { key: key.value }, [h('div', 'slot')]),
+            ],
+          })
+      },
+    })
+    const { host } = defineInterop(App).render()
+    const leaving = host.querySelector('div')!
+
+    key.value = 'b'
+    await nextTick()
+
+    const children = Array.from(host.querySelectorAll('div'))
+    const entering = children.find(child => child !== leaving)!
+    expect(children).toHaveLength(2)
+    expect(leaving.className).toBe('fade-leave-from fade-leave-active')
+    expect(entering.className).toBe('fade-enter-from fade-enter-active')
   })
 
   test('slot fallback should trigger enter hooks when slot content becomes empty', async () => {

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -834,6 +834,363 @@ describe('Transition', () => {
     expect(entering.className).toBe('fade-enter-from fade-enter-active')
   })
 
+  test('vdom slot content should respect out-in transition mode', async () => {
+    let leaveDone: (() => void) | undefined
+    let finishLeaveSynchronously = false
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+      if (finishLeaveSynchronously) done()
+    })
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      provide: true,
+      show: true,
+      onLeave,
+      onEnter,
+    })
+    const Child = compile(
+      `<template>
+        <Transition
+          mode="out-in"
+          :css="false"
+          @leave="data.onLeave"
+          @enter="data.onEnter"
+        >
+          <slot />
+        </Transition>
+      </template>`,
+      data,
+    )
+    // A render function can remove the slot source entirely, while compiled
+    // dynamic slots retain an empty slots object.
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(
+            Child,
+            null,
+            data.value.provide
+              ? {
+                  default: () => [
+                    h(
+                      data.value.show ? 'div' : 'span',
+                      data.value.show ? 'first' : 'second',
+                    ),
+                  ],
+                }
+              : undefined,
+          )
+      },
+    })
+    const { host } = defineInterop(App).render()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')?.textContent).toBe('first')
+    expect(host.querySelector('span')).toBeNull()
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('div')).toBeNull()
+    expect(host.querySelector('span')?.textContent).toBe('second')
+    expect(onEnter).toHaveBeenCalledOnce()
+
+    data.value.show = true
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledTimes(2)
+    expect(host.querySelector('div')).toBeNull()
+
+    data.value.provide = false
+    await nextTick()
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('div')).toBeNull()
+    expect(host.querySelector('span')).toBeNull()
+    expect(onEnter).toHaveBeenCalledOnce()
+
+    data.value.provide = true
+    await nextTick()
+    finishLeaveSynchronously = true
+    data.value.show = false
+    await nextTick()
+
+    expect(host.querySelector('div')).toBeNull()
+    expect(host.querySelector('span')?.textContent).toBe('second')
+    expect(onEnter).toHaveBeenCalledTimes(3)
+  })
+
+  test('vdom KeepAlive slot content should respect out-in transition mode', async () => {
+    let leaveDone: (() => void) | undefined
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onFirstSetup = vi.fn()
+    const data = ref({
+      show: true,
+      onLeave,
+      onEnter,
+      onFirstSetup,
+    })
+    const First = compile(
+      `<script setup>
+        const data = _data
+        data.value.onFirstSetup()
+      </script>
+      <template>
+        <div>first</div>
+      </template>`,
+      data,
+      {},
+      { vapor: false },
+    )
+    const Second = compile(
+      `<template><span>second</span></template>`,
+      data,
+      {},
+      { vapor: false },
+    )
+    const Child = compile(
+      `<template>
+        <Transition
+          mode="out-in"
+          :css="false"
+          @leave="data.onLeave"
+          @enter="data.onEnter"
+        >
+          <slot />
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <KeepAlive>
+            <components.First v-if="data.show" />
+            <components.Second v-else />
+          </KeepAlive>
+        </components.Child>
+      </template>`,
+      data,
+      { Child, First, Second },
+      { vapor: false },
+    )
+    const { host } = defineInterop(App as any).render()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')?.textContent).toBe('first')
+    expect(host.querySelector('span')).toBeNull()
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('div')).toBeNull()
+    expect(host.querySelector('span')?.textContent).toBe('second')
+    expect(onEnter).toHaveBeenCalledOnce()
+
+    data.value.show = true
+    await nextTick()
+    expect(host.querySelector('div')).toBeNull()
+    expect(host.querySelector('span')?.textContent).toBe('second')
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('div')?.textContent).toBe('first')
+    expect(host.querySelector('span')).toBeNull()
+    expect(onFirstSetup).toHaveBeenCalledOnce()
+  })
+
+  test('vdom Teleport slot content should respect out-in transition mode', async () => {
+    const target = document.createElement('div')
+    target.id = 'vdom-slot-transition-target'
+    document.body.appendChild(target)
+    let leaveDone: (() => void) | undefined
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      show: true,
+      onLeave,
+      onEnter,
+    })
+    const Child = compile(
+      `<template>
+        <Transition
+          mode="out-in"
+          :css="false"
+          @leave="data.onLeave"
+          @enter="data.onEnter"
+        >
+          <slot />
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <Teleport to="#vdom-slot-transition-target">
+            <div v-if="data.show">first</div>
+            <span v-else>second</span>
+          </Teleport>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+      { vapor: false },
+    )
+    defineInterop(App as any).render()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(target.querySelector('div')?.textContent).toBe('first')
+    expect(target.querySelector('span')).toBeNull()
+
+    leaveDone!()
+    await nextTick()
+
+    expect(target.querySelector('div')).toBeNull()
+    expect(target.querySelector('span')?.textContent).toBe('second')
+    expect(onEnter).toHaveBeenCalledOnce()
+    target.remove()
+  })
+
+  test('vdom slot content should respect in-out transition mode', async () => {
+    let enterDone: (() => void) | undefined
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => {
+      enterDone = done
+    })
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({
+      show: true,
+      onEnter,
+      onLeave,
+    })
+    const Child = compile(
+      `<template>
+        <Transition
+          mode="in-out"
+          :css="false"
+          @enter="data.onEnter"
+          @leave="data.onLeave"
+        >
+          <slot />
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <div v-if="data.show">first</div>
+          <span v-else>second</span>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+      { vapor: false },
+    )
+    const { host } = defineInterop(App as any).render()
+
+    data.value.show = false
+    await nextTick()
+
+    expect(onEnter).toHaveBeenCalledOnce()
+    expect(onLeave).not.toHaveBeenCalled()
+    expect(host.querySelector('div')?.textContent).toBe('first')
+    expect(host.querySelector('span')?.textContent).toBe('second')
+
+    enterDone!()
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')?.textContent).toBe('first')
+
+    leaveDone!()
+    await nextTick()
+
+    expect(host.querySelector('div')).toBeNull()
+    expect(host.querySelector('span')?.textContent).toBe('second')
+  })
+
+  test('vdom slot out-in should skip a component that renders a comment', async () => {
+    const data = ref({
+      show: true,
+      empty: false,
+    })
+    const Empty = compile(
+      `<script setup>
+        const data = _data
+      </script>
+      <template><div v-if="data.empty" /></template>`,
+      data,
+      {},
+      { vapor: false },
+    )
+    const Child = compile(
+      `<template>
+        <Transition mode="out-in" :css="false">
+          <slot />
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <components.Empty v-if="data.show" />
+          <div v-else id="next">next</div>
+        </components.Child>
+      </template>`,
+      data,
+      { Child, Empty },
+      { vapor: false },
+    )
+    const { host } = defineInterop(App as any).render()
+    // A comment-root component should be replaced directly instead of going
+    // through an intermediate out-in placeholder.
+    const insertBefore = vi.spyOn(Node.prototype, 'insertBefore')
+
+    data.value.show = false
+    await nextTick()
+
+    const insertedComment = insertBefore.mock.calls.some(
+      ([node]) => node.nodeType === Node.COMMENT_NODE,
+    )
+    insertBefore.mockRestore()
+    expect(host.querySelector('#next')?.textContent).toBe('next')
+    expect(insertedComment).toBe(false)
+  })
+
   test('slot fallback should trigger enter hooks when slot content becomes empty', async () => {
     const onBeforeEnter = vi.fn()
     const onEnter = vi.fn()

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src'
 import { resolveTransitionBlock } from '../../src/components/Transition'
 import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
-import { Fragment, defineComponent, h, nextTick, ref } from 'vue'
+import { Fragment, Transition, defineComponent, h, nextTick, ref } from 'vue'
 import { compile, makeInteropRender, makeRender } from '../_utils'
 
 const define = makeRender()
@@ -725,13 +725,62 @@ describe('Transition', () => {
     expect(host.innerHTML).not.toContain('<div>fallback</div>')
   })
 
-  test('vdom slot content should participate in leave transition', async () => {
-    const data = ref({
-      show: true,
+  test('does not treat inherited VDOM transition hooks as Vapor state', async () => {
+    const show = ref(true)
+    const onEnter = vi.fn()
+    const onLeave = vi.fn()
+    const Child = compile(`<template><slot /></template>`, show)
+    const App = defineComponent({
+      setup() {
+        return () => {
+          // Force BaseTransition to propagate refreshed VDOM hooks through the
+          // slot root.
+          const visible = show.value
+          return h(
+            Transition,
+            { mode: 'out-in', css: false, onEnter, onLeave },
+            {
+              default: () =>
+                h(
+                  Child,
+                  { visible },
+                  {
+                    default: () =>
+                      visible ? h('div', { id: 'content' }, 'content') : [],
+                  },
+                ),
+            },
+          )
+        }
+      },
     })
+    const { host } = defineInterop(App).render()
+
+    show.value = false
+    await nextTick()
+
+    expect(host.querySelector('#content')).toBeNull()
+    expect(onEnter).not.toHaveBeenCalled()
+    expect(onLeave).not.toHaveBeenCalled()
+  })
+
+  test('vdom slot content should participate in transitions', async () => {
+    let enterDone: (() => void) | undefined
+    let leaveDone: (() => void) | undefined
+    const onEnter = vi.fn((_el: Element, done: () => void) => {
+      enterDone = done
+    })
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({ show: true, onEnter, onLeave })
     const Child = compile(
       `<template>
-        <Transition name="fade">
+        <Transition
+          :css="false"
+          @enter="data.onEnter"
+          @leave="data.onLeave"
+        >
           <slot />
         </Transition>
       </template>`,
@@ -753,52 +802,24 @@ describe('Transition', () => {
     )
     const { host } = defineInterop(App as any).render()
 
-    expect(host.innerHTML).toContain('<div>slot</div>')
+    expect(host.querySelector('div')?.textContent).toBe('slot')
 
     data.value.show = false
     await nextTick()
 
-    expect(host.innerHTML).toContain(
-      '<div class="fade-leave-from fade-leave-active">slot</div>',
-    )
-  })
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')?.textContent).toBe('slot')
 
-  test('vdom slot content should participate in enter transition', async () => {
-    const data = ref({
-      show: false,
-    })
-    const Child = compile(
-      `<template>
-        <Transition name="fade">
-          <slot />
-        </Transition>
-      </template>`,
-      data,
-    )
-    const App = compile(
-      `<script setup>
-        const data = _data
-        const components = _components
-      </script>
-      <template>
-        <components.Child>
-          <div v-if="data.show">slot</div>
-        </components.Child>
-      </template>`,
-      data,
-      { Child },
-      { vapor: false },
-    )
-    const { host } = defineInterop(App as any).render()
-
+    leaveDone!()
     expect(host.querySelector('div')).toBeNull()
 
     data.value.show = true
     await nextTick()
 
-    expect(host.innerHTML).toContain(
-      '<div class="fade-enter-from fade-enter-active">slot</div>',
-    )
+    expect(onEnter).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')?.textContent).toBe('slot')
+
+    enterDone!()
   })
 
   test('vdom slot fragment keys should control transition child identity', async () => {
@@ -843,8 +864,9 @@ describe('Transition', () => {
     })
     const onEnter = vi.fn((_el: Element, done: () => void) => done())
     const data = ref({
-      provide: true,
-      show: true,
+      hasSlot: true,
+      tag: 'div',
+      text: 'first',
       onLeave,
       onEnter,
     })
@@ -861,22 +883,15 @@ describe('Transition', () => {
       </template>`,
       data,
     )
-    // A render function can remove the slot source entirely, while compiled
-    // dynamic slots retain an empty slots object.
     const App = defineComponent({
       setup() {
         return () =>
           h(
             Child,
             null,
-            data.value.provide
+            data.value.hasSlot
               ? {
-                  default: () => [
-                    h(
-                      data.value.show ? 'div' : 'span',
-                      data.value.show ? 'first' : 'second',
-                    ),
-                  ],
+                  default: () => h(data.value.tag, data.value.text),
                 }
               : undefined,
           )
@@ -884,195 +899,48 @@ describe('Transition', () => {
     })
     const { host } = defineInterop(App).render()
 
-    data.value.show = false
+    data.value.tag = 'span'
+    data.value.text = 'second'
     await nextTick()
 
     expect(onLeave).toHaveBeenCalledOnce()
     expect(host.querySelector('div')?.textContent).toBe('first')
     expect(host.querySelector('span')).toBeNull()
 
-    leaveDone!()
-    await nextTick()
-
-    expect(host.querySelector('div')).toBeNull()
-    expect(host.querySelector('span')?.textContent).toBe('second')
-    expect(onEnter).toHaveBeenCalledOnce()
-
-    data.value.show = true
-    await nextTick()
-    expect(onLeave).toHaveBeenCalledTimes(2)
-    expect(host.querySelector('div')).toBeNull()
-
-    data.value.provide = false
+    data.value.tag = 'p'
+    data.value.text = 'latest'
     await nextTick()
     leaveDone!()
     await nextTick()
 
     expect(host.querySelector('div')).toBeNull()
     expect(host.querySelector('span')).toBeNull()
+    expect(host.querySelector('p')?.textContent).toBe('latest')
     expect(onEnter).toHaveBeenCalledOnce()
 
-    data.value.provide = true
-    await nextTick()
     finishLeaveSynchronously = true
-    data.value.show = false
+    data.value.tag = 'div'
+    data.value.text = 'sync'
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledTimes(2)
+    expect(host.querySelector('p')).toBeNull()
+    expect(host.querySelector('div')?.textContent).toBe('sync')
+    expect(onEnter).toHaveBeenCalledTimes(2)
+
+    finishLeaveSynchronously = false
+    data.value.tag = 'span'
+    data.value.text = 'discarded'
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledTimes(3)
+    data.value.hasSlot = false
+    await nextTick()
+    leaveDone!()
     await nextTick()
 
     expect(host.querySelector('div')).toBeNull()
-    expect(host.querySelector('span')?.textContent).toBe('second')
-    expect(onEnter).toHaveBeenCalledTimes(3)
-  })
-
-  test('vdom KeepAlive slot content should respect out-in transition mode', async () => {
-    let leaveDone: (() => void) | undefined
-    const onLeave = vi.fn((_el: Element, done: () => void) => {
-      leaveDone = done
-    })
-    const onEnter = vi.fn((_el: Element, done: () => void) => done())
-    const onFirstSetup = vi.fn()
-    const data = ref({
-      show: true,
-      onLeave,
-      onEnter,
-      onFirstSetup,
-    })
-    const First = compile(
-      `<script setup>
-        const data = _data
-        data.value.onFirstSetup()
-      </script>
-      <template>
-        <div>first</div>
-      </template>`,
-      data,
-      {},
-      { vapor: false },
-    )
-    const Second = compile(
-      `<template><span>second</span></template>`,
-      data,
-      {},
-      { vapor: false },
-    )
-    const Child = compile(
-      `<template>
-        <Transition
-          mode="out-in"
-          :css="false"
-          @leave="data.onLeave"
-          @enter="data.onEnter"
-        >
-          <slot />
-        </Transition>
-      </template>`,
-      data,
-    )
-    const App = compile(
-      `<script setup>
-        const data = _data
-        const components = _components
-      </script>
-      <template>
-        <components.Child>
-          <KeepAlive>
-            <components.First v-if="data.show" />
-            <components.Second v-else />
-          </KeepAlive>
-        </components.Child>
-      </template>`,
-      data,
-      { Child, First, Second },
-      { vapor: false },
-    )
-    const { host } = defineInterop(App as any).render()
-
-    data.value.show = false
-    await nextTick()
-
-    expect(onLeave).toHaveBeenCalledOnce()
-    expect(host.querySelector('div')?.textContent).toBe('first')
     expect(host.querySelector('span')).toBeNull()
-
-    leaveDone!()
-    await nextTick()
-
-    expect(host.querySelector('div')).toBeNull()
-    expect(host.querySelector('span')?.textContent).toBe('second')
-    expect(onEnter).toHaveBeenCalledOnce()
-
-    data.value.show = true
-    await nextTick()
-    expect(host.querySelector('div')).toBeNull()
-    expect(host.querySelector('span')?.textContent).toBe('second')
-
-    leaveDone!()
-    await nextTick()
-
-    expect(host.querySelector('div')?.textContent).toBe('first')
-    expect(host.querySelector('span')).toBeNull()
-    expect(onFirstSetup).toHaveBeenCalledOnce()
-  })
-
-  test('vdom Teleport slot content should respect out-in transition mode', async () => {
-    const target = document.createElement('div')
-    target.id = 'vdom-slot-transition-target'
-    document.body.appendChild(target)
-    let leaveDone: (() => void) | undefined
-    const onLeave = vi.fn((_el: Element, done: () => void) => {
-      leaveDone = done
-    })
-    const onEnter = vi.fn((_el: Element, done: () => void) => done())
-    const data = ref({
-      show: true,
-      onLeave,
-      onEnter,
-    })
-    const Child = compile(
-      `<template>
-        <Transition
-          mode="out-in"
-          :css="false"
-          @leave="data.onLeave"
-          @enter="data.onEnter"
-        >
-          <slot />
-        </Transition>
-      </template>`,
-      data,
-    )
-    const App = compile(
-      `<script setup>
-        const data = _data
-        const components = _components
-      </script>
-      <template>
-        <components.Child>
-          <Teleport to="#vdom-slot-transition-target">
-            <div v-if="data.show">first</div>
-            <span v-else>second</span>
-          </Teleport>
-        </components.Child>
-      </template>`,
-      data,
-      { Child },
-      { vapor: false },
-    )
-    defineInterop(App as any).render()
-
-    data.value.show = false
-    await nextTick()
-
-    expect(onLeave).toHaveBeenCalledOnce()
-    expect(target.querySelector('div')?.textContent).toBe('first')
-    expect(target.querySelector('span')).toBeNull()
-
-    leaveDone!()
-    await nextTick()
-
-    expect(target.querySelector('div')).toBeNull()
-    expect(target.querySelector('span')?.textContent).toBe('second')
-    expect(onEnter).toHaveBeenCalledOnce()
-    target.remove()
+    expect(onEnter).toHaveBeenCalledTimes(2)
   })
 
   test('vdom slot content should respect in-out transition mode', async () => {
@@ -1136,59 +1004,6 @@ describe('Transition', () => {
 
     expect(host.querySelector('div')).toBeNull()
     expect(host.querySelector('span')?.textContent).toBe('second')
-  })
-
-  test('vdom slot out-in should skip a component that renders a comment', async () => {
-    const data = ref({
-      show: true,
-      empty: false,
-    })
-    const Empty = compile(
-      `<script setup>
-        const data = _data
-      </script>
-      <template><div v-if="data.empty" /></template>`,
-      data,
-      {},
-      { vapor: false },
-    )
-    const Child = compile(
-      `<template>
-        <Transition mode="out-in" :css="false">
-          <slot />
-        </Transition>
-      </template>`,
-      data,
-    )
-    const App = compile(
-      `<script setup>
-        const data = _data
-        const components = _components
-      </script>
-      <template>
-        <components.Child>
-          <components.Empty v-if="data.show" />
-          <div v-else id="next">next</div>
-        </components.Child>
-      </template>`,
-      data,
-      { Child, Empty },
-      { vapor: false },
-    )
-    const { host } = defineInterop(App as any).render()
-    // A comment-root component should be replaced directly instead of going
-    // through an intermediate out-in placeholder.
-    const insertBefore = vi.spyOn(Node.prototype, 'insertBefore')
-
-    data.value.show = false
-    await nextTick()
-
-    const insertedComment = insertBefore.mock.calls.some(
-      ([node]) => node.nodeType === Node.COMMENT_NODE,
-    )
-    insertBefore.mockRestore()
-    expect(host.querySelector('#next')?.textContent).toBe('next')
-    expect(insertedComment).toBe(false)
   })
 
   test('slot fallback should trigger enter hooks when slot content becomes empty', async () => {

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -9,6 +9,7 @@ import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
 import {
   Fragment,
   type Ref,
+  Teleport,
   Transition,
   type VNode,
   defineComponent,
@@ -788,6 +789,134 @@ describe('Transition', () => {
     expect(host.querySelector('.content')).toBeNull()
     expect(host.querySelector('.fallback')).not.toBeNull()
     expect(onEnter).toHaveBeenCalledOnce()
+  })
+
+  test('unmounts a leaving fallback during an out-in switch', async () => {
+    let leaveDone: (() => void) | undefined
+    const data = ref({
+      show: false,
+      onEnter: vi.fn(),
+      onLeave: vi.fn((_el: Element, done: () => void) => {
+        leaveDone = done
+      }),
+    })
+    const { app, host } = renderInteropSlotFallbackTransition('out-in', data)
+
+    data.value.show = true
+    await nextTick()
+
+    expect(leaveDone).toBeDefined()
+    expect(host.querySelector('.fallback')).not.toBeNull()
+
+    app.unmount()
+    await nextTick()
+
+    expect(host.innerHTML).toBe('')
+
+    leaveDone!()
+    await nextTick()
+    expect(host.innerHTML).toBe('')
+  })
+
+  test('unmounts leaving vdom content during an out-in switch', async () => {
+    let leaveDone: (() => void) | undefined
+    const data = ref({
+      show: true,
+      onEnter: vi.fn(),
+      onLeave: vi.fn((_el: Element, done: () => void) => {
+        leaveDone = done
+      }),
+    })
+    const { app, host } = renderInteropSlotFallbackTransition('out-in', data)
+
+    data.value.show = false
+    await nextTick()
+
+    expect(leaveDone).toBeDefined()
+    expect(host.querySelector('.content')).not.toBeNull()
+
+    app.unmount()
+    await nextTick()
+
+    expect(host.innerHTML).toBe('')
+
+    leaveDone!()
+    await nextTick()
+    expect(host.innerHTML).toBe('')
+  })
+
+  test('unmounts a leaving Vapor component used as vdom slot content', async () => {
+    let leaveDone: (() => void) | undefined
+    const Content = defineVaporComponent({
+      setup() {
+        return template('<span class="content">content</span>')()
+      },
+    })
+    const data = ref({
+      show: true,
+      onEnter: vi.fn(),
+      onLeave: vi.fn((_el: Element, done: () => void) => {
+        leaveDone = done
+      }),
+    })
+    const { app, host } = renderInteropSlotFallbackTransition(
+      'out-in',
+      data,
+      () => h(Content),
+    )
+
+    data.value.show = false
+    await nextTick()
+
+    expect(leaveDone).toBeDefined()
+    expect(host.querySelector('.content')).not.toBeNull()
+
+    app.unmount()
+    await nextTick()
+
+    expect(host.innerHTML).toBe('')
+
+    leaveDone!()
+    await nextTick()
+    expect(host.innerHTML).toBe('')
+  })
+
+  test('unmounts leaving Teleport content from its target', async () => {
+    let leaveDone: (() => void) | undefined
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const data = ref({
+      show: true,
+      onEnter: vi.fn(),
+      onLeave: vi.fn((_el: Element, done: () => void) => {
+        leaveDone = done
+      }),
+    })
+    const { app, host } = renderInteropSlotFallbackTransition(
+      'out-in',
+      data,
+      () =>
+        h(Teleport, { to: target }, [
+          h('span', { class: 'content' }, 'content'),
+        ]),
+    )
+
+    data.value.show = false
+    await nextTick()
+
+    expect(leaveDone).toBeDefined()
+    expect(target.querySelector('.content')).not.toBeNull()
+
+    app.unmount()
+    await nextTick()
+
+    expect(host.innerHTML).toBe('')
+    expect(target.innerHTML).toBe('')
+
+    leaveDone!()
+    await nextTick()
+    expect(target.innerHTML).toBe('')
+    target.remove()
   })
 
   test('slot fallback should wait for vdom content enter in in-out mode', async () => {

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -8,10 +8,11 @@ import {
   setBlockKey,
   template,
 } from '../../src'
-import { nextTick, ref } from '@vue/runtime-dom'
-import { compile, makeRender } from '../_utils'
+import { defineComponent, h, nextTick, ref } from '@vue/runtime-dom'
+import { compile, makeInteropRender, makeRender } from '../_utils'
 
 const define = makeRender()
+const defineInterop = makeInteropRender()
 const timeout = (n = 0) => new Promise(r => setTimeout(r, n))
 
 describe('TransitionGroup', () => {
@@ -273,6 +274,39 @@ describe('TransitionGroup', () => {
     leaveDone && leaveDone()
     await nextTick()
     expect(host.querySelectorAll('.item').length).toBe(1)
+  })
+
+  test('preserves vdom slot children', async () => {
+    const items = ref(['a', 'b'])
+    const Child = compile(
+      `<template>
+        <TransitionGroup>
+          <slot />
+        </TransitionGroup>
+      </template>`,
+      ref({}),
+    )
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(Child, null, {
+            default: () =>
+              items.value.map(item => h('div', { key: item }, item)),
+          })
+      },
+    })
+    const { host } = defineInterop(App).render()
+
+    expect(
+      Array.from(host.querySelectorAll('div'), el => el.textContent),
+    ).toEqual(['a', 'b'])
+
+    items.value = ['b', 'c']
+    await nextTick()
+
+    expect(
+      Array.from(host.querySelectorAll('div'), el => el.textContent),
+    ).toEqual(['b', 'c'])
   })
 
   test('registers full transition hooks when Transition is used later', async () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -12127,6 +12127,39 @@ describe('VDOM interop', () => {
     expect(formatHtml(container.innerHTML)).toBe('<div>content</div>')
   })
 
+  test('hydrate VDOM slot content inside Vapor Transition', async () => {
+    const data = reactive({ show: true })
+    const { container } = await testWithVDOMApp(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.VaporChild>
+          <div v-if="data.show">content</div>
+        </components.VaporChild>
+      </template>`,
+      {
+        VaporChild: {
+          code: `<template>
+            <Transition name="fade">
+              <slot />
+            </Transition>
+          </template>`,
+          vapor: true,
+        },
+      },
+      data,
+    )
+
+    data.show = false
+    await nextTick()
+
+    expect(container.querySelector('div')?.className).toBe(
+      'fade-leave-from fade-leave-active',
+    )
+  })
+
   test('hydrate compiled VDOM slot child keeps owner root current after branch update', async () => {
     const data = reactive({
       child: 'span',

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -12145,6 +12145,7 @@ describe('VDOM interop', () => {
             <Transition name="fade">
               <slot />
             </Transition>
+            <span id="after">after</span>
           </template>`,
           vapor: true,
         },
@@ -12157,6 +12158,9 @@ describe('VDOM interop', () => {
 
     expect(container.querySelector('div')?.className).toBe(
       'fade-leave-from fade-leave-active',
+    )
+    expect(container.querySelector('#after')?.previousElementSibling).toBe(
+      container.querySelector('div'),
     )
   })
 

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -12164,6 +12164,65 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate Vapor Transition fallback in out-in mode', async () => {
+    let leaveDone: (() => void) | undefined
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = reactive({
+      show: false,
+      onLeave,
+    })
+    // VDOM SSR preserves an all-comment slot inside Transition, so omit the
+    // dynamic slot entirely to make the fallback the server-rendered branch.
+    const { container } = await testWithVDOMApp(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.VaporChild>
+          <template #default v-if="data.show">
+            <div class="content">content</div>
+          </template>
+        </components.VaporChild>
+      </template>`,
+      {
+        VaporChild: {
+          code: `<script setup>const data = _data</script>
+            <template>
+              <Transition
+                mode="out-in"
+                :css="false"
+                @leave="data.onLeave"
+              >
+                <slot><div class="fallback">fallback</div></slot>
+              </Transition>
+            </template>`,
+          vapor: true,
+        },
+      },
+      data,
+    )
+    const fallback = container.querySelector('.fallback')
+
+    expect(fallback).not.toBeNull()
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+
+    data.show = true
+    await nextTick()
+
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(container.querySelector('.fallback')).toBe(fallback)
+    expect(container.querySelector('.content')).toBeNull()
+
+    leaveDone!()
+    await nextTick()
+
+    expect(container.querySelector('.fallback')).toBeNull()
+    expect(container.querySelector('.content')?.textContent).toBe('content')
+  })
+
   test('hydrate compiled VDOM slot child keeps owner root current after branch update', async () => {
     const data = reactive({
       child: 'span',

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -26,6 +26,7 @@ import { isInteropEnabled } from './vdomInteropState'
 import { isSuspenseEnabled } from './suspense'
 
 export interface VaporTransitionHooks extends TransitionHooks {
+  __vapor: true
   state: TransitionState
   props: TransitionProps
   instance: VaporComponentInstance

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -77,6 +77,7 @@ export const ensureTransitionHooksRegistered = (): void => {
     registered = true
     registerTransitionHooks(
       applyTransitionHooksImpl,
+      applyTransitionLeaveHooksImpl,
       deferBranchUpdateDuringLeaveImpl,
       removeBranchWithLeaveImpl,
     )
@@ -205,6 +206,7 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
     )
 
     let appliedHooks = {
+      __vapor: true,
       state,
       // use proxy to keep props reference stable
       props: propsProxy,
@@ -350,6 +352,7 @@ export function resolveTransitionHooks(
     state,
     instance,
   ) as VaporTransitionHooks
+  hooks.__vapor = true
   hooks.state = state
   hooks.props = props
   hooks.instance = instance as VaporComponentInstance
@@ -448,13 +451,13 @@ function isStructuralTransitionFragment(fragment: VaporFragment): boolean {
   )
 }
 
-function applyTransitionLeaveHooksImpl(
+export function applyTransitionLeaveHooksImpl(
   block: Block,
   enterHooks: VaporTransitionHooks,
   afterLeaveCb: () => void,
-): void {
+): boolean {
   const leavingBlock = resolveTransitionBlock(block)
-  if (!leavingBlock) return undefined
+  if (!leavingBlock) return false
 
   const { props, state, instance } = enterHooks
   const leavingHooks = resolveTransitionHooks(
@@ -509,6 +512,7 @@ function applyTransitionLeaveHooksImpl(
       enterHooks.delayedLeave = delayedLeaveCb
     }
   }
+  return true
 }
 
 function deferBranchUpdateDuringLeaveImpl(

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -140,6 +140,7 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
         applyTransitionHooksImpl,
         () => false,
         () => false,
+        () => false,
       )
     }
 

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -461,6 +461,7 @@ export class SlotFragment
   // can preserve block ownership after the outlet node is gone.
   customElementFallback?: Block
   activeFallback: Block | null = null
+  fallbackInserted = false
   fallbackScope?: EffectScope
   lastNodesValid?: boolean
   pendingRecheck = false
@@ -503,6 +504,9 @@ export class SlotFragment
   ): void {
     this.disposed = false
     insert(this.nodes, parent, anchor, parentSuspense)
+    if (this.activeFallback === this.nodes) {
+      this.fallbackInserted = true
+    }
   }
 
   private removeSlot(parent?: ParentNode): void {
@@ -513,6 +517,7 @@ export class SlotFragment
       // the exposed fallback was just torn down by remove() above; null it
       // so disposeSlotResolution does not remove it a second time
       this.activeFallback = null
+      this.fallbackInserted = false
     }
     this.onContentInvalid.length = 0
     disposeSlotResolution(this)

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -1,7 +1,7 @@
 import { EffectScope } from '@vue/reactivity'
 import {
   type Block,
-  type TransitionOptions,
+  type VaporTransitionHooks,
   insert,
   isValidSlot,
   remove,
@@ -12,7 +12,11 @@ import {
   hasSlotFallback,
   withSlotBoundary,
 } from './slotBoundary'
-import { applyTransitionHooks, isTransitionEnabled } from './transition'
+import {
+  applyTransitionHooks,
+  applyTransitionLeaveHooks,
+  isTransitionEnabled,
+} from './transition'
 import { setBlockKey } from './helpers/setKey'
 
 // Slot resolution.
@@ -93,6 +97,8 @@ export interface SlotResolutionState {
   boundary: SlotBoundaryContext
   // The committed fallback block, or null while content is exposed.
   activeFallback: Block | null
+  // A committed fallback can be invalid and therefore remain detached.
+  fallbackInserted: boolean
   // Detached scope owning the active fallback's effects (see
   // renderFallbackInScope); stopped by clearSlotFallback.
   fallbackScope?: EffectScope
@@ -105,6 +111,7 @@ export interface SlotResolutionState {
   pendingRecheckForce: boolean
   // Reentrancy guard, set while renderSlotFallback runs user fallback code.
   isRenderingFallback: boolean
+  $transition?: VaporTransitionHooks
 
   getContent(): Block
   getParentNode(): ParentNode | null
@@ -145,15 +152,29 @@ function clearSlotFallback(state: SlotResolutionState): void {
   const fallback = state.activeFallback
   if (fallback) {
     const parentNode = state.getParentNode()
-    if (parentNode) {
+    if (state.fallbackInserted && parentNode) {
       remove(fallback, parentNode)
     }
     state.activeFallback = null
+    state.fallbackInserted = false
   }
   if (state.fallbackScope) {
     state.fallbackScope.stop()
     state.fallbackScope = undefined
   }
+}
+
+export function leaveSlotFallback(
+  state: SlotResolutionState,
+  hooks: VaporTransitionHooks,
+  afterLeave: () => void,
+): boolean {
+  const fallback = state.activeFallback
+  if (!fallback || !applyTransitionLeaveHooks(fallback, hooks, afterLeave)) {
+    return false
+  }
+  clearSlotFallback(state)
+  return true
 }
 
 // Renders the fallback into a dedicated detached scope: the fallback must
@@ -196,6 +217,7 @@ export function insertActiveSlotFallback(state: SlotResolutionState): void {
     return
   }
   insert(fallback, parentNode, state.getAnchor())
+  state.fallbackInserted = true
 }
 
 // `detachContent` is true only on the first content -> fallback switch: the
@@ -207,26 +229,23 @@ function commitSlotFallback(
   scope: EffectScope,
   detachContent: boolean,
 ): void {
+  state.activeFallback = block
+  state.fallbackScope = scope
+  state.fallbackInserted = isHydrating
+  if (isTransitionEnabled) {
+    if (state.$transition) {
+      // Match VDOM slot fallback branch identity so fallback enter does not
+      // early-remove the currently leaving slot content.
+      setBlockKey(block, '_fb')
+      state.$transition = applyTransitionHooks(block, state.$transition)
+    }
+  }
   if (detachContent && !isHydrating) {
     const contentInvalidCallbacks = state.boundary.onContentInvalid
     if (contentInvalidCallbacks) {
       for (let i = 0; i < contentInvalidCallbacks.length; i++) {
         contentInvalidCallbacks[i]()
       }
-    }
-  }
-  state.activeFallback = block
-  state.fallbackScope = scope
-  if (isTransitionEnabled) {
-    const transitionState = state as SlotResolutionState & TransitionOptions
-    if (transitionState.$transition) {
-      // Match VDOM slot fallback branch identity so fallback enter does not
-      // early-remove the currently leaving slot content.
-      setBlockKey(block, '_fb')
-      transitionState.$transition = applyTransitionHooks(
-        block,
-        transitionState.$transition,
-      )
     }
   }
   insertActiveSlotFallback(state)

--- a/packages/runtime-vapor/src/transition.ts
+++ b/packages/runtime-vapor/src/transition.ts
@@ -10,6 +10,11 @@ type ApplyTransitionHooksFn = (
   block: Block,
   hooks: VaporTransitionHooks,
 ) => VaporTransitionHooks
+type ApplyTransitionLeaveHooksFn = (
+  block: Block,
+  hooks: VaporTransitionHooks,
+  afterLeave: () => void,
+) => boolean
 type DeferBranchUpdateDuringLeaveFn = (
   frag: DynamicFragment,
   render: BlockFn | undefined,
@@ -26,6 +31,7 @@ type RemoveBranchWithLeaveFn = (
 ) => boolean
 
 export let applyTransitionHooks: ApplyTransitionHooksFn
+export let applyTransitionLeaveHooks: ApplyTransitionLeaveHooksFn
 // Branch-switch scheduling for DynamicFragment.update(): defer the incoming
 // branch while a leave is in progress, and apply leave hooks (plus the
 // deferred re-render for out-in) when tearing down the outgoing branch.
@@ -42,11 +48,13 @@ export let isTransitionEnabled = false
 
 export function registerTransitionHooks(
   applyHooks: ApplyTransitionHooksFn,
+  applyLeaveHooks: ApplyTransitionLeaveHooksFn,
   deferBranchUpdate: DeferBranchUpdateDuringLeaveFn,
   removeBranch: RemoveBranchWithLeaveFn,
 ): void {
   isTransitionEnabled = true
   applyTransitionHooks = applyHooks
+  applyTransitionLeaveHooks = applyLeaveHooks
   deferBranchUpdateDuringLeave = deferBranchUpdate
   removeBranchWithLeave = removeBranch
 }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -40,7 +40,7 @@ import {
   normalizeRef,
   normalizeVNode,
   onScopeDispose,
-  prepareTransitionBranch,
+  prepareTransition,
   queuePostFlushCb,
   queuePostRenderEffect,
   renderSlot,
@@ -196,7 +196,7 @@ function prepareInteropSlotTransitionBranch(
   }
   const branch = resolveTransitionChild([vnode], true)!
   if (transition) {
-    prepareTransitionBranch(
+    prepareTransition(
       branch,
       transition.props,
       transition.state,
@@ -1778,7 +1778,7 @@ function renderVDOMSlot(
                   : null
               if (prevVNode && transition) {
                 // The previous VNode is already the prepared renderer subtree.
-                prepareTransitionBranch(
+                prepareTransition(
                   prevVNode,
                   transition.props,
                   transition.state,

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -22,6 +22,7 @@ import {
   type VaporInteropInterface,
   VaporSlot as VaporSlotVNode,
   callWithAsyncErrorHandling,
+  createCommentVNode,
   createInternalObject,
   createVNode,
   currentInstance,
@@ -31,7 +32,6 @@ import {
   ensureVaporSlotFallback,
   getInheritedScopeIds,
   getTransitionRawChildren,
-  hasTransitionChildChanged,
   invokeDirectiveHook,
   isEmitListener,
   isKeepAlive,
@@ -41,7 +41,7 @@ import {
   normalizeRef,
   normalizeVNode,
   onScopeDispose,
-  prepareTransition,
+  prepareTransitionSwitch,
   queuePostFlushCb,
   queuePostRenderEffect,
   renderSlot,
@@ -181,11 +181,17 @@ function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
   return children.length === 1 ? children[0] : undefined
 }
 
+interface InteropSlotTransition {
+  vnode: VNode
+  deferred: boolean
+}
+
 function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
-  prevVNode?: VNode | null,
-): VNode | undefined {
+  previous: VNode | undefined,
+  resumeAfterLeave: () => void,
+): InteropSlotTransition | undefined {
   const transition = frag.$transition
   const instance = frag.renderInstance
   // The slot renders before VaporTransition propagates its hooks on the first
@@ -197,31 +203,25 @@ function prepareInteropSlotTransition(
     return
   }
   const branch = resolveTransitionChild([vnode], true)!
-  if (transition) {
-    const prepared = prepareTransition(
-      branch,
-      transition.props,
-      transition.state,
-      transition.instance,
-    )
-
-    // Match BaseTransition by refreshing the leaving child's hooks with the latest
-    // transition props. Compare resolved children because KeepAlive and Teleport
-    // may retain the same wrapper VNode while switching their inner child.
-    if (
-      prevVNode &&
-      prepared &&
-      hasTransitionChildChanged(prevVNode, prepared.inner)
-    ) {
-      prepareTransition(
-        prevVNode,
-        transition.props,
-        transition.state,
-        transition.instance,
-      )
+  if (!transition) {
+    return {
+      vnode: branch,
+      deferred: false,
     }
   }
-  return branch
+
+  const prepared = prepareTransitionSwitch(
+    previous,
+    branch,
+    transition.props,
+    transition.state,
+    transition.instance,
+    resumeAfterLeave,
+  )
+  return {
+    vnode: prepared || createCommentVNode(),
+    deferred: transition.state.isLeaving,
+  }
 }
 
 function getInteropTransitionType(vnode: VNode): VNode['type'] | undefined {
@@ -1476,6 +1476,13 @@ function renderVDOMSlot(
   let currentParentNode: ParentNode | null = null
   let currentAnchor: Node | null = null
   let disposed = false
+  let pendingOutIn:
+    | {
+        content: VNode | Block | undefined
+        placeholder: VNode
+        valid: boolean
+      }
+    | undefined
   const scope = effectScope()
   const slotBoundary = frag.slotBoundary
   let isContentUpdateRecheck = false
@@ -1581,6 +1588,49 @@ function renderVDOMSlot(
     notifyUpdated()
   }
 
+  const trackSlotVNode = (vnode: VNode): void => {
+    const refreshSlotVNode = () => {
+      const prevValid = contentState.valid
+      const prevOutput = frag.nodes
+      setRenderedContent(vnode)
+      recheckResolutionAfterContentUpdate()
+      if (
+        contentState.valid !== prevValid ||
+        !isSameResolvedOutput(prevOutput, frag.nodes)
+      ) {
+        notifyUpdated()
+      }
+    }
+    trackSlotVNodeUpdatesWithRefresh(
+      vnode,
+      refreshSlotVNode,
+      notifyBeforeUpdate,
+    )
+  }
+
+  const patchSlotVNode = (
+    previous: VNode | null,
+    next: VNode,
+    slotScopeIds: string[] | null,
+    valid: boolean,
+  ): void => {
+    frag.vnode = next
+    frag.$key = getVNodeKey(next)
+    trackSlotVNode(next)
+    internals.p(
+      previous,
+      next,
+      currentParentNode!,
+      currentAnchor,
+      parentComponent as any,
+      suspense,
+      undefined,
+      slotScopeIds,
+    )
+    setRenderedContent(next, valid)
+    finishContentUpdate()
+  }
+
   const removeRenderedContent = (
     rendered: VNode | Block,
     parentNode?: ParentNode,
@@ -1598,6 +1648,46 @@ function renderVDOMSlot(
     } else {
       remove(rendered, contentDetached ? undefined : parentNode)
     }
+  }
+
+  const resumeOutIn = (): void => {
+    // A user leave hook may finish synchronously while the renderer is still
+    // patching the placeholder. Resume after that patch.
+    queuePostFlushCb(() => {
+      const pending = pendingOutIn
+      pendingOutIn = undefined
+      if (!pending || disposed || !currentParentNode) {
+        return
+      }
+
+      const content = pending.content
+      if (isVNode(content)) {
+        const pendingTransition = prepareInteropSlotTransition(
+          frag,
+          content,
+          undefined,
+          NOOP,
+        )
+        const pendingVNode = pendingTransition
+          ? pendingTransition.vnode
+          : content
+        patchSlotVNode(
+          pending.placeholder,
+          pendingVNode,
+          content.slotScopeIds,
+          pending.valid,
+        )
+      } else {
+        frag.vnode = null
+        frag.$key = undefined
+        removeRenderedContent(pending.placeholder, currentParentNode)
+        if (content) {
+          insert(content, currentParentNode, currentAnchor, suspense)
+        }
+        setRenderedContent(content || null, pending.valid)
+        finishContentUpdate()
+      }
+    })
   }
 
   frag.insert = (parentNode, anchor, parentSuspense) => {
@@ -1637,6 +1727,7 @@ function renderVDOMSlot(
     }
     scope.stop()
     disposed = true
+    pendingOutIn = undefined
     if (contentState.rendered) {
       removeRenderedContent(contentState.rendered, parentNode)
     }
@@ -1692,12 +1783,15 @@ function renderVDOMSlot(
                   ? slotContent
                   : undefined
               if (isVNode(hydratedContent)) {
-                const transitionBranch = prepareInteropSlotTransition(
+                const hydratedTransition = prepareInteropSlotTransition(
                   frag,
                   hydratedContent,
+                  undefined,
+                  NOOP,
                 )
-                const renderedHydratedContent =
-                  transitionBranch || hydratedContent
+                const renderedHydratedContent = hydratedTransition
+                  ? hydratedTransition.vnode
+                  : hydratedContent
                 frag.vnode = renderedHydratedContent
                 frag.$key = getVNodeKey(renderedHydratedContent)
                 const refreshSlotVNode = () => {
@@ -1749,6 +1843,12 @@ function renderVDOMSlot(
               return
             }
 
+            if (pendingOutIn) {
+              pendingOutIn.content = slotContent
+              pendingOutIn.valid = slotContentValid
+              return
+            }
+
             if (isVNode(slotContent)) {
               const prevRendered = contentState.rendered
               if (slotResolutionState.activeFallback && !slotContentValid) {
@@ -1769,46 +1869,48 @@ function renderVDOMSlot(
                 (!slotResolutionState.activeFallback || contentState.valid)
                   ? prevRendered
                   : null
-              const transitionBranch = prepareInteropSlotTransition(
+              const nextTransition = prepareInteropSlotTransition(
                 frag,
                 slotContent,
-                prevVNode,
+                prevVNode || undefined,
+                resumeOutIn,
               )
-              const renderedSlotContent = transitionBranch || slotContent
-              frag.vnode = renderedSlotContent
-              frag.$key = getVNodeKey(renderedSlotContent)
-              const refreshSlotVNode = () => {
-                const prevValid = contentState.valid
-                const prevOutput = frag.nodes
-                setRenderedContent(renderedSlotContent)
-                recheckResolutionAfterContentUpdate()
-                if (
-                  contentState.valid !== prevValid ||
-                  !isSameResolvedOutput(prevOutput, frag.nodes)
-                ) {
-                  notifyUpdated()
+              const renderedSlotContent = nextTransition
+                ? nextTransition.vnode
+                : slotContent
+              if (prevVNode && nextTransition && nextTransition.deferred) {
+                pendingOutIn = {
+                  content: slotContent,
+                  placeholder: renderedSlotContent,
+                  valid: slotContentValid,
                 }
+                frag.vnode = renderedSlotContent
+                frag.$key = getVNodeKey(renderedSlotContent)
+                // The renderer owns the placeholder while the outgoing VNode
+                // remains in the DOM until its leave finishes.
+                contentState.rendered = renderedSlotContent
+                internals.p(
+                  prevVNode,
+                  renderedSlotContent,
+                  currentParentNode!,
+                  currentAnchor,
+                  parentComponent as any,
+                  suspense,
+                  undefined,
+                  null,
+                )
+                return
               }
-              trackSlotVNodeUpdatesWithRefresh(
-                renderedSlotContent,
-                refreshSlotVNode,
-                notifyBeforeUpdate,
-              )
               if (prevRendered && !prevIsVNode) {
                 removeRenderedContent(prevRendered, currentParentNode!)
               }
-              internals.p(
+              // pass slotScopeIds for :slotted styles
+              patchSlotVNode(
                 prevVNode,
                 renderedSlotContent,
-                currentParentNode!,
-                currentAnchor,
-                parentComponent as any,
-                suspense,
-                undefined, // namespace
-                slotContent.slotScopeIds, // pass slotScopeIds for :slotted styles
+                slotContent.slotScopeIds,
+                slotContentValid,
               )
-              setRenderedContent(renderedSlotContent, slotContentValid)
-              finishContentUpdate()
               return
             }
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -181,19 +181,18 @@ function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
   return children.length === 1 ? children[0] : undefined
 }
 
-interface InteropSlotTransition {
-  vnode: VNode
-  deferred: boolean
-}
-
 function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
   previous: VNode | undefined,
   resumeAfterLeave: () => void,
-): InteropSlotTransition | undefined {
+): VNode | undefined {
   const transition = frag.$transition
   const instance = frag.renderInstance
+  // TransitionGroup owns list resolution; never collapse its VDOM fragment
+  // into the single branch expected by BaseTransition.
+  if (transition && transition.applyGroup) return
+
   // The slot renders before VaporTransition propagates its hooks on the first
   // render, but it must already use the same renderer branch as BaseTransition.
   if (
@@ -204,24 +203,19 @@ function prepareInteropSlotTransition(
   }
   const branch = resolveTransitionChild([vnode], true)!
   if (!transition) {
-    return {
-      vnode: branch,
-      deferred: false,
-    }
+    return branch
   }
 
-  const prepared = prepareTransitionSwitch(
-    previous,
-    branch,
-    transition.props,
-    transition.state,
-    transition.instance,
-    resumeAfterLeave,
+  return (
+    prepareTransitionSwitch(
+      previous,
+      branch,
+      transition.props,
+      transition.state,
+      transition.instance,
+      resumeAfterLeave,
+    ) || createCommentVNode()
   )
-  return {
-    vnode: prepared || createCommentVNode(),
-    deferred: transition.state.isLeaving,
-  }
 }
 
 function getInteropTransitionType(vnode: VNode): VNode['type'] | undefined {
@@ -1662,15 +1656,9 @@ function renderVDOMSlot(
 
       const content = pending.content
       if (isVNode(content)) {
-        const pendingTransition = prepareInteropSlotTransition(
-          frag,
-          content,
-          undefined,
-          NOOP,
-        )
-        const pendingVNode = pendingTransition
-          ? pendingTransition.vnode
-          : content
+        const pendingVNode =
+          prepareInteropSlotTransition(frag, content, undefined, NOOP) ||
+          content
         patchSlotVNode(
           pending.placeholder,
           pendingVNode,
@@ -1789,9 +1777,8 @@ function renderVDOMSlot(
                   undefined,
                   NOOP,
                 )
-                const renderedHydratedContent = hydratedTransition
-                  ? hydratedTransition.vnode
-                  : hydratedContent
+                const renderedHydratedContent =
+                  hydratedTransition || hydratedContent
                 frag.vnode = renderedHydratedContent
                 frag.$key = getVNodeKey(renderedHydratedContent)
                 const refreshSlotVNode = () => {
@@ -1875,10 +1862,14 @@ function renderVDOMSlot(
                 prevVNode || undefined,
                 resumeOutIn,
               )
-              const renderedSlotContent = nextTransition
-                ? nextTransition.vnode
-                : slotContent
-              if (prevVNode && nextTransition && nextTransition.deferred) {
+              const renderedSlotContent = nextTransition || slotContent
+              const transition = frag.$transition
+              if (
+                prevVNode &&
+                nextTransition &&
+                transition &&
+                transition.state.isLeaving
+              ) {
                 pendingOutIn = {
                   content: slotContent,
                   placeholder: renderedSlotContent,

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -15,6 +15,7 @@ import {
   type Slots,
   Static,
   type SuspenseBoundary,
+  type TransitionElement,
   type TransitionHooks,
   type VNode,
   type VNodeArrayChildren,
@@ -38,6 +39,7 @@ import {
   isVNode,
   isHydrating as isVdomHydrating,
   isHydratingEnabled as isVdomHydratingEnabled,
+  leaveCbKey,
   normalizeRef,
   normalizeVNode,
   onScopeDispose,
@@ -153,6 +155,8 @@ import {
 import type { NodeRef } from './apiTemplateRef'
 import {
   ensureTransitionHooksRegistered,
+  getTransitionElement,
+  resolveTransitionBlock,
   setTransitionHooks as setVaporTransitionHooks,
 } from './components/Transition'
 import { isVaporTransition, registerTransitionInterop } from './transition'
@@ -244,15 +248,29 @@ function getVNodeKey(vnode: VNode | undefined): VNode['key'] | undefined {
   return child && child.key
 }
 
-function getInteropTransitionElement(vnode: VNode): Element | undefined {
-  if (vnode.component) {
-    return getInteropTransitionElement(vnode.component.subTree)
+function getInteropTransitionElement(
+  vnode: VNode | undefined,
+): Element | undefined {
+  if (!vnode) return
+  const component = vnode.component as
+    | ComponentInternalInstance
+    | VaporComponentInstance
+    | null
+  if (isVaporComponent(component)) {
+    const block = component.block && resolveTransitionBlock(component.block)
+    return block && getTransitionElement(block)
+  }
+  if (component) {
+    return getInteropTransitionElement(component.subTree)
   }
   if (vnode.el instanceof Element) {
     return vnode.el
   }
-  if (vnode.type === Fragment) {
-    const child = getRawTransitionChild(vnode)
+  if (
+    (vnode.type === Fragment || vnode.shapeFlag & ShapeFlags.TELEPORT) &&
+    isArray(vnode.children)
+  ) {
+    const child = resolveTransitionChild(vnode.children as VNode[])
     if (child) return getInteropTransitionElement(child)
   }
 }
@@ -1492,6 +1510,7 @@ function renderVDOMSlot(
         content: VNode | Block | undefined
         placeholder: VNode | null
         contentValid: boolean
+        leavingElement?: Element
       }
     | undefined
   const scope = effectScope()
@@ -1754,7 +1773,13 @@ function renderVDOMSlot(
     }
     scope.stop()
     disposed = true
+    // out-in transfers logical ownership before the outgoing branch's
+    // physical leave finishes, so disposal must cancel that leave explicitly.
+    const leavingElement = pendingOutIn && pendingOutIn.leavingElement
     pendingOutIn = undefined
+    const leave =
+      leavingElement && (leavingElement as TransitionElement)[leaveCbKey]
+    if (leave) leave(true)
     if (contentState.rendered) {
       removeRenderedContent(contentState.rendered, parentNode)
     }
@@ -1895,10 +1920,16 @@ function renderVDOMSlot(
                 transition
               ) {
                 if (mode === 'out-in') {
+                  const fallback = slotResolutionState.activeFallback
+                  const leavingBlock =
+                    fallback && resolveTransitionBlock(fallback)
+                  const leavingElement =
+                    leavingBlock && getTransitionElement(leavingBlock)
                   pendingOutIn = {
                     content: slotContent,
                     placeholder: null,
                     contentValid: true,
+                    leavingElement,
                   }
                   if (
                     leaveSlotFallback(
@@ -1949,10 +1980,13 @@ function renderVDOMSlot(
                       resumeOutIn,
                     )
                   ) {
+                    const leavingElement =
+                      getInteropTransitionElement(prevVNode)
                     pendingOutIn = {
                       content: slotContent,
                       placeholder,
                       contentValid: false,
+                      leavingElement,
                     }
                     frag.vnode = placeholder
                     frag.$key = getVNodeKey(placeholder)
@@ -1992,10 +2026,12 @@ function renderVDOMSlot(
                 transition &&
                 transition.state.isLeaving
               ) {
+                const leavingElement = getInteropTransitionElement(prevVNode)
                 pendingOutIn = {
                   content: slotContent,
                   placeholder: nextVNode,
                   contentValid: slotContentValid,
+                  leavingElement,
                 }
                 frag.vnode = nextVNode
                 frag.$key = getVNodeKey(nextVNode)

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -31,6 +31,7 @@ import {
   ensureVaporSlotFallback,
   getInheritedScopeIds,
   getTransitionRawChildren,
+  hasTransitionChildChanged,
   invokeDirectiveHook,
   isEmitListener,
   isKeepAlive,
@@ -183,6 +184,7 @@ function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
 function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
+  prevVNode?: VNode | null,
 ): VNode | undefined {
   const transition = frag.$transition
   const instance = frag.renderInstance
@@ -196,12 +198,28 @@ function prepareInteropSlotTransition(
   }
   const branch = resolveTransitionChild([vnode], true)!
   if (transition) {
-    prepareTransition(
+    const prepared = prepareTransition(
       branch,
       transition.props,
       transition.state,
       transition.instance,
     )
+
+    // Match BaseTransition by refreshing the leaving child's hooks with the latest
+    // transition props. Compare resolved children because KeepAlive and Teleport
+    // may retain the same wrapper VNode while switching their inner child.
+    if (
+      prevVNode &&
+      prepared &&
+      hasTransitionChildChanged(prevVNode, prepared.inner)
+    ) {
+      prepareTransition(
+        prevVNode,
+        transition.props,
+        transition.state,
+        transition.instance,
+      )
+    }
   }
   return branch
 }
@@ -1745,10 +1763,16 @@ function renderVDOMSlot(
                 finishContentUpdate()
                 return
               }
-              const transition = frag.$transition
+              const prevIsVNode = isVNode(prevRendered)
+              const prevVNode =
+                prevIsVNode &&
+                (!slotResolutionState.activeFallback || contentState.valid)
+                  ? prevRendered
+                  : null
               const transitionBranch = prepareInteropSlotTransition(
                 frag,
                 slotContent,
+                prevVNode,
               )
               const renderedSlotContent = transitionBranch || slotContent
               frag.vnode = renderedSlotContent
@@ -1770,21 +1794,6 @@ function renderVDOMSlot(
                 refreshSlotVNode,
                 notifyBeforeUpdate,
               )
-              const prevIsVNode = isVNode(prevRendered)
-              const prevVNode =
-                prevIsVNode &&
-                (!slotResolutionState.activeFallback || contentState.valid)
-                  ? prevRendered
-                  : null
-              if (prevVNode && transition) {
-                // The previous VNode is already the prepared renderer subtree.
-                prepareTransition(
-                  prevVNode,
-                  transition.props,
-                  transition.state,
-                  transition.instance,
-                )
-              }
               if (prevRendered && !prevIsVNode) {
                 removeRenderedContent(prevRendered, currentParentNode!)
               }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -266,10 +266,10 @@ function getInteropTransitionElement(
   if (vnode.el instanceof Element) {
     return vnode.el
   }
-  if (
-    (vnode.type === Fragment || vnode.shapeFlag & ShapeFlags.TELEPORT) &&
-    isArray(vnode.children)
-  ) {
+  if (vnode.type === Fragment) {
+    const child = getRawTransitionChild(vnode)
+    if (child) return getInteropTransitionElement(child)
+  } else if (vnode.shapeFlag & ShapeFlags.TELEPORT && isArray(vnode.children)) {
     const child = resolveTransitionChild(vnode.children as VNode[])
     if (child) return getInteropTransitionElement(child)
   }
@@ -2875,7 +2875,7 @@ function isSameResolvedOutput(prev: Block, next: Block): boolean {
 }
 
 function normalizeInteropSlots(rawSlots: any): any {
-  if (rawSlots == null) return rawSlots
+  if (rawSlots == null) return EMPTY_OBJ
   // VDOM children bypass runtime-core's component slot initialization here,
   // so normalize raw children into a callable default slot first.
   if (!isObject(rawSlots) || isArray(rawSlots) || isVNode(rawSlots)) {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -40,9 +40,11 @@ import {
   normalizeRef,
   normalizeVNode,
   onScopeDispose,
+  prepareTransitionBranch,
   queuePostFlushCb,
   queuePostRenderEffect,
   renderSlot,
+  resolveTransitionChild,
   restoreCurrentInstance,
   setCurrentInstance,
   setTransitionHooks as setVNodeTransitionHooks,
@@ -150,7 +152,7 @@ import {
   ensureTransitionHooksRegistered,
   setTransitionHooks as setVaporTransitionHooks,
 } from './components/Transition'
-import { registerTransitionInterop } from './transition'
+import { isVaporTransition, registerTransitionInterop } from './transition'
 import { interopKey, setInteropEnabled } from './vdomInteropState'
 import {
   type KeepAliveInstance,
@@ -176,6 +178,32 @@ function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
   if (!vnode) return
   const children = getTransitionRawChildren([vnode])
   return children.length === 1 ? children[0] : undefined
+}
+
+function prepareInteropSlotTransitionBranch(
+  frag: RenderContextFragment,
+  vnode: VNode,
+): VNode | undefined {
+  const transition = frag.$transition
+  const instance = frag.renderInstance
+  // The slot renders before VaporTransition propagates its hooks on the first
+  // render, but it must already use the same renderer branch as BaseTransition.
+  if (
+    !transition &&
+    !(instance && isVaporTransition(instance.type as VaporComponent))
+  ) {
+    return
+  }
+  const branch = resolveTransitionChild([vnode], true)!
+  if (transition) {
+    prepareTransitionBranch(
+      branch,
+      transition.props,
+      transition.state,
+      transition.instance,
+    )
+  }
+  return branch
 }
 
 function getInteropTransitionType(vnode: VNode): VNode['type'] | undefined {
@@ -1646,36 +1674,50 @@ function renderVDOMSlot(
                   ? slotContent
                   : undefined
               if (isVNode(hydratedContent)) {
-                frag.vnode = hydratedContent
-                frag.$key = getVNodeKey(hydratedContent)
+                const transitionBranch = prepareInteropSlotTransitionBranch(
+                  frag,
+                  hydratedContent,
+                )
+                const renderedHydratedContent =
+                  transitionBranch || hydratedContent
+                frag.vnode = renderedHydratedContent
+                frag.$key = getVNodeKey(renderedHydratedContent)
                 const refreshSlotVNode = () => {
-                  frag.nodes = resolveVNodeNodes(hydratedContent)
+                  frag.nodes = resolveVNodeNodes(renderedHydratedContent)
                   notifyUpdated()
                 }
                 trackSlotVNodeUpdatesWithRefresh(
-                  hydratedContent,
+                  renderedHydratedContent,
                   refreshSlotVNode,
                   notifyBeforeUpdate,
                 )
                 // Forwarded slot fragments that resolve to an empty SSR range
                 // should stay on that range instead of re-entering it through
                 // generic Fragment hydration.
+                const hydrationParent = parentNode(currentHydrationNode!)!
                 if (
                   !hydrateForwardedEmptySlotFragment(
-                    hydratedContent,
+                    renderedHydratedContent,
                     parentComponent,
                     slotContentValid,
                   )
                 ) {
-                  hydrateVNode(hydratedContent, parentComponent as any)
+                  hydrateVNode(
+                    renderedHydratedContent,
+                    parentComponent as any,
+                    renderedHydratedContent === hydratedContent
+                      ? null
+                      : hydratedContent.slotScopeIds,
+                  )
                 }
                 // Remember the slot outlet insertion point outside the hydrated VNode range.
                 // The hydrated content itself may be removed by later VDOM patches before the
                 // fallback is inserted.
-                const hydratedEnd = hydratedContent.anchor as Node
-                currentParentNode = hydratedEnd.parentNode as ParentNode
-                currentAnchor = hydratedEnd.nextSibling
-                setRenderedContent(hydratedContent, slotContentValid)
+                currentParentNode = hydrationParent
+                currentAnchor = internals.n(
+                  renderedHydratedContent,
+                ) as Node | null
+                setRenderedContent(renderedHydratedContent, slotContentValid)
               } else if (hydratedContent) {
                 frag.vnode = null
                 frag.$key = undefined
@@ -1703,12 +1745,18 @@ function renderVDOMSlot(
                 finishContentUpdate()
                 return
               }
-              frag.vnode = slotContent
-              frag.$key = getVNodeKey(slotContent)
+              const transition = frag.$transition
+              const transitionBranch = prepareInteropSlotTransitionBranch(
+                frag,
+                slotContent,
+              )
+              const renderedSlotContent = transitionBranch || slotContent
+              frag.vnode = renderedSlotContent
+              frag.$key = getVNodeKey(renderedSlotContent)
               const refreshSlotVNode = () => {
                 const prevValid = contentState.valid
                 const prevOutput = frag.nodes
-                setRenderedContent(slotContent)
+                setRenderedContent(renderedSlotContent)
                 recheckResolutionAfterContentUpdate()
                 if (
                   contentState.valid !== prevValid ||
@@ -1718,7 +1766,7 @@ function renderVDOMSlot(
                 }
               }
               trackSlotVNodeUpdatesWithRefresh(
-                slotContent,
+                renderedSlotContent,
                 refreshSlotVNode,
                 notifyBeforeUpdate,
               )
@@ -1728,12 +1776,21 @@ function renderVDOMSlot(
                 (!slotResolutionState.activeFallback || contentState.valid)
                   ? prevRendered
                   : null
+              if (prevVNode && transition) {
+                // The previous VNode is already the prepared renderer subtree.
+                prepareTransitionBranch(
+                  prevVNode,
+                  transition.props,
+                  transition.state,
+                  transition.instance,
+                )
+              }
               if (prevRendered && !prevIsVNode) {
                 removeRenderedContent(prevRendered, currentParentNode!)
               }
               internals.p(
                 prevVNode,
-                slotContent,
+                renderedSlotContent,
                 currentParentNode!,
                 currentAnchor,
                 parentComponent as any,
@@ -1741,7 +1798,7 @@ function renderVDOMSlot(
                 undefined, // namespace
                 slotContent.slotScopeIds, // pass slotScopeIds for :slotted styles
               )
-              setRenderedContent(slotContent, slotContentValid)
+              setRenderedContent(renderedSlotContent, slotContentValid)
               finishContentUpdate()
               return
             }
@@ -1833,6 +1890,7 @@ export const vaporInteropPlugin: Plugin = app => {
 function hydrateVNode(
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null,
+  slotScopeIds: string[] | null = null,
 ) {
   const node = currentHydrationNode!
   if (!vdomHydrateNode) vdomHydrateNode = ensureHydrationRenderer().hydrateNode!
@@ -1841,7 +1899,7 @@ function hydrateVNode(
     vnode,
     parentComponent,
     null,
-    null,
+    slotScopeIds,
     false,
   )
   if (nextNode) setCurrentHydrationNode(nextNode)

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -88,6 +88,7 @@ import {
   NOOP,
   ShapeFlags,
   extend,
+  hasOwn,
   isArray,
   isFunction,
   isObject,
@@ -181,20 +182,37 @@ function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
   return children.length === 1 ? children[0] : undefined
 }
 
+function isVaporTransitionHooks(
+  hooks: TransitionHooks | undefined,
+): hooks is VaporTransitionHooks {
+  return !!(
+    hooks &&
+    hasOwn(hooks, 'state') &&
+    hasOwn(hooks, 'props') &&
+    hasOwn(hooks, 'instance')
+  )
+}
+
 function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
   previous: VNode | undefined,
   resumeAfterLeave: () => void,
 ): VNode | undefined {
-  const transition = frag.$transition
+  const transition = frag.$transition as TransitionHooks | undefined
   const instance = frag.renderInstance
+  // Hooks inherited from VDOM BaseTransition already belong to its state
+  // machine. Only forward them through the Vapor slot boundary.
+  if (transition && !isVaporTransitionHooks(transition)) {
+    setVNodeTransitionHooks(vnode, transition)
+    return
+  }
   // TransitionGroup owns list resolution; never collapse its VDOM fragment
   // into the single branch expected by BaseTransition.
   if (transition && transition.applyGroup) return
 
-  // The slot renders before VaporTransition propagates its hooks on the first
-  // render, but it must already use the same renderer branch as BaseTransition.
+  // The slot can render before VaporTransition propagates its hooks, notably
+  // during hydration, but it must already use BaseTransition's branch shape.
   if (
     !transition &&
     !(instance && isVaporTransition(instance.type as VaporComponent))
@@ -1474,7 +1492,7 @@ function renderVDOMSlot(
     | {
         content: VNode | Block | undefined
         placeholder: VNode
-        valid: boolean
+        contentValid: boolean
       }
     | undefined
   const scope = effectScope()
@@ -1582,26 +1600,6 @@ function renderVDOMSlot(
     notifyUpdated()
   }
 
-  const trackSlotVNode = (vnode: VNode): void => {
-    const refreshSlotVNode = () => {
-      const prevValid = contentState.valid
-      const prevOutput = frag.nodes
-      setRenderedContent(vnode)
-      recheckResolutionAfterContentUpdate()
-      if (
-        contentState.valid !== prevValid ||
-        !isSameResolvedOutput(prevOutput, frag.nodes)
-      ) {
-        notifyUpdated()
-      }
-    }
-    trackSlotVNodeUpdatesWithRefresh(
-      vnode,
-      refreshSlotVNode,
-      notifyBeforeUpdate,
-    )
-  }
-
   const patchSlotVNode = (
     previous: VNode | null,
     next: VNode,
@@ -1610,7 +1608,19 @@ function renderVDOMSlot(
   ): void => {
     frag.vnode = next
     frag.$key = getVNodeKey(next)
-    trackSlotVNode(next)
+    const refreshSlotVNode = () => {
+      const prevValid = contentState.valid
+      const prevOutput = frag.nodes
+      setRenderedContent(next)
+      recheckResolutionAfterContentUpdate()
+      if (
+        contentState.valid !== prevValid ||
+        !isSameResolvedOutput(prevOutput, frag.nodes)
+      ) {
+        notifyUpdated()
+      }
+    }
+    trackSlotVNodeUpdatesWithRefresh(next, refreshSlotVNode, notifyBeforeUpdate)
     internals.p(
       previous,
       next,
@@ -1656,14 +1666,14 @@ function renderVDOMSlot(
 
       const content = pending.content
       if (isVNode(content)) {
-        const pendingVNode =
+        const nextVNode =
           prepareInteropSlotTransition(frag, content, undefined, NOOP) ||
           content
         patchSlotVNode(
           pending.placeholder,
-          pendingVNode,
+          nextVNode,
           content.slotScopeIds,
-          pending.valid,
+          pending.contentValid,
         )
       } else {
         frag.vnode = null
@@ -1672,7 +1682,7 @@ function renderVDOMSlot(
         if (content) {
           insert(content, currentParentNode, currentAnchor, suspense)
         }
-        setRenderedContent(content || null, pending.valid)
+        setRenderedContent(content || null, pending.contentValid)
         finishContentUpdate()
       }
     })
@@ -1771,22 +1781,21 @@ function renderVDOMSlot(
                   ? slotContent
                   : undefined
               if (isVNode(hydratedContent)) {
-                const hydratedTransition = prepareInteropSlotTransition(
+                const transitionChild = prepareInteropSlotTransition(
                   frag,
                   hydratedContent,
                   undefined,
                   NOOP,
                 )
-                const renderedHydratedContent =
-                  hydratedTransition || hydratedContent
-                frag.vnode = renderedHydratedContent
-                frag.$key = getVNodeKey(renderedHydratedContent)
+                const hydrationVNode = transitionChild || hydratedContent
+                frag.vnode = hydrationVNode
+                frag.$key = getVNodeKey(hydrationVNode)
                 const refreshSlotVNode = () => {
-                  frag.nodes = resolveVNodeNodes(renderedHydratedContent)
+                  frag.nodes = resolveVNodeNodes(hydrationVNode)
                   notifyUpdated()
                 }
                 trackSlotVNodeUpdatesWithRefresh(
-                  renderedHydratedContent,
+                  hydrationVNode,
                   refreshSlotVNode,
                   notifyBeforeUpdate,
                 )
@@ -1796,15 +1805,15 @@ function renderVDOMSlot(
                 const hydrationParent = parentNode(currentHydrationNode!)!
                 if (
                   !hydrateForwardedEmptySlotFragment(
-                    renderedHydratedContent,
+                    hydrationVNode,
                     parentComponent,
                     slotContentValid,
                   )
                 ) {
                   hydrateVNode(
-                    renderedHydratedContent,
+                    hydrationVNode,
                     parentComponent as any,
-                    renderedHydratedContent === hydratedContent
+                    hydrationVNode === hydratedContent
                       ? null
                       : hydratedContent.slotScopeIds,
                   )
@@ -1813,10 +1822,8 @@ function renderVDOMSlot(
                 // The hydrated content itself may be removed by later VDOM patches before the
                 // fallback is inserted.
                 currentParentNode = hydrationParent
-                currentAnchor = internals.n(
-                  renderedHydratedContent,
-                ) as Node | null
-                setRenderedContent(renderedHydratedContent, slotContentValid)
+                currentAnchor = internals.n(hydrationVNode) as Node | null
+                setRenderedContent(hydrationVNode, slotContentValid)
               } else if (hydratedContent) {
                 frag.vnode = null
                 frag.$key = undefined
@@ -1832,7 +1839,7 @@ function renderVDOMSlot(
 
             if (pendingOutIn) {
               pendingOutIn.content = slotContent
-              pendingOutIn.valid = slotContentValid
+              pendingOutIn.contentValid = slotContentValid
               return
             }
 
@@ -1856,33 +1863,33 @@ function renderVDOMSlot(
                 (!slotResolutionState.activeFallback || contentState.valid)
                   ? prevRendered
                   : null
-              const nextTransition = prepareInteropSlotTransition(
+              const transitionChild = prepareInteropSlotTransition(
                 frag,
                 slotContent,
                 prevVNode || undefined,
                 resumeOutIn,
               )
-              const renderedSlotContent = nextTransition || slotContent
+              const nextVNode = transitionChild || slotContent
               const transition = frag.$transition
               if (
                 prevVNode &&
-                nextTransition &&
+                transitionChild &&
                 transition &&
                 transition.state.isLeaving
               ) {
                 pendingOutIn = {
                   content: slotContent,
-                  placeholder: renderedSlotContent,
-                  valid: slotContentValid,
+                  placeholder: nextVNode,
+                  contentValid: slotContentValid,
                 }
-                frag.vnode = renderedSlotContent
-                frag.$key = getVNodeKey(renderedSlotContent)
+                frag.vnode = nextVNode
+                frag.$key = getVNodeKey(nextVNode)
                 // The renderer owns the placeholder while the outgoing VNode
                 // remains in the DOM until its leave finishes.
-                contentState.rendered = renderedSlotContent
+                contentState.rendered = nextVNode
                 internals.p(
                   prevVNode,
-                  renderedSlotContent,
+                  nextVNode,
                   currentParentNode!,
                   currentAnchor,
                   parentComponent as any,
@@ -1895,10 +1902,11 @@ function renderVDOMSlot(
               if (prevRendered && !prevIsVNode) {
                 removeRenderedContent(prevRendered, currentParentNode!)
               }
-              // pass slotScopeIds for :slotted styles
+              // Preserve the original slot wrapper's scope IDs for :slotted
+              // styles.
               patchSlotVNode(
                 prevVNode,
-                renderedSlotContent,
+                nextVNode,
                 slotContent.slotScopeIds,
                 slotContentValid,
               )

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -41,6 +41,7 @@ import {
   normalizeRef,
   normalizeVNode,
   onScopeDispose,
+  prepareTransitionLeave,
   prepareTransitionSwitch,
   queuePostFlushCb,
   queuePostRenderEffect,
@@ -88,7 +89,6 @@ import {
   NOOP,
   ShapeFlags,
   extend,
-  hasOwn,
   isArray,
   isFunction,
   isObject,
@@ -141,6 +141,7 @@ import {
   type SlotResolutionState,
   disposeSlotResolution,
   insertActiveSlotFallback,
+  leaveSlotFallback,
   markSlotResolutionDirty,
   recheckSlotResolution,
 } from './slotFragment'
@@ -185,12 +186,7 @@ function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
 function isVaporTransitionHooks(
   hooks: TransitionHooks | undefined,
 ): hooks is VaporTransitionHooks {
-  return !!(
-    hooks &&
-    hasOwn(hooks, 'state') &&
-    hasOwn(hooks, 'props') &&
-    hasOwn(hooks, 'instance')
-  )
+  return !!hooks && (hooks as VaporTransitionHooks).__vapor === true
 }
 
 function prepareInteropSlotTransition(
@@ -198,6 +194,7 @@ function prepareInteropSlotTransition(
   vnode: VNode,
   previous: VNode | undefined,
   resumeAfterLeave: () => void,
+  delayedLeaveSource?: TransitionHooks,
 ): VNode | undefined {
   const transition = frag.$transition as TransitionHooks | undefined
   const instance = frag.renderInstance
@@ -232,6 +229,7 @@ function prepareInteropSlotTransition(
       transition.state,
       transition.instance,
       resumeAfterLeave,
+      delayedLeaveSource || transition,
     ) || createCommentVNode()
   )
 }
@@ -1488,10 +1486,11 @@ function renderVDOMSlot(
   let currentParentNode: ParentNode | null = null
   let currentAnchor: Node | null = null
   let disposed = false
+  let pendingInOutVNode: VNode | undefined
   let pendingOutIn:
     | {
         content: VNode | Block | undefined
-        placeholder: VNode
+        placeholder: VNode | null
         contentValid: boolean
       }
     | undefined
@@ -1501,6 +1500,24 @@ function renderVDOMSlot(
   let localFallback: BlockFn | undefined
   let slotResolutionState!: SlotResolutionState
   const cleanupInvalidContent = () => {
+    const pending = pendingInOutVNode
+    if (pending) {
+      pendingInOutVNode = undefined
+      const transition = slotResolutionState.$transition
+      const fallback = slotResolutionState.activeFallback
+      if (transition) {
+        prepareTransitionLeave(
+          pending,
+          fallback && isValidSlot(fallback) ? transition : undefined,
+          transition.props,
+          transition.state,
+          transition.instance,
+          NOOP,
+        )
+      }
+      internals.um(pending, parentComponent as any, null, true)
+      return
+    }
     if (currentParentNode) {
       removeAttachedNodes(contentState.nodes, currentParentNode)
     }
@@ -1524,9 +1541,19 @@ function renderVDOMSlot(
   slotResolutionState = {
     boundary,
     activeFallback: null,
+    fallbackInserted: false,
     pendingRecheck: false,
     pendingRecheckForce: false,
     isRenderingFallback: false,
+    get $transition() {
+      const transition = frag.$transition
+      return transition && isVaporTransitionHooks(transition)
+        ? transition
+        : undefined
+    },
+    set $transition(transition) {
+      frag.$transition = transition
+    },
     getContent: () => contentState.nodes,
     getParentNode: () => currentParentNode,
     getAnchor: () => currentAnchor,
@@ -1678,7 +1705,9 @@ function renderVDOMSlot(
       } else {
         frag.vnode = null
         frag.$key = undefined
-        removeRenderedContent(pending.placeholder, currentParentNode)
+        if (pending.placeholder) {
+          removeRenderedContent(pending.placeholder, currentParentNode)
+        }
         if (content) {
           insert(content, currentParentNode, currentAnchor, suspense)
         }
@@ -1845,6 +1874,9 @@ function renderVDOMSlot(
 
             if (isVNode(slotContent)) {
               const prevRendered = contentState.rendered
+              const transition = slotResolutionState.$transition
+              const mode = transition && transition.props.mode
+              let delayedLeaveSource: TransitionHooks | undefined
               if (slotResolutionState.activeFallback && !slotContentValid) {
                 // Re-run the slot only to refresh validity. While fallback is
                 // active, a still-invalid VNode must stay out of the live DOM.
@@ -1857,20 +1889,103 @@ function renderVDOMSlot(
                 finishContentUpdate()
                 return
               }
+              if (
+                slotResolutionState.activeFallback &&
+                slotContentValid &&
+                transition
+              ) {
+                if (mode === 'out-in') {
+                  pendingOutIn = {
+                    content: slotContent,
+                    placeholder: null,
+                    contentValid: true,
+                  }
+                  if (
+                    leaveSlotFallback(
+                      slotResolutionState,
+                      transition,
+                      resumeOutIn,
+                    )
+                  ) {
+                    return
+                  }
+                  pendingOutIn = undefined
+                } else if (mode === 'in-out') {
+                  // Keep the fallback's current enter hooks separate from the
+                  // delayed leave that will be forwarded to the incoming VNode.
+                  const enterHooks = extend({}, transition)
+                  delete enterHooks.delayedLeave
+                  leaveSlotFallback(slotResolutionState, enterHooks, NOOP)
+                  delayedLeaveSource = enterHooks
+                }
+              }
               const prevIsVNode = isVNode(prevRendered)
               const prevVNode =
                 prevIsVNode &&
                 (!slotResolutionState.activeFallback || contentState.valid)
                   ? prevRendered
                   : null
+              if (
+                prevVNode &&
+                !slotContentValid &&
+                transition &&
+                hasSlotFallback(boundary)
+              ) {
+                if (mode === 'out-in') {
+                  const placeholder =
+                    prepareInteropSlotTransition(
+                      frag,
+                      slotContent,
+                      undefined,
+                      NOOP,
+                    ) || createCommentVNode()
+                  if (
+                    prepareTransitionLeave(
+                      prevVNode,
+                      undefined,
+                      transition.props,
+                      transition.state,
+                      transition.instance,
+                      resumeOutIn,
+                    )
+                  ) {
+                    pendingOutIn = {
+                      content: slotContent,
+                      placeholder,
+                      contentValid: false,
+                    }
+                    frag.vnode = placeholder
+                    frag.$key = getVNodeKey(placeholder)
+                    contentState.rendered = placeholder
+                    internals.p(
+                      prevVNode,
+                      placeholder,
+                      currentParentNode!,
+                      currentAnchor,
+                      parentComponent as any,
+                      suspense,
+                      undefined,
+                      null,
+                    )
+                    return
+                  }
+                } else if (mode === 'in-out') {
+                  pendingInOutVNode = prevVNode
+                  frag.vnode = null
+                  frag.$key = undefined
+                  setRenderedContent(null)
+                  finishContentUpdate()
+                  return
+                }
+              }
               const transitionChild = prepareInteropSlotTransition(
                 frag,
                 slotContent,
                 prevVNode || undefined,
                 resumeOutIn,
+                delayedLeaveSource,
               )
               const nextVNode = transitionChild || slotContent
-              const transition = frag.$transition
               if (
                 prevVNode &&
                 transitionChild &&
@@ -2199,6 +2314,7 @@ function renderVaporSlot(
     slotResolutionState = {
       boundary: localFallbackBoundary,
       activeFallback: null,
+      fallbackInserted: false,
       pendingRecheck: false,
       pendingRecheckForce: false,
       isRenderingFallback: false,

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -180,7 +180,7 @@ function getRawTransitionChild(vnode: VNode | undefined): VNode | undefined {
   return children.length === 1 ? children[0] : undefined
 }
 
-function prepareInteropSlotTransitionBranch(
+function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
 ): VNode | undefined {
@@ -1674,7 +1674,7 @@ function renderVDOMSlot(
                   ? slotContent
                   : undefined
               if (isVNode(hydratedContent)) {
-                const transitionBranch = prepareInteropSlotTransitionBranch(
+                const transitionBranch = prepareInteropSlotTransition(
                   frag,
                   hydratedContent,
                 )
@@ -1746,7 +1746,7 @@ function renderVDOMSlot(
                 return
               }
               const transition = frag.$transition
-              const transitionBranch = prepareInteropSlotTransitionBranch(
+              const transitionBranch = prepareInteropSlotTransition(
                 frag,
                 slotContent,
               )


### PR DESCRIPTION
Closes #15155

Resolve VDOM slot output using the same child selection and transition hook preparation as BaseTransition. Prepare both the incoming and previously rendered branches so enter and leave transitions work correctly, including keyed fragment identity.

Hydrate the resolved physical branch while preserving slot scope IDs and the surrounding insertion anchor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Vapor Transition/TransitionGroup and VDOM slot interop, improving slot fallback handling and coordination in both `out-in` and `in-out` modes.
* **Bug Fixes**
  * Fixed transition sequencing and DOM/class behavior during deferred leaves/enters, keyed fragment swaps, and mid-transition slot switching, including hydration scenarios.
  * Improved reliability of fallback insertion/removal so the correct content shows at the right time.
* **Tests**
  * Expanded Transition, TransitionGroup, and hydration coverage, adding cases for slot fallback vs VDOM content timing and DOM correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->