### PR TITLE
fix(runtime-vapor): avoid duplicate leave during KeepAlive pruning

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -361,7 +361,10 @@ export function baseResolveTransitionHooks(
     }
   }
 
-  const hooks: TransitionHooks<TransitionElement> = {
+  const hooks: TransitionHooks<TransitionElement> & {
+    state: TransitionState
+  } = {
+    state,
     mode,
     persisted,
     beforeEnter(el) {

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -21,7 +21,7 @@ import {
   extend,
 } from '@vue/shared'
 import type { LooseRawProps, VaporComponent } from '../../src/component'
-import { ifFlags, makeRender } from '../_utils'
+import { compile, ifFlags, makeRender } from '../_utils'
 import { VaporKeepAlive } from '../../src/components/KeepAlive'
 import {
   child,
@@ -1330,6 +1330,43 @@ describe('VaporKeepAlive', () => {
       await nextTick()
       // C should be pruned because B was used last so C is the oldest cached
       assertCount([2, 2, 1, 1, 1, 2, 2, 0, 1, 1, 1, 1])
+    })
+
+    test('prunes the cached branch with a single leave when max is reached', async () => {
+      const CompA = compile(`<template><div>A</div></template>`, ref())
+      const CompB = compile(`<template><div>B</div></template>`, ref())
+      const leaves: Array<() => void> = []
+      const data = shallowRef({
+        current: CompA,
+        onLeave: (_el: Element, done: () => void) => leaves.push(done),
+      })
+      const App = compile(
+        `<template>
+          <Transition :css="false" @leave="data.onLeave">
+            <KeepAlive :max="1">
+              <component :is="data.current" />
+            </KeepAlive>
+          </Transition>
+        </template>`,
+        data,
+      )
+      const { host, app } = define(App as any).render()
+      const a = host.firstElementChild
+
+      data.value = {
+        ...data.value,
+        current: CompB,
+      }
+      await nextTick()
+
+      expect(leaves).toHaveLength(1)
+      expect(a!.parentNode).toBe(host)
+      leaves[0]()
+      await nextTick()
+      expect(a!.parentNode).toBeNull()
+      expect(host.innerHTML).toBe('<div>B</div><!--dynamic-component-->')
+
+      app.unmount()
     })
   })
 

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1401,6 +1401,38 @@ describe('VaporKeepAlive', () => {
       leaves[0]()
       expect(a!.parentNode).toBeNull()
     })
+
+    test('does not resume an out-in branch after app unmount', async () => {
+      const CompA = compile(`<template><div>A</div></template>`, ref())
+      const CompB = compile(`<template><div>B</div></template>`, ref())
+      const leaves: Array<() => void> = []
+      const data = shallowRef({
+        current: CompA,
+        onLeave: (_el: Element, done: () => void) => leaves.push(done),
+      })
+      const App = compile(
+        `<template>
+          <Transition mode="out-in" :css="false" @leave="data.onLeave">
+            <KeepAlive :max="2">
+              <component :is="data.current" />
+            </KeepAlive>
+          </Transition>
+        </template>`,
+        data,
+      )
+      const { host, app } = define(App as any).render()
+
+      data.value = { ...data.value, current: CompB }
+      await nextTick()
+
+      expect(leaves).toHaveLength(1)
+      app.unmount()
+      expect(host.innerHTML).toBe('')
+
+      expect(() => leaves[0]()).not.toThrow()
+      await nextTick()
+      expect(host.innerHTML).toBe('')
+    })
   })
 
   describe('cache invalidation', () => {

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1368,6 +1368,39 @@ describe('VaporKeepAlive', () => {
 
       app.unmount()
     })
+
+    test('unmounts KeepAlive while a cached branch is leaving', async () => {
+      const CompA = compile(`<template><div>A</div></template>`, ref())
+      const CompB = compile(`<template><div>B</div></template>`, ref())
+      const leaves: Array<() => void> = []
+      const data = shallowRef({
+        current: CompA,
+        onLeave: (_el: Element, done: () => void) => leaves.push(done),
+      })
+      const App = compile(
+        `<template>
+          <Transition :css="false" @leave="data.onLeave">
+            <KeepAlive :max="2">
+              <component :is="data.current" />
+            </KeepAlive>
+          </Transition>
+        </template>`,
+        data,
+      )
+      const { host, app } = define(App as any).render()
+      const a = host.firstElementChild
+
+      data.value = { ...data.value, current: CompB }
+      await nextTick()
+
+      expect(leaves).toHaveLength(1)
+      expect(a!.parentNode).toBe(host)
+      app.unmount()
+      expect(leaves).toHaveLength(1)
+      expect(a!.parentNode).toBeNull()
+      leaves[0]()
+      expect(a!.parentNode).toBeNull()
+    })
   })
 
   describe('cache invalidation', () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -2974,6 +2974,144 @@ describe('vdomInterop', () => {
           app.unmount()
         })
 
+        it.each([
+          ['component type', (component: any) => component],
+          ['component VNode', (component: any) => h(component)],
+        ])(
+          'prunes a VDOM %s with a single leave when max is reached',
+          async (_, toValue) => {
+            const CompA = defineComponent({
+              setup: () => () => h('div', 'A'),
+            })
+            const CompB = defineComponent({
+              setup: () => () => h('div', 'B'),
+            })
+            const leaves: Array<() => void> = []
+            const data = shallowRef({
+              current: toValue(CompA),
+              onLeave: (_el: Element, done: () => void) => leaves.push(done),
+            })
+            const App = compile(
+              `<template>
+              <Transition :css="false" @leave="data.onLeave">
+                <KeepAlive :max="1">
+                  <component :is="data.current" />
+                </KeepAlive>
+              </Transition>
+            </template>`,
+              data,
+            )
+            const { host, app } = define(App as any).render()
+            const a = host.firstElementChild
+
+            data.value = {
+              ...data.value,
+              current: toValue(CompB),
+            }
+            await nextTick()
+
+            expect(leaves).toHaveLength(1)
+            expect(a!.parentNode).toBe(host)
+            leaves[0]()
+            await nextTick()
+            expect(a!.parentNode).toBeNull()
+            expect(host.innerHTML).toBe('<div>B</div><!--dynamic-component-->')
+
+            app.unmount()
+          },
+        )
+
+        it('prunes a Vapor component VNode with a single out-in leave', async () => {
+          const VaporCompA = compile(
+            `<template><div>vapor A</div></template>`,
+            ref(),
+          )
+          const VaporCompB = compile(
+            `<template><div>vapor B</div></template>`,
+            ref(),
+          )
+          const leaves: Array<() => void> = []
+          const data = shallowRef({
+            current: h(VaporCompA),
+            onLeave: (_el: Element, done: () => void) => leaves.push(done),
+          })
+          const App = compile(
+            `<template>
+              <Transition mode="out-in" :css="false" @leave="data.onLeave">
+                <KeepAlive :max="1">
+                  <component :is="data.current" />
+                </KeepAlive>
+              </Transition>
+            </template>`,
+            data,
+          )
+          const { host, app } = define(App as any).render()
+          const a = host.firstElementChild
+
+          data.value = {
+            ...data.value,
+            current: h(VaporCompB),
+          }
+          await nextTick()
+
+          expect(leaves).toHaveLength(1)
+          expect(a!.parentNode).toBe(host)
+          leaves[0]()
+          await nextTick()
+          expect(leaves).toHaveLength(1)
+          expect(a!.parentNode).toBeNull()
+          expect(host.innerHTML).toBe(
+            '<div>vapor B</div><!--dynamic-component-->',
+          )
+
+          app.unmount()
+        })
+
+        it('does not reinsert the Vapor root of a pruned VDOM component after leave', async () => {
+          const VaporRoot = compile(
+            `<template><div>vapor root</div></template>`,
+            ref(),
+          )
+          const CompA = defineComponent({
+            setup: () => () => h(VaporRoot),
+          })
+          const CompB = defineComponent({
+            setup: () => () => h('div', 'B'),
+          })
+          const leaves: Array<() => void> = []
+          const data = shallowRef({
+            current: CompA,
+            onLeave: (_el: Element, done: () => void) => leaves.push(done),
+          })
+          const App = compile(
+            `<template>
+              <Transition :css="false" @leave="data.onLeave">
+                <KeepAlive :max="1">
+                  <component :is="data.current" />
+                </KeepAlive>
+              </Transition>
+            </template>`,
+            data,
+          )
+          const { host, app } = define(App as any).render()
+          const a = host.firstElementChild
+
+          data.value = {
+            ...data.value,
+            current: CompB,
+          }
+          await nextTick()
+
+          expect(leaves).toHaveLength(1)
+          expect(a!.parentNode).toBe(host)
+          leaves[0]()
+          await nextTick()
+          expect(a!.parentNode).toBeNull()
+          expect(host.innerHTML).toBe('<div>B</div><!--dynamic-component-->')
+
+          app.unmount()
+        })
+
         it('unmounts inactive cached inner VDOM components during KeepAlive hmr rerender', async () => {
           const hooksA = {
             unmounted: vi.fn(),

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -3021,6 +3021,44 @@ describe('vdomInterop', () => {
           },
         )
 
+        it('keeps the VDOM root of a cached Vapor component in the host while leaving', async () => {
+          const VDOMCompA = defineComponent({
+            setup: () => () => h('div', 'A'),
+          })
+          const VaporCompA = defineVaporComponent({
+            setup: () => createComponent(VDOMCompA as any),
+          })
+          const VaporCompB = compile(`<template><div>B</div></template>`, ref())
+          const leaves: Array<() => void> = []
+          const data = shallowRef({
+            current: VaporCompA,
+            onLeave: (_el: Element, done: () => void) => leaves.push(done),
+          })
+          const App = compile(
+            `<template>
+              <Transition :css="false" @leave="data.onLeave">
+                <KeepAlive :max="1">
+                  <component :is="data.current" />
+                </KeepAlive>
+              </Transition>
+            </template>`,
+            data,
+          )
+          const { host, app } = define(App as any).render()
+          const a = host.firstElementChild
+
+          data.value = { ...data.value, current: VaporCompB }
+          await nextTick()
+
+          expect(leaves).toHaveLength(1)
+          expect(a!.parentNode).toBe(host)
+          leaves[0]()
+          await nextTick()
+          expect(a!.parentNode).toBeNull()
+
+          app.unmount()
+        })
+
         it('removes a VDOM leave finished from onUnmounted', async () => {
           let finishLeave: (() => void) | undefined
           const CompA = defineComponent({

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -3021,6 +3021,82 @@ describe('vdomInterop', () => {
           },
         )
 
+        it('removes a VDOM leave finished from onUnmounted', async () => {
+          let finishLeave: (() => void) | undefined
+          const CompA = defineComponent({
+            setup() {
+              onUnmounted(() => finishLeave!())
+              return () => h('div', 'A')
+            },
+          })
+          const CompB = defineComponent({
+            setup: () => () => h('div', 'B'),
+          })
+          const data = shallowRef({
+            current: CompA,
+            onLeave: (_el: Element, done: () => void) => {
+              finishLeave = done
+            },
+          })
+          const App = compile(
+            `<template>
+              <Transition :css="false" @leave="data.onLeave">
+                <KeepAlive :max="1">
+                  <component :is="data.current" />
+                </KeepAlive>
+              </Transition>
+            </template>`,
+            data,
+          )
+          const { host, app } = define(App as any).render()
+          const a = host.firstElementChild
+
+          data.value = { ...data.value, current: CompB }
+          await nextTick()
+
+          expect(a!.parentNode).toBeNull()
+
+          app.unmount()
+        })
+
+        it('unmounts KeepAlive while a cached VDOM branch is leaving', async () => {
+          const CompA = defineComponent({
+            setup: () => () => h('div', 'A'),
+          })
+          const CompB = defineComponent({
+            setup: () => () => h('div', 'B'),
+          })
+          const leaves: Array<() => void> = []
+          const data = shallowRef({
+            current: CompA,
+            onLeave: (_el: Element, done: () => void) => leaves.push(done),
+          })
+          const App = compile(
+            `<template>
+              <Transition :css="false" @leave="data.onLeave">
+                <KeepAlive :max="2">
+                  <component :is="data.current" />
+                </KeepAlive>
+              </Transition>
+            </template>`,
+            data,
+          )
+          const { host, app } = define(App as any).render()
+          const a = host.firstElementChild
+
+          data.value = { ...data.value, current: CompB }
+          await nextTick()
+
+          expect(leaves).toHaveLength(1)
+          expect(a!.parentNode).toBe(host)
+          app.unmount()
+          expect(leaves).toHaveLength(1)
+          expect(a!.parentNode).toBeNull()
+          leaves[0]()
+          await nextTick()
+          expect(a!.parentNode).toBeNull()
+        })
+
         it('prunes a Vapor component VNode with a single out-in leave', async () => {
           const VaporCompA = compile(
             `<template><div>vapor A</div></template>`,
@@ -3974,6 +4050,51 @@ describe('vdomInterop', () => {
       current.value = VaporChild
       await nextTick()
       expect(root.innerHTML).toBe('<div>updated</div>')
+    })
+
+    test('unmounts VDOM KeepAlive while a Vapor child is leaving', async () => {
+      const VaporCompA = compile(
+        `<template><div>vapor A</div></template>`,
+        ref(),
+      )
+      const VaporCompB = compile(
+        `<template><div>vapor B</div></template>`,
+        ref(),
+      )
+      const current = shallowRef<any>(VaporCompA)
+      const leaves: Array<() => void> = []
+      const App = defineComponent({
+        setup() {
+          return () =>
+            h(
+              Transition,
+              {
+                css: false,
+                onLeave: (_el: Element, done: () => void) => leaves.push(done),
+              },
+              {
+                default: () => h(KeepAlive, { max: 2 }, () => h(current.value)),
+              },
+            )
+        },
+      })
+      const root = document.createElement('div')
+      const app = createApp(App)
+      app.use(vaporInteropPlugin)
+      app.mount(root)
+      const a = root.firstElementChild
+
+      current.value = VaporCompB
+      await nextTick()
+
+      expect(leaves).toHaveLength(1)
+      expect(a!.parentNode).toBe(root)
+      app.unmount()
+      expect(leaves).toHaveLength(1)
+      expect(a!.parentNode).toBeNull()
+      leaves[0]()
+      await nextTick()
+      expect(a!.parentNode).toBeNull()
     })
 
     test('should invoke vnode hooks on activate/deactivate', async () => {

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -272,6 +272,7 @@ export function move(
         anchor,
         parentSuspense,
         (block as TransitionBlock).$transition,
+        moveType,
       )
     } else {
       move(

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -33,6 +33,8 @@ export interface VaporTransitionHooks extends TransitionHooks {
   // Temporarily skips enter/move during TransitionGroup FLIP measurement.
   // Leave transitions intentionally ignore this flag.
   disabled?: boolean
+  // KeepAlive uses this target to reuse a deactivation leave during pruning.
+  deactivationTarget?: ParentNode
   // TransitionGroup sets this to handle applying hooks to list children
   applyGroup?: (
     block: Block,
@@ -212,8 +214,8 @@ export function move(
           block,
           (block as TransitionBlock).$transition as TransitionHooks,
           () => {
-            // if the component is unmounted after leave finish, remove the block
-            // to avoid retaining a detached node.
+            // A cache prune can unmount the component while its deactivation
+            // leave is pending. Remove instead of parking it when leave ends.
             if (
               moveType === MoveType.LEAVE &&
               parentComponent &&
@@ -301,19 +303,27 @@ export function remove(block: Block, parent?: ParentNode): void {
 }
 
 export function removeNode(block: Node, parent?: ParentNode): void {
-  if (
-    isTransitionEnabled &&
-    (block as TransitionBlock).$transition &&
-    block instanceof Element
-  ) {
-    performTransitionLeave(
-      block,
-      (block as TransitionBlock).$transition as TransitionHooks,
-      () => parent && parent.removeChild(block),
-    )
-  } else {
-    parent && parent.removeChild(block)
+  if (isTransitionEnabled && block instanceof Element) {
+    const transition = (block as TransitionBlock).$transition
+    if (transition) {
+      const deactivationTarget = transition.deactivationTarget
+      if (deactivationTarget) {
+        // Reuse the deactivation leave: detach an already parked node, or
+        // leave a live node to its pending leave callback.
+        if (block.parentNode === deactivationTarget) {
+          parent && block.remove()
+        }
+        return
+      }
+      performTransitionLeave(
+        block,
+        transition,
+        () => parent && parent.removeChild(block),
+      )
+      return
+    }
   }
+  parent && parent.removeChild(block)
 }
 
 export function removeFragment(

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -193,35 +193,38 @@ export function move(
 ): void {
   anchor = anchor === 0 ? parent.$fc || _child(parent) : anchor
   if (block instanceof Node) {
+    const transition =
+      isTransitionEnabled && block instanceof Element
+        ? (block as TransitionBlock).$transition
+        : undefined
+    if (transition && moveType === MoveType.ENTER) {
+      transition.deactivationTarget = undefined
+    }
     // only apply transition on Element nodes
-    if (
-      isTransitionEnabled &&
-      block instanceof Element &&
-      (block as TransitionBlock).$transition &&
-      !(block as TransitionBlock).$transition!.disabled &&
-      moveType !== MoveType.REORDER
-    ) {
+    if (transition && !transition.disabled && moveType !== MoveType.REORDER) {
       if (moveType === MoveType.ENTER) {
         performTransitionEnter(
           block,
-          (block as TransitionBlock).$transition as TransitionHooks,
+          transition,
           () => parent.insertBefore(block, anchor as Node),
           parentSuspense,
           true,
         )
       } else {
+        if (parentComponent) {
+          transition.deactivationTarget = parent
+        }
         performTransitionLeave(
           block,
-          (block as TransitionBlock).$transition as TransitionHooks,
+          transition,
           () => {
-            // A cache prune can unmount the component while its deactivation
-            // leave is pending. Remove instead of parking it when leave ends.
+            // Remove instead of parking if deactivation is followed by unmount.
             if (
               moveType === MoveType.LEAVE &&
               parentComponent &&
               parentComponent.isUnmounted
             ) {
-              block.remove()
+              ;(block as ChildNode).remove()
             } else {
               parent.insertBefore(block, anchor as Node)
             }
@@ -309,8 +312,11 @@ export function removeNode(block: Node, parent?: ParentNode): void {
       const deactivationTarget = transition.deactivationTarget
       if (deactivationTarget) {
         // Deactivation already started leave; unmount must not start it again.
-        if (block.parentNode === deactivationTarget) {
-          parent && block.remove()
+        if (
+          transition.state.isUnmounting ||
+          block.parentNode === deactivationTarget
+        ) {
+          block.remove()
         }
         return
       }

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -33,7 +33,7 @@ export interface VaporTransitionHooks extends TransitionHooks {
   // Temporarily skips enter/move during TransitionGroup FLIP measurement.
   // Leave transitions intentionally ignore this flag.
   disabled?: boolean
-  // KeepAlive uses this target to reuse a deactivation leave during pruning.
+  // Prevents unmount from starting another leave after deactivation.
   deactivationTarget?: ParentNode
   // TransitionGroup sets this to handle applying hooks to list children
   applyGroup?: (
@@ -308,8 +308,7 @@ export function removeNode(block: Node, parent?: ParentNode): void {
     if (transition) {
       const deactivationTarget = transition.deactivationTarget
       if (deactivationTarget) {
-        // Reuse the deactivation leave: detach an already parked node, or
-        // leave a live node to its pending leave callback.
+        // Deactivation already started leave; unmount must not start it again.
         if (block.parentNode === deactivationTarget) {
           parent && block.remove()
         }

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -21,17 +21,10 @@ import {
   warn,
   watch,
 } from '@vue/runtime-dom'
-import {
-  type Block,
-  type TransitionBlock,
-  findBlockBoundary,
-  move,
-  remove,
-} from '../block'
+import { type Block, findBlockBoundary, move, remove } from '../block'
 import {
   type VaporComponent,
   type VaporComponentInstance,
-  getRootElement,
   isVaporComponent,
 } from '../component'
 import {
@@ -273,12 +266,6 @@ const VaporKeepAliveImpl = defineVaporComponent({
       // don't unmount if the instance is the current one
       if (cached && (!current || cached !== current)) {
         unsetShapeFlag(cached)
-        const root = isVaporComponent(cached) ? getRootElement(cached) : cached
-        const transition = root && (root as TransitionBlock).$transition
-        if (transition) {
-          // Avoid running leave again when unmount follows deactivation.
-          transition.deactivationTarget = storageContainer
-        }
         // A pruned branch may still be leaving and not yet be in storageContainer.
         const parentNode = findBlockBoundary(cached).parentNode
         if (parentNode) remove(cached, parentNode as ParentNode)
@@ -345,7 +332,9 @@ const VaporKeepAliveImpl = defineVaporComponent({
         }
 
         unsetShapeFlag(cached)
-        remove(cached, storageContainer)
+        // A pending leave may still own the branch in its live parent.
+        const parentNode = findBlockBoundary(cached).parentNode
+        remove(cached, parentNode ? (parentNode as ParentNode) : undefined)
       })
 
       // Same-tick branch switches can tear down KeepAlive after the next branch

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -276,7 +276,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
         const root = isVaporComponent(cached) ? getRootElement(cached) : cached
         const transition = root && (root as TransitionBlock).$transition
         if (transition) {
-          // Reuse the deactivation leave instead of starting another on prune.
+          // Avoid running leave again when unmount follows deactivation.
           transition.deactivationTarget = storageContainer
         }
         // A pruned branch may still be leaving and not yet be in storageContainer.

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -21,10 +21,17 @@ import {
   warn,
   watch,
 } from '@vue/runtime-dom'
-import { type Block, findBlockBoundary, move, remove } from '../block'
+import {
+  type Block,
+  type TransitionBlock,
+  findBlockBoundary,
+  move,
+  remove,
+} from '../block'
 import {
   type VaporComponent,
   type VaporComponentInstance,
+  getRootElement,
   isVaporComponent,
 } from '../component'
 import {
@@ -266,6 +273,12 @@ const VaporKeepAliveImpl = defineVaporComponent({
       // don't unmount if the instance is the current one
       if (cached && (!current || cached !== current)) {
         unsetShapeFlag(cached)
+        const root = isVaporComponent(cached) ? getRootElement(cached) : cached
+        const transition = root && (root as TransitionBlock).$transition
+        if (transition) {
+          // Reuse the deactivation leave instead of starting another on prune.
+          transition.deactivationTarget = storageContainer
+        }
         // A pruned branch may still be leaving and not yet be in storageContainer.
         const parentNode = findBlockBoundary(cached).parentNode
         if (parentNode) remove(cached, parentNode as ParentNode)

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -557,6 +557,10 @@ function removeBranchWithLeaveImpl(
   ) {
     const instance = currentInstance
     applyTransitionLeaveHooksImpl(frag.nodes, transition, () => {
+      if (transition.state.isUnmounting || (instance && instance.isUnmounted)) {
+        frag.pending = undefined
+        return
+      }
       // By the time this deferred out-in branch runs, the renderEffect
       // has finished and currentInstance may have changed, so restore
       // the captured instance.

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -353,7 +353,6 @@ export function resolveTransitionHooks(
     instance,
   ) as VaporTransitionHooks
   hooks.__vapor = true
-  hooks.state = state
   hooks.props = props
   hooks.instance = instance as VaporComponentInstance
   return hooks

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -13,6 +13,7 @@ import {
 } from './block'
 import {
   type GenericComponentInstance,
+  type MoveType,
   type SuspenseBoundary,
   type TransitionHooks,
   type VNode,
@@ -86,6 +87,7 @@ export class VaporFragment<
     anchor: Node | null,
     parentSuspense?: SuspenseBoundary | null,
     transitionHooks?: TransitionHooks,
+    moveType?: MoveType,
   ) => void
   remove?: (parent?: ParentNode, transitionHooks?: TransitionHooks) => void
   hydrate?(...args: any[]): void

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1075,7 +1075,13 @@ function mountVNode(
     syncNodes()
   }
 
-  frag.insert = (parentNode, anchor, parentSuspense, transition) => {
+  frag.insert = (
+    parentNode,
+    anchor,
+    parentSuspense,
+    transition,
+    moveType = MoveType.REORDER,
+  ) => {
     if (isHydrating) return
     const operationSuspense =
       parentSuspense === undefined ? suspense : parentSuspense
@@ -1118,11 +1124,20 @@ function mountVNode(
         isMounted = true
       } else {
         // move
+        if (transition) {
+          const vaporTransition = transition as VaporTransitionHooks
+          if (moveType === MoveType.ENTER) {
+            vaporTransition.deactivationTarget = undefined
+          } else if (moveType === MoveType.LEAVE) {
+            vaporTransition.deactivationTarget = parentNode
+          }
+          setVNodeTransitionHooks(vnode, transition)
+        }
         internals.m(
           vnode,
           parentNode,
           anchor,
-          MoveType.REORDER,
+          moveType,
           parentComponent as any,
           operationSuspense,
         )
@@ -1295,7 +1310,13 @@ function createVDOMComponent(
   vnode.scopeId = getCurrentScopeId() || null
   vnode.slotScopeIds = currentSlotScopeIds
 
-  frag.insert = (parentNode, anchor, parentSuspense, transition) => {
+  frag.insert = (
+    parentNode,
+    anchor,
+    parentSuspense,
+    transition,
+    moveType = MoveType.REORDER,
+  ) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
     const operationSuspense = suspense
@@ -1332,11 +1353,20 @@ function createVDOMComponent(
         isMounted = true
       } else {
         // move
+        if (transition) {
+          const vaporTransition = transition as VaporTransitionHooks
+          if (moveType === MoveType.ENTER) {
+            vaporTransition.deactivationTarget = undefined
+          } else if (moveType === MoveType.LEAVE) {
+            vaporTransition.deactivationTarget = parentNode
+          }
+          setVNodeTransitionHooks(vnode, transition)
+        }
         internals.m(
           vnode,
           parentNode,
           anchor,
-          MoveType.REORDER,
+          moveType,
           parentComponent as any,
           operationSuspense,
         )

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -573,10 +573,11 @@ const vaporInteropImpl: Omit<
 
   move(vnode, container, anchor, moveType, parentSuspense) {
     const block = vnode.vb || (vnode.component as any)
+    // Let a pending leave detect if its Vapor owner is pruned before it ends.
+    const owner = isVaporComponent(block) ? block : undefined
     // Resolved Vapor blocks exclude the VDOM-owned opening marker, but a
     // pending hydration range includes it. Avoid moving `vnode.el` twice.
-    const pendingRangeOwnsFragmentStart =
-      isVaporComponent(block) && !!block.pendingBlock
+    const pendingRangeOwnsFragmentStart = !!(owner && owner.pendingBlock)
     if (
       vnode.el &&
       vnode.el !== vnode.anchor &&
@@ -592,7 +593,7 @@ const vaporInteropImpl: Omit<
         parentSuspense,
       )
     }
-    move(block, container, anchor, moveType, undefined, parentSuspense)
+    move(block, container, anchor, moveType, owner, parentSuspense)
     move(
       vnode.anchor as any,
       container,
@@ -1005,6 +1006,8 @@ function mountVNode(
 
   let isMounted = false
   const unmount = (parentNode?: ParentNode, transition?: TransitionHooks) => {
+    const deactivationTarget =
+      transition && (transition as VaporTransitionHooks).deactivationTarget
     if (transition) setVNodeTransitionHooks(vnode, transition)
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
       const keepAliveCtx = (parentComponent as KeepAliveInstance).ctx
@@ -1024,7 +1027,15 @@ function mountVNode(
         )
       }
     } else {
-      internals.um(vnode, parentComponent as any, null, !!parentNode)
+      internals.um(
+        vnode,
+        parentComponent as any,
+        null,
+        !!parentNode && !deactivationTarget,
+      )
+      if (deactivationTarget) {
+        removeAttachedNodes(resolveVNodeNodes(vnode), deactivationTarget)
+      }
     }
 
     if (vnode.anchor && parentNode && vnode.anchor.parentNode === parentNode) {
@@ -1209,6 +1220,8 @@ function createVDOMComponent(
       if (!transition) removeDom(parentNode)
       return
     }
+    const deactivationTarget =
+      transition && (transition as VaporTransitionHooks).deactivationTarget
     // unset ref
     if (rawRef) vdomSetRef(rawRef, null, null, vnode, true)
     if (transition) setVNodeTransitionHooks(vnode, transition)
@@ -1225,9 +1238,13 @@ function createVDOMComponent(
     }
     isUnmounted = true
     isMounted = false
-    internals.umt(vnode.component!, null, !!parentNode)
-    // VDOM transitions own their leaving DOM until the leave finishes.
-    if (!transition) removeDom(parentNode)
+    internals.umt(vnode.component!, null, !!parentNode && !deactivationTarget)
+    // Ordinary VDOM transitions own their leaving DOM until leave finishes.
+    if (deactivationTarget) {
+      removeDom(deactivationTarget)
+    } else if (!transition) {
+      removeDom(parentNode)
+    }
   }
 
   frag.hydrate = () => {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -935,6 +935,20 @@ function removeAttachedNodes(block: Block, parent: ParentNode): void {
   }
 }
 
+function cleanupDeactivatedNodes(
+  vnode: VNode,
+  target: ParentNode,
+  liveParent?: ParentNode,
+): void {
+  const nodes = resolveVNodeNodes(vnode)
+  if (liveParent) removeAttachedNodes(nodes, liveParent)
+  const cleanup = () => removeAttachedNodes(nodes, target)
+  cleanup()
+  // A VDOM unmounted hook can finish leave before the instance is marked
+  // unmounted and park the nodes after the synchronous cleanup.
+  queuePostRenderEffect(cleanup, undefined, null)
+}
+
 function appendVnodeHook(
   vnode: VNode,
   key: 'onVnodeBeforeUpdate' | 'onVnodeUpdated',
@@ -1013,6 +1027,10 @@ function mountVNode(
       const keepAliveCtx = (parentComponent as KeepAliveInstance).ctx
       keepAliveCtx.clearCurrent!(frag)
       const storageContainer = keepAliveCtx.getStorageContainer()
+      if (transition) {
+        ;(transition as VaporTransitionHooks).deactivationTarget =
+          storageContainer
+      }
       if ((vnode.type as any).__vapor) {
         deactivate(vnode.component as any, storageContainer)
         // Move the VNode-owned end anchor with the inner Vapor block.
@@ -1034,7 +1052,13 @@ function mountVNode(
         !!parentNode && !deactivationTarget,
       )
       if (deactivationTarget) {
-        removeAttachedNodes(resolveVNodeNodes(vnode), deactivationTarget)
+        cleanupDeactivatedNodes(
+          vnode,
+          deactivationTarget,
+          (transition as VaporTransitionHooks).state.isUnmounting
+            ? parentNode
+            : undefined,
+        )
       }
     }
 
@@ -1056,6 +1080,9 @@ function mountVNode(
     const operationSuspense =
       parentSuspense === undefined ? suspense : parentSuspense
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
+      if (transition) {
+        ;(transition as VaporTransitionHooks).deactivationTarget = undefined
+      }
       if ((vnode.type as any).__vapor) {
         activate(vnode.component as any, parentNode, anchor, operationSuspense)
         insert(vnode.anchor as Node, parentNode, anchor)
@@ -1227,9 +1254,14 @@ function createVDOMComponent(
     if (transition) setVNodeTransitionHooks(vnode, transition)
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
       keepAliveCtx!.clearCurrent!(frag)
+      const storageContainer = keepAliveCtx!.getStorageContainer()
+      if (transition) {
+        ;(transition as VaporTransitionHooks).deactivationTarget =
+          storageContainer
+      }
       vdomDeactivate(
         vnode,
-        keepAliveCtx!.getStorageContainer(),
+        storageContainer,
         internals,
         parentComponent as any,
         null,
@@ -1241,7 +1273,13 @@ function createVDOMComponent(
     internals.umt(vnode.component!, null, !!parentNode && !deactivationTarget)
     // Ordinary VDOM transitions own their leaving DOM until leave finishes.
     if (deactivationTarget) {
-      removeDom(deactivationTarget)
+      cleanupDeactivatedNodes(
+        vnode,
+        deactivationTarget,
+        (transition as VaporTransitionHooks).state.isUnmounting
+          ? parentNode
+          : undefined,
+      )
     } else if (!transition) {
       removeDom(parentNode)
     }
@@ -1262,6 +1300,9 @@ function createVDOMComponent(
     if (parentSuspense !== undefined) suspense = parentSuspense
     const operationSuspense = suspense
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
+      if (transition) {
+        ;(transition as VaporTransitionHooks).deactivationTarget = undefined
+      }
       vdomActivate(
         vnode,
         parentNode,


### PR DESCRIPTION
- reuse the pending deactivation leave when pruning a cached branch
- preserve DOM ownership across Vapor and VDOM interop removal paths
- cover max pruning and out-in transition behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed KeepAlive cache pruning during transitions so outgoing content remains mounted until its leave transition completes.
  * Prevented pruned components from being reinserted after transition completion.
  * Improved out-in transition behavior for both standard and Vapor-rendered components.
  * Ensured previously cached content is removed cleanly when replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->