### PR TITLE
fix(vapor): align component v-text and v-html with vdom

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vHtml.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vHtml.spec.ts.snap
@@ -1,5 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`v-html > pass innerHTML prop to component 1`] = `
+"import { createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n0 = _createAssetComponent("Comp", { innerHTML: () => (_ctx.foo) }, null, true)
+  return n0
+}"
+`;
+
+exports[`v-html > pass innerHTML prop to dynamic component 1`] = `
+"import { createDynamicComponent as _createDynamicComponent } from 'vue';
+
+export function render(_ctx) {
+  const n0 = _createDynamicComponent(() => (_ctx.Comp), { innerHTML: () => (_ctx.foo) }, null, 1 /* SINGLE_ROOT */)
+  return n0
+}"
+`;
+
 exports[`v-html > should convert v-html to innerHTML 1`] = `
 "import { setHtml as _setHtml, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
@@ -40,26 +58,6 @@ const t0 = _template("<div>", 1)
 export function render(_ctx) {
   const n0 = t0()
   _setHtml(n0, "")
-  return n0
-}"
-`;
-
-exports[`v-html > work with component 1`] = `
-"import { createAssetComponent as _createAssetComponent, setBlockHtml as _setBlockHtml, renderEffect as _renderEffect } from 'vue';
-
-export function render(_ctx) {
-  const n0 = _createAssetComponent("Comp", null, null, true)
-  _renderEffect(() => _setBlockHtml(n0, _ctx.foo))
-  return n0
-}"
-`;
-
-exports[`v-html > work with dynamic component 1`] = `
-"import { createDynamicComponent as _createDynamicComponent, setBlockHtml as _setBlockHtml, renderEffect as _renderEffect } from 'vue';
-
-export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.Comp), null, null, 1 /* SINGLE_ROOT */)
-  _renderEffect(() => _setBlockHtml(n0, _ctx.foo))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vText.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vText.spec.ts.snap
@@ -1,5 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`v-text > pass textContent prop to component 1`] = `
+"import { toDisplayString as _toDisplayString, createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n0 = _createAssetComponent("Comp", { textContent: () => (_toDisplayString(_ctx.foo)) }, null, true)
+  return n0
+}"
+`;
+
+exports[`v-text > pass textContent prop to dynamic component 1`] = `
+"import { toDisplayString as _toDisplayString, createDynamicComponent as _createDynamicComponent } from 'vue';
+
+export function render(_ctx) {
+  const n0 = _createDynamicComponent(() => (_ctx.Comp), { textContent: () => (_toDisplayString(_ctx.foo)) }, null, 1 /* SINGLE_ROOT */)
+  return n0
+}"
+`;
+
 exports[`v-text > should convert v-text to setText 1`] = `
 "import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div> ", 1)
@@ -30,26 +48,6 @@ const t0 = _template("<div>", 3)
 
 export function render(_ctx) {
   const n0 = t0()
-  return n0
-}"
-`;
-
-exports[`v-text > work with component 1`] = `
-"import { createAssetComponent as _createAssetComponent, toDisplayString as _toDisplayString, setBlockText as _setBlockText, renderEffect as _renderEffect } from 'vue';
-
-export function render(_ctx) {
-  const n0 = _createAssetComponent("Comp", null, null, true)
-  _renderEffect(() => _setBlockText(n0, _toDisplayString(_ctx.foo)))
-  return n0
-}"
-`;
-
-exports[`v-text > work with dynamic component 1`] = `
-"import { createDynamicComponent as _createDynamicComponent, toDisplayString as _toDisplayString, setBlockText as _setBlockText, renderEffect as _renderEffect } from 'vue';
-
-export function render(_ctx) {
-  const n0 = _createDynamicComponent(() => (_ctx.Comp), null, null, 1 /* SINGLE_ROOT */)
-  _renderEffect(() => _setBlockText(n0, _toDisplayString(_ctx.foo)))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vHtml.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vHtml.spec.ts
@@ -55,16 +55,18 @@ describe('v-html', () => {
     expect(code).matchSnapshot()
   })
 
-  test('work with dynamic component', () => {
+  test('pass innerHTML prop to dynamic component', () => {
     const { code } = compileWithVHtml(`<component :is="Comp" v-html="foo"/>`)
     expect(code).matchSnapshot()
-    expect(code).contains('setBlockHtml(n0, _ctx.foo))')
+    expect(code).contains('{ innerHTML: () => (_ctx.foo) }')
+    expect(code).not.contains('setBlockHtml')
   })
 
-  test('work with component', () => {
+  test('pass innerHTML prop to component', () => {
     const { code } = compileWithVHtml(`<Comp v-html="foo"/>`)
     expect(code).matchSnapshot()
-    expect(code).contains('setBlockHtml(n0, _ctx.foo))')
+    expect(code).contains('{ innerHTML: () => (_ctx.foo) }')
+    expect(code).not.contains('setBlockHtml')
   })
 
   test('should raise error and ignore children when v-html is present', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vText.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vText.spec.ts
@@ -58,16 +58,62 @@ describe('v-text', () => {
     expect(code).matchSnapshot()
   })
 
-  test('work with dynamic component', () => {
+  test('pass textContent prop to dynamic component', () => {
     const { code } = compileWithVText(`<component :is="Comp" v-text="foo"/>`)
     expect(code).matchSnapshot()
-    expect(code).contains('setBlockText(n0, _toDisplayString(_ctx.foo))')
+    expect(code).contains('{ textContent: () => (_toDisplayString(_ctx.foo)) }')
+    expect(code).not.contains('setBlockText')
   })
 
-  test('work with component', () => {
+  test('pass textContent prop to component', () => {
     const { code } = compileWithVText(`<Comp v-text="foo"/>`)
     expect(code).matchSnapshot()
-    expect(code).contains('setBlockText(n0, _toDisplayString(_ctx.foo))')
+    expect(code).contains('{ textContent: () => (_toDisplayString(_ctx.foo)) }')
+    expect(code).not.contains('setBlockText')
+  })
+
+  test('preserve constant component prop values', () => {
+    const number = compileWithVText(`<Comp v-text="1"/>`).code
+    expect(number).contains('{ textContent: 1 }')
+    expect(number).not.contains('toDisplayString')
+
+    const undefinedValue = compileWithVText(`<Comp v-text="undefined"/>`).code
+    expect(undefinedValue).contains('{ textContent: undefined }')
+    expect(undefinedValue).not.contains('toDisplayString')
+
+    const setupConst = compileWithVText(`<Comp v-text="foo"/>`, {
+      bindingMetadata: {
+        foo: BindingTypes.SETUP_CONST,
+      },
+      inline: true,
+    }).code
+    expect(setupConst).contains('{ textContent: () => (foo) }')
+    expect(setupConst).not.contains('toDisplayString')
+
+    const functionValue = compileWithVText(`<Comp v-text="() => 1"/>`).code
+    expect(functionValue).contains('{ textContent: () => (() => 1) }')
+    expect(functionValue).not.contains('toDisplayString')
+
+    const functionWithReference = compileWithVText(
+      `<Comp v-text="() => foo"/>`,
+    ).code
+    expect(functionWithReference).contains('toDisplayString')
+
+    const setupConstExpression = compileWithVText(`<Comp v-text="foo + 1"/>`, {
+      bindingMetadata: {
+        foo: BindingTypes.SETUP_CONST,
+      },
+      inline: true,
+    }).code
+    expect(setupConstExpression).contains('toDisplayString')
+  })
+
+  test('escape constant text in native element templates', () => {
+    const { code, ir } = compileWithVText(`<div v-text="'<b>foo</b>'"/>`)
+    expect([...ir.template.keys()]).toEqual(['<div>&lt;b&gt;foo&lt;/b&gt;'])
+    expect(code).contains(
+      'const t0 = _template("<div>&lt;b&gt;foo&lt;/b&gt;", 3)',
+    )
   })
 
   test('work with plain template createElement path', () => {

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -491,7 +491,10 @@ function genProp(
   wrapHandler = true,
   directStaticLiteral = false,
 ) {
-  const values = genPropValue(prop.values, context)
+  let values = genPropValue(prop.values, context)
+  if (prop.toDisplayString) {
+    values = genCall(context.helper('toDisplayString'), values)
+  }
   return [
     ...genPropKey(prop, context),
     ': ',

--- a/packages/compiler-vapor/src/generators/html.ts
+++ b/packages/compiler-vapor/src/generators/html.ts
@@ -9,14 +9,9 @@ export function genSetHtml(
 ): CodeFragment[] {
   const { helper } = context
 
-  const { value, element, isComponent } = oper
+  const { value, element } = oper
   return [
     NEWLINE,
-    ...genCall(
-      // use setBlockHtml for component
-      isComponent ? helper('setBlockHtml') : helper('setHtml'),
-      `n${element}`,
-      genExpression(value, context),
-    ),
+    ...genCall(helper('setHtml'), `n${element}`, genExpression(value, context)),
   ]
 }

--- a/packages/compiler-vapor/src/generators/text.ts
+++ b/packages/compiler-vapor/src/generators/text.ts
@@ -10,16 +10,11 @@ export function genSetText(
   context: CodegenContext,
 ): CodeFragment[] {
   const { helper } = context
-  const { element, values, generated, isComponent } = oper
+  const { element, values, generated } = oper
   const texts = combineValues(values, context)
   return [
     NEWLINE,
-    ...genCall(
-      // use setBlockText for component
-      isComponent ? helper('setBlockText') : helper('setText'),
-      `${generated && !isComponent ? 'x' : 'n'}${element}`,
-      texts,
-    ),
+    ...genCall(helper('setText'), `${generated ? 'x' : 'n'}${element}`, texts),
   ]
 }
 

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -167,7 +167,6 @@ export interface SetTextIRNode extends BaseIRNode {
   element: number
   values: SimpleExpressionNode[]
   generated?: boolean // whether this is a generated empty text node by `processTextLikeContainer`
-  isComponent?: boolean
 }
 
 export type KeyOverride = [find: string, replacement: string]
@@ -194,7 +193,6 @@ export interface SetHtmlIRNode extends BaseIRNode {
   type: IRNodeTypes.SET_HTML
   element: number
   value: SimpleExpressionNode
-  isComponent?: boolean
 }
 
 export interface SetTemplateRefIRNode extends BaseIRNode {

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -49,6 +49,7 @@ export type DirectiveTransform = (
 export interface DirectiveTransformResult {
   key: SimpleExpressionNode
   value: SimpleExpressionNode
+  toDisplayString?: boolean
   modifier?: '.' | '^'
   runtimeCamelize?: boolean
   handler?: boolean

--- a/packages/compiler-vapor/src/transforms/vHtml.ts
+++ b/packages/compiler-vapor/src/transforms/vHtml.ts
@@ -3,7 +3,9 @@ import type { DirectiveTransform, TransformContext } from '../transform'
 import {
   DOMErrorCodes,
   type ElementNode,
+  ElementTypes,
   createDOMCompilerError,
+  createSimpleExpression,
   findDir,
 } from '@vue/compiler-dom'
 import { EMPTY_EXPRESSION } from './utils'
@@ -37,10 +39,16 @@ export const transformVHtml: DirectiveTransform = (dir, node, context) => {
   }
   ignoreVHtmlChildren(node, context, 'template')
 
+  if (node.tagType === ElementTypes.COMPONENT) {
+    return {
+      key: createSimpleExpression('innerHTML', true, loc),
+      value: exp,
+    }
+  }
+
   context.registerEffect([exp], {
     type: IRNodeTypes.SET_HTML,
     element: context.reference(),
     value: exp,
-    isComponent: node.tagType === 1,
   })
 }

--- a/packages/compiler-vapor/src/transforms/vText.ts
+++ b/packages/compiler-vapor/src/transforms/vText.ts
@@ -1,13 +1,19 @@
 import {
+  type BindingMetadata,
+  BindingTypes,
   DOMErrorCodes,
   ElementTypes,
+  type SimpleExpressionNode,
   createDOMCompilerError,
+  createSimpleExpression,
+  isStaticPropertyKey,
+  walkIdentifiers,
 } from '@vue/compiler-dom'
+import { escapeHtml, isGloballyAllowed, isVoidTag } from '@vue/shared'
 import { IRNodeTypes } from '../ir'
 import { EMPTY_EXPRESSION } from './utils'
 import type { DirectiveTransform } from '../transform'
-import { getLiteralExpressionValue } from '../utils'
-import { isVoidTag } from '../../../shared/src'
+import { getLiteralExpressionValue, isConstantExpression } from '../utils'
 import { markNonTemplate, registerSyntheticTextChild } from './transformText'
 import { shouldUseCreateElement } from './transformElement'
 
@@ -34,6 +40,17 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
     return
   }
 
+  if (node.tagType === ElementTypes.COMPONENT) {
+    return {
+      key: createSimpleExpression('textContent', true),
+      value: exp,
+      toDisplayString: !isConstantVTextExpression(
+        exp,
+        context.options.bindingMetadata,
+      ),
+    }
+  }
+
   const literal = getLiteralExpressionValue(exp)
   const useCreateElement = shouldUseCreateElement(context.node, context)
   if (literal != null) {
@@ -45,10 +62,9 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
         parent: context.reference(),
       })
     } else {
-      context.childrenTemplate = [String(literal)]
+      context.childrenTemplate = [escapeHtml(literal)]
     }
   } else {
-    const isComponent = node.tagType === ElementTypes.COMPONENT
     let id: number | undefined
     if (useCreateElement) {
       id = registerSyntheticTextChild(context, '')
@@ -57,7 +73,7 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
         elements: [id],
         parent: context.reference(),
       })
-    } else if (!isComponent) {
+    } else {
       context.childrenTemplate = [' ']
       context.registerOperation({
         type: IRNodeTypes.GET_TEXT_CHILD,
@@ -69,7 +85,46 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
       element: useCreateElement ? id! : context.reference(),
       values: [exp],
       generated: !useCreateElement,
-      isComponent,
     })
   }
+}
+
+function isConstantVTextExpression(
+  exp: SimpleExpressionNode,
+  bindings: BindingMetadata,
+): boolean {
+  if (isConstantExpression(exp)) {
+    return true
+  }
+  if (exp.ast === null) {
+    const type = bindings[exp.content]
+    return (
+      type === BindingTypes.SETUP_CONST || type === BindingTypes.LITERAL_CONST
+    )
+  }
+  if (!exp.ast) {
+    return false
+  }
+
+  let isConstant = true
+  walkIdentifiers(
+    exp.ast,
+    (id, parent, _parentStack, isReferenced) => {
+      if (parent && isStaticPropertyKey(id, parent)) {
+        return
+      }
+      const needsPrefix =
+        isReferenced && !isGloballyAllowed(id.name) && id.name !== 'require'
+      if (
+        needsPrefix ||
+        parent?.type === 'CallExpression' ||
+        parent?.type === 'NewExpression' ||
+        parent?.type === 'MemberExpression'
+      ) {
+        isConstant = false
+      }
+    },
+    true,
+  )
+  return isConstant
 }

--- a/packages/compiler-vapor/src/transforms/vText.ts
+++ b/packages/compiler-vapor/src/transforms/vText.ts
@@ -9,13 +9,17 @@ import {
   isStaticPropertyKey,
   walkIdentifiers,
 } from '@vue/compiler-dom'
-import { escapeHtml, isGloballyAllowed, isVoidTag } from '@vue/shared'
+import { escapeHtml, isGloballyAllowed, isVoidTag, makeMap } from '@vue/shared'
 import { IRNodeTypes } from '../ir'
 import { EMPTY_EXPRESSION } from './utils'
 import type { DirectiveTransform } from '../transform'
 import { getLiteralExpressionValue, isConstantExpression } from '../utils'
 import { markNonTemplate, registerSyntheticTextChild } from './transformText'
 import { shouldUseCreateElement } from './transformElement'
+
+const isRawTextContainer = /*@__PURE__*/ makeMap(
+  'iframe,noembed,noframes,noscript,script,style,xmp',
+)
 
 export const transformVText: DirectiveTransform = (dir, node, context) => {
   let { exp, loc } = dir
@@ -54,7 +58,7 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
   const literal = getLiteralExpressionValue(exp)
   const useCreateElement = shouldUseCreateElement(context.node, context)
   if (literal != null) {
-    if (useCreateElement) {
+    if (useCreateElement || isRawTextContainer(node.tag)) {
       const id = registerSyntheticTextChild(context, '', [exp])
       context.registerOperation({
         type: IRNodeTypes.INSERT_NODE,
@@ -89,6 +93,8 @@ export const transformVText: DirectiveTransform = (dir, node, context) => {
   }
 }
 
+// Keep this aligned with the constant classification used by compiler-dom's
+// transformExpression + getConstantType path for v-text.
 function isConstantVTextExpression(
   exp: SimpleExpressionNode,
   bindings: BindingMetadata,

--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -796,6 +796,30 @@ describe('component', () => {
     expect(el.textContent).toBe('<b>foo</b>')
   })
 
+  it('mounts raw text element literal v-text as text', () => {
+    const Comp = compile(
+      `<template><iframe v-text="'<b>foo</b>'" /></template>`,
+      ref('unused'),
+    )
+
+    const { host } = define(Comp).render()
+    const iframe = host.firstChild as HTMLIFrameElement
+    expect(iframe.textContent).toBe('<b>foo</b>')
+  })
+
+  it('does not parse closing tags in raw text element literal v-text', () => {
+    const value = '</iframe><div>injected</div>'
+    const Comp = compile(
+      `<template><iframe v-text="'${value}'" /></template>`,
+      ref('unused'),
+    )
+
+    const { host } = define(Comp).render()
+    const iframe = host.firstChild as HTMLIFrameElement
+    expect(iframe.textContent).toBe(value)
+    expect(host.childElementCount).toBe(1)
+  })
+
   it('mounts plain template elements with slot content', () => {
     const data = ref('unused')
     const Child = compile(

--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -784,6 +784,18 @@ describe('component', () => {
     expect(templateEl.textContent).toBe('<b>foo</b>')
   })
 
+  it('mounts native element literal v-text as text', () => {
+    const Comp = compile(
+      `<template><div v-text="'<b>foo</b>'" /></template>`,
+      ref('unused'),
+    )
+
+    const { host } = define(Comp).render()
+    const el = host.firstChild as HTMLDivElement
+    expect(el.firstChild!.nodeType).toBe(Node.TEXT_NODE)
+    expect(el.textContent).toBe('<b>foo</b>')
+  })
+
   it('mounts plain template elements with slot content', () => {
     const data = ref('unused')
     const Child = compile(

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1573,6 +1573,46 @@ describe('attribute fallthrough', () => {
     expect(host.innerHTML).toBe('<div>prop:&lt;i&gt;two&lt;/i&gt;</div>')
   })
 
+  it('warns when v-text cannot fall through to a text root', () => {
+    const Child = compile(`<template>child</template>`, ref(null))
+    const Parent = compile(
+      `<template><components.Child v-text="data" /></template>`,
+      ref('foo'),
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.textContent).toBe('child')
+    expect(`Extraneous non-props attributes (textContent)`).toHaveBeenWarned()
+  })
+
+  it('warns when v-html cannot fall through to a text root', () => {
+    const Child = compile(`<template>child</template>`, ref(null))
+    const Parent = compile(
+      `<template><components.Child v-html="data" /></template>`,
+      ref('<b>foo</b>'),
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.textContent).toBe('child')
+    expect(`Extraneous non-props attributes (innerHTML)`).toHaveBeenWarned()
+  })
+
+  it('does not warn for filtered functional fallthrough on a text root', () => {
+    const { component: Child } = define(() => template('child')())
+    Child.props = ['foo']
+    const Parent = compile(
+      `<template><components.Child v-text="data" /></template>`,
+      ref('foo'),
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.textContent).toBe('child')
+    expect(`Extraneous non-props attributes`).not.toHaveBeenWarned()
+  })
+
   it('applies v-text fallthrough after switching dynamic components', async () => {
     const state = ref({ current: 'A', content: '<b>one</b>' })
     const A = compile(`<template><div>A</div></template>`, ref(null))

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1526,4 +1526,110 @@ describe('attribute fallthrough', () => {
     const el = host.children[0]
     expect(el.classList.length).toBe(0)
   })
+
+  it('passes v-text to components as a reactive textContent prop', async () => {
+    const value = ref('<b>one</b>')
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps(['textContent'])
+      </script>
+      <template><div>prop:{{ props.textContent }}</div></template>`,
+      ref(null),
+    )
+    const Parent = compile(
+      `<template><components.Child v-text="data" /></template>`,
+      value,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe('<div>prop:&lt;b&gt;one&lt;/b&gt;</div>')
+
+    value.value = '<i>two</i>'
+    await nextTick()
+    expect(host.innerHTML).toBe('<div>prop:&lt;i&gt;two&lt;/i&gt;</div>')
+  })
+
+  it('passes v-html to components as a reactive innerHTML prop', async () => {
+    const value = ref('<b>one</b>')
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps(['innerHTML'])
+      </script>
+      <template><div>prop:{{ props.innerHTML }}</div></template>`,
+      ref(null),
+    )
+    const Parent = compile(
+      `<template><components.Child v-html="data" /></template>`,
+      value,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe('<div>prop:&lt;b&gt;one&lt;/b&gt;</div>')
+
+    value.value = '<i>two</i>'
+    await nextTick()
+    expect(host.innerHTML).toBe('<div>prop:&lt;i&gt;two&lt;/i&gt;</div>')
+  })
+
+  it('applies v-text fallthrough after switching dynamic components', async () => {
+    const state = ref({ current: 'A', content: '<b>one</b>' })
+    const A = compile(`<template><div>A</div></template>`, ref(null))
+    const B = compile(`<template><div>B</div></template>`, ref(null))
+    const Parent = compile(
+      `<template>
+        <component
+          :is="components[data.current]"
+          v-text="data.content"
+        />
+      </template>`,
+      state,
+      { A, B },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe(
+      '<div>&lt;b&gt;one&lt;/b&gt;</div><!--dynamic-component-->',
+    )
+
+    state.value = { ...state.value, current: 'B' }
+    await nextTick()
+    expect(host.innerHTML).toBe(
+      '<div>&lt;b&gt;one&lt;/b&gt;</div><!--dynamic-component-->',
+    )
+
+    state.value = { ...state.value, content: '<i>two</i>' }
+    await nextTick()
+    expect(host.innerHTML).toBe(
+      '<div>&lt;i&gt;two&lt;/i&gt;</div><!--dynamic-component-->',
+    )
+  })
+
+  it('applies v-html fallthrough after switching dynamic components', async () => {
+    const state = ref({ current: 'A', content: '<b>one</b>' })
+    const A = compile(`<template><div>A</div></template>`, ref(null))
+    const B = compile(`<template><div>B</div></template>`, ref(null))
+    const Parent = compile(
+      `<template>
+        <component
+          :is="components[data.current]"
+          v-html="data.content"
+        />
+      </template>`,
+      state,
+      { A, B },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe('<div><b>one</b></div><!--dynamic-component-->')
+
+    state.value = { ...state.value, current: 'B' }
+    await nextTick()
+    expect(host.innerHTML).toBe('<div><b>one</b></div><!--dynamic-component-->')
+
+    state.value = { ...state.value, content: '<i>two</i>' }
+    await nextTick()
+    expect(host.innerHTML).toBe('<div><i>two</i></div><!--dynamic-component-->')
+  })
 })

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -1,9 +1,7 @@
-import { NOOP, VaporDynamicComponentFlags, toDisplayString } from '@vue/shared'
+import { NOOP } from '@vue/shared'
 import {
   setDynamicProp as _setDynamicProp,
   setAttr,
-  setBlockHtml,
-  setBlockText,
   setClass,
   setClassName,
   setDynamicProps,
@@ -17,7 +15,6 @@ import { setStyle } from '../../src/dom/prop'
 import {
   VaporComponentInstance,
   applyFallthroughProps,
-  createComponent,
   isApplyingFallthroughProps,
 } from '../../src/component'
 import {
@@ -29,13 +26,7 @@ import {
   svgNS,
   xlinkNS,
 } from '@vue/runtime-dom'
-import { makeRender } from '../_utils'
-import {
-  createDynamicComponent,
-  defineVaporComponent,
-  renderEffect,
-  template,
-} from '../../src'
+import { renderEffect } from '../../src'
 
 let removeComponentInstance = NOOP
 beforeEach(() => {
@@ -46,8 +37,6 @@ beforeEach(() => {
 afterEach(() => {
   removeComponentInstance()
 })
-
-const define = makeRender()
 
 describe('patchProp', () => {
   describe('setClass', () => {
@@ -826,210 +815,6 @@ describe('patchProp', () => {
       expect(el.innerHTML).toBe('<p>foo</p>')
       setHtml(el, '<p>bar</p>')
       expect(el.innerHTML).toBe('<p>bar</p>')
-    })
-  })
-
-  describe('setBlockText', () => {
-    test('with dynamic component', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return template('<div>child</div>', 1)()
-        },
-      })
-      const value = ref('foo')
-      const { html } = define({
-        setup() {
-          const n1 = createDynamicComponent(
-            () => Comp,
-            null,
-            null,
-            VaporDynamicComponentFlags.SINGLE_ROOT,
-          )
-          renderEffect(() => setBlockText(n1, toDisplayString(value)))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<div>foo</div><!--dynamic-component-->')
-    })
-
-    test('with dynamic component with fallback', async () => {
-      const value = ref('foo')
-      const { html } = define({
-        setup() {
-          const n1 = createDynamicComponent(
-            () => 'button',
-            null,
-            null,
-            VaporDynamicComponentFlags.SINGLE_ROOT,
-          )
-          renderEffect(() => setBlockText(n1, toDisplayString(value)))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<button>foo</button><!--dynamic-component-->')
-    })
-
-    test('with component', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return template('<div>child</div>', 1)()
-        },
-      })
-      const value = ref('foo')
-      const { html } = define({
-        setup() {
-          const n1 = createComponent(Comp, null, null, true)
-          renderEffect(() => setBlockText(n1, toDisplayString(value)))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<div>foo</div>')
-    })
-
-    test('with component renders multiple roots nodes', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return [
-            template('<div>child</div>')(),
-            template('<div>child</div>')(),
-          ]
-        },
-      })
-      const value = ref('foo')
-      const { html } = define({
-        setup() {
-          const n1 = createComponent(Comp, null, null, true)
-          renderEffect(() => setBlockText(n1, toDisplayString(value)))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<div>child</div><div>child</div>')
-      expect('Extraneous non-props attributes (textContent)').toHaveBeenWarned()
-    })
-
-    test('with component renders text node', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return template('child')()
-        },
-      })
-      const value = ref('foo')
-      const { html } = define({
-        setup() {
-          const n1 = createComponent(Comp, null, null, true)
-          renderEffect(() => setBlockText(n1, toDisplayString(value)))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('child')
-      expect('Extraneous non-props attributes (textContent)').toHaveBeenWarned()
-    })
-  })
-
-  describe('setBlockHtml', () => {
-    test('with dynamic component', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return template('<div>child</div>', 1)()
-        },
-      })
-      const value = ref('<p>foo</p>')
-      const { html } = define({
-        setup() {
-          const n1 = createDynamicComponent(
-            () => Comp,
-            null,
-            null,
-            VaporDynamicComponentFlags.SINGLE_ROOT,
-          )
-          renderEffect(() => setBlockHtml(n1, value.value))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<div><p>foo</p></div><!--dynamic-component-->')
-    })
-
-    test('with dynamic component with fallback', async () => {
-      const value = ref('<p>foo</p>')
-      const { html } = define({
-        setup() {
-          const n1 = createDynamicComponent(
-            () => 'button',
-            null,
-            null,
-            VaporDynamicComponentFlags.SINGLE_ROOT,
-          )
-          renderEffect(() => setBlockHtml(n1, value.value))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<button><p>foo</p></button><!--dynamic-component-->')
-    })
-
-    test('with component', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return template('<div>child</div>', 1)()
-        },
-      })
-      const value = ref('<p>foo</p>')
-      const { html } = define({
-        setup() {
-          const n1 = createComponent(Comp, null, null, true)
-          renderEffect(() => setBlockHtml(n1, value.value))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<div><p>foo</p></div>')
-    })
-
-    test('with component renders multiple roots', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return [
-            template('<div>child</div>')(),
-            template('<div>child</div>')(),
-          ]
-        },
-      })
-      const value = ref('<p>foo</p>')
-      const { html } = define({
-        setup() {
-          const n1 = createComponent(Comp, null, null, true)
-          renderEffect(() => setBlockHtml(n1, value.value))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('<div>child</div><div>child</div>')
-      expect('Extraneous non-props attributes (innerHTML)').toHaveBeenWarned()
-    })
-
-    test('with component renders text node', async () => {
-      const Comp = defineVaporComponent({
-        setup() {
-          return template('child')()
-        },
-      })
-      const value = ref('<p>foo</p>')
-      const { html } = define({
-        setup() {
-          const n1 = createComponent(Comp, null, null, true)
-          renderEffect(() => setBlockHtml(n1, value.value))
-          return n1
-        },
-      }).render()
-
-      expect(html()).toBe('child')
-      expect('Extraneous non-props attributes (innerHTML)').toHaveBeenWarned()
     })
   })
 })

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1523,14 +1523,20 @@ function applyFallthroughAttrs(
       })
     // ensure the render effect is cleaned up when the branch scope is stopped
     scope ? scope.run(applyEffect) : applyEffect()
-  } else if (
-    __DEV__ &&
-    (hasSlotFragment ||
-      (dynamicRoot && dynamicRoot.hasNonSingleRoot) ||
-      (isTeleportEnabled && containsTeleportFragment(block)) ||
-      (!instance.accessedAttrs && isArray(block) && block.length))
-  ) {
-    warnExtraneousAttributes(instance.attrs)
+  } else if (__DEV__) {
+    const accessedAttrs = instance.accessedAttrs
+    const fallthroughAttrs = getFallthroughAttrs()
+    if (
+      fallthroughAttrs &&
+      Object.keys(fallthroughAttrs).length &&
+      (hasSlotFragment ||
+        (dynamicRoot && dynamicRoot.hasNonSingleRoot) ||
+        (isTeleportEnabled && containsTeleportFragment(block)) ||
+        (!accessedAttrs &&
+          (block instanceof Text || (isArray(block) && block.length))))
+    ) {
+      warnExtraneousAttributes(instance.attrs)
+    }
   }
 }
 

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -5,7 +5,6 @@ import {
   canSetValueDirectly,
   getEscapedCssVarName,
   includeBooleanAttr,
-  isArray,
   isOn,
   isSpecialBooleanAttr,
   isString,
@@ -46,7 +45,6 @@ import {
 import {
   type VaporComponentInstance,
   isApplyingFallthroughProps,
-  isVaporComponent,
   shouldUseFunctionalFallthrough,
 } from '../component'
 import {
@@ -461,46 +459,6 @@ export function setElementText(
   }
 }
 
-export function setBlockText(
-  block: Block & { $txt?: string },
-  value: unknown,
-): void {
-  value = value == null ? '' : value
-  if (block.$txt !== value) {
-    setTextToBlock(block, (block.$txt = value as string))
-  }
-}
-
-/**
- * dev only
- */
-function warnCannotSetProp(prop: string): void {
-  warn(
-    `Extraneous non-props attributes (` +
-      `${prop}) ` +
-      `were passed to component but could not be automatically inherited ` +
-      `because component renders text or multiple root nodes.`,
-  )
-}
-
-function setTextToBlock(block: Block, value: any): void {
-  if (block instanceof Node) {
-    if (block instanceof Element) {
-      block.textContent = value
-    } else if (__DEV__) {
-      warnCannotSetProp('textContent')
-    }
-  } else if (isVaporComponent(block)) {
-    setTextToBlock(block.block, value)
-  } else if (isArray(block)) {
-    if (__DEV__) {
-      warnCannotSetProp('textContent')
-    }
-  } else {
-    setTextToBlock(block.nodes, value)
-  }
-}
-
 export function setHtml(el: TargetElement, value: any): void {
   value = value == null ? '' : unsafeToTrustedHTML(value)
   // Align with vdom hydration: server-rendered innerHTML content is trusted
@@ -512,39 +470,6 @@ export function setHtml(el: TargetElement, value: any): void {
   }
   if (el.$html !== value) {
     el.innerHTML = el.$html = value
-  }
-}
-
-export function setBlockHtml(
-  block: Block & { $html?: string },
-  value: any,
-): void {
-  value = value == null ? '' : unsafeToTrustedHTML(value)
-  // trust SSR content during hydration, see setHtml
-  if (isHydrating) {
-    block.$html = value
-    return
-  }
-  if (block.$html !== value) {
-    setHtmlToBlock(block, (block.$html = value))
-  }
-}
-
-function setHtmlToBlock(block: Block, value: any): void {
-  if (block instanceof Node) {
-    if (block instanceof Element) {
-      block.innerHTML = value
-    } else if (__DEV__) {
-      warnCannotSetProp('innerHTML')
-    }
-  } else if (isVaporComponent(block)) {
-    setHtmlToBlock(block.block, value)
-  } else if (isArray(block)) {
-    if (__DEV__) {
-      warnCannotSetProp('innerHTML')
-    }
-  } else {
-    setHtmlToBlock(block.nodes, value)
   }
 }
 

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -37,9 +37,7 @@ export { template } from './dom/template'
 export { createTextNode, child, nthChild, next, txt } from './dom/node'
 export {
   setText,
-  setBlockText,
   setHtml,
-  setBlockHtml,
   setClass,
   setClassName,
   setStyle,


### PR DESCRIPTION
Compile component v-text and v-html directives as textContent and innerHTML props so reactive updates and attribute fallthrough follow the normal component prop flow.

Preserve values that VDOM considers constant, escape literal v-text content embedded in native element templates, and remove the obsolete setBlockText and setBlockHtml runtime helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `v-text` and `v-html` behavior on components, including reactive updates and dynamic component changes.
  * Preserved literal text safely, escaping HTML-like content instead of interpreting it as markup.
  * Improved HTML updates when elements are recreated during hydration.

* **Tests**
  * Added coverage for component bindings, escaping, HTML insertion, and fallthrough behavior.
  * Updated compiler and runtime tests for consistent text and HTML rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->