### PR TITLE
dx(runtime-core): warn when innerHTML/textContent overrides children (close #5081)

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -92,6 +92,50 @@ describe('vnode', () => {
     expect(`VNode created with invalid key (NaN)`).toHaveBeenWarned()
   })
 
+  // #5081
+  describe('children overridden by innerHTML / textContent', () => {
+    test('warn on text children', () => {
+      createVNode('div', { innerHTML: '<span/>' }, 'hello')
+      expect(
+        `The \`innerHTML\` prop on <div> will override its children`,
+      ).toHaveBeenWarned()
+    })
+
+    test('warn on array children', () => {
+      createVNode('div', { innerHTML: '<span/>' }, [createVNode('span')])
+      expect(
+        `The \`innerHTML\` prop on <div> will override its children`,
+      ).toHaveBeenWarned()
+    })
+
+    test('warn on textContent', () => {
+      createVNode('div', { textContent: 'text' }, 'hello')
+      expect(
+        `The \`textContent\` prop on <div> will override its children`,
+      ).toHaveBeenWarned()
+    })
+
+    test('no warning when the prop is nullish', () => {
+      createVNode('div', { innerHTML: undefined }, 'hello')
+      createVNode('div', { innerHTML: null }, 'hello')
+      createVNode('div', { textContent: undefined }, 'hello')
+      expect(`will override its children`).not.toHaveBeenWarned()
+    })
+
+    test('no warning without renderable children', () => {
+      createVNode('div', { innerHTML: '<span/>' })
+      createVNode('div', { innerHTML: '<span/>' }, '')
+      createVNode('div', { innerHTML: '<span/>' }, [])
+      expect(`will override its children`).not.toHaveBeenWarned()
+    })
+
+    test('no warning for component vnodes', () => {
+      const Comp = { props: ['innerHTML'], render: () => null }
+      createVNode(Comp, { innerHTML: '<span/>' }, { default: () => 'slot' })
+      expect(`will override its children`).not.toHaveBeenWarned()
+    })
+  })
+
   test('create with class component', () => {
     class Component {
       $props: any

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -499,6 +499,25 @@ function createBaseVNode(
     warn(`VNode created with invalid key (NaN). VNode type:`, vnode.type)
   }
 
+  // #5081 validate children that will be silently discarded by innerHTML /
+  // textContent. The template compiler already errors on `v-html` / `v-text`
+  // used with children, but render functions have no such check.
+  if (__DEV__ && props && vnode.shapeFlag & ShapeFlags.ELEMENT) {
+    const overwritingProp =
+      props.innerHTML != null
+        ? 'innerHTML'
+        : props.textContent != null
+          ? 'textContent'
+          : null
+    if (overwritingProp && hasContentChildren(vnode.children)) {
+      warn(
+        `The \`${overwritingProp}\` prop on <${vnode.type as string}> will ` +
+          `override its children. Remove either the \`${overwritingProp}\` ` +
+          `prop or the children.`,
+      )
+    }
+  }
+
   // track vnode for block tree
   if (
     isBlockTreeEnabled > 0 &&
@@ -527,6 +546,18 @@ function createBaseVNode(
 }
 
 export { createBaseVNode as createElementVNode }
+
+/**
+ * dev only
+ * Whether children would actually render something. Empty text and empty
+ * arrays are ignored, mirroring the compiler's `node.children.length` check
+ * for `v-html` / `v-text`.
+ */
+function hasContentChildren(children: VNode['children']): boolean {
+  if (isString(children)) return children !== ''
+  if (isArray(children)) return children.length > 0
+  return false
+}
 
 export const createVNode = (
   __DEV__ ? createVNodeWithArgsTransform : _createVNode

--- a/packages/server-renderer/__tests__/render.spec.ts
+++ b/packages/server-renderer/__tests__/render.spec.ts
@@ -664,6 +664,9 @@ function testRender(type: string, render: typeof renderToString) {
             ),
           ),
         ).toBe(`<div><span>hello</span></div>`)
+        expect(
+          `The \`innerHTML\` prop on <div> will override its children`,
+        ).toHaveBeenWarned()
       })
 
       test('textContent', async () => {
@@ -678,6 +681,9 @@ function testRender(type: string, render: typeof renderToString) {
             ),
           ),
         ).toBe(`<div>${escapeHtml(`<span>hello</span>`)}</div>`)
+        expect(
+          `The \`textContent\` prop on <div> will override its children`,
+        ).toHaveBeenWarned()
       })
 
       test('textarea value', async () => {


### PR DESCRIPTION
### Summary

The template compiler already reports an error when `v-html` / `v-text` is used on an element that has children:

```
// packages/compiler-dom/src/errors.ts
[DOMErrorCodes.X_V_HTML_WITH_CHILDREN]: `v-html will override element children.`
```

Render functions have no equivalent check, so the same mistake goes through silently:

```js
h('div', { innerHTML: '<span>html</span>' }, 'a')
// renders <div><span>html</span></div> — 'a' is dropped without any hint
```

This PR closes that gap with a dev-only warning in `createBaseVNode`, mirroring the compiler's behaviour for render functions.

### Notes on the original report

The `TypeError: Cannot read properties of undefined (reading '__asyncLoader')` from the original repro no longer reproduces on `main` — `h('div', { innerHTML: undefined }, 'a')` renders its children fine today. What remains is the silent override described by the issue title, which is what this PR addresses.

A warning is used rather than a thrown error, since throwing would break existing code that relies on the override (including two of this repo's own SSR tests).

### False positives considered

The warning is intentionally narrow — it only fires when children really are discarded:

- `shapeFlag & ShapeFlags.ELEMENT` — component vnodes that merely receive `innerHTML` as a regular prop are skipped, since their children are slots and are not overridden.
- `props.innerHTML != null` — matches the `value != null` guard in `patchDOMProp`; with a nullish value the children survive, so `h('div', { innerHTML: undefined }, 'a')` does not warn.
- `hasContentChildren()` — empty text and empty arrays are ignored, mirroring the compiler's `node.children.length` check.

### Behaviour change

Two existing SSR tests (`innerHTML` / `textContent` in `packages/server-renderer/__tests__/render.spec.ts`) deliberately pass `'ignored'` as children to assert the override. They now also assert the warning.

### Verification

- Full unit suite passes (`vitest run --project "unit*"`).
- `tsc --noEmit`, eslint and prettier are clean.
- Zero production cost: after `pnpm build vue -f global`, neither the warning message nor `hasContentChildren` appears in `vue.global.prod.js` — the whole check is tree-shaken away.

close #5081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added development-time warnings when `innerHTML` or `textContent` overrides non-empty element children.
  * Applied the same warning behavior during server-side rendering.
  * Avoids warnings for empty or nullish content and component nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->