### PR TITLE
fix(runtime-vapor): defer KeepAlive branch removal until cache pruning

### DIFF
--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -21,7 +21,7 @@ import {
   extend,
 } from '@vue/shared'
 import type { LooseRawProps, VaporComponent } from '../../src/component'
-import { ifFlags, makeRender } from '../_utils'
+import { compile, ifFlags, makeRender } from '../_utils'
 import { VaporKeepAlive } from '../../src/components/KeepAlive'
 import {
   child,
@@ -1330,6 +1330,85 @@ describe('VaporKeepAlive', () => {
       await nextTick()
       // C should be pruned because B was used last so C is the oldest cached
       assertCount([2, 2, 1, 1, 1, 2, 2, 0, 1, 1, 1, 1])
+    })
+
+    test('unmounts without deactivating a branch pruned during the same switch', async () => {
+      const deactivatedA = vi.fn()
+      const unmountedA = vi.fn()
+      const CompA = defineVaporComponent({
+        setup() {
+          onDeactivated(deactivatedA)
+          onUnmounted(unmountedA)
+          return template('<div>A</div>')()
+        },
+      })
+      const CompB = compile(`<template><div>B</div></template>`, ref())
+      const leaves: Array<() => void> = []
+      const data = shallowRef({
+        current: CompA,
+        onLeave: (_el: Element, done: () => void) => leaves.push(done),
+      })
+      const App = compile(
+        `<template>
+          <Transition :css="false" @leave="data.onLeave">
+            <KeepAlive :max="1">
+              <component :is="data.current" />
+            </KeepAlive>
+          </Transition>
+        </template>`,
+        data,
+      )
+      const { host, app } = define(App as any).render()
+      const a = host.firstElementChild
+
+      data.value = { ...data.value, current: CompB }
+      await nextTick()
+
+      expect(deactivatedA).not.toHaveBeenCalled()
+      expect(unmountedA).toHaveBeenCalledOnce()
+      expect(leaves).toHaveLength(1)
+      expect(a!.parentNode).toBe(host)
+
+      leaves[0]()
+      await nextTick()
+      expect(a!.parentNode).toBeNull()
+
+      app.unmount()
+    })
+
+    test('unmounts an incoming branch superseded during mount', async () => {
+      const deactivatedB = vi.fn()
+      const unmountedB = vi.fn()
+      const CompA = compile(`<template><div>A</div></template>`, ref())
+      const CompC = compile(`<template><div>C</div></template>`, ref())
+      const current = shallowRef<VaporComponent>()
+      const CompB = defineVaporComponent({
+        setup() {
+          onBeforeMount(() => (current.value = CompC))
+          onDeactivated(deactivatedB)
+          onUnmounted(unmountedB)
+          return template('<div>B</div>')()
+        },
+      })
+      current.value = CompA
+      const App = compile(
+        `<template>
+          <KeepAlive :max="1">
+            <component :is="data" />
+          </KeepAlive>
+        </template>`,
+        current,
+      )
+      const { host, app } = define(App as any).render()
+
+      current.value = CompB
+      await nextTick()
+
+      expect(host.textContent).toBe('C')
+      expect(deactivatedB).not.toHaveBeenCalled()
+      expect(unmountedB).toHaveBeenCalledOnce()
+
+      app.unmount()
     })
   })
 

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -2915,7 +2915,7 @@ describe('vdomInterop', () => {
           app.unmount()
         })
 
-        it('deactivates then prunes a Vapor component VNode when max is reached', async () => {
+        it('unmounts a Vapor component VNode pruned during the same switch', async () => {
           const deactivatedA = vi.fn()
           const unmountedA = vi.fn()
           const renderA = vi.fn((value: number) => value)
@@ -2962,7 +2962,7 @@ describe('vdomInterop', () => {
           expect(host.innerHTML).toBe(
             '<div>vapor B</div><!--dynamic-component-->',
           )
-          expect(deactivatedA).toHaveBeenCalledOnce()
+          expect(deactivatedA).not.toHaveBeenCalled()
           expect(unmountedA).toHaveBeenCalledOnce()
           expect(a!.parentNode).toBeNull()
 

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -170,7 +170,6 @@ const VaporKeepAliveImpl = defineVaporComponent({
       block: VaporComponentInstance | VaporFragment,
       isCurrent: boolean,
     ) => {
-
       if (cache.has(key)) {
         if (isCurrent) {
           // Only active branches should refresh their recency. Background

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -35,12 +35,13 @@ import { ShapeFlags, invokeArrayFns, isArray } from '@vue/shared'
 import { createElement } from '../dom/node'
 import { unsetRef } from '../refCleanup'
 import {
+  type DynamicFragment,
   type VaporFragment,
   isDynamicFragment,
   isFragment,
   isInteropFragment,
 } from '../fragment'
-import type { EffectScope } from '@vue/reactivity'
+import { EffectScope } from '@vue/reactivity'
 import { isInteropEnabled } from '../vdomInteropState'
 import {
   type VaporKeepAliveContext,
@@ -123,6 +124,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
     }
 
     let current: VaporComponentInstance | VaporFragment | undefined
+    let rootFragment: DynamicFragment | undefined
 
     if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
       ;(keepAliveInstance as any).__v_cache = cache
@@ -154,12 +156,20 @@ const VaporKeepAliveImpl = defineVaporComponent({
       }
     }
 
+    const addCacheKey = (key: CacheKey): void => {
+      const { max } = props
+
+      keys.add(key)
+      if (max && keys.size > parseInt(max as string, 10)) {
+        pruneCacheEntry(keys.values().next().value!)
+      }
+    }
+
     const innerCacheBlock = (
       key: CacheKey,
       block: VaporComponentInstance | VaporFragment,
       isCurrent: boolean,
     ) => {
-      const { max } = props
 
       if (cache.has(key)) {
         if (isCurrent) {
@@ -170,11 +180,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
           keys.add(key)
         }
       } else {
-        keys.add(key)
-        // prune oldest entry
-        if (max && keys.size > parseInt(max as string, 10)) {
-          pruneCacheEntry(keys.values().next().value!)
-        }
+        addCacheKey(key)
       }
 
       cache.set(key, block)
@@ -258,6 +264,25 @@ const VaporKeepAliveImpl = defineVaporComponent({
         }
       }
       return scope
+    }
+
+    const cacheScope = (
+      cacheKey: CacheKey,
+      scopeLookupKey: any,
+      scope: EffectScope,
+    ): void => {
+      const prevScope = keptAliveScopes.get(cacheKey)
+      if (prevScope && prevScope !== scope) {
+        const staleScope = deleteScope(cacheKey)
+        if (staleScope) staleScope.stop()
+      }
+
+      keptAliveScopes.set(cacheKey, scope)
+      // Keep the branch key as a lookup alias until its block exists and the
+      // effective component cache key can be resolved.
+      if (scopeLookupKey !== cacheKey) {
+        keptAliveScopes.set(scopeLookupKey, scope)
+      }
     }
 
     const pruneCacheEntry = (key: CacheKey) => {
@@ -363,10 +388,30 @@ const VaporKeepAliveImpl = defineVaporComponent({
         current = undefined
         deactivate(instance, storageContainer, parentSuspense)
       },
-      acquireBranchScope(key) {
-        return deleteScope(key)
+      prepareBranchRemoval(frag, scope) {
+        // Async-wrapper internals share this context but are not themselves
+        // KeepAlive cache roots.
+        if (frag !== rootFragment) {
+          scope.stop()
+          return false
+        }
+        const cacheKey = frag.keyed
+          ? withCurrentCacheKey(frag.current, () =>
+              processShapeFlag(frag.nodes),
+            )
+          : processShapeFlag(frag.nodes)
+        if (cacheKey === false) {
+          scope.stop()
+          return false
+        }
+        cacheScope(cacheKey, frag.current, scope)
+        return true
       },
-      runBranchRender(frag, fn) {
+      runBranchRender(frag, fn, useScope, removePrevious) {
+        frag.scope = useScope
+          ? deleteScope(frag.current) || new EffectScope()
+          : undefined
+        let incomingCacheKey: CacheKey | false = false
         const run = () => {
           try {
             fn()
@@ -375,32 +420,29 @@ const VaporKeepAliveImpl = defineVaporComponent({
             // This must run before leaving the keyed cache-key context so
             // creating components inside the branch can still resolve the
             // same cache key during initial mount.
-            processShapeFlag(frag.nodes)
+            incomingCacheKey = processShapeFlag(frag.nodes)
           }
         }
-        frag.keyed ? withCurrentCacheKey(frag.current, run) : run()
+        // Unlike VDOM, Vapor has no incoming VNode to identify the cache entry
+        // before rendering, so incoming setup runs before cache pruning decides
+        // whether the outgoing branch is deactivated or unmounted.
+        try {
+          frag.keyed ? withCurrentCacheKey(frag.current, run) : run()
+          if (
+            removePrevious &&
+            incomingCacheKey !== false &&
+            !cache.has(incomingCacheKey)
+          ) {
+            // Apply the cache limit before removing the outgoing branch, but do
+            // not expose the incoming block through the cache before mount.
+            addCacheKey(incomingCacheKey)
+          }
+        } finally {
+          if (removePrevious) removePrevious()
+        }
       },
       processShapeFlag,
       cacheBlock,
-      cacheScope(cacheKey, scopeLookupKey, scope) {
-        // remove stale scope
-        const prevScope = keptAliveScopes.get(cacheKey)
-        if (prevScope && prevScope !== scope) {
-          const staleScope = deleteScope(cacheKey)
-          if (staleScope) {
-            staleScope.stop()
-          }
-        }
-
-        // cacheKey is used for cleanup in pruneCacheEntry.
-        // scopeLookupKey is still needed for acquireBranchScope() before a new
-        // block exists, but keyed branches may resolve to the same effective
-        // cacheKey.
-        keptAliveScopes.set(cacheKey, scope)
-        if (scopeLookupKey !== cacheKey) {
-          keptAliveScopes.set(scopeLookupKey, scope)
-        }
-      },
     }
 
     if (isInteropEnabled) {
@@ -412,12 +454,12 @@ const VaporKeepAliveImpl = defineVaporComponent({
 
     keepAliveInstance.ctx = keepAliveCtx
     let children = slots.default()
-    registerDynamicFragmentHooks(children, keepAliveCtx)
+    rootFragment = registerDynamicFragmentHooks(children, keepAliveCtx)
 
     if (isArray(children)) {
       children = children.filter(child => !(child instanceof Comment))
       if (children.length === 1) {
-        registerDynamicFragmentHooks(children[0], keepAliveCtx)
+        rootFragment = registerDynamicFragmentHooks(children[0], keepAliveCtx)
       }
       if (children.length > 1) {
         if (__DEV__) {
@@ -437,22 +479,8 @@ export const VaporKeepAlive: DefineVaporComponent<{}, string, KeepAliveProps> =
 function registerDynamicFragmentHooks(
   block: Block,
   keepAliveCtx: VaporKeepAliveContext,
-): void {
+): DynamicFragment | undefined {
   if (!isDynamicFragment(block)) return
-
-  ;(block.onBeforeRemove ||= []).push(scope => {
-    // If processShapeFlag returns a cache key, cache the scope and retain it.
-    const cacheKey = block.keyed
-      ? withCurrentCacheKey(block.current, () =>
-          keepAliveCtx.processShapeFlag(block.nodes),
-        )
-      : keepAliveCtx.processShapeFlag(block.nodes)
-    if (cacheKey !== false) {
-      keepAliveCtx.cacheScope(cacheKey, block.current, scope)
-      return true
-    }
-    return false
-  })
 
   ;(block.onUpdated ||= []).unshift(() => {
     if (block.$transition && block.$transition.mode === 'out-in') {
@@ -461,6 +489,7 @@ function registerDynamicFragmentHooks(
       keepAliveCtx.cacheBlock(block)
     }
   })
+  return block
 }
 
 const shouldCache = (

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -98,8 +98,6 @@ export class VaporFragment<
 
   // hooks
   onBeforeInsert?: ((nodes: Block) => void)[]
-  // Return true to keep the branch scope alive after removing its DOM.
-  onBeforeRemove?: ((scope: EffectScope) => boolean)[]
   onRemove?: (() => void)[]
   onBeforeUpdate?: (() => void)[]
   onUpdated?: ((nodes?: Block) => void)[]
@@ -320,18 +318,17 @@ export class DynamicFragment extends RenderContextFragment {
 
     const prevSub = setActiveSub()
     const parent = !isHydrating ? this.getBranchParent() : null
+    let removePrevious: (() => void) | undefined
     // teardown previous branch
     if (wasMounted) {
       const scope = this.scope
+      const previous = this.nodes
+      const removeBranch = () => remove(previous, parent || undefined)
+      let deferRemoval = false
       if (scope) {
-        let retainScope = false
-        const onBeforeRemove = this.onBeforeRemove
-        if (onBeforeRemove) {
-          for (let i = 0; i < onBeforeRemove.length; i++) {
-            retainScope = onBeforeRemove[i](scope) || retainScope
-          }
-        }
-        if (!retainScope) {
+        if (this.keepAliveCtx) {
+          deferRemoval = this.keepAliveCtx.prepareBranchRemoval(this, scope)
+        } else {
           scope.stop()
         }
       }
@@ -343,7 +340,11 @@ export class DynamicFragment extends RenderContextFragment {
         setActiveSub(prevSub)
         return
       }
-      remove(this.nodes, parent || undefined)
+      if (deferRemoval) {
+        removePrevious = removeBranch
+      } else {
+        removeBranch()
+      }
     }
 
     const reusingDeferredAnchor = isHydrating
@@ -357,6 +358,7 @@ export class DynamicFragment extends RenderContextFragment {
       key,
       noScope,
       wasMounted || !!parent,
+      removePrevious,
     )
     setActiveSub(prevSub)
 
@@ -378,6 +380,7 @@ export class DynamicFragment extends RenderContextFragment {
     key: any,
     noScope: boolean = false,
     notifyUpdated: boolean = !!parent,
+    removePrevious?: () => void,
   ): void {
     this.current = key
     if (render) {
@@ -385,17 +388,8 @@ export class DynamicFragment extends RenderContextFragment {
       // A compiler-proven static branch can skip its own EffectScope, but attrs
       // fallthrough still registers branch-owned cleanup.
       const useScope = !noScope || !!this.hasFallthroughAttrs
-      if (useScope) {
-        // try to reuse the kept-alive scope
-        const scope =
-          keepAliveCtx && keepAliveCtx.acquireBranchScope(this.current)
-        if (scope) {
-          this.scope = scope
-        } else {
-          this.scope = new EffectScope()
-        }
-      } else {
-        this.scope = undefined
+      if (!keepAliveCtx) {
+        this.scope = useScope ? new EffectScope() : undefined
       }
 
       const renderBranch = () => {
@@ -423,7 +417,12 @@ export class DynamicFragment extends RenderContextFragment {
       }
 
       keepAliveCtx
-        ? keepAliveCtx.runBranchRender(this, renderBranch)
+        ? keepAliveCtx.runBranchRender(
+            this,
+            renderBranch,
+            useScope,
+            removePrevious,
+          )
         : renderBranch()
 
       if (parent) {
@@ -432,10 +431,15 @@ export class DynamicFragment extends RenderContextFragment {
           onBeforeInsert.forEach(hook => hook(this.nodes))
         }
         insert(this.nodes, parent, this.anchor)
+        if (removePrevious && keepAliveCtx) {
+          // Publish the new cache entry only after it has been mounted.
+          keepAliveCtx.cacheBlock(this)
+        }
       }
     } else {
       this.scope = undefined
       this.nodes = EMPTY_BLOCK
+      if (removePrevious) removePrevious()
     }
 
     const onUpdated = this.onUpdated

--- a/packages/runtime-vapor/src/keepAlive.ts
+++ b/packages/runtime-vapor/src/keepAlive.ts
@@ -8,15 +8,20 @@ import type { Block } from './block'
 import type { DynamicFragment } from './fragment'
 
 export interface VaporKeepAliveContext {
-  // pre-render: hand back the kept-alive scope for a branch key, if any
-  acquireBranchScope(key: any): EffectScope | undefined
-  // wraps a DynamicFragment branch render: sets up the keyed cache-key
-  // context and marks shape flags once the render settles
-  runBranchRender(frag: DynamicFragment, fn: () => void): void
+  // caches or stops the outgoing branch scope and returns whether its DOM
+  // removal must wait for the incoming cache decision
+  prepareBranchRemoval(frag: DynamicFragment, scope: EffectScope): boolean
+  // acquires the incoming branch scope, sets up the keyed cache-key context,
+  // marks shape flags, then runs any deferred outgoing removal
+  runBranchRender(
+    frag: DynamicFragment,
+    fn: () => void,
+    useScope: boolean,
+    removePrevious?: () => void,
+  ): void
   // marks shape flags at component / interop boundaries
   processShapeFlag(block: Block): any | false
   cacheBlock(block?: Block): void
-  cacheScope(cacheKey: any, scopeLookupKey: any, scope: EffectScope): void
   getStorageContainer(): ParentNode
 }
 


### PR DESCRIPTION
- render the incoming branch before applying the KeepAlive cache limit
- unmount same-switch pruned branches without first deactivating them
- keep branch scope ownership local to the KeepAlive root fragment
- cover superseded incoming branches and Vapor VNode interop