### PR TITLE
fix(reactivity): restore state after array mutation errors

### DIFF
--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -350,6 +350,49 @@ describe('reactivity/reactive/Array', () => {
       expect(index).toBe(2)
       expect(observed.lastSearched).toBe(6)
     })
+
+    test('restores batching when a mutation method throws', () => {
+      class ThrowingArray<T> extends Array<T> {
+        push(..._items: T[]): number {
+          throw new Error('boom')
+        }
+      }
+
+      const observed = reactive(new ThrowingArray<number>())
+      expect(() => observed.push(1)).toThrow('boom')
+
+      const count = ref(0)
+      const countSpy = vi.fn(() => count.value)
+      effect(countSpy)
+
+      count.value++
+      expect(countSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('restores tracking when flushing a mutation throws', () => {
+      const observed = reactive<number[]>([])
+      let shouldThrow = false
+      effect(() => {
+        observed.length
+        if (shouldThrow) {
+          throw new Error('boom')
+        }
+      })
+
+      const tracked = ref(0)
+      const trackedSpy = vi.fn()
+      effect(() => {
+        try {
+          shouldThrow = true
+          observed.push(1)
+        } catch {}
+        tracked.value
+        trackedSpy()
+      })
+
+      tracked.value++
+      expect(trackedSpy).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('Optimized array methods:', () => {

--- a/packages/reactivity/src/arrayInstrumentations.ts
+++ b/packages/reactivity/src/arrayInstrumentations.ts
@@ -365,8 +365,13 @@ function noTracking(
 ) {
   pauseTracking()
   startBatch()
-  const res = (toRaw(self) as any)[method].apply(self, args)
-  endBatch()
-  resetTracking()
-  return res
+  try {
+    return (toRaw(self) as any)[method].apply(self, args)
+  } finally {
+    try {
+      endBatch()
+    } finally {
+      resetTracking()
+    }
+  }
 }


### PR DESCRIPTION
## Problem

Length-altering reactive array methods temporarily pause dependency tracking and start a batch in `noTracking()`.

If the underlying array method throws, for example when a custom Array subclass overrides `push()`, the existing implementation skips both `endBatch()` and `resetTracking()`.

This leaves `batchDepth` above zero, causing subsequent reactive effects to remain queued indefinitely. It can also leave dependency tracking paused.

In addition, `endBatch()` can itself throw while flushing a user effect, so restoring tracking after a regular `endBatch()` call is not sufficient.

## Fix

Wrap the mutation in `try/finally`, and use a nested `finally` for cleanup:

- always call `endBatch()` after the mutation attempt
- always call `resetTracking()`, even if `endBatch()` throws


And I also added regression coverage for:

- restoring batching when an Array subclass mutation method throws
- restoring dependency tracking when an effect throws during batch flushing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of reactive array mutations when an operation throws an error.
  * Ensured batching and dependency tracking are properly restored after failed array updates.
  * Added regression coverage for error handling during overridden and effect-triggered `push` operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->