### PR TITLE
fix(runtime-vapor): constrain expose to Exposed type

### DIFF
--- a/packages-private/dts-test/vapor/functionalComponent.test-d.tsx
+++ b/packages-private/dts-test/vapor/functionalComponent.test-d.tsx
@@ -80,3 +80,13 @@ const Quux: FunctionalVaporComponent<
   return []
 }
 ;<Quux />
+
+const ExposedComp: FunctionalVaporComponent<{}, {}, {}, { foo: string }> = (
+  props,
+  { expose },
+) => {
+  // @ts-expect-error should be error
+  expose({ foo: 1 })
+  return []
+}
+;<ExposedComp />

--- a/packages-private/dts-test/vapor/functionalComponent.test-d.tsx
+++ b/packages-private/dts-test/vapor/functionalComponent.test-d.tsx
@@ -85,6 +85,7 @@ const ExposedComp: FunctionalVaporComponent<{}, {}, {}, { foo: string }> = (
   props,
   { expose },
 ) => {
+  expose({ foo: 'ok' })
   // @ts-expect-error should be error
   expose({ foo: 1 })
   return []

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -160,7 +160,7 @@ export type FunctionalVaporComponent<
     emit: EmitFn<Emits>
     slots: Slots
     attrs: Record<string, any>
-    expose: <T extends Record<string, any> = Exposed>(exposed: T) => void
+    expose: (exposed: Exposed) => void
   },
 ) => VaporRenderResult) &
   Omit<


### PR DESCRIPTION
Add dts test verifying exposing a wrong-typed value is a TS error