### PR TITLE
fix(runtime-vapor): avoid tracking v-show transition hooks

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -370,6 +370,56 @@ describe('Transition', () => {
     expect(calls).toEqual([false, true])
   })
 
+  // #15202
+  test('should not track reactive reads from v-show transition hooks', async () => {
+    const show = ref(false)
+    const count = ref(0)
+    const source = vi.fn(() => show.value)
+    const onBeforeEnter = vi.fn(() => count.value++)
+    const data = ref({ source, onBeforeEnter })
+    const App = compile(
+      `<template>
+        <Transition :css="false" @before-enter="data.onBeforeEnter">
+          <div v-show="data.source()">content</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    define(App as any).render()
+
+    show.value = true
+    await nextTick()
+
+    expect(onBeforeEnter).toHaveBeenCalledTimes(1)
+    expect(count.value).toBe(1)
+    expect(source).toHaveBeenCalledTimes(2)
+  })
+
+  test('should not repeat v-show transition when truthiness is unchanged', async () => {
+    const onBeforeEnter = vi.fn()
+    const data = ref({
+      show: 0,
+      onBeforeEnter,
+    })
+    const App = compile(
+      `<template>
+        <Transition :css="false" @before-enter="data.onBeforeEnter">
+          <div v-show="data.show">content</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    define(App as any).render()
+
+    data.value.show = 1
+    await nextTick()
+    expect(onBeforeEnter).toHaveBeenCalledTimes(1)
+
+    data.value.show = 2
+    await nextTick()
+    expect(onBeforeEnter).toHaveBeenCalledTimes(1)
+  })
+
   test('v-if should own enter and leave when its root also has v-show', async () => {
     const onEnter = vi.fn((_el: Element, done: () => void) => done())
     const onLeave = vi.fn((_el: Element, done: () => void) => done())

--- a/packages/runtime-vapor/src/directives/vShow.ts
+++ b/packages/runtime-vapor/src/directives/vShow.ts
@@ -7,6 +7,7 @@ import {
   warn,
   warnPropMismatch,
 } from '@vue/runtime-dom'
+import { setActiveSub } from '@vue/reactivity'
 import { renderEffect } from '../renderEffect'
 import { isVaporComponent } from '../component'
 import type { Block, TransitionBlock } from '../block'
@@ -101,25 +102,41 @@ function setDisplay(
         el.style.display === 'none' ? '' : el.style.display
     }
 
+    const hidden = !value
+    if (el[vShowHidden] === hidden) return
+    el[vShowHidden] = hidden
+
     const { $transition = transition } = target as TransitionBlock
     if ($transition) {
-      if (value) {
-        $transition.beforeEnter(target)
-        el.style.display = el[vShowOriginalDisplay]!
-        if (deferEnter) {
-          return () => $transition.enter(target)
-        }
-        $transition.enter(target)
-      } else {
-        // during initial render, the element is not yet inserted into the
-        // DOM, and it is hidden, no need to trigger transition
-        if (target.isConnected) {
-          $transition.leave(target, () => {
-            el.style.display = 'none'
-          })
+      const prevSub = setActiveSub()
+      try {
+        if (value) {
+          $transition.beforeEnter(target)
+          el.style.display = el[vShowOriginalDisplay]!
+          if (deferEnter) {
+            return () => {
+              const prevSub = setActiveSub()
+              try {
+                $transition.enter(target)
+              } finally {
+                setActiveSub(prevSub)
+              }
+            }
+          }
+          $transition.enter(target)
         } else {
-          el.style.display = 'none'
+          // during initial render, the element is not yet inserted into the
+          // DOM, and it is hidden, no need to trigger transition
+          if (target.isConnected) {
+            $transition.leave(target, () => {
+              el.style.display = 'none'
+            })
+          } else {
+            el.style.display = 'none'
+          }
         }
+      } finally {
+        setActiveSub(prevSub)
       }
     } else {
       if (
@@ -144,8 +161,6 @@ function setDisplay(
         el.style.display = value ? el[vShowOriginalDisplay]! : 'none'
       }
     }
-
-    el[vShowHidden] = !value
   } else if (__DEV__) {
     warn(
       `v-show used on component with non-single-element root node ` +


### PR DESCRIPTION
close #15202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recursive updates during `v-show` transitions.
  * Transition hooks now execute reliably without unintended reactive tracking, ensuring visibility changes and rendered state remain consistent.

* **Tests**
  * Added regression coverage for reactive state updates triggered during transition hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->