### PR TITLE
docs(runtime-core): clarify watchEffect dependency tracking

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -57,6 +57,9 @@ export function watchEffect(
   effect: WatchEffect,
   options?: WatchEffectOptions,
 ): WatchHandle {
+  // watchEffect tracks dependencies during each synchronous run, so conditional
+  // branches can update the active dependency list between re-runs. For async
+  // effects, only accesses before the first await are tracked.
   return doWatch(effect, null, options)
 }
 


### PR DESCRIPTION
Closes #13688.

Clarifies that `watchEffect` tracks dependencies during each synchronous run, so conditional branches can update the tracked dependency list between re-runs. For async effects, only accesses before the first `await` are tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `watchEffect` tracks dependencies synchronously.
  * Documented conditional dependency updates and the limitation that asynchronous effects only track accesses before the first `await`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->