### PR TITLE
fix(runtime-vapor): schedule async hydration anchors before updates

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -6133,6 +6133,78 @@ describe('Vapor Mode hydration', () => {
       expect(data.value.spy).toHaveBeenCalled()
     })
 
+    test('updates an earlier branch from sibling beforeMount during async component hydration', async () => {
+      const data = ref({ show: true })
+      const innerCode = `
+        <div v-if="data.show">A</div>
+        <components.Mutator />
+      `
+      const mutatorCode = `
+        <script vapor>
+          import { onBeforeMount } from 'vue'
+          const data = _data
+          onBeforeMount(() => {
+            data.value.show = false
+          })
+        </script>
+        <template><span>tail</span></template>
+      `
+      const appCode = `<components.AsyncComp />`
+
+      const SSRMutator = compileVaporComponent(
+        mutatorCode,
+        data,
+        undefined,
+        true,
+      )
+      const SSRInner = compileVaporComponent(
+        innerCode,
+        data,
+        { Mutator: SSRMutator },
+        true,
+      )
+      const SSRAsyncComp = defineAsyncComponent(() => Promise.resolve(SSRInner))
+      const SSRApp = compileVaporComponent(
+        appCode,
+        data,
+        { AsyncComp: SSRAsyncComp },
+        true,
+      )
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+
+      const Mutator = compileVaporComponent(mutatorCode, data)
+      const Inner = compileVaporComponent(innerCode, data, { Mutator })
+      let clientResolve: (comp: any) => void
+      const AsyncComp = defineVaporAsyncComponent(
+        () =>
+          new Promise(resolve => {
+            clientResolve = resolve
+          }),
+      )
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const errorHandler = vi.fn()
+      const app = createVaporSSRApp(App)
+      app.config.errorHandler = errorHandler
+      app.mount(container)
+
+      clientResolve!(Inner)
+      await new Promise(resolve => setTimeout(resolve))
+      await nextTick()
+
+      expect(errorHandler).not.toHaveBeenCalled()
+      expect(container.textContent).toBe('tail')
+
+      data.value.show = true
+      await nextTick()
+      expect(errorHandler).not.toHaveBeenCalled()
+      expect(container.textContent).toBe('Atail')
+    })
+
     // No longer needed, parent component updates in vapor mode no longer
     // cause child components to re-render
     // test.todo('update async wrapper before resolve', async () => {})
@@ -6776,6 +6848,104 @@ describe('Vapor Mode hydration', () => {
 
     describe('suspense', () => {
       describe('VDOM suspense', () => {
+        test('updates an earlier branch from sibling beforeMount during async setup hydration', async () => {
+          const childCode = `
+            <script vapor>
+              const data = _data
+              const components = _components
+              await data.value.wait
+            </script>
+            <template>
+              <div v-if="data.show">A</div>
+              <components.Mutator />
+            </template>
+          `
+          const mutatorCode = `
+            <script vapor>
+              import { onBeforeMount } from 'vue'
+              const data = _data
+              onBeforeMount(() => {
+                data.value.show = false
+              })
+            </script>
+            <template><span>tail</span></template>
+          `
+          const appCode = `
+            <script setup>
+              const components = _components
+            </script>
+            <template>
+              <Suspense>
+                <components.VaporChild />
+              </Suspense>
+            </template>
+          `
+
+          const data = ref({
+            show: true,
+            wait: Promise.resolve(),
+          })
+          const serverMutator = compileVaporComponent(
+            mutatorCode,
+            data,
+            undefined,
+            true,
+          )
+          const serverChild = compileVaporComponent(
+            childCode,
+            data,
+            { Mutator: serverMutator },
+            true,
+          )
+          const serverApp = compile(
+            appCode,
+            data,
+            { VaporChild: serverChild },
+            { vapor: false, ssr: true },
+          )
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(serverApp),
+          )
+
+          let resolve: () => void
+          data.value = {
+            show: true,
+            wait: new Promise<void>(r => {
+              resolve = r
+            }),
+          }
+          const clientMutator = compileVaporComponent(mutatorCode, data)
+          const clientChild = compileVaporComponent(childCode, data, {
+            Mutator: clientMutator,
+          })
+          const clientApp = compile(
+            appCode,
+            data,
+            { VaporChild: clientChild },
+            { vapor: false },
+          )
+          const container = document.createElement('div')
+          container.innerHTML = html
+          document.body.appendChild(container)
+          const errorHandler = vi.fn()
+          const app = runtimeDom.createSSRApp(clientApp)
+          app.config.errorHandler = errorHandler
+          app.use(runtimeVapor.vaporInteropPlugin)
+          app.mount(container)
+
+          resolve!()
+          await new Promise(r => setTimeout(r))
+          await nextTick()
+
+          expect(errorHandler).not.toHaveBeenCalled()
+          expect(container.textContent).toBe('tail')
+
+          data.value.show = true
+          await nextTick()
+          expect(errorHandler).not.toHaveBeenCalled()
+          expect(container.textContent).toBe('Atail')
+        })
+
         test('hydrate VDOM Suspense vapor async setup updates empty v-for before trailing sibling', async () => {
           const data = ref({
             items: [] as string[],

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -1,5 +1,5 @@
 import { isArray } from '@vue/shared'
-import { queuePostFlushCb } from '@vue/runtime-dom'
+import { queueJob, queuePostFlushCb } from '@vue/runtime-dom'
 import {
   advanceHydrationNode,
   cleanupHydrationTail,
@@ -7,6 +7,7 @@ import {
   enterHydrationBoundary,
   isComment,
   isHydrationAnchor,
+  isInAsyncHydration,
   isInDeferredHydrationBoundary,
   locateEndAnchor,
   locateHydrationBoundaryClose,
@@ -159,7 +160,7 @@ function queueAnchorInsert(
 ): void {
   // Create the runtime anchor during the queued insertion so hydration
   // traversal never observes it before it is in its final position.
-  queuePostFlushCb(() => {
+  const insertAnchor = () => {
     let anchor =
       nextNode && getParentNode(nextNode) === parentNode ? nextNode : null
     if (
@@ -170,7 +171,14 @@ function queueAnchorInsert(
       anchor = fallbackNextNode
     }
     parentNode.insertBefore(createAnchor(), anchor)
-  })
+  }
+  if (isInAsyncHydration()) {
+    // Async hydration can queue a branch update before post-flush. Queue its
+    // structural anchor as a pre job so the update sees a live insertion point.
+    queueJob(insertAnchor, undefined, true)
+  } else {
+    queuePostFlushCb(insertAnchor)
+  }
 }
 
 function isReusableAnchorCandidate(

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -121,6 +121,10 @@ let asyncHydrationIsEnabled = false
 let asyncHydrationIsHydrating = false
 let asyncHydrationNode: Node | null = null
 
+export function isInAsyncHydration(): boolean {
+  return deferredHydrationBoundaryDepth > 0 || pendingAsyncHydrationResets > 0
+}
+
 export function enterAsyncHydration(node: Node): () => void {
   if (pendingAsyncHydrationResets++ === 0) {
     asyncHydrationIsEnabled = isHydratingEnabled


### PR DESCRIPTION
- queue structural anchors before updates triggered during async hydration
- cover both async component and async setup hydration paths
- add regression tests for beforeMount-triggered branch updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration reliability for asynchronous components and Suspense content.
  * Prevented hydration errors when sibling components update conditional content during hydration.
  * Ensured hydrated content reflects state changes immediately and continues updating correctly afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->