### PR TITLE
fix(runtime-vapor): remove special boolean attributes for falsy values

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -392,6 +392,22 @@ describe('patchProp', () => {
       expect(el.getAttribute('disabled')).toBe('false')
     })
 
+    test('should set special boolean attribute', () => {
+      const el = document.createElement('input')
+      setAttr(el, 'readonly', true)
+      expect(el.getAttribute('readonly')).toBe('')
+      setAttr(el, 'readonly', false)
+      expect(el.getAttribute('readonly')).toBe(null)
+      setAttr(el, 'readonly', '')
+      expect(el.getAttribute('readonly')).toBe('')
+      setAttr(el, 'readonly', 0)
+      expect(el.getAttribute('readonly')).toBe(null)
+      setAttr(el, 'readonly', '0')
+      expect(el.getAttribute('readonly')).toBe('')
+      setAttr(el, 'readonly', undefined)
+      expect(el.getAttribute('readonly')).toBe(null)
+    })
+
     test('should set symbol attribute values', () => {
       const el = document.createElement('div')
       const symbol = Symbol('foo')

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -7,6 +7,7 @@ import {
   includeBooleanAttr,
   isArray,
   isOn,
+  isSpecialBooleanAttr,
   isString,
   isSymbol,
   normalizeClass,
@@ -123,10 +124,14 @@ export function setAttr(
         el.removeAttributeNS(xlinkNS, key.slice(6, key.length))
       }
     } else {
-      if (value != null) {
-        el.setAttribute(key, isSymbol(value) ? String(value) : value)
-      } else {
+      const isBoolean = isSpecialBooleanAttr(key)
+      if (value == null || (isBoolean && !includeBooleanAttr(value))) {
         el.removeAttribute(key)
+      } else {
+        el.setAttribute(
+          key,
+          isBoolean ? '' : isSymbol(value) ? String(value) : value,
+        )
       }
     }
   }


### PR DESCRIPTION
`:readonly="false"` renders `readonly="false"` in Vapor, which makes the input actually read-only. truthy values are written as `readonly="true"` instead of `readonly=""`. the same applies to the other boolean attributes whose DOM property name differs from the attribute name: `itemscope`, `allowfullscreen`, `formnovalidate`, `ismap`, `nomodule`, `novalidate`.

repro: https://play.vuejs.org/#eNpNjuEKwjAMhF8l5I8K2omCP0Yn+B4FKbWDwtaGNBvI2LsbkYG/kju+O27ByqF5EJl5itiirYETCdQoE8HsqfDd5TTqFViAYw8r9FxG2Glg53IouYr6/lXy8Ibui+x7P9R4cNk2vzqtUCFxpMFLVAVgU6ZJoN2SncPtdaiEbf5wPOJzjlxTybrxam7mfOJgLrh+APS/Q0I=

these keys fail the `key in el` check in `setProp` and go through `setAttr`, which writes the value verbatim. `patchAttr` guards them with `isSpecialBooleanAttr` / `includeBooleanAttr`, so this applies the same guard to `setAttr`.
