### PR TITLE
fix(compiler-core): preserve whitespace around interpolations (fix #7542)

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/compile.spec.ts.snap
@@ -11,7 +11,7 @@ return function render(_ctx, _cache) {
       id: "foo",
       class: _normalizeClass(bar.baz)
     }, [
-      _createTextVNode(_toDisplayString(world.burn()) + " ", 1 /* TEXT */),
+      _createTextVNode(" " + _toDisplayString(world.burn()) + " ", 1 /* TEXT */),
       ok
         ? (_openBlock(), _createElementBlock("div", { key: 0 }, "yes"))
         : (_openBlock(), _createElementBlock(_Fragment, { key: 1 }, [
@@ -35,7 +35,7 @@ return function render(_ctx, _cache) {
     id: "foo",
     class: _normalizeClass(_ctx.bar.baz)
   }, [
-    _createTextVNode(_toDisplayString(_ctx.world.burn()) + " ", 1 /* TEXT */),
+    _createTextVNode(" " + _toDisplayString(_ctx.world.burn()) + " ", 1 /* TEXT */),
     (_ctx.ok)
       ? (_openBlock(), _createElementBlock("div", { key: 0 }, "yes"))
       : (_openBlock(), _createElementBlock(_Fragment, { key: 1 }, [
@@ -58,7 +58,7 @@ export function render(_ctx, _cache) {
     id: "foo",
     class: _normalizeClass(_ctx.bar.baz)
   }, [
-    _createTextVNode(_toDisplayString(_ctx.world.burn()) + " ", 1 /* TEXT */),
+    _createTextVNode(" " + _toDisplayString(_ctx.world.burn()) + " ", 1 /* TEXT */),
     (_ctx.ok)
       ? (_openBlock(), _createElementBlock("div", { key: 0 }, "yes"))
       : (_openBlock(), _createElementBlock(_Fragment, { key: 1 }, [

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -2310,6 +2310,33 @@ describe('compiler: parse', () => {
       expect((ast.children[0] as ElementNode).children.length).toBe(1)
     })
 
+    // #7542
+    test('should preserve whitespaces around an interpolation inside an element', () => {
+      const ast = parse(`<div> \n {{ foo }} \n </div>`)
+      expect((ast.children[0] as ElementNode).children).toMatchObject([
+        {
+          type: NodeTypes.TEXT,
+          content: ' ',
+        },
+        {
+          type: NodeTypes.INTERPOLATION,
+        },
+        {
+          type: NodeTypes.TEXT,
+          content: ' ',
+        },
+      ])
+    })
+
+    test('should remove whitespaces around an interpolation at the root', () => {
+      const ast = parse(` \n {{ foo }} \n `)
+      expect(ast.children).toMatchObject([
+        {
+          type: NodeTypes.INTERPOLATION,
+        },
+      ])
+    })
+
     test('should remove whitespaces w/ newline between elements', () => {
       const ast = parse(`<div/> \n <div/> \n <div/>`)
       expect(ast.children.length).toBe(3)
@@ -2422,6 +2449,15 @@ describe('compiler: parse', () => {
     test('should still remove whitespaces at start/end inside an element', () => {
       const ast = parse(`<div>   <span/>    </div>`)
       expect((ast.children[0] as ElementNode).children.length).toBe(1)
+    })
+
+    test('should still remove whitespaces around an interpolation inside an element', () => {
+      const ast = parse(`<div> \n {{ foo }} \n </div>`)
+      expect((ast.children[0] as ElementNode).children).toMatchObject([
+        {
+          type: NodeTypes.INTERPOLATION,
+        },
+      ])
     })
 
     test('should preserve whitespaces w/ newline between elements', () => {

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -7,8 +7,18 @@ return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent("Comp")
 
   return (_openBlock(), _createBlock(_component_Comp, null, {
-    [_ctx.one]: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
-    [_ctx.two]: _withCtx(({ bar }) => [_toDisplayString(_ctx.foo), _toDisplayString(bar)]),
+    [_ctx.one]: _withCtx(({ foo }) => [
+      " ",
+      _toDisplayString(foo),
+      _toDisplayString(_ctx.bar),
+      " "
+    ]),
+    [_ctx.two]: _withCtx(({ bar }) => [
+      " ",
+      _toDisplayString(_ctx.foo),
+      _toDisplayString(bar),
+      " "
+    ]),
     _: 2 /* DYNAMIC */
   }, 1024 /* DYNAMIC_SLOTS */))
 }"
@@ -167,13 +177,20 @@ return function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_component_Comp, null, {
     default: _withCtx(({ foo }) => [
       _createVNode(_component_Inner, null, {
-        default: _withCtx(({ bar }) => [_toDisplayString(foo), _toDisplayString(bar), _toDisplayString(_ctx.baz)]),
+        default: _withCtx(({ bar }) => [
+          " ",
+          _toDisplayString(foo),
+          _toDisplayString(bar),
+          _toDisplayString(_ctx.baz),
+          " "
+        ]),
         _: 2 /* DYNAMIC */
       }, 1024 /* DYNAMIC_SLOTS */),
       " ",
       _toDisplayString(foo),
       _toDisplayString(_ctx.bar),
-      _toDisplayString(_ctx.baz)
+      _toDisplayString(_ctx.baz),
+      " "
     ]),
     _: 1 /* STABLE */
   }))
@@ -226,8 +243,18 @@ return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent("Comp")
 
   return (_openBlock(), _createBlock(_component_Comp, null, {
-    one: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
-    two: _withCtx(({ bar }) => [_toDisplayString(_ctx.foo), _toDisplayString(bar)]),
+    one: _withCtx(({ foo }) => [
+      " ",
+      _toDisplayString(foo),
+      _toDisplayString(_ctx.bar),
+      " "
+    ]),
+    two: _withCtx(({ bar }) => [
+      " ",
+      _toDisplayString(_ctx.foo),
+      _toDisplayString(bar),
+      " "
+    ]),
     _: 1 /* STABLE */
   }))
 }"

--- a/packages/compiler-core/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vFor.spec.ts
@@ -598,7 +598,7 @@ describe('compiler: v-for', () => {
         ],
       })
       const div = node.children[0] as ElementNode
-      expect((div.children[0] as InterpolationNode).content).toMatchObject({
+      expect((div.children[1] as InterpolationNode).content).toMatchObject({
         type: NodeTypes.COMPOUND_EXPRESSION,
         children: [
           { content: `foo` },

--- a/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vSlot.spec.ts
@@ -200,6 +200,10 @@ describe('compiler: transform component slots', () => {
           },
           returns: [
             {
+              type: NodeTypes.TEXT,
+              content: ` `,
+            },
+            {
               type: NodeTypes.INTERPOLATION,
               content: {
                 content: `foo`,
@@ -211,6 +215,10 @@ describe('compiler: transform component slots', () => {
                 content: `_ctx.bar`,
               },
             },
+            {
+              type: NodeTypes.TEXT,
+              content: ` `,
+            },
           ],
         },
         two: {
@@ -220,6 +228,10 @@ describe('compiler: transform component slots', () => {
             children: [`{ `, { content: `bar` }, ` }`],
           },
           returns: [
+            {
+              type: NodeTypes.TEXT,
+              content: ` `,
+            },
             {
               type: NodeTypes.INTERPOLATION,
               content: {
@@ -231,6 +243,10 @@ describe('compiler: transform component slots', () => {
               content: {
                 content: `bar`,
               },
+            },
+            {
+              type: NodeTypes.TEXT,
+              content: ` `,
             },
           ],
         },
@@ -369,6 +385,10 @@ describe('compiler: transform component slots', () => {
             },
             returns: [
               {
+                type: NodeTypes.TEXT,
+                content: ` `,
+              },
+              {
                 type: NodeTypes.INTERPOLATION,
                 content: {
                   content: `foo`,
@@ -380,6 +400,10 @@ describe('compiler: transform component slots', () => {
                   content: `_ctx.bar`,
                 },
               },
+              {
+                type: NodeTypes.TEXT,
+                content: ` `,
+              },
             ],
           },
           '[_ctx.two]': {
@@ -389,6 +413,10 @@ describe('compiler: transform component slots', () => {
               children: [`{ `, { content: `bar` }, ` }`],
             },
             returns: [
+              {
+                type: NodeTypes.TEXT,
+                content: ` `,
+              },
               {
                 type: NodeTypes.INTERPOLATION,
                 content: {
@@ -400,6 +428,10 @@ describe('compiler: transform component slots', () => {
                 content: {
                   content: `bar`,
                 },
+              },
+              {
+                type: NodeTypes.TEXT,
+                content: ` `,
               },
             ],
           },
@@ -447,6 +479,10 @@ describe('compiler: transform component slots', () => {
                       },
                       returns: [
                         {
+                          type: NodeTypes.TEXT,
+                          content: ` `,
+                        },
+                        {
                           type: NodeTypes.INTERPOLATION,
                           content: {
                             content: `foo`,
@@ -463,6 +499,10 @@ describe('compiler: transform component slots', () => {
                           content: {
                             content: `_ctx.baz`,
                           },
+                        },
+                        {
+                          type: NodeTypes.TEXT,
+                          content: ` `,
                         },
                       ],
                     },
@@ -496,6 +536,10 @@ describe('compiler: transform component slots', () => {
               content: {
                 content: `_ctx.baz`,
               },
+            },
+            {
+              type: NodeTypes.TEXT,
+              content: ` `,
             },
           ],
         },

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -649,7 +649,7 @@ function onCloseTag(el: ElementNode, end: number, isImplied = false) {
 
   // whitespace management
   if (!tokenizer.inRCDATA) {
-    el.children = condenseWhitespace(children)
+    el.children = condenseWhitespace(children, false)
   }
 
   if (ns === Namespaces.HTML && currentOptions.isIgnoreNewlineTag(tag)) {
@@ -834,7 +834,10 @@ function isUpperCase(c: number) {
 }
 
 const windowsNewlineRE = /\r\n/g
-function condenseWhitespace(nodes: TemplateChildNode[]): TemplateChildNode[] {
+function condenseWhitespace(
+  nodes: TemplateChildNode[],
+  isRoot: boolean,
+): TemplateChildNode[] {
   const shouldCondense = currentOptions.whitespace !== 'preserve'
   let removedWhitespace = false
   for (let i = 0; i < nodes.length; i++) {
@@ -844,14 +847,19 @@ function condenseWhitespace(nodes: TemplateChildNode[]): TemplateChildNode[] {
         if (isAllWhitespace(node.content)) {
           const prev = nodes[i - 1] && nodes[i - 1].type
           const next = nodes[i + 1] && nodes[i + 1].type
+          const preserveInterpolationBoundary =
+            shouldCondense &&
+            !isRoot &&
+            ((!prev && next === NodeTypes.INTERPOLATION) ||
+              (!next && prev === NodeTypes.INTERPOLATION))
           // Remove if:
-          // - the whitespace is the first or last node, or:
+          // - the whitespace is the first or last node, except around an
+          //   interpolation in a non-root element in condense mode, or:
           // - (condense mode) the whitespace is between two comments, or:
           // - (condense mode) the whitespace is between comment and element, or:
           // - (condense mode) the whitespace is between two elements AND contains newline
           if (
-            !prev ||
-            !next ||
+            ((!prev || !next) && !preserveInterpolationBoundary) ||
             (shouldCondense &&
               ((prev === NodeTypes.COMMENT &&
                 (next === NodeTypes.COMMENT || next === NodeTypes.ELEMENT)) ||
@@ -1073,7 +1081,7 @@ export function baseParse(input: string, options?: ParserOptions): RootNode {
   const root = (currentRoot = createRoot([], input))
   tokenizer.parse(currentInput)
   root.loc = getLoc(0, input.length)
-  root.children = condenseWhitespace(root.children)
+  root.children = condenseWhitespace(root.children, true)
   currentRoot = null
   return root
 }

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -853,7 +853,7 @@ return (_ctx, _cache) => {
       _: 1 /* STABLE */
     }),
     _createElementVNode("div", { onClick: fn }, _toDisplayString(count.value) + " " + _toDisplayString(constant) + " " + _toDisplayString(_unref(maybe)) + " " + _toDisplayString(_unref(lett)) + " " + _toDisplayString(_unref(other)), 1 /* TEXT */),
-    _createTextVNode(" " + _toDisplayString(tree.foo()), 1 /* TEXT */)
+    _createTextVNode(" " + _toDisplayString(tree.foo()) + " ", 1 /* TEXT */)
   ], 64 /* STABLE_FRAGMENT */))
 }
 }

--- a/packages/runtime-core/__tests__/helpers/withMemo.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/withMemo.spec.ts
@@ -278,17 +278,17 @@ describe('v-memo', () => {
         count: 0,
       }),
     })
-    expect(el.innerHTML).toBe(`<div>0</div><div>0</div><div>0</div>`)
+    expect(el.innerHTML).toBe(`<div> 0 </div><div> 0 </div><div> 0 </div>`)
 
     vm.count = 1
     await nextTick()
     // should not update
-    expect(el.innerHTML).toBe(`<div>0</div><div>0</div><div>0</div>`)
+    expect(el.innerHTML).toBe(`<div> 0 </div><div> 0 </div><div> 0 </div>`)
 
     vm.count = 2
     await nextTick()
     // should update
-    expect(el.innerHTML).toBe(`<div>2</div><div>2</div><div>2</div>`)
+    expect(el.innerHTML).toBe(`<div> 2 </div><div> 2 </div><div> 2 </div>`)
   })
 
   test('v-memo dependency is NaN should be equal', async () => {


### PR DESCRIPTION
## Summary

Preserve condensed boundary whitespace when an interpolation is the first or last child of a non-root element.

This makes interpolated content consistent with static text in inline markup. For example:

```vue
<span>Foo</span>
<span>
  {{ bar }}
</span>
```

now renders with the source whitespace between `Foo` and the interpolated value instead of collapsing the output to `FooBar`.

## Root cause

`condenseWhitespace()` unconditionally removed all-whitespace text nodes at the start and end of every child list. That also removed whitespace adjacent to an interpolation, even though equivalent static text preserves a condensed space.

The parser now distinguishes root-level whitespace from element boundary whitespace. In the default `condense` mode, it keeps a single boundary space next to an interpolation inside an element. Root-level behavior and `whitespace: 'preserve'` behavior remain unchanged.

## Tests

- Added parser coverage for leading and trailing whitespace around interpolations.
- Added guards for root-level whitespace and `whitespace: 'preserve'`.
- Updated compiler and runtime expectations affected by the corrected output.
- `./node_modules/.bin/vitest --project 'unit*' run`
  - 182 test files passed, 1 skipped
  - 3629 tests passed, 6 skipped
- `./node_modules/.bin/tsc --incremental --noEmit`

Fixes #7542
