### PR TITLE
fix(compiler-sfc): avoid walking cached type references

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1791,4 +1791,45 @@ describe('compileScript', () => {
     expect(lang).toBe('coffee')
     expect(scriptAst).not.toBeDefined()
   })
+
+  test('should not walk cached recursive type references', () => {
+    const files: Record<string, string> = {
+      '/issue-15174/types.ts': `
+        export type TreeNode = {
+          parent?: TreeNode
+        }
+
+        export type ItemProps = {
+          node?: TreeNode
+        }
+      `,
+    }
+    const options = {
+      fs: {
+        fileExists: (file: string) => file in files,
+        readFile: (file: string) => files[file],
+      },
+    }
+    const item = `
+      <script setup lang="ts">
+      import type { ItemProps } from './types'
+      defineProps<ItemProps>()
+      </script>
+    `
+
+    expect(() => {
+      compile(
+        `
+          <script setup lang="ts">
+          import type { TreeNode } from './types'
+          defineProps<{ parentNode?: TreeNode['parent'] }>()
+          </script>
+        `,
+        options,
+        { filename: '/issue-15174/App.vue' },
+      )
+      compile(item, options, { filename: '/issue-15174/Second.vue' })
+      compile(item, options, { filename: '/issue-15174/Third.vue' })
+    }).not.toThrow()
+  })
 })

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -787,7 +787,15 @@ function resolveTypeReference(
     node,
     onlyExported,
   )
-  return canCache ? (node._resolvedReference = resolved) : resolved
+  if (canCache) {
+    Object.defineProperty(node, '_resolvedReference', {
+      value: resolved,
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    })
+  }
+  return resolved
 }
 
 function innerResolveTypeReference(


### PR DESCRIPTION
close #15174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of recursive TypeScript type references during compilation.
  * Prevented cached type information from being incorrectly traversed, avoiding compilation failures in affected cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->