### PR TITLE
fix(runtime-vapor): handle custom directives on async components

### DIFF
--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -1,7 +1,9 @@
 import { effectScope, ref } from '@vue/reactivity'
 import {
+  type VaporComponent,
   type VaporDirective,
   createComponent,
+  defineVaporAsyncComponent,
   defineVaporComponent,
   withVaporDirectives,
 } from '../../src'
@@ -195,6 +197,87 @@ describe('custom directive', () => {
 
     expect(first.getAttribute('data-value')).toBe('one')
     expect(second.getAttribute('data-value')).toBe('two')
+
+    app.unmount()
+  })
+
+  it('should apply after async component resolves', async () => {
+    let resolve!: (component: VaporComponent) => void
+    const data = ref(null)
+    const AsyncChild = defineVaporAsyncComponent(
+      () =>
+        new Promise<VaporComponent>(r => {
+          resolve = r
+        }),
+    )
+    const Child = compile(`<template><div /></template>`, data)
+    const teardown = vi.fn()
+    const dir: VaporDirective = vi.fn(el => {
+      ;(el as Element).setAttribute('data-custom', '')
+      return teardown
+    })
+    const App = compile(
+      `<template><components.AsyncChild v-custom /></template>`,
+      data,
+      { AsyncChild },
+    )
+    App.directives = { custom: dir }
+
+    const { host, app } = define(App).render()
+
+    expect(dir).not.toHaveBeenCalled()
+    expect(
+      'Runtime directive used on component with non-element root node',
+    ).not.toHaveBeenWarned()
+
+    resolve(Child)
+    await new Promise(r => setTimeout(r))
+
+    const element = host.firstElementChild!
+    expect(element).toBeInstanceOf(HTMLDivElement)
+    expect(element.getAttribute('data-custom')).toBe('')
+    expect(dir).toHaveBeenCalledOnce()
+    expect(teardown).not.toHaveBeenCalled()
+    expect(
+      'Runtime directive used on component with non-element root node',
+    ).not.toHaveBeenWarned()
+
+    app.unmount()
+    expect(teardown).toHaveBeenCalledOnce()
+  })
+
+  it('should warn after async component resolves to multiple roots', async () => {
+    let resolve!: (component: VaporComponent) => void
+    const data = ref(null)
+    const AsyncChild = defineVaporAsyncComponent(
+      () =>
+        new Promise<VaporComponent>(r => {
+          resolve = r
+        }),
+    )
+    const Child = compile(`<template><div /><span /></template>`, data)
+    const dir: VaporDirective = vi.fn()
+    const App = compile(
+      `<template><components.AsyncChild v-custom /></template>`,
+      data,
+      { AsyncChild },
+    )
+    App.directives = { custom: dir }
+
+    const { app } = define(App).render()
+
+    expect(dir).not.toHaveBeenCalled()
+    expect(
+      'Runtime directive used on component with non-element root node',
+    ).not.toHaveBeenWarned()
+
+    resolve(Child)
+    await new Promise(r => setTimeout(r))
+
+    expect(dir).not.toHaveBeenCalled()
+    expect(
+      'Runtime directive used on component with non-element root node',
+    ).toHaveBeenWarned()
 
     app.unmount()
   })

--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -281,4 +281,60 @@ describe('custom directive', () => {
 
     app.unmount()
   })
+
+  it('should dispose directives while a dynamic async component is pending', async () => {
+    let resolve!: (component: VaporComponent) => void
+    const data = ref({ current: 'div', value: 'one' })
+    const AsyncChild = defineVaporAsyncComponent(
+      () =>
+        new Promise<VaporComponent>(r => {
+          resolve = r
+        }),
+    )
+    const Child = compile(`<template><span /></template>`, data)
+    const teardown = vi.fn()
+    const dir: VaporDirective = vi.fn(el => {
+      watchEffect(() => {
+        ;(el as Element).setAttribute('data-value', data.value.value)
+      })
+      return teardown
+    })
+    const App = compile(
+      `<template><component :is="data.current" v-custom /></template>`,
+      data,
+    )
+    App.components = { AsyncChild }
+    App.directives = { custom: dir }
+
+    const { host, app } = define(App).render()
+    const first = host.firstElementChild!
+
+    expect(first).toBeInstanceOf(HTMLDivElement)
+    expect(first.getAttribute('data-value')).toBe('one')
+    expect(dir).toHaveBeenCalledOnce()
+
+    data.value.current = 'AsyncChild'
+    await nextTick()
+
+    expect(host.firstElementChild).toBeNull()
+    expect(teardown).toHaveBeenCalledOnce()
+    expect(dir).toHaveBeenCalledOnce()
+
+    data.value.value = 'two'
+    await nextTick()
+    expect(first.getAttribute('data-value')).toBe('one')
+
+    resolve(Child)
+    await new Promise(r => setTimeout(r))
+
+    const second = host.firstElementChild!
+    expect(second).toBeInstanceOf(HTMLSpanElement)
+    expect(second).not.toBe(first)
+    expect(second.getAttribute('data-value')).toBe('two')
+    expect(dir).toHaveBeenCalledTimes(2)
+    expect(teardown).toHaveBeenCalledOnce()
+
+    app.unmount()
+    expect(teardown).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -63,6 +63,7 @@ import {
   txt,
   vaporInteropPlugin,
   withAsyncContext,
+  withVaporDirectives,
 } from '../src'
 
 const define = makeInteropRender()
@@ -4472,8 +4473,15 @@ describe('vdomInterop', () => {
       }
     })
 
-    test('renders vapor async wrapper inside VDOM Suspense', async () => {
+    test('renders vapor async wrapper with directive inside VDOM Suspense', async () => {
       const duration = 5
+      const calls: string[] = []
+      const error = new Error('directive error')
+      const dir: VaporDirective = vi.fn(el => {
+        ;(el as Element).setAttribute('data-custom', '')
+        calls.push('directive')
+        throw error
+      })
 
       const VaporAsyncChild = defineVaporAsyncComponent({
         loader: () =>
@@ -4482,6 +4490,8 @@ describe('vdomInterop', () => {
               resolve(
                 defineVaporComponent({
                   setup() {
+                    onBeforeMount(() => calls.push('beforeMount'))
+                    onMounted(() => calls.push('mounted'))
                     return template('<div><button>click</button></div>')()
                   },
                 }) as any,
@@ -4496,7 +4506,11 @@ describe('vdomInterop', () => {
             Suspense as any,
             null,
             {
-              default: () => createComponent(VaporAsyncChild, null, null, true),
+              default: () => {
+                const child = createComponent(VaporAsyncChild, null, null, true)
+                withVaporDirectives(child, [[dir]])
+                return child
+              },
               fallback: () => template('loading')(),
             },
             true,
@@ -4504,18 +4518,29 @@ describe('vdomInterop', () => {
         },
       })
 
-      const { html } = define({
+      const { app, html } = define({
         setup() {
           return () => h(VaporParent as any)
         },
       }).render()
+      const errorHandler = (app.config.errorHandler = vi.fn())
 
       expect(html()).toContain('loading')
+      expect(dir).not.toHaveBeenCalled()
 
       await new Promise(resolve => setTimeout(resolve, duration + 1))
       await nextTick()
 
-      expect(html()).toContain('<div><button>click</button></div>')
+      expect(html()).toContain(
+        '<div data-custom=""><button>click</button></div>',
+      )
+      expect(dir).toHaveBeenCalledOnce()
+      expect(calls).toEqual(['directive', 'beforeMount', 'mounted'])
+      expect(errorHandler).toHaveBeenCalledOnce()
+      expect(errorHandler.mock.calls[0][0]).toBe(error)
+      expect(
+        'Runtime directive used on component with non-element root node',
+      ).not.toHaveBeenWarned()
     })
 
     test('does not suspend vapor async wrapper with suspensible false inside VDOM Suspense', async () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4749,6 +4749,54 @@ describe('vdomInterop', () => {
       expect(html()).toContain('<div><button>click</button></div>')
     })
 
+    test('applies directive to async setup vapor component inside VDOM Suspense', async () => {
+      const pending = deferred()
+      const dir: VaporDirective = vi.fn(el => {
+        ;(el as Element).setAttribute('data-custom', '')
+      })
+      const VaporAsyncChild = defineVaporComponent({
+        async setup() {
+          await pending.promise
+          return template('<div>resolved</div>')()
+        },
+      })
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(
+            Suspense as any,
+            null,
+            {
+              default: () => {
+                const child = createComponent(VaporAsyncChild, null, null, true)
+                withVaporDirectives(child, [[dir]])
+                return child
+              },
+              fallback: () => template('loading')(),
+            },
+            true,
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporParent as any)
+        },
+      }).render()
+
+      expect(html()).toContain('loading')
+      expect(dir).not.toHaveBeenCalled()
+
+      pending.resolve()
+      await flushResolution(pending.promise)
+
+      expect(html()).toContain('<div data-custom="">resolved</div>')
+      expect(dir).toHaveBeenCalledOnce()
+      expect(
+        'Runtime directive used on component with non-element root node',
+      ).not.toHaveBeenWarned()
+    })
+
     test('preserves render context for setup-returned helpers after async setup resumes', async () => {
       const duration = 5
 

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -55,22 +55,33 @@ export function withVaporDirectives(
   let directiveScope: EffectScope | undefined
   let disposed = false
 
+  function stopDirectiveScope() {
+    if (directiveScope) {
+      directiveScope.stop()
+      directiveScope = undefined
+    }
+  }
+
   function applyDirectives() {
     if (disposed) return
 
     const isRootPending = trackRootUpdates(node)
     const element = getRootElement(node)
-    if (!element && isRootPending) return
+    if (!element && isRootPending) {
+      // Keep null as the pending state so a resolved invalid root still warns
+      if (currentElement !== null) {
+        currentElement = null
+        stopDirectiveScope()
+      }
+      return
+    }
     // Only re-apply when the root element changes
     if (element === currentElement) return
 
     currentElement = element
     // The previous root element is no longer directive's target
     // Dispose effects and cleanup bound to the previous root element
-    if (directiveScope) {
-      directiveScope.stop()
-      directiveScope = undefined
-    }
+    stopDirectiveScope()
 
     if (!element) {
       if (__DEV__) {
@@ -143,7 +154,7 @@ export function withVaporDirectives(
   onScopeDispose(() => {
     disposed = true
     // Stop the detached scope when the calling scope is disposed
-    if (directiveScope) directiveScope.stop()
+    stopDirectiveScope()
   }, true)
 
   applyDirectives()

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -3,6 +3,8 @@ import { isArray } from '@vue/shared'
 import {
   type DirectiveModifiers,
   currentInstance,
+  isAsyncWrapper,
+  onBeforeMount,
   onScopeDispose,
   restoreCurrentInstance,
   setCurrentInstance,
@@ -48,7 +50,7 @@ export function withVaporDirectives(
   }
 
   const instance = currentInstance
-  const trackedFragments = new WeakSet<VaporFragment>()
+  const trackedBlocks = new WeakSet<VaporFragment | VaporComponentInstance>()
   let currentElement: Element | null | undefined = null
   let directiveScope: EffectScope | undefined
   let disposed = false
@@ -56,9 +58,9 @@ export function withVaporDirectives(
   function applyDirectives() {
     if (disposed) return
 
-    const pending = trackFragments(node)
+    const isRootPending = trackRootUpdates(node)
     const element = getRootElement(node)
-    if (!element && pending) return
+    if (!element && isRootPending) return
     // Only re-apply when the root element changes
     if (element === currentElement) return
 
@@ -92,22 +94,39 @@ export function withVaporDirectives(
     }
   }
 
-  function trackFragments(block: Block): boolean {
+  function trackRootUpdates(block: Block): boolean {
     if (isVaporComponent(block)) {
-      return trackFragments(block.block)
+      if (__FEATURE_SUSPENSE__ && block.asyncDep && !block.asyncResolved) {
+        if (!trackedBlocks.has(block)) {
+          trackedBlocks.add(block)
+          // Suspense replaces the pending block before the component's first mount
+          onBeforeMount(applyDirectives, block)
+        }
+        return true
+      }
+
+      const innerBlock = block.block
+      if (trackRootUpdates(innerBlock)) return true
+
+      // Async wrappers keep an empty fragment until a renderable branch is available
+      return (
+        isAsyncWrapper(block) &&
+        isFragment(innerBlock) &&
+        innerBlock.nodes === EMPTY_BLOCK
+      )
     }
     // Traverse every child so all nested fragments are tracked
     if (isArray(block)) {
-      let pending = false
+      let hasPendingTarget = false
       for (const child of block) {
-        pending = trackFragments(child) || pending
+        if (trackRootUpdates(child)) hasPendingTarget = true
       }
-      return pending
+      return hasPendingTarget
     }
     if (!isFragment(block)) return false
 
-    if (!trackedFragments.has(block)) {
-      trackedFragments.add(block)
+    if (!trackedBlocks.has(block)) {
+      trackedBlocks.add(block)
       // Re-resolve the root element when the fragment updates
       ;(block.onUpdated ||= []).push(applyDirectives)
     }
@@ -117,7 +136,7 @@ export function withVaporDirectives(
       (isInteropEnabled &&
         isInteropFragment(block) &&
         block.nodes === EMPTY_BLOCK) ||
-      trackFragments(block.nodes)
+      trackRootUpdates(block.nodes)
     )
   }
 


### PR DESCRIPTION
Treat unresolved async wrappers as pending instead of warning about a non-element root. Track fragment updates so directives are applied once a renderable root becomes available.

For async setup under Suspense, retry from beforeMount after the resolved block is created. This preserves lifecycle error handling and applies the directive before the resolved child mounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom directive behavior for asynchronously loaded components.
  * Directives now apply correctly once a valid root element becomes available.
  * Prevented directives from running prematurely while async content is pending.
  * Improved directive cleanup when components are unmounted.
  * Added clearer warnings for directives used on components with multiple roots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->