### PR TITLE
fix(runtime-core): resolve kebab-cased slot names in in-DOM templates

### DIFF
--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -16,7 +16,7 @@ import {
   isVNode,
   openBlock,
 } from '../vnode'
-import { PatchFlags, SlotFlags, extend, isSymbol } from '@vue/shared'
+import { PatchFlags, SlotFlags, extend, hyphenate, isSymbol } from '@vue/shared'
 import { warn } from '../warning'
 import { isAsyncWrapper } from '../apiAsyncComponent'
 
@@ -61,6 +61,16 @@ export function renderSlot(
   }
 
   let slot = slots[name]
+
+  // In-DOM templates are case-insensitive, so a camelCase slot name can only
+  // be written there in its kebab-cased form. Resolve that here, the same way
+  // props and v-on listeners already support kebab -> camel conversion.
+  if (!slot) {
+    const hyphenatedName = hyphenate(name)
+    if (hyphenatedName !== name) {
+      slot = slots[hyphenatedName]
+    }
+  }
 
   if (__DEV__ && slot && slot.length > 1) {
     warn(

--- a/packages/vue/__tests__/slotNameCasing.spec.ts
+++ b/packages/vue/__tests__/slotNameCasing.spec.ts
@@ -30,14 +30,18 @@ describe('slot name casing in in-DOM templates', () => {
     ).toBe(`<div>content</div>`)
   })
 
-  test('an exact match still wins', () => {
+  test('an exact match wins over a competing hyphenated one', () => {
     const container = document.createElement('div')
     createApp({
       components: { Child },
-      template: `<Child><template #dropdownRender>content</template></Child>`,
+      template:
+        `<Child>` +
+        `<template #dropdownRender>exact</template>` +
+        `<template #dropdown-render>hyphenated</template>` +
+        `</Child>`,
     }).mount(container)
 
-    expect(container.innerHTML).toBe(`<div>content</div>`)
+    expect(container.innerHTML).toBe(`<div>exact</div>`)
   })
 
   test('a genuinely kebab-cased slot name is unaffected', () => {

--- a/packages/vue/__tests__/slotNameCasing.spec.ts
+++ b/packages/vue/__tests__/slotNameCasing.spec.ts
@@ -1,0 +1,61 @@
+import { createApp } from '../src'
+
+// https://github.com/vuejs/core/issues/14300
+describe('slot name casing in in-DOM templates', () => {
+  const Child = {
+    template: `<div><slot name="dropdownRender">fallback</slot></div>`,
+  }
+
+  function mountInDom(html: string) {
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    createApp({ components: { Child } }).mount(container)
+    return container.innerHTML
+  }
+
+  test('kebab-cased v-slot resolves a camelCase slot', () => {
+    expect(
+      mountInDom(
+        `<Child><template v-slot:dropdown-render>content</template></Child>`,
+      ),
+    ).toBe(`<div>content</div>`)
+  })
+
+  test('kebab-cased shorthand resolves a camelCase slot', () => {
+    expect(
+      mountInDom(
+        `<Child><template #dropdown-render>content</template></Child>`,
+      ),
+    ).toBe(`<div>content</div>`)
+  })
+
+  test('an exact match still wins', () => {
+    const container = document.createElement('div')
+    createApp({
+      components: { Child },
+      template: `<Child><template #dropdownRender>content</template></Child>`,
+    }).mount(container)
+
+    expect(container.innerHTML).toBe(`<div>content</div>`)
+  })
+
+  test('a genuinely kebab-cased slot name is unaffected', () => {
+    const KebabChild = {
+      template: `<div><slot name="dropdown-render">fallback</slot></div>`,
+    }
+    const container = document.createElement('div')
+    createApp({
+      components: { KebabChild },
+      template: `<KebabChild><template #dropdown-render>content</template></KebabChild>`,
+    }).mount(container)
+
+    expect(container.innerHTML).toBe(`<div>content</div>`)
+  })
+
+  test('falls back when no slot matches', () => {
+    expect(
+      mountInDom(`<Child><template #somethingElse>content</template></Child>`),
+    ).toBe(`<div>fallback</div>`)
+  })
+})


### PR DESCRIPTION
close #14300

In-DOM templates are case-insensitive, so a camelCase slot name cannot be written in one. Vue documents kebab-case as the equivalent form for [component names, props and `v-on` listeners](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats), but slot names had no such resolution — which makes a camelCase slot **unreachable** from an in-DOM template:

```js
const Child = { template: `<div><slot name="dropdownRender">fallback</slot></div>` }
```

```html
<!-- browser lowercases the attribute to "dropdownrender" -> no match -->
<Child><template v-slot:dropdownRender>content</template></Child>

<!-- the documented kebab-case form -> also no match -->
<Child><template v-slot:dropdown-render>content</template></Child>
```

Both render the fallback. The same component works from a string template with `#dropdownRender`, so the slot is only unusable when the parent template comes from the DOM.

## Change

`renderSlot` falls back to the hyphenated name when there is no exact match, mirroring the kebab → camel conversion `componentProps` already performs for props.

- An exact match still takes precedence, so nothing changes for templates that already resolve.
- A slot whose name is genuinely kebab-cased (`<slot name="dropdown-render">`) is unaffected, since the fallback only runs when the exact key is absent.
- The lookup only happens on the miss path, so the common case is unchanged.

This does not make the lowercased `v-slot:dropdownRender` form work — that would need case-insensitive matching, and kebab-case is the documented convention for in-DOM templates.

## Tests

`packages/vue/__tests__/slotNameCasing.spec.ts` covers kebab-cased `v-slot` and `#` shorthand resolving a camelCase slot, an exact match still winning, a genuinely kebab-cased slot name being unaffected, and the fallback still rendering when nothing matches. I confirmed the two tests targeting the bug fail without the change.

`packages/runtime-core`, `packages/runtime-dom` and `packages/vue` report identical results with and without the change on this commit, so there are no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot resolution for in-DOM templates when slot names use camelCase, with automatic hyphenated fallback.
  * Preserved exact slot-name matches and ensured correct fallback content renders when no slot matches.
  * Prevented casing adjustments from altering already kebab-cased slot names.
* **Tests**
  * Added coverage for slot name casing behavior, including precedence rules and fallback rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Known limitation

If a component declares both `<slot name="dropdownRender">` and `<slot name="dropdown-render">`, and the parent supplies only the hyphenated one, both outlets render that content — the exact name resolves through the fallback and the hyphenated name matches directly.

I've deliberately left this unasserted rather than pick a winner. `renderSlot` is called per outlet and only knows the name it was asked for, so detecting the collision would need compiler-level support, and a component declaring two names that differ only by casing convention is ambiguous by nature. Happy to constrain it if you'd rather it were defined.
