### PR TITLE
fix(runtime-vapor): properly prune interop keep-alive entries

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -2862,6 +2862,59 @@ describe('vdomInterop', () => {
           expect(hooksB.unmounted).toHaveBeenCalledTimes(1)
         })
 
+        it.each([
+          ['component type', (component: any) => component],
+          ['component VNode', (component: any) => h(component)],
+        ])('prunes a VDOM %s when max is reached', async (_, toValue) => {
+          const source = ref(0)
+          const renderA = vi.fn()
+          const unmountedA = vi.fn()
+
+          const VDOMCompA = defineComponent({
+            setup() {
+              onUnmounted(unmountedA)
+              return () => {
+                renderA(source.value)
+                return h('div', `vdom A ${source.value}`)
+              }
+            },
+          })
+
+          const VDOMCompB = defineComponent({
+            setup() {
+              return () => h('div', 'vdom B')
+            },
+          })
+
+          const current = shallowRef<any>(toValue(VDOMCompA))
+          const App = compile(
+            `<template>
+              <KeepAlive :max="1">
+                <component :is="data" />
+              </KeepAlive>
+            </template>`,
+            current,
+          )
+          const { host, app } = define(App as any).render()
+          const a = host.firstElementChild
+
+          current.value = toValue(VDOMCompB)
+          await nextTick()
+
+          expect(host.innerHTML).toBe(
+            '<div>vdom B</div><!--dynamic-component-->',
+          )
+          expect(unmountedA).toHaveBeenCalledOnce()
+          expect(a!.parentNode).toBeNull()
+
+          const renderCount = renderA.mock.calls.length
+          source.value++
+          await nextTick()
+          expect(renderA).toHaveBeenCalledTimes(renderCount)
+
+          app.unmount()
+        })
+
         it('unmounts inactive cached inner VDOM components during KeepAlive hmr rerender', async () => {
           const hooksA = {
             unmounted: vi.fn(),

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -2915,6 +2915,65 @@ describe('vdomInterop', () => {
           app.unmount()
         })
 
+        it('deactivates then prunes a Vapor component VNode when max is reached', async () => {
+          const deactivatedA = vi.fn()
+          const unmountedA = vi.fn()
+          const renderA = vi.fn((value: number) => value)
+          const data = ref({
+            source: 0,
+            renderA,
+            deactivatedA,
+            unmountedA,
+          })
+          const VaporCompA = compile(
+            `
+              <script vapor>
+                import { onDeactivated, onUnmounted } from 'vue'
+                const data = _data
+                onDeactivated(data.value.deactivatedA)
+                onUnmounted(data.value.unmountedA)
+              </script>
+              <template>
+                <div>vapor A {{ data.renderA(data.source) }}</div>
+              </template>
+            `,
+            data,
+          )
+          const VaporCompB = compile(
+            `<template><div>vapor B</div></template>`,
+            data,
+          )
+
+          const current = shallowRef<any>(h(VaporCompA))
+          const App = compile(
+            `<template>
+              <KeepAlive :max="1">
+                <component :is="data" />
+              </KeepAlive>
+            </template>`,
+            current,
+          )
+          const { host, app } = define(App as any).render()
+          const a = host.firstElementChild
+
+          current.value = h(VaporCompB)
+          await nextTick()
+
+          expect(host.innerHTML).toBe(
+            '<div>vapor B</div><!--dynamic-component-->',
+          )
+          expect(deactivatedA).toHaveBeenCalledOnce()
+          expect(unmountedA).toHaveBeenCalledOnce()
+          expect(a!.parentNode).toBeNull()
+
+          const renderCount = renderA.mock.calls.length
+          data.value.source++
+          await nextTick()
+          expect(renderA).toHaveBeenCalledTimes(renderCount)
+
+          app.unmount()
+        })
+
         it('unmounts inactive cached inner VDOM components during KeepAlive hmr rerender', async () => {
           const hooksA = {
             unmounted: vi.fn(),

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -525,7 +525,12 @@ const unsetShapeFlag = (cached: VaporComponentInstance | VaporFragment) => {
       }
     }
   } else if (isInteropEnabled) {
-    resetShapeFlag(cached.vnode)
+    const vnode = cached.vnode!
+    resetShapeFlag(vnode)
+    if (isVaporComponent(vnode.component)) {
+      // Vapor VNodes copy their keep-alive flags to the inner instance.
+      unsetShapeFlag(vnode.component)
+    }
   }
 }
 

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -51,6 +51,7 @@ import {
 
 export interface KeepAliveInstance extends VaporComponentInstance {
   ctx: VaporKeepAliveContext & {
+    clearCurrent?: (block: VaporComponentInstance | VaporFragment) => void
     activate: (
       instance: VaporComponentInstance,
       parentNode: ParentNode,
@@ -400,6 +401,13 @@ const VaporKeepAliveImpl = defineVaporComponent({
           keptAliveScopes.set(scopeLookupKey, scope)
         }
       },
+    }
+
+    if (isInteropEnabled) {
+      // Interop bypasses ctx.deactivate(), so clear current only for its block.
+      keepAliveCtx.clearCurrent = block => {
+        if (current === block) current = undefined
+      }
     }
 
     keepAliveInstance.ctx = keepAliveCtx

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1009,12 +1009,15 @@ function mountVNode(
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
       const keepAliveCtx = (parentComponent as KeepAliveInstance).ctx
       keepAliveCtx.clearCurrent!(frag)
+      const storageContainer = keepAliveCtx.getStorageContainer()
       if ((vnode.type as any).__vapor) {
-        deactivate(vnode.component as any, keepAliveCtx.getStorageContainer())
+        deactivate(vnode.component as any, storageContainer)
+        // Move the VNode-owned end anchor with the inner Vapor block.
+        insert(vnode.anchor as Node, storageContainer)
       } else {
         vdomDeactivate(
           vnode,
-          keepAliveCtx.getStorageContainer(),
+          storageContainer,
           internals,
           parentComponent as any,
           null,
@@ -1044,6 +1047,7 @@ function mountVNode(
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
       if ((vnode.type as any).__vapor) {
         activate(vnode.component as any, parentNode, anchor, operationSuspense)
+        insert(vnode.anchor as Node, parentNode, anchor)
       } else {
         vdomActivate(
           vnode,

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1007,15 +1007,14 @@ function mountVNode(
   const unmount = (parentNode?: ParentNode, transition?: TransitionHooks) => {
     if (transition) setVNodeTransitionHooks(vnode, transition)
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
+      const keepAliveCtx = (parentComponent as KeepAliveInstance).ctx
+      keepAliveCtx.clearCurrent!(frag)
       if ((vnode.type as any).__vapor) {
-        deactivate(
-          vnode.component as any,
-          (parentComponent as KeepAliveInstance)!.ctx.getStorageContainer(),
-        )
+        deactivate(vnode.component as any, keepAliveCtx.getStorageContainer())
       } else {
         vdomDeactivate(
           vnode,
-          (parentComponent as KeepAliveInstance)!.ctx.getStorageContainer(),
+          keepAliveCtx.getStorageContainer(),
           internals,
           parentComponent as any,
           null,
@@ -1117,7 +1116,7 @@ function createVDOMComponent(
   )
   const { frag, syncNodes } = createVNodeFragment(vnode)
   const keepAliveCtx = isKeepAliveEnabled
-    ? getKeepAliveContext(parentComponent)
+    ? (getKeepAliveContext(parentComponent) as KeepAliveInstance['ctx'] | null)
     : null
 
   if (keepAliveCtx) {
@@ -1210,6 +1209,7 @@ function createVDOMComponent(
     if (rawRef) vdomSetRef(rawRef, null, null, vnode, true)
     if (transition) setVNodeTransitionHooks(vnode, transition)
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
+      keepAliveCtx!.clearCurrent!(frag)
       vdomDeactivate(
         vnode,
         keepAliveCtx!.getStorageContainer(),


### PR DESCRIPTION
- sync KeepAlive state before interop deactivation
- fully unmount max-pruned component types and VNodes
- cover lifecycle, DOM, and reactive effect cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KeepAlive behavior when switching between dynamic component types.
  * Correctly removes previously displayed components when the cache limit is reached.
  * Prevented pruned components from rendering again after removal.
  * Ensured unmounting and cleanup callbacks are triggered reliably for interoperable components.

* **Tests**
  * Added coverage for KeepAlive pruning, DOM updates, unmount hooks, and post-pruning updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->