### PR TITLE
fix(runtime-vapor): defer KeepAlive updates while async setup is pending

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -25,7 +25,11 @@ import {
   type RendererNode,
   queuePostRenderEffect,
 } from '../renderer'
-import { queuePostFlushCb } from '../scheduler'
+import {
+  type SchedulerJob,
+  SchedulerJobFlags,
+  queuePostFlushCb,
+} from '../scheduler'
 import { filterSingleRoot, updateHOCHostEl } from '../componentRenderUtils'
 import { assertNumber, warn } from '../warning'
 import { ErrorCodes, handleError } from '../errorHandling'
@@ -290,7 +294,13 @@ function patchSuspense(
       }
       // reset suspense state
       suspense.deps = 0
-      // discard effects from pending branch
+      // discard effects from the pending branch, except retained recovery jobs
+      for (let i = 0; i < suspense.effects.length; i++) {
+        const effect = suspense.effects[i] as SchedulerJob
+        if (effect.flags! & SchedulerJobFlags.REQUEUE_ON_SUSPENSE_DISCARD) {
+          queuePostFlushCb(effect)
+        }
+      }
       suspense.effects.length = 0
       // discard previous container
       suspense.hiddenContainer = createElement('div')

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -21,6 +21,11 @@ export enum SchedulerJobFlags {
    */
   ALLOW_RECURSE = 1 << 1,
   DISPOSED = 1 << 2,
+  /**
+   * Requeue a Suspense effect if its pending branch is discarded.
+   * @internal
+   */
+  REQUEUE_ON_SUSPENSE_DISCARD = 1 << 3,
 }
 
 export interface SchedulerJob extends Function {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -18,6 +18,7 @@ import {
   defineAsyncComponent,
   defineComponent,
   h,
+  markRaw,
   nextTick,
   reactive,
   ref,
@@ -7062,6 +7063,115 @@ describe('Vapor Mode hydration', () => {
             <!--[--><p>fallback</p><span>tail</span><!--]-->
             "
           `)
+        })
+
+        test('defers direct KeepAlive updates while hydrating async setup', async () => {
+          let resolveClient!: () => void
+          const asyncSetup = vi.fn()
+          const syncSetup = vi.fn()
+          const serverData = ref({
+            wait: Promise.resolve(),
+            asyncSetup: () => {},
+            syncSetup: () => {},
+            current: null as any,
+          })
+          const clientData = ref({
+            wait: new Promise<void>(resolve => {
+              resolveClient = resolve
+            }),
+            asyncSetup,
+            syncSetup,
+            current: null as any,
+          })
+          const asyncCode = `
+            <script vapor>
+              const data = _data
+              data.value.asyncSetup()
+              await data.value.wait
+            </script>
+            <template><span>async</span></template>
+          `
+          const syncCode = `
+            <script vapor>
+              const data = _data
+              data.value.syncSetup()
+            </script>
+            <template><span>sync</span></template>
+          `
+          const parentCode = `
+            <script setup vapor>
+              const data = _data
+            </script>
+            <template>
+              <KeepAlive>
+                <component :is="data.current" />
+              </KeepAlive>
+            </template>
+          `
+
+          const serverChild = compileVaporComponent(
+            asyncCode,
+            serverData,
+            undefined,
+            true,
+          )
+          serverData.value.current = markRaw(serverChild)
+          let Parent = compileVaporComponent(
+            parentCode,
+            serverData,
+            undefined,
+            true,
+          )
+          const App = defineComponent({
+            setup() {
+              return () =>
+                h(runtimeDom.Suspense, null, {
+                  default: () => h(Parent),
+                  fallback: () => h('p', 'pending'),
+                })
+            },
+          })
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(App),
+          )
+
+          const asyncChild = compileVaporComponent(asyncCode, clientData)
+          const syncChild = compileVaporComponent(syncCode, clientData)
+          clientData.value.current = markRaw(asyncChild)
+          Parent = compileVaporComponent(parentCode, clientData)
+
+          const container = document.createElement('div')
+          container.innerHTML = html
+          const serverRoot = container.firstChild
+          document.body.appendChild(container)
+          const app = runtimeDom.createSSRApp(App)
+          app.use(runtimeVapor.vaporInteropPlugin)
+
+          try {
+            app.mount(container)
+
+            clientData.value.current = markRaw(syncChild)
+            await nextTick()
+            clientData.value.current = markRaw(asyncChild)
+            await nextTick()
+
+            expect(asyncSetup).toHaveBeenCalledOnce()
+            expect(syncSetup).not.toHaveBeenCalled()
+            expect(container.firstChild).toBe(serverRoot)
+            expect(container.textContent).toBe('async')
+
+            resolveClient()
+            await new Promise(resolve => setTimeout(resolve))
+
+            expect(asyncSetup).toHaveBeenCalledOnce()
+            expect(syncSetup).not.toHaveBeenCalled()
+            expect(container.firstChild).toBe(serverRoot)
+            expect(container.textContent).toBe('async')
+          } finally {
+            resolveClient()
+            app.unmount()
+            container.remove()
+          }
         })
 
         test('preserves nested pending SSR range until parent transition leave', async () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -5643,6 +5643,60 @@ describe('vdomInterop', () => {
           host.remove()
         }
       })
+
+      test('finishes a still-active async root after its Suspense generation is replaced', async () => {
+        const pending = deferred()
+        const otherPending = deferred()
+        const asyncSetup = vi.fn()
+        const data = ref({
+          wait: pending.promise,
+          asyncSetup,
+          syncSetup: vi.fn(),
+          current: null as any,
+        })
+        const { InitialChild, AsyncChild } = makeChildren(data)
+        data.value.current = InitialChild
+        const VaporParent = compile(
+          `<script setup vapor>
+              const data = _data
+              const VaporKeepAlive = _components.VaporKeepAlive
+            </script>
+            <template>
+              <VaporKeepAlive>
+                <component :is="data.current" />
+              </VaporKeepAlive>
+            </template>`,
+          data,
+          { VaporKeepAlive },
+        )
+        const branch = shallowRef<any>(VaporParent)
+        const { host, app } = mountSuspenseApp(branch)
+
+        try {
+          await nextTick()
+          data.value.current = AsyncChild
+          await nextTick()
+          expect(asyncSetup).toHaveBeenCalledOnce()
+
+          branch.value = makeOtherAsync(otherPending)
+          await nextTick()
+          branch.value = VaporParent
+          await nextTick()
+
+          pending.resolve()
+          await flushResolution(pending.promise)
+
+          expect(asyncSetup).toHaveBeenCalledOnce()
+          expect(host.innerHTML).toBe(
+            '<span>async</span><!--dynamic-component-->',
+          )
+        } finally {
+          pending.resolve()
+          otherPending.resolve()
+          app.unmount()
+          host.remove()
+        }
+      })
     })
 
     test('renders vapor async wrapper with directive inside VDOM Suspense', async () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4199,7 +4199,7 @@ describe('vdomInterop', () => {
       return { promise, resolve }
     }
 
-    async function flushResolution(promise: Promise<void>) {
+    async function flushResolution(promise: Promise<unknown>) {
       await promise
       await Promise.resolve()
       await nextTick()
@@ -4597,9 +4597,11 @@ describe('vdomInterop', () => {
           }),
       })
       app.use(vaporInteropPlugin)
+      let loaded!: Promise<unknown>
 
       try {
         app.mount(host)
+        loaded = AsyncChild.__asyncLoader!()
 
         data.value.current = SyncChild
         await nextTick()
@@ -4608,9 +4610,15 @@ describe('vdomInterop', () => {
 
         expect(loader).toHaveBeenCalledOnce()
         expect(syncSetup).not.toHaveBeenCalled()
+
+        pending.resolve()
+        await flushResolution(loaded)
+
+        expect(syncSetup).not.toHaveBeenCalled()
+        expect(host.textContent).toBe('async')
       } finally {
         pending.resolve()
-        await flushResolution(pending.promise)
+        await flushResolution(loaded)
         app.unmount()
         host.remove()
       }

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4545,6 +4545,157 @@ describe('vdomInterop', () => {
       }
     })
 
+    test('does not defer KeepAlive updates across a nested Suspense boundary', async () => {
+      const pending = deferred()
+      const asyncSetup = vi.fn()
+      const syncSetup = vi.fn()
+      const data = ref({ wait: pending.promise, asyncSetup, syncSetup })
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.asyncSetup()
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      const current = shallowRef<any>(AsyncChild)
+      const Root = defineVaporComponent({
+        setup() {
+          // Exclude raw Suspense from caching to isolate boundary ownership.
+          return createComponent(
+            VaporKeepAlive,
+            { include: 'Never' },
+            {
+              default: () =>
+                createDynamicComponent(() =>
+                  h(Suspense, null, {
+                    default: () => h(current.value),
+                    fallback: () => h('p', 'pending'),
+                  }),
+                ),
+            },
+          )
+        },
+      })
+      const host = document.createElement('div')
+      const app = createVaporApp(Root)
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+        expect(host.textContent).toBe('pending')
+
+        current.value = SyncChild
+        await nextTick()
+
+        expect(asyncSetup).toHaveBeenCalledOnce()
+        expect(syncSetup).toHaveBeenCalledOnce()
+        expect(host.textContent).toBe('sync')
+      } finally {
+        pending.resolve()
+        app.unmount()
+        host.remove()
+      }
+    })
+
+    test('skips transient KeepAlive branches when async setup starts after Suspense resolves', async () => {
+      const pending = deferred()
+      const asyncSetup = vi.fn()
+      const syncSetup = vi.fn()
+      const onResolve = vi.fn()
+      const data = ref({ wait: pending.promise, asyncSetup, syncSetup })
+      const InitialChild = compile(
+        `<template><span>initial</span></template>`,
+        data,
+      )
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.asyncSetup()
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      const current = shallowRef<any>(InitialChild)
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(VaporKeepAlive, null, {
+            default: () => createDynamicComponent(() => current.value),
+          })
+        },
+      })
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(
+            Suspense,
+            { onResolve },
+            {
+              default: () => h(VaporParent),
+              fallback: () => h('p', 'pending'),
+            },
+          ),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+        await nextTick()
+
+        expect(onResolve).toHaveBeenCalledOnce()
+        expect(host.innerHTML).toBe(
+          '<span>initial</span><!--dynamic-component-->',
+        )
+
+        current.value = AsyncChild
+        await nextTick()
+        current.value = SyncChild
+        await nextTick()
+        current.value = AsyncChild
+        await nextTick()
+
+        expect(asyncSetup).toHaveBeenCalledOnce()
+        expect(syncSetup).not.toHaveBeenCalled()
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect(asyncSetup).toHaveBeenCalledOnce()
+        expect(syncSetup).not.toHaveBeenCalled()
+        expect(host.innerHTML).toBe(
+          '<span>async</span><!--dynamic-component-->',
+        )
+
+        current.value = SyncChild
+        await nextTick()
+
+        expect(syncSetup).toHaveBeenCalledOnce()
+        expect(host.innerHTML).toBe('<span>sync</span><!--dynamic-component-->')
+      } finally {
+        pending.resolve()
+        app.unmount()
+        host.remove()
+      }
+    })
+
     test('renders vapor async wrapper with directive inside VDOM Suspense', async () => {
       const duration = 5
       const calls: string[] = []

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4473,6 +4473,78 @@ describe('vdomInterop', () => {
       }
     })
 
+    test('defers KeepAlive updates until its async setup child resolves', async () => {
+      const pending = deferred()
+      const asyncSetup = vi.fn()
+      const syncSetup = vi.fn()
+      const data = ref({ wait: pending.promise, asyncSetup, syncSetup })
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.asyncSetup()
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      const current = shallowRef<any>(AsyncChild)
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(VaporKeepAlive, null, {
+            default: () => createDynamicComponent(() => current.value),
+          })
+        },
+      })
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+
+        current.value = SyncChild
+        await nextTick()
+        current.value = AsyncChild
+        await nextTick()
+
+        expect(asyncSetup).toHaveBeenCalledOnce()
+        expect(syncSetup).not.toHaveBeenCalled()
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect(asyncSetup).toHaveBeenCalledOnce()
+        expect(syncSetup).not.toHaveBeenCalled()
+        expect(host.innerHTML).toBe(
+          '<span>async</span><!--dynamic-component-->',
+        )
+
+        current.value = SyncChild
+        await nextTick()
+
+        expect(syncSetup).toHaveBeenCalledOnce()
+        expect(host.innerHTML).toBe('<span>sync</span><!--dynamic-component-->')
+      } finally {
+        pending.resolve()
+        app.unmount()
+        host.remove()
+      }
+    })
+
     test('renders vapor async wrapper with directive inside VDOM Suspense', async () => {
       const duration = 5
       const calls: string[] = []

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4477,7 +4477,12 @@ describe('vdomInterop', () => {
       const pending = deferred()
       const asyncSetup = vi.fn()
       const syncSetup = vi.fn()
-      const data = ref({ wait: pending.promise, asyncSetup, syncSetup })
+      const data = ref({
+        wait: pending.promise,
+        asyncSetup,
+        syncSetup,
+        current: null as any,
+      })
       const AsyncChild = compile(
         `<script vapor>
           const data = _data
@@ -4495,14 +4500,20 @@ describe('vdomInterop', () => {
         <template><span>sync</span></template>`,
         data,
       )
-      const current = shallowRef<any>(AsyncChild)
-      const VaporParent = defineVaporComponent({
-        setup() {
-          return createComponent(VaporKeepAlive, null, {
-            default: () => createDynamicComponent(() => current.value),
-          })
-        },
-      })
+      data.value.current = AsyncChild
+      const VaporParent = compile(
+        `<script setup vapor>
+          const data = _data
+          const VaporKeepAlive = _components.VaporKeepAlive
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <component :is="data.current" />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive },
+      )
       const host = document.createElement('div')
       const app = createApp({
         render: () =>
@@ -4516,9 +4527,9 @@ describe('vdomInterop', () => {
       try {
         app.mount(host)
 
-        current.value = SyncChild
+        data.value.current = SyncChild
         await nextTick()
-        current.value = AsyncChild
+        data.value.current = AsyncChild
         await nextTick()
 
         expect(asyncSetup).toHaveBeenCalledOnce()
@@ -4533,7 +4544,7 @@ describe('vdomInterop', () => {
           '<span>async</span><!--dynamic-component-->',
         )
 
-        current.value = SyncChild
+        data.value.current = SyncChild
         await nextTick()
 
         expect(syncSetup).toHaveBeenCalledOnce()
@@ -4692,6 +4703,99 @@ describe('vdomInterop', () => {
       }
     })
 
+    test('skips transient components across nested KeepAlive roots', async () => {
+      const pending = deferred()
+      const asyncSetup = vi.fn()
+      const syncSetup = vi.fn()
+      const data = ref({
+        wait: pending.promise,
+        asyncSetup,
+        syncSetup,
+        current: null as any,
+      })
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.asyncSetup()
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const InnerRoot = compile(
+        `<script setup vapor>
+          const VaporKeepAlive = _components.VaporKeepAlive
+          const AsyncChild = _components.AsyncChild
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <AsyncChild />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive, AsyncChild },
+      )
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      data.value.current = InnerRoot
+      const VaporParent = compile(
+        `<script setup vapor>
+          const data = _data
+          const VaporKeepAlive = _components.VaporKeepAlive
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <component :is="data.current" />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+
+        data.value.current = SyncChild
+        await nextTick()
+        data.value.current = InnerRoot
+        await nextTick()
+
+        expect([
+          asyncSetup.mock.calls.length,
+          syncSetup.mock.calls.length,
+        ]).toEqual([1, 0])
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect([
+          asyncSetup.mock.calls.length,
+          syncSetup.mock.calls.length,
+        ]).toEqual([1, 0])
+        expect(host.textContent).toBe('async')
+      } finally {
+        pending.resolve()
+        await flushResolution(pending.promise)
+        app.unmount()
+        host.remove()
+      }
+    })
+
     test('skips transient KeepAlive components in removed branches', async () => {
       const pending = deferred()
       const syncSetup = vi.fn()
@@ -4773,6 +4877,131 @@ describe('vdomInterop', () => {
       }
     })
 
+    test.each([
+      [
+        'preserves deferred KeepAlive updates across nested async roots',
+        false,
+        1,
+        'sync',
+      ],
+      [
+        'skips transient KeepAlive components across nested async roots',
+        true,
+        0,
+        '',
+      ],
+    ] as const)('%s', async (_, removeBranch, syncCalls, textContent) => {
+      const outerPending = deferred()
+      const innerPending = deferred()
+      const outerBeforeMount = deferred()
+      const asyncSetup = vi.fn()
+      const syncSetup = vi.fn()
+      const data = ref({
+        outerWait: outerPending.promise,
+        innerWait: innerPending.promise,
+        outerBeforeMount: outerBeforeMount.resolve,
+        asyncSetup,
+        syncSetup,
+        show: true,
+        current: null as any,
+      })
+      const InnerAsync = compile(
+        `<script vapor>
+          const data = _data
+          data.value.asyncSetup()
+          await data.value.innerWait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const OuterAsync = compile(
+        `<script vapor>
+          import { onBeforeMount } from 'vue'
+          const data = _data
+          const InnerAsync = _components.InnerAsync
+          const VaporKeepAlive = _components.VaporKeepAlive
+          onBeforeMount(() => data.value.outerBeforeMount())
+          await data.value.outerWait
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <InnerAsync />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { InnerAsync, VaporKeepAlive },
+      )
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      data.value.current = OuterAsync
+      const Wrapper = compile(
+        `<script setup vapor>
+          const data = _data
+        </script>
+        <template>
+          <component v-if="data.show" :is="data.current" />
+        </template>`,
+        data,
+      )
+      const VaporParent = compile(
+        `<script setup vapor>
+          const VaporKeepAlive = _components.VaporKeepAlive
+          const Wrapper = _components.Wrapper
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <Wrapper />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive, Wrapper },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+
+        data.value.current = SyncChild
+        await nextTick()
+
+        outerPending.resolve()
+        await outerBeforeMount.promise
+
+        expect(asyncSetup).toHaveBeenCalledOnce()
+
+        if (removeBranch) {
+          data.value.show = false
+          await nextTick()
+        }
+
+        innerPending.resolve()
+        await flushResolution(innerPending.promise)
+
+        expect(syncSetup).toHaveBeenCalledTimes(syncCalls)
+        expect(host.textContent).toBe(textContent)
+      } finally {
+        outerPending.resolve()
+        innerPending.resolve()
+        await flushResolution(innerPending.promise)
+        app.unmount()
+        host.remove()
+      }
+    })
+
     test('does not defer KeepAlive updates across a nested Suspense boundary', async () => {
       const pending = deferred()
       const asyncSetup = vi.fn()
@@ -4840,7 +5069,12 @@ describe('vdomInterop', () => {
       const asyncSetup = vi.fn()
       const syncSetup = vi.fn()
       const onResolve = vi.fn()
-      const data = ref({ wait: pending.promise, asyncSetup, syncSetup })
+      const data = ref({
+        wait: pending.promise,
+        asyncSetup,
+        syncSetup,
+        current: null as any,
+      })
       const InitialChild = compile(
         `<template><span>initial</span></template>`,
         data,
@@ -4862,14 +5096,20 @@ describe('vdomInterop', () => {
         <template><span>sync</span></template>`,
         data,
       )
-      const current = shallowRef<any>(InitialChild)
-      const VaporParent = defineVaporComponent({
-        setup() {
-          return createComponent(VaporKeepAlive, null, {
-            default: () => createDynamicComponent(() => current.value),
-          })
-        },
-      })
+      data.value.current = InitialChild
+      const VaporParent = compile(
+        `<script setup vapor>
+          const data = _data
+          const VaporKeepAlive = _components.VaporKeepAlive
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <component :is="data.current" />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive },
+      )
       const host = document.createElement('div')
       const app = createApp({
         render: () =>
@@ -4893,11 +5133,11 @@ describe('vdomInterop', () => {
           '<span>initial</span><!--dynamic-component-->',
         )
 
-        current.value = AsyncChild
+        data.value.current = AsyncChild
         await nextTick()
-        current.value = SyncChild
+        data.value.current = SyncChild
         await nextTick()
-        current.value = AsyncChild
+        data.value.current = AsyncChild
         await nextTick()
 
         expect(asyncSetup).toHaveBeenCalledOnce()
@@ -4912,7 +5152,7 @@ describe('vdomInterop', () => {
           '<span>async</span><!--dynamic-component-->',
         )
 
-        current.value = SyncChild
+        data.value.current = SyncChild
         await nextTick()
 
         expect(syncSetup).toHaveBeenCalledOnce()

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4545,6 +4545,234 @@ describe('vdomInterop', () => {
       }
     })
 
+    test('defers KeepAlive updates for pending async wrappers', async () => {
+      const pending = deferred()
+      const syncSetup = vi.fn()
+      const data = ref({ current: null as any, syncSetup })
+      const ResolvedChild = compile(
+        `<template><span>async</span></template>`,
+        data,
+      )
+      const loader = vi.fn(() => pending.promise.then(() => ResolvedChild))
+      const AsyncChild = defineVaporAsyncComponent(loader)
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      data.value.current = AsyncChild
+      const VaporParent = compile(
+        `<script setup vapor>
+          const data = _data
+          const VaporKeepAlive = _components.VaporKeepAlive
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <component :is="data.current" />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+
+        data.value.current = SyncChild
+        await nextTick()
+        data.value.current = AsyncChild
+        await nextTick()
+
+        expect(loader).toHaveBeenCalledOnce()
+        expect(syncSetup).not.toHaveBeenCalled()
+      } finally {
+        pending.resolve()
+        await flushResolution(pending.promise)
+        app.unmount()
+        host.remove()
+      }
+    })
+
+    test('skips transient components behind a KeepAlive root wrapper', async () => {
+      const pending = deferred()
+      const asyncSetup = vi.fn()
+      const syncSetup = vi.fn()
+      const data = ref({
+        wait: pending.promise,
+        asyncSetup,
+        syncSetup,
+        current: null as any,
+      })
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.asyncSetup()
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      data.value.current = AsyncChild
+      const Wrapper = compile(
+        `<script setup vapor>
+          const data = _data
+        </script>
+        <template><component :is="data.current" /></template>`,
+        data,
+      )
+      const VaporParent = compile(
+        `<script setup vapor>
+          const VaporKeepAlive = _components.VaporKeepAlive
+          const Wrapper = _components.Wrapper
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <Wrapper />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive, Wrapper },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+
+        data.value.current = SyncChild
+        await nextTick()
+        data.value.current = AsyncChild
+        await nextTick()
+
+        expect([
+          asyncSetup.mock.calls.length,
+          syncSetup.mock.calls.length,
+        ]).toEqual([1, 0])
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect([
+          asyncSetup.mock.calls.length,
+          syncSetup.mock.calls.length,
+        ]).toEqual([1, 0])
+        expect(host.textContent).toBe('async')
+      } finally {
+        pending.resolve()
+        await flushResolution(pending.promise)
+        app.unmount()
+        host.remove()
+      }
+    })
+
+    test('skips transient KeepAlive components in removed branches', async () => {
+      const pending = deferred()
+      const syncSetup = vi.fn()
+      const data = ref({
+        wait: pending.promise,
+        syncSetup,
+        show: true,
+        current: null as any,
+      })
+      const AsyncChild = compile(
+        `<script vapor>
+          const data = _data
+          await data.value.wait
+        </script>
+        <template><span>async</span></template>`,
+        data,
+      )
+      const SyncChild = compile(
+        `<script vapor>
+          const data = _data
+          data.value.syncSetup()
+        </script>
+        <template><span>sync</span></template>`,
+        data,
+      )
+      data.value.current = AsyncChild
+      const Wrapper = compile(
+        `<script setup vapor>
+          const data = _data
+        </script>
+        <template>
+          <component v-if="data.show" :is="data.current" />
+        </template>`,
+        data,
+      )
+      const VaporParent = compile(
+        `<script setup vapor>
+          const VaporKeepAlive = _components.VaporKeepAlive
+          const Wrapper = _components.Wrapper
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <Wrapper />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { VaporKeepAlive, Wrapper },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+
+        data.value.current = SyncChild
+        await nextTick()
+        data.value.show = false
+        await nextTick()
+
+        expect(syncSetup).not.toHaveBeenCalled()
+
+        pending.resolve()
+        await flushResolution(pending.promise)
+
+        expect(syncSetup).not.toHaveBeenCalled()
+        expect(host.textContent).toBe('')
+      } finally {
+        pending.resolve()
+        await flushResolution(pending.promise)
+        app.unmount()
+        host.remove()
+      }
+    })
+
     test('does not defer KeepAlive updates across a nested Suspense boundary', async () => {
       const pending = deferred()
       const asyncSetup = vi.fn()

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -5164,6 +5164,487 @@ describe('vdomInterop', () => {
       }
     })
 
+    describe('stale deferred KeepAlive updates', () => {
+      function makeChildren(data: any) {
+        const InitialChild = compile(
+          `<template><span>initial</span></template>`,
+          data,
+        )
+        const AsyncChild = compile(
+          `<script vapor>
+            const data = _data
+            data.value.asyncSetup()
+            await data.value.wait
+          </script>
+          <template><span>async</span></template>`,
+          data,
+        )
+        const SyncChild = compile(
+          `<script vapor>
+            const data = _data
+            data.value.syncSetup()
+          </script>
+          <template><span>sync</span></template>`,
+          data,
+        )
+        return { InitialChild, AsyncChild, SyncChild }
+      }
+
+      // A VDOM async branch that stays pending while the suspense root is
+      // toggled away from the active vapor branch.
+      function makeOtherAsync(otherPending: { promise: Promise<void> }) {
+        return defineComponent({
+          async setup() {
+            await otherPending.promise
+            return () => h('span', 'other')
+          },
+        })
+      }
+
+      function mountSuspenseApp(branch: ShallowRef<any>) {
+        const host = document.createElement('div')
+        const app = createApp({
+          render: () =>
+            h(Suspense, null, {
+              default: () => h(branch.value),
+              fallback: () => h('p', 'fallback'),
+            }),
+        })
+        app.use(vaporInteropPlugin)
+        app.mount(host)
+        return { host, app }
+      }
+
+      test('replays already-buffered updates when the pending root is skipped', async () => {
+        const pending = deferred()
+        const otherPending = deferred()
+        const asyncSetup = vi.fn()
+        const syncSetup = vi.fn()
+        const data = ref({
+          wait: pending.promise,
+          asyncSetup,
+          syncSetup,
+          current: null as any,
+        })
+        const { InitialChild, AsyncChild, SyncChild } = makeChildren(data)
+        data.value.current = InitialChild
+        const VaporParent = compile(
+          `<script setup vapor>
+            const data = _data
+            const VaporKeepAlive = _components.VaporKeepAlive
+          </script>
+          <template>
+            <VaporKeepAlive>
+              <component :is="data.current" />
+            </VaporKeepAlive>
+          </template>`,
+          data,
+          { VaporKeepAlive },
+        )
+        const branch = shallowRef<any>(VaporParent)
+        const { host, app } = mountSuspenseApp(branch)
+
+        try {
+          await nextTick()
+          data.value.current = AsyncChild
+          await nextTick()
+          expect(asyncSetup).toHaveBeenCalledOnce()
+
+          // buffered while armed; the effect stays dirty and will not be
+          // re-notified for this dependency again
+          data.value.current = SyncChild
+          await nextTick()
+          expect(syncSetup).not.toHaveBeenCalled()
+
+          branch.value = makeOtherAsync(otherPending)
+          await nextTick()
+          branch.value = VaporParent
+          await nextTick()
+
+          // settling the skipped root must replay the buffered switch even
+          // though no further owner effect is triggered
+          pending.resolve()
+          await flushResolution(pending.promise)
+
+          expect(syncSetup).toHaveBeenCalledOnce()
+          expect(host.innerHTML).toBe(
+            '<span>sync</span><!--dynamic-component-->',
+          )
+        } finally {
+          pending.resolve()
+          otherPending.resolve()
+          app.unmount()
+          host.remove()
+        }
+      })
+
+      test('replays stale updates in scheduler order across owner effects', async () => {
+        const pending = deferred()
+        const otherPending = deferred()
+        const asyncSetup = vi.fn()
+        const syncSetup = vi.fn()
+        const data = ref({
+          wait: pending.promise,
+          asyncSetup,
+          syncSetup,
+          show: true,
+          current: null as any,
+        })
+        const { InitialChild, AsyncChild, SyncChild } = makeChildren(data)
+        data.value.current = InitialChild
+        const Wrapper = compile(
+          `<script setup vapor>
+            const data = _data
+          </script>
+          <template>
+            <component v-if="data.show" :is="data.current" />
+          </template>`,
+          data,
+        )
+        const VaporParent = compile(
+          `<script setup vapor>
+            const VaporKeepAlive = _components.VaporKeepAlive
+            const Wrapper = _components.Wrapper
+          </script>
+          <template>
+            <VaporKeepAlive>
+              <Wrapper />
+            </VaporKeepAlive>
+          </template>`,
+          data,
+          { VaporKeepAlive, Wrapper },
+        )
+        const branch = shallowRef<any>(VaporParent)
+        const { host, app } = mountSuspenseApp(branch)
+
+        try {
+          await nextTick()
+          data.value.current = AsyncChild
+          await nextTick()
+          expect(asyncSetup).toHaveBeenCalledOnce()
+
+          // buffer the inner dynamic-component update
+          data.value.current = SyncChild
+          await nextTick()
+
+          branch.value = makeOtherAsync(otherPending)
+          await nextTick()
+          branch.value = VaporParent
+          await nextTick()
+
+          // the outer v-if removal detects the stale state; it must run
+          // before the buffered inner update so the removed branch never
+          // mounts a transient component
+          data.value.show = false
+          await nextTick()
+
+          expect(syncSetup).not.toHaveBeenCalled()
+          expect(host.textContent).toBe('')
+
+          pending.resolve()
+          await flushResolution(pending.promise)
+          expect(syncSetup).not.toHaveBeenCalled()
+          expect(host.textContent).toBe('')
+        } finally {
+          pending.resolve()
+          otherPending.resolve()
+          app.unmount()
+          host.remove()
+        }
+      })
+
+      test('replays a gated flush when its pending branch is discarded', async () => {
+        const pending = deferred()
+        const otherPending = deferred()
+        const asyncSetup = vi.fn()
+        const syncSetup = vi.fn()
+        const data = ref({
+          wait: pending.promise,
+          asyncSetup,
+          syncSetup,
+          current: null as any,
+        })
+        const { InitialChild, AsyncChild, SyncChild } = makeChildren(data)
+        data.value.current = InitialChild
+        const VaporParent = compile(
+          `<script setup vapor>
+            const data = _data
+            const VaporKeepAlive = _components.VaporKeepAlive
+          </script>
+          <template>
+            <VaporKeepAlive>
+              <component :is="data.current" />
+            </VaporKeepAlive>
+          </template>`,
+          data,
+          { VaporKeepAlive },
+        )
+        const branch = shallowRef<any>(VaporParent)
+        const { host, app } = mountSuspenseApp(branch)
+
+        try {
+          await nextTick()
+          expect(host.innerHTML).toBe(
+            '<span>initial</span><!--dynamic-component-->',
+          )
+
+          // a foreign branch starts pending while the vapor branch stays the
+          // visible active branch
+          branch.value = makeOtherAsync(otherPending)
+          await nextTick()
+
+          // the async root mounts into the active branch but registers under
+          // the foreign pending generation, so its registerDep callback runs
+          data.value.current = AsyncChild
+          await nextTick()
+          expect(asyncSetup).toHaveBeenCalledOnce()
+
+          // buffered while armed
+          data.value.current = SyncChild
+          await nextTick()
+          expect(syncSetup).not.toHaveBeenCalled()
+
+          // the root resolves; the flush parks in the foreign generation's
+          // suspense effects, gated exactly like VDOM's retry
+          pending.resolve()
+          await flushResolution(pending.promise)
+          expect(host.innerHTML).toBe(
+            '<span>async</span><!--dynamic-component-->',
+          )
+
+          // toggling back discards the foreign generation while the active
+          // branch survives. The retained flush must leave that generation
+          // and replay the already-buffered switch.
+          branch.value = VaporParent
+          await nextTick()
+          expect(syncSetup).toHaveBeenCalledOnce()
+          expect(host.innerHTML).toBe(
+            '<span>sync</span><!--dynamic-component-->',
+          )
+        } finally {
+          pending.resolve()
+          otherPending.resolve()
+          app.unmount()
+          host.remove()
+        }
+      })
+
+      test('keeps a pending-branch flush gated on the boundary', async () => {
+        const aPending = deferred()
+        const bPending = deferred()
+        const sibPending = deferred()
+        const aSetup = vi.fn()
+        const bSetup = vi.fn()
+        const cSetup = vi.fn()
+        const data = ref({
+          aWait: aPending.promise,
+          bWait: bPending.promise,
+          aSetup,
+          bSetup,
+          cSetup,
+          show: 1,
+          current: null as any,
+        })
+        const AsyncA = compile(
+          `<script vapor>
+            const data = _data
+            data.value.aSetup()
+            await data.value.aWait
+          </script>
+          <template><span>a</span></template>`,
+          data,
+        )
+        const AsyncB = compile(
+          `<script vapor>
+            const data = _data
+            data.value.bSetup()
+            await data.value.bWait
+          </script>
+          <template><span>b</span></template>`,
+          data,
+        )
+        const SyncC = compile(
+          `<script vapor>
+            const data = _data
+            data.value.cSetup()
+          </script>
+          <template><span>c</span></template>`,
+          data,
+        )
+        data.value.current = AsyncA
+        const Wrapper = compile(
+          `<script setup vapor>
+            const data = _data
+          </script>
+          <template>
+            <component v-if="data.show > 0" :is="data.current" />
+          </template>`,
+          data,
+        )
+        const VaporParent = compile(
+          `<script setup vapor>
+            const VaporKeepAlive = _components.VaporKeepAlive
+            const Wrapper = _components.Wrapper
+          </script>
+          <template>
+            <VaporKeepAlive>
+              <Wrapper />
+            </VaporKeepAlive>
+          </template>`,
+          data,
+          { VaporKeepAlive, Wrapper },
+        )
+        // an unrelated async sibling keeps the boundary pending after the
+        // KeepAlive root resolves
+        const Sibling = defineComponent({
+          async setup() {
+            await sibPending.promise
+            return () => h('span', 'sibling')
+          },
+        })
+
+        const host = document.createElement('div')
+        const app = createApp({
+          render: () =>
+            h(Suspense, null, {
+              default: () => h('div', [h(VaporParent), h(Sibling)]),
+              fallback: () => h('p', 'fallback'),
+            }),
+        })
+        app.use(vaporInteropPlugin)
+        app.mount(host)
+
+        try {
+          await nextTick()
+          expect(host.textContent).toBe('fallback')
+          expect(aSetup).toHaveBeenCalledOnce()
+
+          // buffered while A is pending inside the pending branch
+          data.value.current = AsyncB
+          await nextTick()
+          expect(bSetup).not.toHaveBeenCalled()
+
+          // resolving only A must NOT replay the buffered switch yet - the
+          // owners live in the pending branch, so the flush stays gated on
+          // boundary resolution (VDOM parity); B mounting now would join the
+          // current suspense cycle and keep the fallback up indefinitely
+          aPending.resolve()
+          await flushResolution(aPending.promise)
+          expect(bSetup).not.toHaveBeenCalled()
+          expect(host.textContent).toBe('fallback')
+
+          // A different, still-clean owner effect must see the parked flush as
+          // live. Otherwise it replays the buffered switch and mounts B early.
+          data.value.show = 2
+          await nextTick()
+          expect(bSetup).not.toHaveBeenCalled()
+          expect(cSetup).not.toHaveBeenCalled()
+          expect(host.textContent).toBe('fallback')
+
+          // The dirty dynamic-component effect already represents the latest
+          // `current` value without another notification.
+          data.value.current = SyncC
+          await nextTick()
+          expect(bSetup).not.toHaveBeenCalled()
+          expect(cSetup).not.toHaveBeenCalled()
+          expect(host.textContent).toBe('fallback')
+
+          // the boundary resolves once the sibling settles; the gated flush
+          // now renders only the latest switch
+          sibPending.resolve()
+          await flushResolution(sibPending.promise)
+          expect(bSetup).not.toHaveBeenCalled()
+          expect(cSetup).toHaveBeenCalledOnce()
+          expect(host.textContent).toContain('sibling')
+          expect(host.textContent).not.toContain('fallback')
+          expect(host.innerHTML).toContain('<span>c</span>')
+        } finally {
+          aPending.resolve()
+          bPending.resolve()
+          sibPending.resolve()
+          app.unmount()
+          host.remove()
+        }
+      })
+
+      test('survives a gated flush migrated to a pending ancestor and discarded there', async () => {
+        const aPending = deferred()
+        const otherPending = deferred()
+        const aSetup = vi.fn()
+        const syncSetup = vi.fn()
+        const data = ref({
+          wait: aPending.promise,
+          asyncSetup: aSetup,
+          syncSetup,
+          current: null as any,
+        })
+        const { AsyncChild, SyncChild } = makeChildren(data)
+        data.value.current = AsyncChild
+        const VaporParent = compile(
+          `<script setup vapor>
+            const data = _data
+            const VaporKeepAlive = _components.VaporKeepAlive
+          </script>
+          <template>
+            <VaporKeepAlive>
+              <component :is="data.current" />
+            </VaporKeepAlive>
+          </template>`,
+          data,
+          { VaporKeepAlive },
+        )
+        // the VDOM layer between the inner boundary and the vapor chain makes
+        // the chain register with the INNER boundary
+        const Mid = defineComponent({ render: () => h(VaporParent) })
+        const Wrap = defineComponent({
+          render: () =>
+            h(Suspense, null, {
+              default: () => h(Mid),
+              fallback: () => h('p', 'inner fallback'),
+            }),
+        })
+        const branch = shallowRef<any>(Wrap)
+        const { host, app } = mountSuspenseApp(branch)
+
+        try {
+          await nextTick()
+          expect(aSetup).toHaveBeenCalledOnce()
+          expect(host.textContent).toContain('inner fallback')
+
+          // buffered while the root is pending
+          data.value.current = SyncChild
+          await nextTick()
+          expect(syncSetup).not.toHaveBeenCalled()
+
+          // the OUTER boundary starts a foreign pending branch; the inner
+          // boundary (whose generation the state is keyed to) is untouched
+          branch.value = makeOtherAsync(otherPending)
+          await nextTick()
+
+          // the root resolves: the flush parks in the inner boundary's
+          // effects, and the inner resolve() migrates it into the pending
+          // ancestor's effects (parent hand-off). The buffered switch stays
+          // parked - VDOM retry timing
+          aPending.resolve()
+          await flushResolution(aPending.promise)
+          expect(host.innerHTML).toContain('<span>async</span>')
+          expect(syncSetup).not.toHaveBeenCalled()
+
+          // ancestor toggle-back discards the migrated generation while the
+          // whole chain survives. The retained flush must still replay.
+          branch.value = Wrap
+          await nextTick()
+          expect(syncSetup).toHaveBeenCalledOnce()
+          expect(host.innerHTML).toContain('<span>sync</span>')
+        } finally {
+          aPending.resolve()
+          otherPending.resolve()
+          app.unmount()
+          host.remove()
+        }
+      })
+    })
+
     test('renders vapor async wrapper with directive inside VDOM Suspense', async () => {
       const duration = 5
       const calls: string[] = []

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -16,6 +16,7 @@ import {
   NULL_DYNAMIC_COMPONENT,
   type NormalizedPropsOptions,
   type ObjectEmitsOptions,
+  type SchedulerJob,
   type ShallowUnwrapRef,
   type SuspenseBoundary,
   callWithErrorHandling,
@@ -725,9 +726,9 @@ export class VaporComponentInstance<
   // for keep-alive
   shapeFlag?: number
   $key?: any
-  // For A(pending) -> B -> A, defer KeepAlive updates until A resolves so B
-  // is never created and the final branch is rendered, matching VDOM.
-  deferRenderEffects?: boolean
+  // For A(pending) -> B -> A, buffer KeepAlive render effects until A resolves
+  // so only the final branch renders, matching VDOM.
+  deferredRenderEffects?: SchedulerJob[]
 
   // for v-once: caches props/attrs values to ensure they remain frozen
   // even when the component re-renders due to local state changes
@@ -1091,18 +1092,21 @@ export function mountComponent(
     instance.asyncDep &&
     !instance.asyncResolved
   ) {
-    // Match VDOM by deferring KeepAlive updates for a pending async setup child.
     const owner = instance.parent
+    // Suspense does not participate in the component parent chain. Only defer
+    // the direct async child when it shares KeepAlive's boundary, matching VDOM.
     const keepAlive =
       isKeepAliveEnabled &&
-      instance.suspense.pendingBranch &&
       !isAsyncWrapper(instance) &&
       owner &&
       owner.vapor &&
-      isKeepAlive(owner)
+      isKeepAlive(owner) &&
+      owner.suspense === instance.suspense
         ? (owner as KeepAliveInstance)
         : undefined
-    if (keepAlive) keepAlive.deferRenderEffects = true
+    if (keepAlive && !keepAlive.deferredRenderEffects) {
+      keepAlive.deferredRenderEffects = []
+    }
 
     // Moving a still-pending instance, such as a keyed reorder or KeepAlive
     // re-entry, retries `mountComponent`. `insert` relocates its already-mounted
@@ -1157,6 +1161,14 @@ export function mountComponent(
         // Use the pending DOM's live boundary because it may have moved while
         // setup was suspended.
         const { parentNode, nextNode } = findBlockBoundary(pendingBlock)
+        const effects = keepAlive && keepAlive.deferredRenderEffects
+        if (effects) {
+          keepAlive.deferredRenderEffects = undefined
+          // Queue the deferred update before hooks created by the setup result.
+          if (effects.length) {
+            queuePostRenderEffect(effects, undefined, keepAlive.suspense)
+          }
+        }
         if (hydrating) {
           withDeferredHydrationBoundary(() => {
             handleResult()
@@ -1169,11 +1181,6 @@ export function mountComponent(
           handleResult()
           mountComponent(instance, parentNode as ParentNode, nextNode)
           remove(pendingBlock, parentNode as ParentNode)
-        }
-
-        if (keepAlive) {
-          // Suspense flushes the deferred jobs when the branch resolves.
-          keepAlive.deferRenderEffects = false
         }
       } finally {
         if (hydrating) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1168,7 +1168,12 @@ function deferKeepAliveRenderEffects(
         }
         // Run here so updates stay ahead of setup-created Suspense effects.
         for (let i = 0; i < effects.length; i++) {
-          effects[i]()
+          const job = effects[i]
+          callWithErrorHandling(
+            job,
+            job.i,
+            job.i ? ErrorCodes.COMPONENT_UPDATE : ErrorCodes.SCHEDULER,
+          )
         }
       },
     }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -726,8 +726,8 @@ export class VaporComponentInstance<
   // for keep-alive
   shapeFlag?: number
   $key?: any
-  // For A(pending) -> B -> A, buffer KeepAlive render effects until A resolves
-  // so only the final branch renders, matching VDOM.
+  // Share a buffer along the KeepAlive component-root chain so
+  // A(pending) -> B -> A renders only the final branch, matching VDOM.
   deferredRenderEffects?: SchedulerJob[]
 
   // for v-once: caches props/attrs values to ensure they remain frozen
@@ -1080,6 +1080,60 @@ export function createPlainElement(
   return el
 }
 
+interface DeferredKeepAliveEffects {
+  effects: SchedulerJob[]
+  owners: VaporComponentInstance[]
+  suspense: SuspenseBoundary
+}
+
+function deferKeepAliveRenderEffects(
+  instance: VaporComponentInstance,
+): DeferredKeepAliveEffects | undefined {
+  const suspense = instance.suspense!
+  const owners: VaporComponentInstance[] = []
+  if (isHydrating) {
+    // Ancestor blocks are not committed during hydration. Preserve the direct
+    // KeepAlive-owner path; wrapper roots cannot be proven here.
+    const owner = instance.parent
+    if (
+      owner &&
+      owner.vapor &&
+      isKeepAlive(owner) &&
+      owner.suspense === suspense
+    ) {
+      owners.push(owner as VaporComponentInstance)
+    }
+  } else {
+    let child: Block = instance
+    let owner = instance.parent
+    while (owner && owner.vapor && owner.suspense === suspense) {
+      const vaporOwner = owner as VaporComponentInstance
+      let root = vaporOwner.block
+      // Dynamic component and v-if roots use fragments in Vapor where VDOM
+      // exposes the active component directly as `subTree.component`.
+      while (isDynamicFragment(root) && !root.isSlot) {
+        root = root.nodes
+      }
+      if (root !== child) return
+
+      owners.push(vaporOwner)
+      if (isKeepAlive(owner)) break
+
+      child = vaporOwner
+      owner = vaporOwner.parent
+    }
+  }
+
+  const keepAlive = owners[owners.length - 1]
+  if (!keepAlive || !isKeepAlive(keepAlive)) return
+
+  const effects: SchedulerJob[] = []
+  for (let i = 0; i < owners.length; i++) {
+    owners[i].deferredRenderEffects = effects
+  }
+  return { effects, owners, suspense }
+}
+
 export function mountComponent(
   instance: VaporComponentInstance,
   parent: ParentNode,
@@ -1092,22 +1146,6 @@ export function mountComponent(
     instance.asyncDep &&
     !instance.asyncResolved
   ) {
-    const owner = instance.parent
-    // Suspense does not participate in the component parent chain. Only defer
-    // the direct async child when it shares KeepAlive's boundary, matching VDOM.
-    const keepAlive =
-      isKeepAliveEnabled &&
-      !isAsyncWrapper(instance) &&
-      owner &&
-      owner.vapor &&
-      isKeepAlive(owner) &&
-      owner.suspense === instance.suspense
-        ? (owner as KeepAliveInstance)
-        : undefined
-    if (keepAlive && !keepAlive.deferredRenderEffects) {
-      keepAlive.deferredRenderEffects = []
-    }
-
     // Moving a still-pending instance, such as a keyed reorder or KeepAlive
     // re-entry, retries `mountComponent`. `insert` relocates its already-mounted
     // DOM without registering the async dependency again.
@@ -1129,6 +1167,7 @@ export function mountComponent(
       return
     }
 
+    const deferred = isKeepAliveEnabled && deferKeepAliveRenderEffects(instance)
     const hydrating = isHydrating
     if (!hydrating) {
       // Keep a placeholder in the DOM while async setup is pending so
@@ -1161,12 +1200,23 @@ export function mountComponent(
         // Use the pending DOM's live boundary because it may have moved while
         // setup was suspended.
         const { parentNode, nextNode } = findBlockBoundary(pendingBlock)
-        const effects = keepAlive && keepAlive.deferredRenderEffects
-        if (effects) {
-          keepAlive.deferredRenderEffects = undefined
-          // Queue the deferred update before hooks created by the setup result.
-          if (effects.length) {
-            queuePostRenderEffect(effects, undefined, keepAlive.suspense)
+        if (deferred) {
+          const { effects, owners, suspense } = deferred
+          const keepAlive = owners[owners.length - 1]
+          if (keepAlive.deferredRenderEffects === effects) {
+            for (let i = 0; i < owners.length; i++) {
+              if (owners[i].deferredRenderEffects === effects) {
+                owners[i].deferredRenderEffects = undefined
+              }
+            }
+            if (effects.length > 1) {
+              // Restore normal Vapor scheduler order before post-flush.
+              effects.sort((a, b) => a.order! - b.order!)
+            }
+            // Queue the deferred update before hooks created by the setup result.
+            if (effects.length) {
+              queuePostRenderEffect(effects, undefined, suspense)
+            }
           }
         }
         if (hydrating) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -725,6 +725,9 @@ export class VaporComponentInstance<
   // for keep-alive
   shapeFlag?: number
   $key?: any
+  // For A(pending) -> B -> A, defer KeepAlive updates until A resolves so B
+  // is never created and the final branch is rendered, matching VDOM.
+  deferRenderEffects?: boolean
 
   // for v-once: caches props/attrs values to ensure they remain frozen
   // even when the component re-renders due to local state changes
@@ -1088,6 +1091,19 @@ export function mountComponent(
     instance.asyncDep &&
     !instance.asyncResolved
   ) {
+    // Match VDOM by deferring KeepAlive updates for a pending async setup child.
+    const owner = instance.parent
+    const keepAlive =
+      isKeepAliveEnabled &&
+      instance.suspense.pendingBranch &&
+      !isAsyncWrapper(instance) &&
+      owner &&
+      owner.vapor &&
+      isKeepAlive(owner)
+        ? (owner as KeepAliveInstance)
+        : undefined
+    if (keepAlive) keepAlive.deferRenderEffects = true
+
     // Moving a still-pending instance, such as a keyed reorder or KeepAlive
     // re-entry, retries `mountComponent`. `insert` relocates its already-mounted
     // DOM without registering the async dependency again.
@@ -1153,6 +1169,11 @@ export function mountComponent(
           handleResult()
           mountComponent(instance, parentNode as ParentNode, nextNode)
           remove(pendingBlock, parentNode as ParentNode)
+        }
+
+        if (keepAlive) {
+          // Suspense flushes the deferred jobs when the branch resolves.
+          keepAlive.deferRenderEffects = false
         }
       } finally {
         if (hydrating) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -726,9 +726,9 @@ export class VaporComponentInstance<
   // for keep-alive
   shapeFlag?: number
   $key?: any
-  // Share a buffer along the KeepAlive component-root chain so
-  // A(pending) -> B -> A renders only the final branch, matching VDOM.
-  deferredRenderEffects?: SchedulerJob[]
+  // Share deferred updates across async roots on the KeepAlive component-root
+  // chain so A(pending) -> B -> A renders only the final branch, matching VDOM.
+  deferredKeepAliveUpdates?: DeferredKeepAliveUpdates
 
   // for v-once: caches props/attrs values to ensure they remain frozen
   // even when the component re-renders due to local state changes
@@ -1080,17 +1080,22 @@ export function createPlainElement(
   return el
 }
 
-interface DeferredKeepAliveEffects {
+interface DeferredKeepAliveUpdates {
   effects: SchedulerJob[]
   owners: VaporComponentInstance[]
   suspense: SuspenseBoundary
+  pendingId: number
+  pendingRoot?: VaporComponentInstance
+  flushQueued: boolean
+  flushJob: SchedulerJob
 }
 
 function deferKeepAliveRenderEffects(
   instance: VaporComponentInstance,
-): DeferredKeepAliveEffects | undefined {
+): DeferredKeepAliveUpdates | undefined {
   const suspense = instance.suspense!
   const owners: VaporComponentInstance[] = []
+  let keepAlive: VaporComponentInstance | undefined
   if (isHydrating) {
     // Ancestor blocks are not committed during hydration. Preserve the direct
     // KeepAlive-owner path; wrapper roots cannot be proven here.
@@ -1101,7 +1106,8 @@ function deferKeepAliveRenderEffects(
       isKeepAlive(owner) &&
       owner.suspense === suspense
     ) {
-      owners.push(owner as VaporComponentInstance)
+      keepAlive = owner as VaporComponentInstance
+      owners.push(keepAlive)
     }
   } else {
     let child: Block = instance
@@ -1117,21 +1123,68 @@ function deferKeepAliveRenderEffects(
       if (root !== child) return
 
       owners.push(vaporOwner)
-      if (isKeepAlive(owner)) break
+      if (isKeepAlive(owner)) {
+        // Use the outermost KeepAlive so nested async roots share one state,
+        // matching VDOM's component-root update.
+        keepAlive = vaporOwner
+      }
 
       child = vaporOwner
       owner = vaporOwner.parent
     }
   }
 
-  const keepAlive = owners[owners.length - 1]
-  if (!keepAlive || !isKeepAlive(keepAlive)) return
+  if (!keepAlive) return
 
-  const effects: SchedulerJob[] = []
-  for (let i = 0; i < owners.length; i++) {
-    owners[i].deferredRenderEffects = effects
+  let deferred = keepAlive.deferredKeepAliveUpdates
+  if (
+    !deferred ||
+    deferred.suspense !== suspense ||
+    deferred.pendingId !== instance.suspenseId
+  ) {
+    const state: DeferredKeepAliveUpdates = {
+      effects: [],
+      owners: [],
+      suspense,
+      pendingId: instance.suspenseId,
+      pendingRoot: instance,
+      flushQueued: false,
+      flushJob: () => {
+        state.flushQueued = false
+        // A resolved root may synchronously mount another pending async root.
+        if (keepAlive.deferredKeepAliveUpdates !== state || state.pendingRoot) {
+          return
+        }
+
+        const { effects, owners } = state
+        for (let i = 0; i < owners.length; i++) {
+          if (owners[i].deferredKeepAliveUpdates === state) {
+            owners[i].deferredKeepAliveUpdates = undefined
+          }
+        }
+        if (effects.length > 1) {
+          // Restore normal Vapor scheduler order across nested async roots.
+          effects.sort((a, b) => a.order! - b.order!)
+        }
+        // Run here so updates stay ahead of setup-created Suspense effects.
+        for (let i = 0; i < effects.length; i++) {
+          effects[i]()
+        }
+      },
+    }
+    deferred = state
+  } else {
+    deferred.pendingRoot = instance
   }
-  return { effects, owners, suspense }
+
+  for (let i = 0; i < owners.length; i++) {
+    const owner = owners[i]
+    if (owner.deferredKeepAliveUpdates !== deferred) {
+      owner.deferredKeepAliveUpdates = deferred
+      deferred.owners.push(owner)
+    }
+  }
+  return deferred
 }
 
 export function mountComponent(
@@ -1201,22 +1254,17 @@ export function mountComponent(
         // setup was suspended.
         const { parentNode, nextNode } = findBlockBoundary(pendingBlock)
         if (deferred) {
-          const { effects, owners, suspense } = deferred
-          const keepAlive = owners[owners.length - 1]
-          if (keepAlive.deferredRenderEffects === effects) {
-            for (let i = 0; i < owners.length; i++) {
-              if (owners[i].deferredRenderEffects === effects) {
-                owners[i].deferredRenderEffects = undefined
-              }
-            }
-            if (effects.length > 1) {
-              // Restore normal Vapor scheduler order before post-flush.
-              effects.sort((a, b) => a.order! - b.order!)
-            }
-            // Queue the deferred update before hooks created by the setup result.
-            if (effects.length) {
-              queuePostRenderEffect(effects, undefined, suspense)
-            }
+          if (deferred.pendingRoot === instance) {
+            deferred.pendingRoot = undefined
+          }
+          // Reserve one Suspense effect position for the whole async root chain.
+          if (!deferred.flushQueued) {
+            deferred.flushQueued = true
+            queuePostRenderEffect(
+              deferred.flushJob,
+              undefined,
+              deferred.suspense,
+            )
           }
         }
         if (hydrating) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1082,157 +1082,6 @@ export function createPlainElement(
   return el
 }
 
-export interface DeferredKeepAliveUpdates {
-  effects: SchedulerJob[]
-  owners: VaporComponentInstance[]
-  suspense: SuspenseBoundary
-  pendingId: number
-  pendingRoot?: VaporComponentInstance
-  flushQueued: boolean
-  flushJob: SchedulerJob
-}
-
-/**
- * A deferred state stays live while its async root is pending or its flush is
- * queued for the same Suspense generation. The flush is requeued if that
- * generation is discarded, so `flushQueued` cannot strand buffered updates.
- */
-export function isDeferredKeepAliveStateLive(
-  state: DeferredKeepAliveUpdates,
-): boolean {
-  const suspense = state.suspense
-  if (suspense.isUnmounted || state.pendingId !== suspense.pendingId) {
-    return false
-  }
-  if (state.flushQueued) return true
-  const root = state.pendingRoot
-  return !!root && !root.isUnmounted
-}
-
-export function settleDeferredKeepAliveUpdates(
-  state: DeferredKeepAliveUpdates,
-  currentJob?: SchedulerJob,
-): void {
-  const { effects, owners } = state
-  // Idempotent: a settle hook and a stale-detecting render effect may both
-  // settle the same state.
-  state.effects = []
-  state.owners = []
-  state.pendingRoot = undefined
-  for (let i = 0; i < owners.length; i++) {
-    if (owners[i].deferredKeepAliveUpdates === state) {
-      owners[i].deferredKeepAliveUpdates = undefined
-    }
-  }
-  // Replay buffered updates so owner effects captured before the state went
-  // stale are not lost. The detecting job joins the batch so the whole set
-  // runs in scheduler order - an outer removal must still precede a buffered
-  // inner update; stopped jobs no-op on their dirty check.
-  if (currentJob && !effects.includes(currentJob)) {
-    effects.push(currentJob)
-  }
-  if (effects.length > 1) {
-    effects.sort((a, b) => a.order! - b.order!)
-  }
-  for (let i = 0; i < effects.length; i++) {
-    const job = effects[i]
-    callWithErrorHandling(
-      job,
-      job.i,
-      job.i ? ErrorCodes.COMPONENT_UPDATE : ErrorCodes.SCHEDULER,
-    )
-  }
-}
-
-function deferKeepAliveRenderEffects(
-  instance: VaporComponentInstance,
-): DeferredKeepAliveUpdates | undefined {
-  const suspense = instance.suspense!
-  const owners: VaporComponentInstance[] = []
-  let keepAlive: VaporComponentInstance | undefined
-  if (isHydrating) {
-    // Ancestor blocks are not committed during hydration. Preserve the direct
-    // KeepAlive-owner path; wrapper roots cannot be proven here.
-    const owner = instance.parent
-    if (
-      owner &&
-      owner.vapor &&
-      isKeepAlive(owner) &&
-      owner.suspense === suspense
-    ) {
-      keepAlive = owner as VaporComponentInstance
-      owners.push(keepAlive)
-    }
-  } else {
-    let child: Block = instance
-    let owner = instance.parent
-    while (owner && owner.vapor && owner.suspense === suspense) {
-      const vaporOwner = owner as VaporComponentInstance
-      let root = vaporOwner.block
-      // Dynamic component and v-if roots use fragments in Vapor where VDOM
-      // exposes the active component directly as `subTree.component`.
-      while (isDynamicFragment(root) && !root.isSlot) {
-        root = root.nodes
-      }
-      if (root !== child) return
-
-      owners.push(vaporOwner)
-      if (isKeepAlive(owner)) {
-        // Use the outermost KeepAlive so nested async roots share one state,
-        // matching VDOM's component-root update.
-        keepAlive = vaporOwner
-      }
-
-      child = vaporOwner
-      owner = vaporOwner.parent
-    }
-  }
-
-  if (!keepAlive) return
-
-  let deferred = keepAlive.deferredKeepAliveUpdates
-  if (
-    !deferred ||
-    deferred.suspense !== suspense ||
-    deferred.pendingId !== instance.suspenseId
-  ) {
-    // Runs when the boundary resolves (or on the resolving tick when it
-    // has no pending branch), ahead of setup-created Suspense effects.
-    const flushJob: SchedulerJob = () => {
-      state.flushQueued = false
-      // A resolved root may synchronously mount another pending async root.
-      if (keepAlive.deferredKeepAliveUpdates !== state || state.pendingRoot) {
-        return
-      }
-      settleDeferredKeepAliveUpdates(state)
-    }
-    flushJob.flags = SchedulerJobFlags.REQUEUE_ON_SUSPENSE_DISCARD
-    const state: DeferredKeepAliveUpdates = {
-      effects: [],
-      owners: [],
-      suspense,
-      pendingId: instance.suspenseId,
-      pendingRoot: instance,
-      flushQueued: false,
-      flushJob,
-    }
-    // Owner effects settle a stale state before mounting a new root. Nested
-    // roots from an accepted continuation share this generation and reuse it.
-    deferred = state
-  } else {
-    deferred.pendingRoot = instance
-  }
-
-  for (let i = 0; i < owners.length; i++) {
-    const owner = owners[i]
-    if (owner.deferredKeepAliveUpdates !== deferred) {
-      owner.deferredKeepAliveUpdates = deferred
-      deferred.owners.push(owner)
-    }
-  }
-  return deferred
-}
-
 export function mountComponent(
   instance: VaporComponentInstance,
   parent: ParentNode,
@@ -1266,6 +1115,7 @@ export function mountComponent(
       return
     }
 
+    const suspense = instance.suspense
     const deferred = isKeepAliveEnabled && deferKeepAliveRenderEffects(instance)
     const hydrating = isHydrating
     if (!hydrating) {
@@ -1277,9 +1127,13 @@ export function mountComponent(
 
     instance.asyncDepRegistered = true
     const component = instance.type
-    instance.suspense.registerDep(instance, setupResult => {
-      // Final suspense retry after async setup resolves. Restore hydrating
-      // mode so the last mount does not fall back to fresh DOM insertion.
+    let asyncSetupFinished = false
+    const finishAsyncSetup = (setupResult: any): void => {
+      if (asyncSetupFinished) return
+      asyncSetupFinished = true
+      instance.asyncResolved = true
+      // Restore hydrating mode for the final mount so stale-generation
+      // recovery does not fall back to fresh DOM insertion.
       const reset =
         instance.restoreAsyncContext && instance.restoreAsyncContext()
       // handleSetupResult may invoke the render function, which creates
@@ -1299,23 +1153,6 @@ export function mountComponent(
         // Use the pending DOM's live boundary because it may have moved while
         // setup was suspended.
         const { parentNode, nextNode } = findBlockBoundary(pendingBlock)
-        if (deferred) {
-          if (deferred.pendingRoot === instance) {
-            deferred.pendingRoot = undefined
-          }
-          // Reserve one flush for the whole async root chain, gated on the
-          // nearest boundary like VDOM's deferred retry. If the boundary
-          // discards that generation, the marked flush moves to the ordinary
-          // post queue so the surviving Vapor owners cannot stay dirty forever.
-          if (!deferred.flushQueued) {
-            deferred.flushQueued = true
-            queuePostRenderEffect(
-              deferred.flushJob,
-              undefined,
-              deferred.suspense,
-            )
-          }
-        }
         if (hydrating) {
           withDeferredHydrationBoundary(() => {
             handleResult()
@@ -1337,15 +1174,42 @@ export function mountComponent(
         instance.restoreAsyncContext = undefined
         if (reset) reset()
       }
+    }
+    
+    suspense.registerDep(instance, setupResult => {
+      if (deferred) {
+        if (deferred.pendingRoot === instance) {
+          deferred.pendingRoot = undefined
+        }
+        // Reserve one flush for the whole async root chain, gated on the
+        // nearest boundary like VDOM's deferred retry. If the boundary
+        // discards that generation, the marked flush moves to the ordinary
+        // post queue so the surviving Vapor owners cannot stay dirty forever.
+        if (!deferred.flushQueued) {
+          deferred.flushQueued = true
+          queuePostRenderEffect(deferred.flushJob, undefined, deferred.suspense)
+        }
+      }
+      finishAsyncSetup(setupResult)
     })
+
     if (deferred) {
       const state = deferred
-      // Suspense skips the registerDep callback above for roots unmounted
-      // early or superseded pending cycles, leaving buffered updates with no
-      // flush and possibly no future owner notification to recover through.
-      // This hook settles after Suspense's own callback (registered above),
-      // so when the callback did run, its queued flush wins.
-      instance.asyncDep!.catch(NOOP).then(() => {
+      // Suspense skips the callback above for unmounted roots or stale
+      // generations. If the replacement generation is already gone, complete
+      // a surviving instance before replaying deferred owner updates. The
+      // normal callback runs first and makes this a no-op.
+      instance.asyncDep!.catch(NOOP).then(setupResult => {
+        if (asyncSetupFinished) return
+        // A foreign pending generation cannot own this surviving instance's
+        // mount hooks because discarding it would discard those hooks too.
+        if (
+          !instance.isUnmounted &&
+          !suspense.isUnmounted &&
+          !suspense.pendingBranch
+        ) {
+          finishAsyncSetup(setupResult)
+        }
         if (!state.flushQueued && state.pendingRoot === instance) {
           settleDeferredKeepAliveUpdates(state)
         }
@@ -1737,4 +1601,156 @@ function registerDynamicFragmentFallthroughAttrs(
   ;(frag.onBeforeInsert ||= []).push(nodes =>
     applyFallthroughAttrs(nodes, instance, getFallthroughAttrs, frag.scope!),
   )
+}
+
+
+export interface DeferredKeepAliveUpdates {
+  effects: SchedulerJob[]
+  owners: VaporComponentInstance[]
+  suspense: SuspenseBoundary
+  pendingId: number
+  pendingRoot?: VaporComponentInstance
+  flushQueued: boolean
+  flushJob: SchedulerJob
+}
+
+/**
+ * A deferred state stays live while its async root is pending or its flush is
+ * queued for the same Suspense generation. The flush is requeued if that
+ * generation is discarded, so `flushQueued` cannot strand buffered updates.
+ */
+export function isDeferredKeepAliveStateLive(
+  state: DeferredKeepAliveUpdates,
+): boolean {
+  const suspense = state.suspense
+  if (suspense.isUnmounted || state.pendingId !== suspense.pendingId) {
+    return false
+  }
+  if (state.flushQueued) return true
+  const root = state.pendingRoot
+  return !!root && !root.isUnmounted
+}
+
+export function settleDeferredKeepAliveUpdates(
+  state: DeferredKeepAliveUpdates,
+  currentJob?: SchedulerJob,
+): void {
+  const { effects, owners } = state
+  // Idempotent: a settle hook and a stale-detecting render effect may both
+  // settle the same state.
+  state.effects = []
+  state.owners = []
+  state.pendingRoot = undefined
+  for (let i = 0; i < owners.length; i++) {
+    if (owners[i].deferredKeepAliveUpdates === state) {
+      owners[i].deferredKeepAliveUpdates = undefined
+    }
+  }
+  // Replay buffered updates so owner effects captured before the state went
+  // stale are not lost. The detecting job joins the batch so the whole set
+  // runs in scheduler order - an outer removal must still precede a buffered
+  // inner update; stopped jobs no-op on their dirty check.
+  if (currentJob && !effects.includes(currentJob)) {
+    effects.push(currentJob)
+  }
+  if (effects.length > 1) {
+    effects.sort((a, b) => a.order! - b.order!)
+  }
+  for (let i = 0; i < effects.length; i++) {
+    const job = effects[i]
+    callWithErrorHandling(
+      job,
+      job.i,
+      job.i ? ErrorCodes.COMPONENT_UPDATE : ErrorCodes.SCHEDULER,
+    )
+  }
+}
+
+function deferKeepAliveRenderEffects(
+  instance: VaporComponentInstance,
+): DeferredKeepAliveUpdates | undefined {
+  const suspense = instance.suspense!
+  const owners: VaporComponentInstance[] = []
+  let keepAlive: VaporComponentInstance | undefined
+  if (isHydrating) {
+    // Ancestor blocks are not committed during hydration. Preserve the direct
+    // KeepAlive-owner path; wrapper roots cannot be proven here.
+    const owner = instance.parent
+    if (
+      owner &&
+      owner.vapor &&
+      isKeepAlive(owner) &&
+      owner.suspense === suspense
+    ) {
+      keepAlive = owner as VaporComponentInstance
+      owners.push(keepAlive)
+    }
+  } else {
+    let child: Block = instance
+    let owner = instance.parent
+    while (owner && owner.vapor && owner.suspense === suspense) {
+      const vaporOwner = owner as VaporComponentInstance
+      let root = vaporOwner.block
+      // Dynamic component and v-if roots use fragments in Vapor where VDOM
+      // exposes the active component directly as `subTree.component`.
+      while (isDynamicFragment(root) && !root.isSlot) {
+        root = root.nodes
+      }
+      if (root !== child) return
+
+      owners.push(vaporOwner)
+      if (isKeepAlive(owner)) {
+        // Use the outermost KeepAlive so nested async roots share one state,
+        // matching VDOM's component-root update.
+        keepAlive = vaporOwner
+      }
+
+      child = vaporOwner
+      owner = vaporOwner.parent
+    }
+  }
+
+  if (!keepAlive) return
+
+  let deferred = keepAlive.deferredKeepAliveUpdates
+  if (
+    !deferred ||
+    deferred.suspense !== suspense ||
+    deferred.pendingId !== instance.suspenseId
+  ) {
+    // Runs when the boundary resolves (or on the resolving tick when it
+    // has no pending branch), ahead of setup-created Suspense effects.
+    const flushJob: SchedulerJob = () => {
+      state.flushQueued = false
+      // A resolved root may synchronously mount another pending async root.
+      if (keepAlive.deferredKeepAliveUpdates !== state || state.pendingRoot) {
+        return
+      }
+      settleDeferredKeepAliveUpdates(state)
+    }
+    flushJob.flags = SchedulerJobFlags.REQUEUE_ON_SUSPENSE_DISCARD
+    const state: DeferredKeepAliveUpdates = {
+      effects: [],
+      owners: [],
+      suspense,
+      pendingId: instance.suspenseId,
+      pendingRoot: instance,
+      flushQueued: false,
+      flushJob,
+    }
+    // Owner effects settle a stale state before mounting a new root. Nested
+    // roots from an accepted continuation share this generation and reuse it.
+    deferred = state
+  } else {
+    deferred.pendingRoot = instance
+  }
+
+  for (let i = 0; i < owners.length; i++) {
+    const owner = owners[i]
+    if (owner.deferredKeepAliveUpdates !== deferred) {
+      owner.deferredKeepAliveUpdates = deferred
+      deferred.owners.push(owner)
+    }
+  }
+  return deferred
 }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1175,7 +1175,7 @@ export function mountComponent(
         if (reset) reset()
       }
     }
-    
+
     suspense.registerDep(instance, setupResult => {
       if (deferred) {
         if (deferred.pendingRoot === instance) {
@@ -1602,7 +1602,6 @@ function registerDynamicFragmentFallthroughAttrs(
     applyFallthroughAttrs(nodes, instance, getFallthroughAttrs, frag.scope!),
   )
 }
-
 
 export interface DeferredKeepAliveUpdates {
   effects: SchedulerJob[]

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -17,6 +17,7 @@ import {
   type NormalizedPropsOptions,
   type ObjectEmitsOptions,
   type SchedulerJob,
+  SchedulerJobFlags,
   type ShallowUnwrapRef,
   type SuspenseBoundary,
   callWithErrorHandling,
@@ -55,6 +56,7 @@ import {
 } from '@vue/reactivity'
 import {
   EMPTY_OBJ,
+  NOOP,
   type Prettify,
   ShapeFlags,
   hasOwn,
@@ -1080,7 +1082,7 @@ export function createPlainElement(
   return el
 }
 
-interface DeferredKeepAliveUpdates {
+export interface DeferredKeepAliveUpdates {
   effects: SchedulerJob[]
   owners: VaporComponentInstance[]
   suspense: SuspenseBoundary
@@ -1088,6 +1090,58 @@ interface DeferredKeepAliveUpdates {
   pendingRoot?: VaporComponentInstance
   flushQueued: boolean
   flushJob: SchedulerJob
+}
+
+/**
+ * A deferred state stays live while its async root is pending or its flush is
+ * queued for the same Suspense generation. The flush is requeued if that
+ * generation is discarded, so `flushQueued` cannot strand buffered updates.
+ */
+export function isDeferredKeepAliveStateLive(
+  state: DeferredKeepAliveUpdates,
+): boolean {
+  const suspense = state.suspense
+  if (suspense.isUnmounted || state.pendingId !== suspense.pendingId) {
+    return false
+  }
+  if (state.flushQueued) return true
+  const root = state.pendingRoot
+  return !!root && !root.isUnmounted
+}
+
+export function settleDeferredKeepAliveUpdates(
+  state: DeferredKeepAliveUpdates,
+  currentJob?: SchedulerJob,
+): void {
+  const { effects, owners } = state
+  // Idempotent: a settle hook and a stale-detecting render effect may both
+  // settle the same state.
+  state.effects = []
+  state.owners = []
+  state.pendingRoot = undefined
+  for (let i = 0; i < owners.length; i++) {
+    if (owners[i].deferredKeepAliveUpdates === state) {
+      owners[i].deferredKeepAliveUpdates = undefined
+    }
+  }
+  // Replay buffered updates so owner effects captured before the state went
+  // stale are not lost. The detecting job joins the batch so the whole set
+  // runs in scheduler order - an outer removal must still precede a buffered
+  // inner update; stopped jobs no-op on their dirty check.
+  if (currentJob && !effects.includes(currentJob)) {
+    effects.push(currentJob)
+  }
+  if (effects.length > 1) {
+    effects.sort((a, b) => a.order! - b.order!)
+  }
+  for (let i = 0; i < effects.length; i++) {
+    const job = effects[i]
+    callWithErrorHandling(
+      job,
+      job.i,
+      job.i ? ErrorCodes.COMPONENT_UPDATE : ErrorCodes.SCHEDULER,
+    )
+  }
 }
 
 function deferKeepAliveRenderEffects(
@@ -1142,6 +1196,17 @@ function deferKeepAliveRenderEffects(
     deferred.suspense !== suspense ||
     deferred.pendingId !== instance.suspenseId
   ) {
+    // Runs when the boundary resolves (or on the resolving tick when it
+    // has no pending branch), ahead of setup-created Suspense effects.
+    const flushJob: SchedulerJob = () => {
+      state.flushQueued = false
+      // A resolved root may synchronously mount another pending async root.
+      if (keepAlive.deferredKeepAliveUpdates !== state || state.pendingRoot) {
+        return
+      }
+      settleDeferredKeepAliveUpdates(state)
+    }
+    flushJob.flags = SchedulerJobFlags.REQUEUE_ON_SUSPENSE_DISCARD
     const state: DeferredKeepAliveUpdates = {
       effects: [],
       owners: [],
@@ -1149,34 +1214,10 @@ function deferKeepAliveRenderEffects(
       pendingId: instance.suspenseId,
       pendingRoot: instance,
       flushQueued: false,
-      flushJob: () => {
-        state.flushQueued = false
-        // A resolved root may synchronously mount another pending async root.
-        if (keepAlive.deferredKeepAliveUpdates !== state || state.pendingRoot) {
-          return
-        }
-
-        const { effects, owners } = state
-        for (let i = 0; i < owners.length; i++) {
-          if (owners[i].deferredKeepAliveUpdates === state) {
-            owners[i].deferredKeepAliveUpdates = undefined
-          }
-        }
-        if (effects.length > 1) {
-          // Restore normal Vapor scheduler order across nested async roots.
-          effects.sort((a, b) => a.order! - b.order!)
-        }
-        // Run here so updates stay ahead of setup-created Suspense effects.
-        for (let i = 0; i < effects.length; i++) {
-          const job = effects[i]
-          callWithErrorHandling(
-            job,
-            job.i,
-            job.i ? ErrorCodes.COMPONENT_UPDATE : ErrorCodes.SCHEDULER,
-          )
-        }
-      },
+      flushJob,
     }
+    // Owner effects settle a stale state before mounting a new root. Nested
+    // roots from an accepted continuation share this generation and reuse it.
     deferred = state
   } else {
     deferred.pendingRoot = instance
@@ -1262,7 +1303,10 @@ export function mountComponent(
           if (deferred.pendingRoot === instance) {
             deferred.pendingRoot = undefined
           }
-          // Reserve one Suspense effect position for the whole async root chain.
+          // Reserve one flush for the whole async root chain, gated on the
+          // nearest boundary like VDOM's deferred retry. If the boundary
+          // discards that generation, the marked flush moves to the ordinary
+          // post queue so the surviving Vapor owners cannot stay dirty forever.
           if (!deferred.flushQueued) {
             deferred.flushQueued = true
             queuePostRenderEffect(
@@ -1294,6 +1338,19 @@ export function mountComponent(
         if (reset) reset()
       }
     })
+    if (deferred) {
+      const state = deferred
+      // Suspense skips the registerDep callback above for roots unmounted
+      // early or superseded pending cycles, leaving buffered updates with no
+      // flush and possibly no future owner notification to recover through.
+      // This hook settles after Suspense's own callback (registered above),
+      // so when the callback did run, its queued flush wins.
+      instance.asyncDep!.catch(NOOP).then(() => {
+        if (!state.flushQueued && state.pendingRoot === instance) {
+          settleDeferredKeepAliveUpdates(state)
+        }
+      })
+    }
     return
   }
 

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -11,7 +11,12 @@ import {
   startMeasure,
   warn,
 } from '@vue/runtime-dom'
-import { type VaporComponentInstance, isVaporComponent } from './component'
+import {
+  type VaporComponentInstance,
+  isDeferredKeepAliveStateLive,
+  isVaporComponent,
+  settleDeferredKeepAliveUpdates,
+} from './component'
 import { inOnceSlot } from './componentSlots'
 import { invokeArrayFns } from '@vue/shared'
 import { isSuspenseEnabled } from './suspense'
@@ -42,10 +47,18 @@ export class RenderEffect extends ReactiveEffect {
           this.i &&
           this.i.deferredKeepAliveUpdates
         if (deferred) {
-          deferred.effects.push(this.job)
-        } else {
-          this.run()
+          if (isDeferredKeepAliveStateLive(deferred)) {
+            deferred.effects.push(this.job)
+            return
+          }
+          // The pending root can no longer resolve through this state
+          // (unmounted early or superseded suspense cycle) - drop the stale
+          // state and replay its buffered updates together with this job in
+          // scheduler order (this job re-enters with the state cleared).
+          settleDeferredKeepAliveUpdates(deferred, this.job)
+          return
         }
+        this.run()
       }
     }
 

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -34,7 +34,13 @@ export class RenderEffect extends ReactiveEffect {
 
     const job: SchedulerJob = () => {
       if (this.dirty) {
-        this.run()
+        // KeepAlive sets this while a direct async setup child blocks Suspense.
+        if (this.i && this.i.deferRenderEffects) {
+          // Queue with Suspense to match VDOM's cache-before-update ordering.
+          queuePostRenderEffect(this.job, undefined, this.i.suspense)
+        } else {
+          this.run()
+        }
       }
     }
 

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -35,14 +35,14 @@ export class RenderEffect extends ReactiveEffect {
 
     const job: SchedulerJob = () => {
       if (this.dirty) {
-        // KeepAlive defers updates while its async setup root is pending.
+        // A pending KeepAlive async root defers updates along its root chain.
         const deferred =
           __FEATURE_SUSPENSE__ &&
           isSuspenseEnabled &&
           this.i &&
-          this.i.deferredRenderEffects
+          this.i.deferredKeepAliveUpdates
         if (deferred) {
-          deferred.push(this.job)
+          deferred.effects.push(this.job)
         } else {
           this.run()
         }

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -35,7 +35,7 @@ export class RenderEffect extends ReactiveEffect {
 
     const job: SchedulerJob = () => {
       if (this.dirty) {
-        // KeepAlive defers updates while its direct async setup child is pending.
+        // KeepAlive defers updates while its async setup root is pending.
         const deferred =
           __FEATURE_SUSPENSE__ &&
           isSuspenseEnabled &&

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -14,6 +14,7 @@ import {
 import { type VaporComponentInstance, isVaporComponent } from './component'
 import { inOnceSlot } from './componentSlots'
 import { invokeArrayFns } from '@vue/shared'
+import { isSuspenseEnabled } from './suspense'
 
 export class RenderEffect extends ReactiveEffect {
   i: VaporComponentInstance | null
@@ -34,10 +35,14 @@ export class RenderEffect extends ReactiveEffect {
 
     const job: SchedulerJob = () => {
       if (this.dirty) {
-        // KeepAlive sets this while a direct async setup child blocks Suspense.
-        if (this.i && this.i.deferRenderEffects) {
-          // Queue with Suspense to match VDOM's cache-before-update ordering.
-          queuePostRenderEffect(this.job, undefined, this.i.suspense)
+        // KeepAlive defers updates while its direct async setup child is pending.
+        const deferred =
+          __FEATURE_SUSPENSE__ &&
+          isSuspenseEnabled &&
+          this.i &&
+          this.i.deferredRenderEffects
+        if (deferred) {
+          deferred.push(this.job)
         } else {
           this.run()
         }


### PR DESCRIPTION
- defer Vapor KeepAlive root-chain updates while async setup is pending, avoiding transient branch renders and matching VDOM behavior
- preserve deferred updates across component-root wrappers, nested KeepAlive roots, and nested async roots in the same Suspense pending cycle
- restore normal Vapor scheduler ordering and component update error handling when flushing deferred effects, with direct-owner hydration support
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when switching cached views during asynchronous loading.
  * Prevented stale or skipped Suspense branches from applying outdated updates.
  * Ensured asynchronous component setup completes correctly without duplicate execution.
  * Preserved existing server-rendered content during hydration while async components resolve.
  * Improved recovery and update handling when pending Suspense content is replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->