### PR TITLE
fix(compiler-vapor): escape constant v-text in templates

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vText.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vText.spec.ts.snap
@@ -12,6 +12,16 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 }"
 `;
 
+exports[`v-text > should escape constant v-text in template 1`] = `
+"import { template as _template } from 'vue';
+const t0 = _template("<div>&lt;span&gt;foo&lt;/span&gt;", 3)
+
+export function render(_ctx) {
+  const n0 = t0()
+  return n0
+}"
+`;
+
 exports[`v-text > should raise error and ignore children when v-text is present 1`] = `
 "import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div> ", 1)
@@ -40,6 +50,16 @@ exports[`v-text > work with component 1`] = `
 export function render(_ctx) {
   const n0 = _createAssetComponent("Comp", null, null, true)
   _renderEffect(() => _setBlockText(n0, _toDisplayString(_ctx.foo)))
+  return n0
+}"
+`;
+
+exports[`v-text > work with constant v-text on component 1`] = `
+"import { createAssetComponent as _createAssetComponent, setBlockText as _setBlockText } from 'vue';
+
+export function render(_ctx) {
+  const n0 = _createAssetComponent("Comp", null, null, true)
+  _setBlockText(n0, '<span>oops</span>')
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vText.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vText.spec.ts
@@ -58,6 +58,17 @@ describe('v-text', () => {
     expect(code).matchSnapshot()
   })
 
+  test('should escape constant v-text in template', () => {
+    const { code, ir } = compileWithVText(
+      `<div v-text="'<span>foo</span>'"></div>`,
+    )
+
+    expect([...ir.template.keys()]).toEqual([
+      '<div>&lt;span&gt;foo&lt;/span&gt;',
+    ])
+    expect(code).matchSnapshot()
+  })
+
   test('work with dynamic component', () => {
     const { code } = compileWithVText(`<component :is="Comp" v-text="foo"/>`)
     expect(code).matchSnapshot()
@@ -68,6 +79,16 @@ describe('v-text', () => {
     const { code } = compileWithVText(`<Comp v-text="foo"/>`)
     expect(code).matchSnapshot()
     expect(code).contains('setBlockText(n0, _toDisplayString(_ctx.foo))')
+  })
+
+  test('work with constant v-text on component', () => {
+    const { code, helpers } = compileWithVText(
+      `<Comp v-text="'<span>oops</span>'"/>`,
+    )
+
+    expect(helpers).contains('setBlockText')
+    expect(code).contains("_setBlockText(n0, '<span>oops</span>')")
+    expect(code).matchSnapshot()
   })
 
   test('work with plain template createElement path', () => {

--- a/packages/compiler-vapor/src/transforms/vText.ts
+++ b/packages/compiler-vapor/src/transforms/vText.ts
@@ -7,7 +7,7 @@ import { IRNodeTypes } from '../ir'
 import { EMPTY_EXPRESSION } from './utils'
 import type { DirectiveTransform } from '../transform'
 import { getLiteralExpressionValue } from '../utils'
-import { isVoidTag } from '../../../shared/src'
+import { escapeHtml, isVoidTag } from '../../../shared/src'
 import { markNonTemplate, registerSyntheticTextChild } from './transformText'
 import { shouldUseCreateElement } from './transformElement'
 
@@ -36,6 +36,7 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
 
   const literal = getLiteralExpressionValue(exp)
   const useCreateElement = shouldUseCreateElement(context.node, context)
+  const isComponent = node.tagType === ElementTypes.COMPONENT
   if (literal != null) {
     if (useCreateElement) {
       const id = registerSyntheticTextChild(context, '', [exp])
@@ -44,11 +45,18 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
         elements: [id],
         parent: context.reference(),
       })
+    } else if (isComponent) {
+      context.registerOperation({
+        type: IRNodeTypes.SET_TEXT,
+        element: context.reference(),
+        values: [exp],
+        generated: true,
+        isComponent,
+      })
     } else {
-      context.childrenTemplate = [String(literal)]
+      context.childrenTemplate = [escapeHtml(literal)]
     }
   } else {
-    const isComponent = node.tagType === ElementTypes.COMPONENT
     let id: number | undefined
     if (useCreateElement) {
       id = registerSyntheticTextChild(context, '')


### PR DESCRIPTION
Constant `v-text` values are not escape correctly on native elements and components in Vapor mode.

[Reproduction](https://play.vuejs.org/#eNqdUk1PAjEQ/SuTXrhAV4F4IAuJGg56UKMem5jNMmCx2zZtdyUh/HenxUUiHwdObee9eX3zsWa31vKmRjZiuS+dtAE8htpCU1jjJkLLis4A96ayMHemgg7P4iMmdYQWujTaBwi4CjCGTu5toSdzY/Is3YhCtyRMYvQIWFlVBKQXQD6TTboAXI8g5ULTi1pjweIhGGRbZtZS93L6BzlH/j+rMCCFVNrFCsMDhaO+82yvcNZlwVPf5nLBl95oav46kgUrSUkqdM82SOqrYCNISMQKpcz3Y4oFV2O3jZefWH4diS/9KsYEe3Ho0TUo2A4LhVsguYzw9O0pOd6BlZnVithnwFf0RtXR45Z2V+sZ2d7jJbcPaXmkXrz76Sqg9m1R0WhkbhJfMFqm2MRTpf/ZHfBhyhN6Q11sF/HE9p7bvDTbrX7ulQm7ef0C/wf20aCL9umrAb/hVz1X8j7b/ACngwzD)