### PR TITLE
fix(compiler-sfc): keep scope id on :deep() selector lists with nesting (fix #15205)

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -195,6 +195,25 @@ color: red
     `)
   })
 
+  test(':deep() in a selector list with nested rules', () => {
+    expect(
+      compileScoped(`.a, .b :deep(.c) { color: red; > span { color: blue; } }`),
+    ).toMatchInlineSnapshot(`
+      ".a[data-v-test], .b[data-v-test] .c { color: red;
+      > span { color: blue;
+      }
+      }"
+    `)
+    expect(
+      compileScoped(`.b :deep(.c), .a { color: red; > span { color: blue; } }`),
+    ).toMatchInlineSnapshot(`
+      ".b[data-v-test] .c, .a[data-v-test] { color: red;
+      > span { color: blue;
+      }
+      }"
+    `)
+  })
+
   test('::v-slotted', () => {
     expect(compileScoped(`:slotted(.foo) { color: red; }`))
       .toMatchInlineSnapshot(`

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -85,6 +85,12 @@ function processRule(id: string, rule: Rule) {
     parent = parent.parent
   }
   rule.selector = selectorParser(selectorRoot => {
+    // A selector list can mix :deep() members with plain scoped ones. Resolve
+    // the rule's deep status up-front so rewriting a member doesn't depend on
+    // where it sits in the list relative to the :deep() member.
+    if (selectorRoot.some(selector => selector.some(isDeepSelector))) {
+      ;(rule as any).__deep = true
+    }
     selectorRoot.each(selector => {
       rewriteSelector(id, rule, selector, selectorRoot, deep)
     })


### PR DESCRIPTION
When a scoped style rule mixes a comma-separated selector list, a `:deep()` member, and nested child rules, one of the plain members can end up without a scope id, so its selector leaks to the whole page.

The rule's `:deep` status is set as a side effect while each member of the list is rewritten. A member that comes before the `:deep()` one reads the status as not-yet-deep and skips the scope id. This resolves the status once for the whole list before any member is rewritten, so every member gets scoped regardless of its position.

Fixes #15205


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scoped CSS handling for `:deep()` selectors when combined with nested rules.
  * Ensured selector scoping remains correct regardless of selector order.
  * Preserved nested child selectors in affected styles.

* **Tests**
  * Added regression coverage for deep selectors within selector lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->