### PR TITLE
fix(runtime-vapor): restore concurrent async hydration context

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -3,6 +3,7 @@ import {
   child,
   createComponent,
   createPlainElement,
+  createVaporApp,
   createVaporSSRApp,
   defineVaporAsyncComponent,
   defineVaporComponent,
@@ -14632,5 +14633,72 @@ describe('VDOM interop', () => {
     show.value = false
     await nextTick()
     expect(container.innerHTML).toBe('<div><a><span>after</span></a></div>')
+  })
+
+  test('does not leak concurrent async hydration context', async () => {
+    const resolvers: Array<() => void> = []
+    const mountedHtml: string[] = []
+    const Fresh = compileVaporComponent('<strong>fresh</strong>')
+    const mountFresh = () => {
+      const container = document.createElement('div')
+      createVaporApp(Fresh).mount(container)
+      return container.innerHTML
+    }
+    const serverData = ref({
+      waits: [Promise.resolve(), Promise.resolve()],
+      afterAwait: () => {},
+    })
+    const clientData = ref({
+      waits: [
+        new Promise<void>(resolve => resolvers.push(resolve)),
+        new Promise<void>(resolve => resolvers.push(resolve)),
+      ],
+      afterAwait: () => mountedHtml.push(mountFresh()),
+    })
+    const childCode = `
+      <script vapor>
+        const data = _data
+        const props = defineProps(['id'])
+        await data.value.waits[props.id]
+        Promise.resolve().then(data.value.afterAwait)
+      </script>
+      <template><span>{{ props.id }}</span></template>
+    `
+
+    let AsyncChild = compileVaporComponent(
+      childCode,
+      serverData,
+      undefined,
+      true,
+    )
+    const App = defineComponent({
+      setup: () => () =>
+        h(runtimeDom.Suspense, null, {
+          default: () =>
+            h('div', [h(AsyncChild, { id: 0 }), h(AsyncChild, { id: 1 })]),
+        }),
+    })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(App),
+    )
+
+    AsyncChild = compileVaporComponent(childCode, clientData)
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    const app = runtimeDom.createSSRApp(App)
+    app.use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    resolvers.forEach(resolve => resolve())
+    await new Promise(resolve => setTimeout(resolve))
+    expect(container.textContent).toBe('01')
+    expect(mountedHtml).toEqual([
+      '<strong>fresh</strong>',
+      '<strong>fresh</strong>',
+    ])
+    expect(mountFresh()).toBe('<strong>fresh</strong>')
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    app.unmount()
   })
 })

--- a/packages/runtime-vapor/src/apiSetupHelpers.ts
+++ b/packages/runtime-vapor/src/apiSetupHelpers.ts
@@ -4,7 +4,7 @@ import {
 } from '@vue/runtime-dom'
 import {
   currentHydrationNode,
-  enterHydration,
+  enterAsyncHydration,
   isHydrating,
 } from './dom/hydration'
 import type { VaporComponentInstance } from './component'
@@ -15,7 +15,7 @@ export function withAsyncContext(getAwaitable: () => any): [any, () => void] {
     const hydrationNode = currentHydrationNode!
     // After `__restore()` brings back the component instance, vapor still needs
     // its own hydration state restored so setup can continue adopting SSR nodes.
-    instance.restoreAsyncContext = () => enterHydration(hydrationNode)
+    instance.restoreAsyncContext = () => enterAsyncHydration(hydrationNode)
   }
 
   return baseWithAsyncContext(getAwaitable)

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -114,20 +114,32 @@ export function hydrateNode(node: Node, fn: () => void): void {
   return performHydration(fn, setup, cleanup)
 }
 
-export function enterHydration(node: Node): () => void {
-  const prevHydrationEnabled = isHydratingEnabled
-  if (!prevHydrationEnabled) {
+// withAsyncContext defers cleanup, so async hydration continuations may overlap.
+// Preserve the state captured before the first restore as their shared baseline.
+let pendingAsyncHydrationResets = 0
+let asyncHydrationIsEnabled = false
+let asyncHydrationIsHydrating = false
+let asyncHydrationNode: Node | null = null
+
+export function enterAsyncHydration(node: Node): () => void {
+  if (pendingAsyncHydrationResets++ === 0) {
+    asyncHydrationIsEnabled = isHydratingEnabled
+    asyncHydrationIsHydrating = isHydrating
+    asyncHydrationNode = currentHydrationNode
+  }
+  if (!isHydratingEnabled) {
     setIsHydratingEnabled(true)
   }
 
-  const prev = setIsHydrating(true)
-  const prevHydrationNode = currentHydrationNode
+  setIsHydrating(true)
   currentHydrationNode = node
 
   return () => {
-    currentHydrationNode = prevHydrationNode
-    setIsHydrating(prev)
-    if (!prevHydrationEnabled) {
+    pendingAsyncHydrationResets--
+    // Restore the shared baseline instead of another continuation's state.
+    currentHydrationNode = asyncHydrationNode
+    setIsHydrating(asyncHydrationIsHydrating)
+    if (!asyncHydrationIsEnabled) {
       setIsHydratingEnabled(false)
     }
   }


### PR DESCRIPTION
- preserve a shared baseline across overlapping async setup continuations
- restore the baseline on each cleanup instead of restoring sibling state
- add regression coverage for concurrent hydration and subsequent CSR mounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration reliability for multiple concurrent asynchronous components.
  * Prevented hydration state from leaking between component instances.
  * Reduced the risk of hydration mismatch warnings during asynchronous rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->