### PR TITLE
fix(reactivity): handle Object.defineProperty mutations

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -160,6 +160,118 @@ describe('reactivity/reactive', () => {
     expect(run).toBe(1)
   })
 
+  test('Object.defineProperty should trigger effects', () => {
+    const observed = reactive<{ foo: number; bar?: number }>({ foo: 1 })
+    let foo
+    let bar
+    const fooSpy = vi.fn(() => {
+      foo = observed.foo
+    })
+    const barSpy = vi.fn(() => {
+      bar = observed.bar
+    })
+    effect(fooSpy)
+    effect(barSpy)
+
+    Object.defineProperty(observed, 'foo', {
+      value: 2,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    })
+    expect(foo).toBe(2)
+    expect(fooSpy).toHaveBeenCalledTimes(2)
+
+    // defining the same descriptor should not trigger
+    Object.defineProperty(observed, 'foo', {
+      value: 2,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    })
+    expect(fooSpy).toHaveBeenCalledTimes(2)
+
+    // regular assignment should not trigger once from each proxy trap
+    observed.foo = 3
+    expect(foo).toBe(3)
+    expect(fooSpy).toHaveBeenCalledTimes(3)
+
+    Reflect.defineProperty(observed, 'bar', {
+      value: 3,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    })
+    expect(bar).toBe(3)
+    expect(barSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('replacing an accessor should update effect dependencies', () => {
+    const first = ref(1)
+    const second = ref(1)
+    const observed = reactive<{ value: number }>({} as { value: number })
+    Object.defineProperty(observed, 'value', {
+      configurable: true,
+      get: () => first.value,
+    })
+
+    let dummy
+    const spy = vi.fn(() => {
+      dummy = observed.value
+    })
+    effect(spy)
+
+    Object.defineProperty(observed, 'value', {
+      configurable: true,
+      get: () => second.value,
+    })
+    expect(dummy).toBe(1)
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    first.value = 2
+    expect(spy).toHaveBeenCalledTimes(2)
+    second.value = 2
+    expect(dummy).toBe(2)
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
+  test('failed defineProperty operation should not trigger effects', () => {
+    const original = {} as { foo: number }
+    Object.defineProperty(original, 'foo', {
+      value: 1,
+      configurable: false,
+      writable: false,
+    })
+    const observed = reactive(original)
+    const spy = vi.fn(() => observed.foo)
+    effect(spy)
+
+    expect(Reflect.defineProperty(observed, 'foo', { value: 2 })).toBe(false)
+    expect(observed.foo).toBe(1)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  test('defineProperty nested in a setter should trigger effects', () => {
+    const nested = reactive({ value: 0 })
+    const spy = vi.fn(() => nested.value)
+    effect(spy)
+
+    const observed = reactive({
+      set value(value: number) {
+        Object.defineProperty(nested, 'value', {
+          value,
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        })
+      },
+    })
+    observed.value = 1
+
+    expect(nested.value).toBe(1)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
   test('original value change should reflect in observed value (Object)', () => {
     const original: any = { foo: 1 }
     const observed = reactive(original)

--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -47,6 +47,39 @@ describe('reactivity/reactive/Array', () => {
     expect(original[2]).toBe(value)
   })
 
+  test('Object.defineProperty should trigger array effects', () => {
+    const observed = reactive([1, 2, 3])
+    let first
+    let last
+    let length
+    const spy = vi.fn(() => {
+      first = observed[0]
+      last = observed[2]
+      length = observed.length
+    })
+    effect(spy)
+
+    Object.defineProperty(observed, '0', {
+      value: 10,
+    })
+    expect(first).toBe(10)
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    Reflect.defineProperty(observed, '3', {
+      value: 4,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    })
+    expect(length).toBe(4)
+    expect(spy).toHaveBeenCalledTimes(3)
+
+    Object.defineProperty(observed, 'length', { value: 1 })
+    expect(last).toBeUndefined()
+    expect(length).toBe(1)
+    expect(spy).toHaveBeenCalledTimes(4)
+  })
+
   test('Array identity methods should work with raw values', () => {
     const raw = {}
     const arr = reactive([{}, {}])

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -90,6 +90,27 @@ describe('reactivity/readonly', () => {
       expect(
         `Delete operation on key "Symbol(qux)" failed: target is readonly.`,
       ).toHaveBeenWarnedLast()
+
+      Object.defineProperty(wrapped, 'foo', {
+        value: 2,
+        configurable: true,
+      })
+      expect(wrapped.foo).toBe(1)
+      expect(original.foo).toBe(1)
+      expect(
+        `DefineProperty operation on key "foo" failed: target is readonly.`,
+      ).toHaveBeenWarnedLast()
+
+      expect(
+        Reflect.defineProperty(wrapped, 'added', {
+          value: 1,
+          configurable: true,
+        }),
+      ).toBe(true)
+      expect('added' in wrapped).toBe(false)
+      expect(
+        `DefineProperty operation on key "added" failed: target is readonly.`,
+      ).toHaveBeenWarnedLast()
     })
 
     it('should not trigger effects', () => {

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -134,6 +134,31 @@ class BaseReactiveHandler implements ProxyHandler<Target> {
   }
 }
 
+interface SetOperation {
+  target: object
+  key: string | symbol
+  previous: SetOperation | undefined
+}
+
+// Reflect.set() may invoke the defineProperty trap when the receiver is the
+// reactive proxy. Keep the active operation so the mutation is triggered only
+// once while still allowing direct defineProperty calls inside user setters.
+let activeSetOperation: SetOperation | undefined
+
+function hasDescriptorChanged(
+  oldDescriptor: PropertyDescriptor,
+  newDescriptor: PropertyDescriptor,
+): boolean {
+  return (
+    oldDescriptor.configurable !== newDescriptor.configurable ||
+    oldDescriptor.enumerable !== newDescriptor.enumerable ||
+    oldDescriptor.writable !== newDescriptor.writable ||
+    oldDescriptor.get !== newDescriptor.get ||
+    oldDescriptor.set !== newDescriptor.set ||
+    hasChanged(oldDescriptor.value, newDescriptor.value)
+  )
+}
+
 class MutableReactiveHandler extends BaseReactiveHandler {
   constructor(isShallow = false) {
     super(false, isShallow)
@@ -174,12 +199,23 @@ class MutableReactiveHandler extends BaseReactiveHandler {
     const hadKey = isArrayWithIntegerKey
       ? Number(key) < target.length
       : hasOwn(target, key)
-    const result = Reflect.set(
+    const operation: SetOperation = {
       target,
       key,
-      value,
-      isRef(target) ? target : receiver,
-    )
+      previous: activeSetOperation,
+    }
+    activeSetOperation = operation
+    let result: boolean
+    try {
+      result = Reflect.set(
+        target,
+        key,
+        value,
+        isRef(target) ? target : receiver,
+      )
+    } finally {
+      activeSetOperation = operation.previous
+    }
     // don't trigger if target is something up in the prototype chain of original
     if (target === toRaw(receiver) && result) {
       if (!hadKey) {
@@ -189,6 +225,41 @@ class MutableReactiveHandler extends BaseReactiveHandler {
       }
     }
     return result
+  }
+
+  defineProperty(
+    target: Record<string | symbol, unknown>,
+    key: string | symbol,
+    descriptor: PropertyDescriptor,
+  ): boolean {
+    const oldDescriptor = Reflect.getOwnPropertyDescriptor(target, key)
+    const hadKey =
+      isArray(target) && isIntegerKey(key)
+        ? Number(key) < target.length
+        : oldDescriptor !== undefined
+    const result = Reflect.defineProperty(target, key, descriptor)
+    if (!result) {
+      return false
+    }
+
+    const operation = activeSetOperation
+    if (operation && operation.target === target && operation.key === key) {
+      // The outer set trap handles triggering with its normalized values.
+      return true
+    }
+
+    const newDescriptor = Reflect.getOwnPropertyDescriptor(target, key)!
+    const oldValue = oldDescriptor && oldDescriptor.value
+    const newValue = newDescriptor.value
+    if (!hadKey) {
+      trigger(target, TriggerOpTypes.ADD, key, newValue)
+    } else if (
+      !oldDescriptor ||
+      hasDescriptorChanged(oldDescriptor, newDescriptor)
+    ) {
+      trigger(target, TriggerOpTypes.SET, key, newValue, oldValue)
+    }
+    return true
   }
 
   deleteProperty(
@@ -241,6 +312,16 @@ class ReadonlyReactiveHandler extends BaseReactiveHandler {
     if (__DEV__) {
       warn(
         `Delete operation on key "${String(key)}" failed: target is readonly.`,
+        target,
+      )
+    }
+    return true
+  }
+
+  defineProperty(target: object, key: string | symbol) {
+    if (__DEV__) {
+      warn(
+        `DefineProperty operation on key "${String(key)}" failed: target is readonly.`,
         target,
       )
     }


### PR DESCRIPTION
## Summary

- add a defineProperty trap that triggers ADD or SET effects after successful property definitions
- preserve existing assignment semantics and avoid duplicate triggers from the nested Reflect.set defineProperty path
- make the set-operation guard reentrant so direct definitions inside user setters still trigger
- prevent Object.defineProperty and Reflect.defineProperty from mutating readonly proxies
- cover objects, accessors, failed definitions, arrays, length changes, and readonly behavior

## Tests

- pnpm test-unit --run
- pnpm check
- pnpm eslint packages/reactivity/src/baseHandlers.ts packages/reactivity/__tests__/reactive.spec.ts packages/reactivity/__tests__/reactiveArray.spec.ts packages/reactivity/__tests__/readonly.spec.ts
- pnpm prettier --check packages/reactivity/src/baseHandlers.ts packages/reactivity/__tests__/reactive.spec.ts packages/reactivity/__tests__/reactiveArray.spec.ts packages/reactivity/__tests__/readonly.spec.ts

Fixes #15182
Fixes #7602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reactive updates when properties are added, modified, or redefined using standard property-definition APIs.
  * Prevented duplicate effect notifications during property assignments.
  * Improved reactive array updates when indexes or array length change.
  * Readonly objects now consistently prevent property definitions while preserving values and providing appropriate warnings.
* **Tests**
  * Added coverage for property descriptors, accessors, nested setters, arrays, and readonly behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->