### PR TITLE
fix(compiler-vapor): generate v-model after prop effects

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -159,6 +159,27 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: vModel transform > generates dynamic model after dynamic type initialization 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, applyDynamicModel as _applyDynamicModel, template as _template } from 'vue';
+const t0 = _template("<input>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => _setProp(n0, "type", _ctx.type))
+  _applyDynamicModel(n0, () => (_ctx.model), _value => (_ctx.model = _value))
+  return n0
+}"
+`;
+
+exports[`compiler: vModel transform > generates dynamic model after dynamic type initialization 2`] = `
+"
+  const n0 = t0()
+  _setProp(n0, "type", type)
+  _applyDynamicModel(n0, () => (model), _value => (model = _value))
+  return n0
+"
+`;
+
 exports[`compiler: vModel transform > modifiers > .lazy 1`] = `
 "import { applyTextModel as _applyTextModel, template as _template } from 'vue';
 const t0 = _template("<input>", 1)
@@ -297,13 +318,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: vModel transform > should support w/ dynamic v-bind 1`] = `
-"import { applyDynamicModel as _applyDynamicModel, setDynamicProps as _setDynamicProps, renderEffect as _renderEffect, template as _template } from 'vue';
+"import { setDynamicProps as _setDynamicProps, renderEffect as _renderEffect, applyDynamicModel as _applyDynamicModel, template as _template } from 'vue';
 const t0 = _template("<input>", 1)
 
 export function render(_ctx) {
   const n0 = t0()
-  _applyDynamicModel(n0, () => (_ctx.model), _value => (_ctx.model = _value))
   _renderEffect(() => _setDynamicProps(n0, [_ctx.obj]))
+  _applyDynamicModel(n0, () => (_ctx.model), _value => (_ctx.model = _value))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vModel.spec.ts
@@ -1,6 +1,7 @@
 import { makeCompile } from './_utils'
 import {
   IRNodeTypes,
+  compile as compileVapor,
   transformChildren,
   transformElement,
   transformVModel,
@@ -460,5 +461,18 @@ describe('compiler: vModel transform', () => {
     ]`,
       )
     })
+  })
+
+  test('generates dynamic model after dynamic type initialization', () => {
+    const source = '<input :type="type" v-model="model" />'
+    const reactive = compileVapor(source, { prefixIdentifiers: true }).code
+    const constant = compileVapor(source, {
+      prefixIdentifiers: true,
+      inline: true,
+      bindingMetadata: { type: BindingTypes.LITERAL_CONST },
+    }).code
+
+    expect(reactive).toMatchSnapshot()
+    expect(constant).toMatchSnapshot()
   })
 })

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -55,6 +55,10 @@ export function genBlockContent(
 ): CodeFragment[] {
   const [frag, push] = buildCodeFragment()
   const { dynamic, effect, operation, returns } = block
+  // Built-in v-model needs to run after initial DOM props are applied. This is
+  // especially important for inputs with a dynamic type, since the runtime
+  // selects the text, checkbox, or radio implementation from the DOM property.
+  const modelOperations = operation.filter(isVModelOperation)
   const resetBlock = context.enterBlock(block)
   const singleUseAssetComponentNames = root
     ? collectSingleUseAssetComponents(block)
@@ -98,9 +102,10 @@ export function genBlockContent(
     push: (...items: CodeFragment[]) => number,
   ) => {
     while (operationIndex < operationEnd) {
-      push(
-        ...genOperationWithInsertionState(operation[operationIndex], context),
-      )
+      const oper = operation[operationIndex]
+      if (!isVModelOperation(oper)) {
+        push(...genOperationWithInsertionState(oper, context))
+      }
       operationIndex++
     }
 
@@ -147,12 +152,22 @@ export function genBlockContent(
   }
 
   if (operationIndex < operation.length) {
-    push(...genOperations(operation.slice(operationIndex), context))
+    push(
+      ...genOperations(
+        operation
+          .slice(operationIndex)
+          .filter(oper => !isVModelOperation(oper)),
+        context,
+      ),
+    )
   }
   if (effectIndex < effect.length) {
     push(...genEffectRange(effectIndex, effect.length, genEffectsExtraFrag))
   } else if (genEffectsExtraFrag) {
     push(...genEffects([], context, genEffectsExtraFrag))
+  }
+  if (modelOperations.length) {
+    push(...genOperations(modelOperations, context))
   }
 
   push(NEWLINE, `return `)
@@ -202,6 +217,14 @@ export function genBlockContent(
       )
     }
   }
+}
+
+function isVModelOperation(oper: OperationNode): boolean {
+  return (
+    oper.type === IRNodeTypes.DIRECTIVE &&
+    oper.builtin === true &&
+    oper.name === 'model'
+  )
 }
 
 export function markSlotRootOperations(block: BlockIRNode): void {


### PR DESCRIPTION
close #15200

Generate built-in v-model operations after initial DOM prop operations and reactive effects. This ensures dynamic input types are applied before applyDynamicModel selects the text, checkbox, or radio implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic `v-model` behavior for inputs whose type is initialized dynamically.
  * Improved reactive and constant-binding model generation to ensure updates occur in the correct order.

* **Tests**
  * Added regression coverage for dynamic input types and `v-model` compilation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->