### PR TITLE
improve general error handling @renderToStream

### DIFF
--- a/packages/server-renderer/__tests__/webStream.spec.ts
+++ b/packages/server-renderer/__tests__/webStream.spec.ts
@@ -12,6 +12,20 @@ afterEach(() => {
   delete global.ReadableStream
 })
 
+async function populate(reader: ReadableStreamDefaultReader<any>) {
+  const decoder = new TextDecoder()
+
+  let res = ''
+  await reader.read().then(function read({ done, value }): any {
+    if (!done) {
+      res += decoder.decode(value)
+      return reader.read().then(read)
+    }
+  })
+
+  return res
+}
+
 test('renderToWebStream', async () => {
   const Async = defineAsyncComponent(() =>
     Promise.resolve({
@@ -25,15 +39,8 @@ test('renderToWebStream', async () => {
   const stream = renderToWebStream(createApp(App))
 
   const reader = stream.getReader()
-  const decoder = new TextDecoder()
 
-  let res = ''
-  await reader.read().then(function read({ done, value }): any {
-    if (!done) {
-      res += decoder.decode(value)
-      return reader.read().then(read)
-    }
-  })
+  let res = await populate(reader)
 
   expect(res).toBe(`<!--[--><div>parent</div><div>async</div><!--]-->`)
 })
@@ -52,15 +59,82 @@ test('pipeToWebWritable', async () => {
   pipeToWebWritable(createApp(App), {}, writable as any)
 
   const reader = readable.getReader()
-  const decoder = new TextDecoder()
 
-  let res = ''
-  await reader.read().then(function read({ done, value }): any {
-    if (!done) {
-      res += decoder.decode(value)
-      return reader.read().then(read)
-    }
-  })
+  let res = await populate(reader)
 
   expect(res).toBe(`<!--[--><div>parent</div><div>async</div><!--]-->`)
+})
+
+test('pipeToWebWritable destroy passes error to writer.abort', async () => {
+  const error = new Error('render failure')
+  const App = {
+    render: () => {
+      throw error
+    },
+  }
+
+  const abortMock = vi.fn().mockResolvedValue(undefined)
+  const closeMock = vi.fn().mockResolvedValue(undefined)
+  const writerMock = {
+    ready: Promise.resolve(),
+    write: vi.fn().mockResolvedValue(undefined),
+    close: closeMock,
+    abort: abortMock,
+  }
+  const writableMock = {
+    getWriter: () => writerMock,
+  } as any
+
+  const consoleErrorSpy = vi
+    .spyOn(console, 'error')
+    .mockImplementation(() => {})
+
+  pipeToWebWritable(createApp(App), {}, writableMock)
+
+  await new Promise(r => setTimeout(r, 0))
+
+  expect(abortMock).toHaveBeenCalledWith(error)
+  expect(closeMock).not.toHaveBeenCalled()
+
+  expect(
+    'Unhandled error during execution of render function',
+  ).toHaveBeenWarned()
+
+  consoleErrorSpy.mockRestore()
+})
+
+test('pipeToWebWritable destroy swallows rejected abort', async () => {
+  const error = new Error('render failure')
+  const abortError = new Error('abort failed')
+  const App = {
+    render: () => {
+      throw error
+    },
+  }
+
+  const abortMock = vi.fn().mockRejectedValue(abortError)
+  const writerMock = {
+    ready: Promise.resolve(),
+    write: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    abort: abortMock,
+  }
+  const writableMock = {
+    getWriter: () => writerMock,
+  } as any
+
+  const consoleErrorSpy = vi
+    .spyOn(console, 'error')
+    .mockImplementation(() => {})
+
+  pipeToWebWritable(createApp(App), {}, writableMock)
+
+  await new Promise(r => setTimeout(r, 0))
+
+  expect(abortMock).toHaveBeenCalledWith(error)
+  expect(
+    'Unhandled error during execution of render function',
+  ).toHaveBeenWarned()
+
+  consoleErrorSpy.mockRestore()
 })

--- a/packages/server-renderer/__tests__/webStream.spec.ts
+++ b/packages/server-renderer/__tests__/webStream.spec.ts
@@ -18,9 +18,10 @@ async function populate(reader: ReadableStreamDefaultReader<any>) {
   let res = ''
   await reader.read().then(function read({ done, value }): any {
     if (!done) {
-      res += decoder.decode(value)
+      res += decoder.decode(value, { stream: true })
       return reader.read().then(read)
     }
+    res += decoder.decode()
   })
 
   return res

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -17,7 +17,7 @@ export interface SimpleReadable {
   push(chunk: string | null): void
   /**
    Call destroy when an error occurred
-   @param error - error that happened. Typed as unknown.
+   @param error - error that happened. Typed as any.
    */
   destroy(error: any): void
 }
@@ -211,8 +211,9 @@ export function pipeToWebWritable(
     destroy(err) {
       console.error('Error while destroying stream: ', err)
 
-      // ignore: handling error already
-      writer.abort(err).catch(_ => {})
+      writer.abort(err).catch(_ => {
+        // ignore: handling error already
+      })
     },
   })
 }

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -15,7 +15,11 @@ const { isVNode } = ssrUtils
 
 export interface SimpleReadable {
   push(chunk: string | null): void
-  destroy(err: any): void
+  /**
+   Call destroy when an error occurred
+   @param error - error that happened. Typed as unknown.
+   */
+  destroy(error: any): void
 }
 
 async function unrollBuffer(
@@ -205,10 +209,9 @@ export function pipeToWebWritable(
       }
     },
     destroy(err) {
-      // TODO better error handling?
-      // eslint-disable-next-line no-console
-      console.log(err)
-      writer.close()
+      console.error('Error while destroying stream: ', err)
+
+      writer.abort(err).catch(_ => {})
     },
   })
 }

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -211,6 +211,7 @@ export function pipeToWebWritable(
     destroy(err) {
       console.error('Error while destroying stream: ', err)
 
+      // ignore: handling error already
       writer.abort(err).catch(_ => {})
     },
   })


### PR DESCRIPTION
- improved error clarification in interface `SimpleReadable`
- Improve error handling when destroy has error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when streaming content to web writable destinations.
  * Stream failures now abort destinations cleanly without attempting to close them.
  * Prevented secondary rejection errors from obscuring the original rendering failure.
  * Updated stream-destruction notifications to use error-level console logging for clearer diagnostics.
  * Improved reliability when rendering fails during streamed output, including destinations that reject abort requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->