### PR TITLE
fix(runtime-vapor): preserve move semantics for VDOM roots

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -2865,6 +2865,65 @@ describe('vdomInterop', () => {
         it.each([
           ['component type', (component: any) => component],
           ['component VNode', (component: any) => h(component)],
+        ])(
+          'moves a VDOM %s root through the current KeepAlive leave transition',
+          async (_, toValue) => {
+            const VDOMCompA = defineComponent({
+              setup: () => () => h('div', 'A'),
+            })
+            const vdomRoot = shallowRef<any>(toValue(VDOMCompA))
+            const VaporCompA = compile(
+              `<template><component :is="data" /></template>`,
+              vdomRoot,
+            )
+            const VaporCompB = compile(
+              `<template><div>B</div></template>`,
+              ref(),
+            )
+            let finishLeave: (() => void) | undefined
+            const firstLeave = vi.fn(
+              (_el: Element, done: () => void) => (finishLeave = done),
+            )
+            const secondLeave = vi.fn(
+              (_el: Element, done: () => void) => (finishLeave = done),
+            )
+            const data = shallowRef({
+              current: VaporCompA,
+              onLeave: firstLeave,
+            })
+            const App = compile(
+              `<template>
+                <Transition :css="false" @leave="data.onLeave">
+                  <KeepAlive :max="2">
+                    <component :is="data.current" />
+                  </KeepAlive>
+                </Transition>
+              </template>`,
+              data,
+            )
+            const { host, app } = define(App as any).render()
+            const a = host.firstElementChild
+
+            data.value = { ...data.value, onLeave: secondLeave }
+            await nextTick()
+            data.value = { ...data.value, current: VaporCompB }
+            await nextTick()
+
+            expect(firstLeave).not.toHaveBeenCalled()
+            expect(secondLeave).toHaveBeenCalledOnce()
+            expect(a!.parentNode).toBe(host)
+
+            finishLeave!()
+            await nextTick()
+            expect(a!.parentNode).not.toBe(host)
+
+            app.unmount()
+          },
+        )
+
+        it.each([
+          ['component type', (component: any) => component],
+          ['component VNode', (component: any) => h(component)],
         ])('prunes a VDOM %s when max is reached', async (_, toValue) => {
           const source = ref(0)
           const renderA = vi.fn()

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -267,6 +267,7 @@ export function move(
         anchor,
         parentSuspense,
         (block as TransitionBlock).$transition,
+        moveType,
       )
     } else {
       move(

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -13,6 +13,7 @@ import {
 } from './block'
 import {
   type GenericComponentInstance,
+  type MoveType,
   type SuspenseBoundary,
   type TransitionHooks,
   type VNode,
@@ -86,6 +87,7 @@ export class VaporFragment<
     anchor: Node | null,
     parentSuspense?: SuspenseBoundary | null,
     transitionHooks?: TransitionHooks,
+    moveType?: MoveType,
   ) => void
   remove?: (parent?: ParentNode, transitionHooks?: TransitionHooks) => void
   hydrate?(...args: any[]): void

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1040,7 +1040,13 @@ function mountVNode(
     syncNodes()
   }
 
-  frag.insert = (parentNode, anchor, parentSuspense, transition) => {
+  frag.insert = (
+    parentNode,
+    anchor,
+    parentSuspense,
+    transition,
+    moveType = MoveType.REORDER,
+  ) => {
     if (isHydrating) return
     const operationSuspense =
       parentSuspense === undefined ? suspense : parentSuspense
@@ -1080,11 +1086,14 @@ function mountVNode(
         isMounted = true
       } else {
         // move
+        if (transition && moveType !== MoveType.REORDER) {
+          setVNodeTransitionHooks(vnode, transition)
+        }
         internals.m(
           vnode,
           parentNode,
           anchor,
-          MoveType.REORDER,
+          moveType,
           parentComponent as any,
           operationSuspense,
         )
@@ -1240,7 +1249,13 @@ function createVDOMComponent(
   vnode.scopeId = getCurrentScopeId() || null
   vnode.slotScopeIds = currentSlotScopeIds
 
-  frag.insert = (parentNode, anchor, parentSuspense, transition) => {
+  frag.insert = (
+    parentNode,
+    anchor,
+    parentSuspense,
+    transition,
+    moveType = MoveType.REORDER,
+  ) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
     const operationSuspense = suspense
@@ -1274,11 +1289,14 @@ function createVDOMComponent(
         isMounted = true
       } else {
         // move
+        if (transition && moveType !== MoveType.REORDER) {
+          setVNodeTransitionHooks(vnode, transition)
+        }
         internals.m(
           vnode,
           parentNode,
           anchor,
-          MoveType.REORDER,
+          moveType,
           parentComponent as any,
           operationSuspense,
         )


### PR DESCRIPTION
- forward fragment move types to VDOM interop roots
- apply current transition hooks during enter and leave moves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component replacement during active leave transitions.
  * Ensured the previous rendered content remains visible until its leave transition completes.
  * Applied the correct transition behavior when moving content, including non-reorder movements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->