### PR TITLE
fix(vapor): mark forwarded root slot outlets

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -147,7 +147,7 @@ export function render(_ctx) {
   const _component_Comp = _resolveComponent("Comp")
   const n2 = _createComponentWithFallback(_component_Comp, null, () => {
     const n1 = _createComponentWithFallback(_component_Comp, null, _extend(() => {
-      const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
+      const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
       return n0
     }, { _: 8 /* NON_STABLE */ }))
     return n1
@@ -161,7 +161,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag only 1`] = `
 
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
+    const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n1
@@ -173,7 +173,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ template 1`]
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
+    const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n2
@@ -186,7 +186,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-for 1`] = 
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
-      const n2 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
+      const n2 = _createSlot("default", null, null, 20 /* SLOT_ROOT, SHARED_FALLBACK */)
       return n2
     }, undefined, 48 /* IS_FRAGMENT, SLOT_ROOT */)
     return n0
@@ -201,7 +201,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-if 1`] = `
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.ok), () => {
-      const n2 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
+      const n2 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
       return n2
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
@@ -394,7 +394,7 @@ export function render(_ctx) {
         return n4
       }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
       return n2
-    }, 4 /* SLOT_ROOT */)
+    }, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n5
@@ -473,7 +473,7 @@ export function render(_ctx) {
       () => (_createForSlots(_ctx.slots, (_, name) => ({
         name: name,
         fn: () => {
-          const n0 = _createSlot(() => (name), null, null, 4 /* SLOT_ROOT */)
+          const n0 = _createSlot(() => (name), null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
           return n0
         }
       })))
@@ -643,7 +643,7 @@ exports[`compiler: transform slot > slot owner context > slot with slot outlet i
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
+    const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -147,7 +147,7 @@ export function render(_ctx) {
   const _component_Comp = _resolveComponent("Comp")
   const n2 = _createComponentWithFallback(_component_Comp, null, () => {
     const n1 = _createComponentWithFallback(_component_Comp, null, _extend(() => {
-      const n0 = _createSlot()
+      const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
       return n0
     }, { _: 8 /* NON_STABLE */ }))
     return n1
@@ -161,7 +161,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag only 1`] = `
 
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot()
+    const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n1
@@ -173,7 +173,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ template 1`]
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot()
+    const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n2
@@ -186,7 +186,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-for 1`] = 
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
-      const n2 = _createSlot()
+      const n2 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
       return n2
     }, undefined, 48 /* IS_FRAGMENT, SLOT_ROOT */)
     return n0
@@ -201,7 +201,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-if 1`] = `
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.ok), () => {
-      const n2 = _createSlot()
+      const n2 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
       return n2
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
@@ -394,7 +394,7 @@ export function render(_ctx) {
         return n4
       }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
       return n2
-    })
+    }, 4 /* SLOT_ROOT */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n5
@@ -473,7 +473,7 @@ export function render(_ctx) {
       () => (_createForSlots(_ctx.slots, (_, name) => ({
         name: name,
         fn: () => {
-          const n0 = _createSlot(() => (name))
+          const n0 = _createSlot(() => (name), null, null, 4 /* SLOT_ROOT */)
           return n0
         }
       })))
@@ -643,7 +643,7 @@ exports[`compiler: transform slot > slot owner context > slot with slot outlet i
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot()
+    const n0 = _createSlot("default", null, null, 4 /* SLOT_ROOT */)
     return n0
   }, { _: 8 /* NON_STABLE */ }), true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
@@ -143,6 +143,12 @@ describe('compiler: v-once', () => {
     expect(ir.block.operation).lengthOf(0)
   })
 
+  test('root slot outlet in slot content', () => {
+    const { code } = compileWithOnce(`<Comp><slot v-once /></Comp>`)
+
+    expect(code).not.toContain('SLOT_ROOT')
+  })
+
   test('inside v-once', () => {
     const { ir, code } = compileWithOnce(`<div v-once><div v-once/></div>`)
 

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
   IRNodeTypes,
   IRSlotType,
+  compile as compileVapor,
   transformChildren,
   transformComment,
   transformElement,
@@ -23,6 +24,8 @@ import { makeCompile } from './_utils'
 const dynamicSlotRootFlag = `${VaporDynamicComponentFlags.SLOT_ROOT} /* SLOT_ROOT */`
 const slotNonStableFlag = `_: ${VaporSlotFlags.NON_STABLE} /* NON_STABLE */`
 const slotRootFlag = `${VaporSlotFlags.SLOT_ROOT} /* SLOT_ROOT */`
+const keyedSlotRootCallRE =
+  /const (n\d+) = _createKeyedFragment\([\s\S]*?\n\s*}, true\)\n\s*return \1/
 
 const compileWithSlots = makeCompile({
   nodeTransforms: [
@@ -755,6 +758,28 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code).toMatch(/const n\d+ = _createSlot\(\)/)
+    })
+
+    test('root slot outlet with dynamic key tracks the keyed fragment and outlet', () => {
+      const { code } = compileVapor(`<Comp><slot :key="key" /></Comp>`, {
+        prefixIdentifiers: true,
+      })
+
+      expect(code).toContain(
+        `_createSlot("default", null, null, ${slotRootFlag})`,
+      )
+      expect(code).toMatch(keyedSlotRootCallRE)
+    })
+
+    test('keyed slot block with stable sibling does not track slot boundary', () => {
+      const { code } = compileVapor(
+        `<Comp><template :key="key"><slot /><span /></template></Comp>`,
+        { prefixIdentifiers: true },
+      )
+
+      expect(code).toContain('_createKeyedFragment(')
+      expect(code).not.toContain('SLOT_ROOT')
+      expect(code).not.toMatch(keyedSlotRootCallRE)
     })
 
     test('<slot> tag w/ v-if', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -24,6 +24,8 @@ import { makeCompile } from './_utils'
 const dynamicSlotRootFlag = `${VaporDynamicComponentFlags.SLOT_ROOT} /* SLOT_ROOT */`
 const slotNonStableFlag = `_: ${VaporSlotFlags.NON_STABLE} /* NON_STABLE */`
 const slotRootFlag = `${VaporSlotFlags.SLOT_ROOT} /* SLOT_ROOT */`
+const inheritedFallbackSlotRootFlag = `${VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK} /* SLOT_ROOT, INHERIT_FALLBACK */`
+const sharedFallbackSlotRootFlag = `${VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.SHARED_FALLBACK} /* SLOT_ROOT, SHARED_FALLBACK */`
 const keyedSlotRootCallRE =
   /const (n\d+) = _createKeyedFragment\([\s\S]*?\n\s*}, true\)\n\s*return \1/
 
@@ -719,7 +721,7 @@ describe('compiler: transform slot', () => {
       const { code } = compileWithSlots(`<Comp><slot/></Comp>`)
       expect(code).toContain(slotNonStableFlag)
       expect(code).toContain(
-        `_createSlot("default", null, null, ${slotRootFlag})`,
+        `_createSlot("default", null, null, ${inheritedFallbackSlotRootFlag})`,
       )
       expect(code).toMatchSnapshot()
     })
@@ -728,7 +730,40 @@ describe('compiler: transform slot', () => {
       const { code } = compileWithSlots(`<Comp><slot/><span/></Comp>`)
 
       expect(code).not.toContain('SLOT_ROOT')
+      expect(code).not.toContain('INHERIT_FALLBACK')
       expect(code).not.toContain(slotNonStableFlag)
+    })
+
+    test('multiple dynamic slot roots share the enclosing fallback decision', () => {
+      const { code } = compileWithSlots(
+        `<Comp><slot name="a"/><slot name="b"/></Comp>`,
+      )
+
+      expect(code.match(/SHARED_FALLBACK/g)).toHaveLength(2)
+      expect(code).toContain(sharedFallbackSlotRootFlag)
+    })
+
+    test('slot root shares fallback with a dynamic sibling', () => {
+      const { code } = compileWithSlots(`<Comp><slot/><span v-if="ok"/></Comp>`)
+
+      expect(code).toContain(sharedFallbackSlotRootFlag)
+    })
+
+    test('v-once slot root shares fallback without update tracking', () => {
+      const { code } = compileVapor(
+        `<Comp><slot v-once name="a"/><slot name="b"/></Comp>`,
+      )
+
+      expect(code.match(/SHARED_FALLBACK/g)).toHaveLength(2)
+      expect(code).toContain('ONCE, SHARED_FALLBACK')
+      expect(code).not.toContain('ONCE, SLOT_ROOT')
+    })
+
+    test('v-once unique slot root inherits fallback without update tracking', () => {
+      const { code } = compileVapor(`<Comp><slot v-once /></Comp>`)
+
+      expect(code).toContain('ONCE, INHERIT_FALLBACK')
+      expect(code).not.toContain('ONCE, SLOT_ROOT')
     })
 
     test.each([
@@ -749,6 +784,7 @@ describe('compiler: transform slot', () => {
         expect(code).not.toContain(
           `_createSlot("default", null, null, ${slotRootFlag})`,
         )
+        expect(code).not.toContain('INHERIT_FALLBACK')
       },
     )
 
@@ -766,7 +802,7 @@ describe('compiler: transform slot', () => {
       })
 
       expect(code).toContain(
-        `_createSlot("default", null, null, ${slotRootFlag})`,
+        `_createSlot("default", null, null, ${inheritedFallbackSlotRootFlag})`,
       )
       expect(code).toMatch(keyedSlotRootCallRE)
     })

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -715,10 +715,46 @@ describe('compiler: transform slot', () => {
     test('<slot> tag only', () => {
       const { code } = compileWithSlots(`<Comp><slot/></Comp>`)
       expect(code).toContain(slotNonStableFlag)
-      expect(code).not.toContain(
+      expect(code).toContain(
         `_createSlot("default", null, null, ${slotRootFlag})`,
       )
       expect(code).toMatchSnapshot()
+    })
+
+    test('root slot outlet with stable sibling does not notify parent', () => {
+      const { code } = compileWithSlots(`<Comp><slot/><span/></Comp>`)
+
+      expect(code).not.toContain('SLOT_ROOT')
+      expect(code).not.toContain(slotNonStableFlag)
+    })
+
+    test.each([
+      [
+        'v-if branch',
+        `<Comp><template v-if="ok"><slot/><span/></template></Comp>`,
+      ],
+      [
+        'v-for item',
+        `<Comp><template v-for="item in items"><slot/><span/></template></Comp>`,
+      ],
+    ])(
+      'root slot outlet with stable sibling in %s does not notify parent',
+      (_, source) => {
+        const { code } = compileWithSlots(source)
+
+        expect(code).toContain('SLOT_ROOT')
+        expect(code).not.toContain(
+          `_createSlot("default", null, null, ${slotRootFlag})`,
+        )
+      },
+    )
+
+    test('root slot outlet with stable sibling in forwarded fallback does not notify parent', () => {
+      const { code } = compileWithSlots(
+        `<Comp><slot><slot/><span/></slot></Comp>`,
+      )
+
+      expect(code).toMatch(/const n\d+ = _createSlot\(\)/)
     })
 
     test('<slot> tag w/ v-if', () => {

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -27,6 +27,7 @@ import {
 } from './operation'
 import { genChildren, genSelf } from './template'
 import { toValidAssetId } from '@vue/compiler-dom'
+import { VaporSlotFlags } from '@vue/shared'
 
 export function genBlock(
   oper: BlockIRNode,
@@ -227,42 +228,52 @@ function isVModelOperation(oper: OperationNode): boolean {
   )
 }
 
-export function markSlotRootOperations(block: BlockIRNode): void {
+export function markSlotRootOperations(
+  block: BlockIRNode,
+  context: CodegenContext,
+): void {
+  if (hasStableSlotRoot(block, context)) return
+
   for (let i = 0; i < block.returns.length; i++) {
     const child = findReturnedDynamic(block, block.returns[i])
     const operation = child && child.operation
     if (!operation) continue
 
     if (operation.type === IRNodeTypes.IF) {
-      markSlotRootIf(operation)
+      markSlotRootIf(operation, context)
     } else if (operation.type === IRNodeTypes.FOR) {
-      markSlotRootFor(operation)
+      markSlotRootFor(operation, context)
     } else if (operation.type === IRNodeTypes.CREATE_COMPONENT_NODE) {
       markSlotRootComponent(operation)
+    } else if (
+      operation.type === IRNodeTypes.SLOT_OUTLET_NODE &&
+      !(operation.flags & VaporSlotFlags.ONCE)
+    ) {
+      operation.flags |= VaporSlotFlags.SLOT_ROOT
     }
   }
 }
 
-function markSlotRootIf(operation: IfIRNode): void {
+function markSlotRootIf(operation: IfIRNode, context: CodegenContext): void {
   if (!operation.once) {
     operation.slotRoot = true
   }
-  markSlotRootOperations(operation.positive)
+  markSlotRootOperations(operation.positive, context)
 
   const negative = operation.negative
   if (!negative) return
   if (negative.type === IRNodeTypes.IF) {
-    markSlotRootIf(negative)
+    markSlotRootIf(negative, context)
   } else {
-    markSlotRootOperations(negative)
+    markSlotRootOperations(negative, context)
   }
 }
 
-function markSlotRootFor(operation: ForIRNode): void {
+function markSlotRootFor(operation: ForIRNode, context: CodegenContext): void {
   if (!operation.once) {
     operation.slotRoot = true
   }
-  markSlotRootOperations(operation.render)
+  markSlotRootOperations(operation.render, context)
 }
 
 function markSlotRootComponent(operation: CreateComponentIRNode): void {
@@ -279,6 +290,62 @@ export function findReturnedDynamic(
     const child = block.dynamic.children[i]
     if (child.id === id) return child
   }
+}
+
+const commentOnlyTemplateRE = /^(?:<!--[\s\S]*?-->)+$/
+
+// A slot can skip fallback/boundary tracking when at least one root is stable.
+// Components count as valid even if their own render result is a comment.
+export function hasStableSlotRoot(
+  block: BlockIRNode,
+  context: CodegenContext,
+): boolean {
+  let hasValidRoot = false
+  for (let i = 0; i < block.returns.length; i++) {
+    const id = block.returns[i]
+    const child = findReturnedDynamic(block, id)
+    const operation = child && child.operation
+    if (!operation) {
+      if (child && isStableTemplateSlotRoot(child, context)) {
+        hasValidRoot = true
+      }
+      continue
+    }
+
+    switch (operation.type) {
+      case IRNodeTypes.CREATE_COMPONENT_NODE:
+        if (!operation.dynamic || operation.dynamic.isStatic) {
+          hasValidRoot = true
+          continue
+        }
+        // Align with VDOM fallback semantics:
+        // <component :is="view" /> renders fallback when view is null because
+        // the dynamic component root becomes a comment vnode. This differs from
+        // <Foo />, whose component vnode is valid slot content even if Foo
+        // renders null/comment. Keep scanning because a stable sibling can
+        // still make the whole slot content valid.
+        continue
+      case IRNodeTypes.KEY:
+        if (hasStableSlotRoot(operation.block, context)) {
+          hasValidRoot = true
+          continue
+        }
+        continue
+      default:
+        continue
+    }
+  }
+  return hasValidRoot
+}
+
+function isStableTemplateSlotRoot(
+  child: IRDynamicInfo,
+  context: CodegenContext,
+): boolean {
+  if (child.template == null) return false
+  const content = context.ir.template.entries[child.template].content
+  // Preserved whitespace is a real text root; trim only for comment detection.
+  return content !== '' && !commentOnlyTemplateRE.test(content.trim())
 }
 
 interface AssetComponentUsage {

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -243,6 +243,9 @@ export function markSlotRootOperations(
       markSlotRootIf(operation, context)
     } else if (operation.type === IRNodeTypes.FOR) {
       markSlotRootFor(operation, context)
+    } else if (operation.type === IRNodeTypes.KEY) {
+      operation.slotRoot = true
+      markSlotRootOperations(operation.block, context)
     } else if (operation.type === IRNodeTypes.CREATE_COMPONENT_NODE) {
       markSlotRootComponent(operation)
     } else if (

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -231,8 +231,10 @@ function isVModelOperation(oper: OperationNode): boolean {
 export function markSlotRootOperations(
   block: BlockIRNode,
   context: CodegenContext,
+  sharedFallback: boolean = false,
 ): void {
   if (hasStableSlotRoot(block, context)) return
+  sharedFallback = sharedFallback || hasMultipleDynamicSlotRoots(block)
 
   for (let i = 0; i < block.returns.length; i++) {
     const child = findReturnedDynamic(block, block.returns[i])
@@ -240,35 +242,43 @@ export function markSlotRootOperations(
     if (!operation) continue
 
     if (operation.type === IRNodeTypes.IF) {
-      markSlotRootIf(operation, context)
+      markSlotRootIf(operation, context, sharedFallback)
     } else if (operation.type === IRNodeTypes.FOR) {
       markSlotRootFor(operation, context)
     } else if (operation.type === IRNodeTypes.KEY) {
       operation.slotRoot = true
-      markSlotRootOperations(operation.block, context)
+      markSlotRootOperations(operation.block, context, sharedFallback)
     } else if (operation.type === IRNodeTypes.CREATE_COMPONENT_NODE) {
       markSlotRootComponent(operation)
-    } else if (
-      operation.type === IRNodeTypes.SLOT_OUTLET_NODE &&
-      !(operation.flags & VaporSlotFlags.ONCE)
-    ) {
-      operation.flags |= VaporSlotFlags.SLOT_ROOT
+    } else if (operation.type === IRNodeTypes.SLOT_OUTLET_NODE) {
+      if (!(operation.flags & VaporSlotFlags.ONCE)) {
+        operation.flags |= VaporSlotFlags.SLOT_ROOT
+      }
+      if (sharedFallback) {
+        operation.flags |= VaporSlotFlags.SHARED_FALLBACK
+      } else {
+        operation.flags |= VaporSlotFlags.INHERIT_FALLBACK
+      }
     }
   }
 }
 
-function markSlotRootIf(operation: IfIRNode, context: CodegenContext): void {
+function markSlotRootIf(
+  operation: IfIRNode,
+  context: CodegenContext,
+  sharedFallback: boolean,
+): void {
   if (!operation.once) {
     operation.slotRoot = true
   }
-  markSlotRootOperations(operation.positive, context)
+  markSlotRootOperations(operation.positive, context, sharedFallback)
 
   const negative = operation.negative
   if (!negative) return
   if (negative.type === IRNodeTypes.IF) {
-    markSlotRootIf(negative, context)
+    markSlotRootIf(negative, context, sharedFallback)
   } else {
-    markSlotRootOperations(negative, context)
+    markSlotRootOperations(negative, context, sharedFallback)
   }
 }
 
@@ -276,7 +286,16 @@ function markSlotRootFor(operation: ForIRNode, context: CodegenContext): void {
   if (!operation.once) {
     operation.slotRoot = true
   }
-  markSlotRootOperations(operation.render, context)
+  markSlotRootOperations(operation.render, context, true)
+}
+
+function hasMultipleDynamicSlotRoots(block: BlockIRNode): boolean {
+  let count = 0
+  for (let i = 0; i < block.returns.length; i++) {
+    const child = findReturnedDynamic(block, block.returns[i])
+    if (child && child.operation && ++count > 1) return true
+  }
+  return false
 }
 
 function markSlotRootComponent(operation: CreateComponentIRNode): void {

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -9,11 +9,8 @@ import {
 } from '@vue/shared'
 import type { CodegenContext } from '../generate'
 import {
-  type BlockIRNode,
   type CreateComponentIRNode,
-  type IRDynamicInfo,
   IRDynamicPropsKind,
-  IRNodeTypes,
   type IRProp,
   type IRProps,
   type IRPropsStatic,
@@ -48,7 +45,7 @@ import {
 } from '@vue/compiler-dom'
 import { genDirectivesForElement } from './directive'
 import { genEventHandler } from './event'
-import { findReturnedDynamic, genBlock, markSlotRootOperations } from './block'
+import { genBlock, hasStableSlotRoot, markSlotRootOperations } from './block'
 import {
   type DestructureMap,
   type DestructureMapValue,
@@ -789,7 +786,7 @@ function genSlotBlockWithProps(
   const exitSlotBlock = context.enterSlotBlock()
   const hasStableRoot = hasStableSlotRoot(oper, context)
   if (!hasStableRoot) {
-    markSlotRootOperations(oper)
+    markSlotRootOperations(oper, context)
   }
   let blockFn = context.withId(
     () => genBlock(oper, context, propsName ? [propsName] : []),
@@ -824,60 +821,4 @@ function genSlotFlags(flags: number): string {
   }
 
   return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
-}
-
-const commentOnlyTemplateRE = /^(?:<!--[\s\S]*?-->)+$/
-
-// A slot can skip fallback/boundary tracking when at least one root is stable.
-// Components count as valid even if their own render result is a comment.
-function hasStableSlotRoot(
-  block: BlockIRNode,
-  context: CodegenContext,
-): boolean {
-  let hasValidRoot = false
-  for (let i = 0; i < block.returns.length; i++) {
-    const id = block.returns[i]
-    const child = findReturnedDynamic(block, id)
-    const operation = child && child.operation
-    if (!operation) {
-      if (child && isStableTemplateSlotRoot(child, context)) {
-        hasValidRoot = true
-      }
-      continue
-    }
-
-    switch (operation.type) {
-      case IRNodeTypes.CREATE_COMPONENT_NODE:
-        if (!operation.dynamic || operation.dynamic.isStatic) {
-          hasValidRoot = true
-          continue
-        }
-        // Align with VDOM fallback semantics:
-        // <component :is="view" /> renders fallback when view is null because
-        // the dynamic component root becomes a comment vnode. This differs from
-        // <Foo />, whose component vnode is valid slot content even if Foo
-        // renders null/comment. Keep scanning because a stable sibling can
-        // still make the whole slot content valid.
-        continue
-      case IRNodeTypes.KEY:
-        if (hasStableSlotRoot(operation.block, context)) {
-          hasValidRoot = true
-          continue
-        }
-        continue
-      default:
-        continue
-    }
-  }
-  return hasValidRoot
-}
-
-function isStableTemplateSlotRoot(
-  child: IRDynamicInfo,
-  context: CodegenContext,
-): boolean {
-  if (child.template == null) return false
-  const content = context.ir.template.entries[child.template].content
-  // Preserved whitespace is a real text root; trim only for comment detection.
-  return content !== '' && !commentOnlyTemplateRE.test(content.trim())
 }

--- a/packages/compiler-vapor/src/generators/key.ts
+++ b/packages/compiler-vapor/src/generators/key.ts
@@ -8,7 +8,7 @@ export function genKey(
   oper: KeyIRNode,
   context: CodegenContext,
 ): CodeFragment[] {
-  const { id, value, block } = oper
+  const { id, value, block, slotRoot } = oper
   const [frag, push] = buildCodeFragment()
   const blockFn = genBlock(block, context)
 
@@ -19,6 +19,7 @@ export function genKey(
       context.helper('createKeyedFragment'),
       [`() => (`, ...genExpression(value, context), ')'],
       blockFn,
+      slotRoot ? 'true' : false,
     ),
   )
 

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -18,7 +18,7 @@ export function genSlotOutlet(
   if (fallback) {
     if (context.inSlotBlock) {
       // Forwarded fallback validity affects the owning slot's exposed branch;
-      markSlotRootOperations(fallback)
+      markSlotRootOperations(fallback, context)
     }
     fallbackArg = genBlock(fallback, context)
   }

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -66,6 +66,12 @@ function genSlotFlags(flags: number): string | undefined {
   if (flags & VaporSlotFlags.SLOT_ROOT) {
     names.push('SLOT_ROOT')
   }
+  if (flags & VaporSlotFlags.SHARED_FALLBACK) {
+    names.push('SHARED_FALLBACK')
+  }
+  if (flags & VaporSlotFlags.INHERIT_FALLBACK) {
+    names.push('INHERIT_FALLBACK')
+  }
 
   return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
 }

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -133,6 +133,7 @@ export interface KeyIRNode extends BaseIRNode, EffectBoundary, InsertionState {
   id: number
   value: SimpleExpressionNode
   block: BlockIRNode
+  slotRoot?: boolean
 }
 
 export interface SetBlockKeyIRNode extends BaseIRNode {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -268,6 +268,8 @@ export interface VaporInteropInterface {
     fallback?: any, // VaporSlot
     once?: boolean,
     slotRoot?: boolean,
+    sharedFallback?: boolean,
+    inheritFallback?: boolean,
   ) => any
   vdomMountVNode: (
     vnode: VNode,

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -270,6 +270,7 @@ export interface VaporInteropInterface {
     slotRoot?: boolean,
     sharedFallback?: boolean,
     inheritFallback?: boolean,
+    adoptAnchor?: Node,
   ) => any
   vdomMountVNode: (
     vnode: VNode,

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1565,7 +1565,11 @@ describe('component: slots', () => {
       app.mount(root)
 
       expect(root.innerHTML).toBe('<span>fallback</span>')
-      const fallbackNodes = ['<span>fallback</span>', 'text:""']
+      const fallbackNodes = [
+        '<span>fallback</span>',
+        'text:""', // VDOM slot host
+        'text:""', // receiver slot
+      ]
       expect(childNodes()).toEqual(fallbackNodes)
 
       data.value = 'second'
@@ -2265,6 +2269,55 @@ describe('component: slots', () => {
       await nextTick()
       expect(root.textContent).toBe('fallback')
       expect(root.innerHTML).toBe('<span>fallback</span><!--slot-->')
+      app.unmount()
+    })
+
+    test('vdom local fallback restores before a stable sibling', async () => {
+      const data = ref({ showA: false })
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><b>receiver fallback</b></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Receiver>
+            <slot name="a"><span v-if="data.showA">A</span></slot>
+            <span>C</span>
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        data,
+        components,
+        { vapor: false },
+      )
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
+
+      expect(root.textContent).toBe('C')
+
+      data.value.showA = true
+      await nextTick()
+      expect(root.textContent).toBe('AC')
+
+      data.value.showA = false
+      await nextTick()
+      expect(root.textContent).toBe('C')
+
+      data.value.showA = true
+      await nextTick()
+      expect(root.textContent).toBe('AC')
       app.unmount()
     })
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -83,6 +83,10 @@ const slotRootIfShape = VaporBlockShape.SINGLE_ROOT | VaporIfFlags.SLOT_ROOT
 const keyedSlotRootIfShape = keyedIfShape | VaporIfFlags.SLOT_ROOT
 const slotRootForFlags = VaporVForFlags.SLOT_ROOT
 const nonStableSlot = { _: VaporSlotFlags.NON_STABLE } as const
+const inheritedFallbackSlotRootFlags =
+  VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK
+const createInheritedSlotRoot = (name: string, fallback?: BlockFn) =>
+  createSlot(name, null, fallback, inheritedFallbackSlotRootFlags)
 
 function renderWithSlots(slots: any): any {
   let instance: any
@@ -127,7 +131,7 @@ function createTestSlotResolutionState(options: {
     fallbackInserted: false,
     pendingRecheck: false,
     pendingRecheckForce: false,
-    isRenderingFallback: false,
+    isReconciling: false,
     getContent: () => options.content || [],
     getParentNode: () => options.parentNode || null,
     getAnchor: () => options.anchor || null,
@@ -287,12 +291,38 @@ describe('component: slots', () => {
         run: fn => fn(),
         markDirty: vi.fn(),
       }
-      const frag = withSlotBoundary(parentBoundary, () => new SlotFragment())
+      const frag = withSlotBoundary(
+        parentBoundary,
+        () => new SlotFragment(false, false, true),
+      )
 
       frag.updateSlot(undefined, localFallback)
 
       expect(frag.activeFallback).toBeInstanceOf(Text)
       expect((frag.activeFallback as Text).textContent).toBe('local fallback')
+      expect(localFallback).toHaveBeenCalled()
+      expect(inheritedFallback).not.toHaveBeenCalled()
+    })
+
+    test('shared fallback slot root leaves inherited fallback to parent', () => {
+      const localFallback = vi.fn(() => [])
+      const inheritedFallback = vi.fn(() =>
+        document.createTextNode('inherited fallback'),
+      )
+      const parentBoundary: SlotBoundaryContext = {
+        parent: null,
+        getFallback: () => inheritedFallback,
+        run: fn => fn(),
+        markDirty: vi.fn(),
+      }
+      const frag = withSlotBoundary(
+        parentBoundary,
+        () => new SlotFragment(true, true),
+      )
+
+      frag.updateSlot(undefined, localFallback)
+
+      expect(isValidBlock(frag)).toBe(false)
       expect(localFallback).toHaveBeenCalled()
       expect(inheritedFallback).not.toHaveBeenCalled()
     })
@@ -304,7 +334,10 @@ describe('component: slots', () => {
         run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
-      const frag = withSlotBoundary(parentBoundary, () => new SlotFragment())
+      const frag = withSlotBoundary(
+        parentBoundary,
+        () => new SlotFragment(false, false, true),
+      )
       let fallbackBoundary: any
 
       frag.updateSlot(undefined, () => {
@@ -327,7 +360,10 @@ describe('component: slots', () => {
         run: (fn: () => any) => fn(),
         markDirty: vi.fn(),
       }
-      const frag = withSlotBoundary(parentBoundary, () => new SlotFragment())
+      const frag = withSlotBoundary(
+        parentBoundary,
+        () => new SlotFragment(false, false, true),
+      )
       const child = new DynamicFragment('if', false, false)
       let initialized = false
 
@@ -790,7 +826,7 @@ describe('component: slots', () => {
         fallbackInserted: false,
         pendingRecheck: false,
         pendingRecheckForce: false,
-        isRenderingFallback: false,
+        isReconciling: false,
         getContent: () => [],
         getParentNode: () => container,
         getAnchor: () => anchor,
@@ -836,7 +872,7 @@ describe('component: slots', () => {
         fallbackInserted: false,
         pendingRecheck: false,
         pendingRecheckForce: false,
-        isRenderingFallback: false,
+        isReconciling: false,
         getContent: () => [],
         getParentNode: () => container,
         getAnchor: () => anchor,
@@ -1129,7 +1165,7 @@ describe('component: slots', () => {
       })
     })
 
-    test('empty forwarded slot hydration does not clean following sibling', async () => {
+    test('empty slot hydration does not clean following sibling', async () => {
       const start = document.createComment('[')
       const end = document.createComment(']')
       const footer = document.createElement('footer')
@@ -1143,7 +1179,6 @@ describe('component: slots', () => {
         hydrateNode(start, () => {
           withHydratingSlotBoundary(() => {
             frag = new SlotFragment()
-            frag.forwarded = true
             setCurrentHydrationNode(footer)
             hydrateDynamicFragmentAnchor(frag, true)
           })
@@ -1159,7 +1194,7 @@ describe('component: slots', () => {
       expect(`Hydration children mismatch`).not.toHaveBeenWarned()
     })
 
-    test('non-forwarded empty slot hydration reuses its close anchor', () => {
+    test('empty slot hydration reuses its close anchor', () => {
       const start = document.createComment('[')
       const end = document.createComment(']')
       const host = document.createElement('div')
@@ -1829,6 +1864,578 @@ describe('component: slots', () => {
       createApp(App).use(vaporInteropPlugin).mount(root)
 
       expect(root.innerHTML).toBe('child fallback<!--slot-->')
+    })
+
+    test('multiple forwarded roots resolve receiver fallback once', async () => {
+      const data = ref({ showA: false, showB: false })
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot name="a" />
+            <slot name="b" />
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup vapor>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Carrier>
+            <template #a><span v-if="data.showA">A</span></template>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        data,
+        components,
+      )
+
+      const { host } = define(App).render()
+
+      expect(host.textContent).toBe('fallback')
+      expect(host.innerHTML).toBe('<span>fallback</span><!--slot-->')
+
+      data.value.showA = true
+      await nextTick()
+      expect(host.textContent).toBe('A')
+
+      data.value.showA = false
+      data.value.showB = true
+      await nextTick()
+      expect(host.textContent).toBe('B')
+
+      data.value.showA = true
+      await nextTick()
+      expect(host.textContent).toBe('AB')
+
+      data.value.showA = false
+      data.value.showB = false
+      await nextTick()
+      expect(host.textContent).toBe('fallback')
+      expect(host.innerHTML).toBe('<span>fallback</span><!--slot-->')
+    })
+
+    test('slot fallback removes invalid static content before unmount', async () => {
+      const data = ref({ mount: true, show: true })
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Receiver>
+            <!--sentinel--><span v-if="data.show">content</span>
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup vapor>
+        const components = _components
+        const data = _data
+        </script>
+        <template><components.Carrier v-if="data.mount" /></template>`,
+        data,
+        components,
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+      app.mount(root)
+
+      expect(root.textContent).toBe('content')
+
+      data.value.show = false
+      await nextTick()
+      expect(root.textContent).toBe('fallback')
+      expect(root.innerHTML).not.toContain('sentinel')
+
+      data.value.mount = false
+      await nextTick()
+      expect(root.textContent).toBe('')
+      expect(root.childNodes).toHaveLength(1)
+      app.unmount()
+      expect(root.childNodes).toHaveLength(0)
+    })
+
+    test('nested fallbacks do not cross a shared fallback boundary', () => {
+      const data = ref({})
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>receiver fallback</span></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot name="a"><slot name="x" /></slot>
+            <slot name="b"><slot name="y" /></slot>
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup vapor>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        data,
+        components,
+      )
+
+      const { host } = define(App).render()
+
+      expect(host.textContent).toBe('receiver fallback')
+    })
+
+    test('nested vdom fallbacks do not cross a shared fallback boundary', () => {
+      const data = ref({})
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>receiver fallback</span></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot name="a"><slot name="x" /></slot>
+            <slot name="b"><slot name="y" /></slot>
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        data,
+        components,
+        { vapor: false },
+      )
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+
+      app.mount(root)
+
+      expect(root.textContent).toBe('receiver fallback')
+      app.unmount()
+    })
+
+    test.each([
+      ['vapor', true],
+      ['vdom', false],
+    ])(
+      'shared local fallback preserves nested %s slot hosts',
+      async (_, vapor) => {
+        const data = ref({ showX: true, showY: false })
+        const components: Record<string, any> = {}
+        components.Receiver = compile(
+          `<template><slot><span>receiver fallback</span></slot></template>`,
+          data,
+          components,
+        )
+        components.Carrier = compile(
+          `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot name="a"><slot name="x" /><slot name="y" /></slot>
+            <slot name="b" />
+          </components.Receiver>
+        </template>`,
+          data,
+          components,
+        )
+        const App = compile(
+          `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #x><span v-if="data.showX">X</span></template>
+            <template #y><span v-if="data.showY">Y</span></template>
+          </components.Carrier>
+        </template>`,
+          data,
+          components,
+          { vapor },
+        )
+        const root = document.createElement('div')
+        const app = vapor
+          ? createVaporApp(App)
+          : createApp(App).use(vaporInteropPlugin)
+
+        app.mount(root)
+        expect(root.textContent).toBe('X')
+
+        data.value.showX = false
+        await nextTick()
+        expect(root.textContent).toBe('receiver fallback')
+
+        data.value.showY = true
+        await nextTick()
+        expect(root.textContent).toBe('Y')
+
+        app.unmount()
+      },
+    )
+
+    test('forwarded root shares receiver fallback with a dynamic sibling', async () => {
+      const data = ref({ showSlot: false, showSibling: false })
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Receiver>
+            <slot />
+            <span v-if="data.showSibling">sibling</span>
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup vapor>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Carrier>
+            <span v-if="data.showSlot">slot</span>
+          </components.Carrier>
+        </template>`,
+        data,
+        components,
+      )
+
+      const { host } = define(App).render()
+
+      expect(host.textContent).toBe('fallback')
+
+      data.value.showSibling = true
+      await nextTick()
+      expect(host.textContent).toBe('sibling')
+
+      data.value.showSlot = true
+      await nextTick()
+      expect(host.textContent).toBe('slotsibling')
+
+      data.value.showSlot = false
+      data.value.showSibling = false
+      await nextTick()
+      expect(host.textContent).toBe('fallback')
+    })
+
+    test('v-once forwarded root shares receiver fallback with a sibling', async () => {
+      const data = ref(false)
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot v-once name="a" />
+            <slot name="b" />
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const appSource = `<script setup>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Carrier>
+            <template #a><span v-if="false">A</span></template>
+            <template #b><span v-if="data">B</span></template>
+          </components.Carrier>
+        </template>`
+      const App = compile(appSource, data, components)
+
+      const { host } = define(App).render()
+
+      expect(host.textContent).toBe('fallback')
+
+      data.value = true
+      await nextTick()
+      expect(host.textContent).toBe('B')
+
+      data.value = false
+      const VDOMApp = compile(appSource, data, components, { vapor: false })
+      const root = document.createElement('div')
+      const app = createApp(VDOMApp).use(vaporInteropPlugin)
+      app.mount(root)
+
+      expect(root.textContent).toBe('fallback')
+
+      data.value = true
+      await nextTick()
+      expect(root.textContent).toBe('B')
+      app.unmount()
+    })
+
+    test('multiple forwarded roots from vdom resolve receiver fallback once', async () => {
+      const data = ref({ showA: false, showB: false })
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot name="a" />
+            <slot name="b" />
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Carrier>
+            <template #a><span v-if="data.showA">A</span></template>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        data,
+        components,
+        { vapor: false },
+      )
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
+
+      expect(root.textContent).toBe('fallback')
+      expect(root.innerHTML).toBe('<span>fallback</span><!--slot-->')
+
+      data.value.showA = true
+      await nextTick()
+      expect(root.textContent).toBe('A')
+      expect(root.innerHTML).toBe('<span>A</span><!--slot-->')
+
+      data.value.showA = false
+      data.value.showB = true
+      await nextTick()
+      expect(root.textContent).toBe('B')
+      expect(root.innerHTML).toBe('<span>B</span><!--slot-->')
+
+      data.value.showA = true
+      await nextTick()
+      expect(root.textContent).toBe('AB')
+      expect(root.innerHTML).toBe('<span>A</span><span>B</span><!--slot-->')
+
+      data.value.showA = false
+      data.value.showB = false
+      await nextTick()
+      expect(root.textContent).toBe('fallback')
+      expect(root.innerHTML).toBe('<span>fallback</span><!--slot-->')
+      app.unmount()
+    })
+
+    test('v-once forwarded root from vdom parks invalid content', async () => {
+      const show = ref(true)
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        show,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot v-once name="a" />
+            <slot name="b" />
+          </components.Receiver>
+        </template>`,
+        show,
+        components,
+      )
+      const App = compile(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #a><span v-if="false">A</span></template>
+            <template #b><span v-if="data">B</span></template>
+          </components.Carrier>
+        </template>`,
+        show,
+        components,
+        { vapor: false },
+      )
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
+
+      expect(root.textContent).toBe('B')
+      const contentNodeCount = root.childNodes.length
+      expect(contentNodeCount).toBeGreaterThan(2)
+
+      show.value = false
+      await nextTick()
+      expect(root.textContent).toBe('fallback')
+      expect(root.childNodes).toHaveLength(3)
+
+      show.value = true
+      await nextTick()
+      expect(root.textContent).toBe('B')
+      expect(root.childNodes).toHaveLength(contentNodeCount)
+
+      show.value = false
+      await nextTick()
+      app.unmount()
+      expect(root.childNodes).toHaveLength(0)
+    })
+
+    test('slot root detaches invalid static comment content', async () => {
+      const show = ref(true)
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><span>fallback</span></slot></template>`,
+        show,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components</script>
+        <template>
+          <components.Receiver>
+            <slot name="a" />
+            <slot name="b" />
+          </components.Receiver>
+        </template>`,
+        show,
+        components,
+      )
+      const App = compile(
+        `<script setup vapor>
+        const components = _components
+        const data = _data
+        </script>
+        <template>
+          <components.Carrier>
+            <template #a><!--invalid static comment--></template>
+            <template #b><span v-if="data">B</span></template>
+          </components.Carrier>
+        </template>`,
+        show,
+        components,
+      )
+      const { host } = define(App).render()
+
+      expect(host.innerHTML).toContain('<!--invalid static comment-->')
+
+      show.value = false
+      await nextTick()
+      expect(host.textContent).toBe('fallback')
+      expect(host.innerHTML).not.toContain('<!--invalid static comment-->')
+    })
+
+    test('nested slot under a stable branch does not consume receiver fallback', async () => {
+      const ok = ref(true)
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><b>receiver fallback</b></slot></template>`,
+        ok,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components; const data = _data</script>
+        <template>
+          <components.Receiver>
+            <template v-if="data"><div><slot /></div></template>
+          </components.Receiver>
+        </template>`,
+        ok,
+        components,
+      )
+      const App = compile(
+        `<script setup vapor>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        ok,
+        components,
+      )
+
+      const { host } = define(App).render()
+
+      expect(host.textContent).toBe('')
+
+      ok.value = false
+      await nextTick()
+      expect(host.textContent).toBe('receiver fallback')
+    })
+
+    test('v-for restores slot boundary for newly created roots', async () => {
+      const data = ref({ items: [] as number[], show: false })
+      const components: Record<string, any> = {}
+      components.Receiver = compile(
+        `<template><slot><b>receiver fallback</b></slot></template>`,
+        data,
+        components,
+      )
+      components.Carrier = compile(
+        `<script setup vapor>const components = _components; const data = _data</script>
+        <template>
+          <components.Receiver>
+            <slot v-for="item in data.items" :key="item" />
+          </components.Receiver>
+        </template>`,
+        data,
+        components,
+      )
+      const App = compile(
+        `<script setup vapor>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier><span v-if="data.show">content</span></components.Carrier>
+        </template>`,
+        data,
+        components,
+      )
+
+      const { host } = define(App).render()
+
+      expect(host.textContent).toBe('receiver fallback')
+
+      data.value.items.push(1)
+      await nextTick()
+      data.value.show = true
+      await nextTick()
+      expect(host.textContent).toBe('content')
     })
   })
 
@@ -3699,9 +4306,9 @@ describe('component: slots', () => {
         setup() {
           const n2 = createComponent(Child, null, {
             default: extend(() => {
-              const n0 = createSlot('default', null, () => {
-                return template('<!-- <div></div> -->')()
-              })
+              const n0 = createInheritedSlotRoot('default', () =>
+                template('<!-- <div></div> -->')(),
+              )
               return n0
             }, nonStableSlot),
           })
@@ -3803,7 +4410,7 @@ describe('component: slots', () => {
         setup() {
           const n2 = createComponent(Child, null, {
             default: extend(() => {
-              const n0 = createSlot('default', null, () => {
+              const n0 = createInheritedSlotRoot('default', () => {
                 const n2 = createIf(
                   () => show.value,
                   () => {
@@ -3854,7 +4461,7 @@ describe('component: slots', () => {
         setup() {
           const n2 = createComponent(Child, null, {
             default: extend(() => {
-              const n0 = createSlot('default', null, () => {
+              const n0 = createInheritedSlotRoot('default', () => {
                 const n2 = createFor(
                   () => items.value,
                   for_item0 => {
@@ -3990,11 +4597,11 @@ describe('component: slots', () => {
               {
                 foo: extend(() => {
                   return fallbackText
-                    ? createSlot('foo', null, () => {
+                    ? createInheritedSlotRoot('foo', () => {
                         const n2 = template(`<div>${fallbackText}</div>`)()
                         return n2
                       })
-                    : createSlot('foo', null)
+                    : createInheritedSlotRoot('foo')
                 }, nonStableSlot),
               },
               true,
@@ -4379,7 +4986,7 @@ describe('component: slots', () => {
               VdomSlotWithDynamicFallback,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -4411,7 +5018,7 @@ describe('component: slots', () => {
               VdomSlotWithCountingFallback,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -4447,7 +5054,7 @@ describe('component: slots', () => {
               VdomSlotWithTextFallback,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -4499,7 +5106,7 @@ describe('component: slots', () => {
                       VdomSlotWithReactiveFallback,
                       null,
                       {
-                        foo: () => createSlot('foo', null),
+                        foo: () => createInheritedSlotRoot('foo'),
                       },
                       true,
                     ),
@@ -4555,7 +5162,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -4588,7 +5195,7 @@ describe('component: slots', () => {
               VdomSlotWithReactiveFallback,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -4774,7 +5381,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -4916,7 +5523,7 @@ describe('component: slots', () => {
               VdomSlotWithOptionalFallback,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -4937,7 +5544,7 @@ describe('component: slots', () => {
         expect(root.innerHTML).toBe('<div>fallback</div>')
       })
 
-      test('vdom fallback added later should propagate to nested slot boundaries inside still-valid content', async () => {
+      test('vdom fallback added later does not propagate through stable slot content', async () => {
         const useFallback = ref(false)
         const showInner = ref(true)
 
@@ -5001,12 +5608,10 @@ describe('component: slots', () => {
 
         showInner.value = false
         await nextTick()
-        expect(root.innerHTML).toBe(
-          '<span>stable</span><div>outer fallback</div><!--slot-->',
-        )
+        expect(root.innerHTML).toBe('<span>stable</span><!--if--><!--slot-->')
       })
 
-      test('vdom fallback toggles should wait for the next nested invalidation inside still-valid content', async () => {
+      test('vdom fallback toggles do not affect nested slots inside stable content', async () => {
         const useFallback = ref(false)
         const showInner = ref(false)
 
@@ -5072,12 +5677,10 @@ describe('component: slots', () => {
 
         showInner.value = false
         await nextTick()
-        expect(root.innerHTML).toBe(
-          '<span>stable</span><div>outer fallback</div><!--slot-->',
-        )
+        expect(root.innerHTML).toBe('<span>stable</span><!--if--><!--slot-->')
       })
 
-      test('vdom local fallback should expose inherited fallback to nested slot boundaries', async () => {
+      test('vdom local fallback with stable content does not expose inherited fallback to nested slots', async () => {
         const VaporSlot = createVaporSlot('outer fallback')
 
         const NestedFallbackContainer = defineVaporComponent({
@@ -5106,12 +5709,10 @@ describe('component: slots', () => {
 
         const root = document.createElement('div')
         createApp(App).use(vaporInteropPlugin).mount(root)
-        expect(root.innerHTML).toBe(
-          '<span>local stable</span><div>outer fallback</div>',
-        )
+        expect(root.innerHTML).toBe('<span>local stable</span>')
       })
 
-      test('vdom local fallback should expose inherited fallback to nested interop vapor slot outlets', async () => {
+      test('vdom local fallback does not expose inherited fallback to nested component slots', async () => {
         const VaporSlot = createVaporSlot('outer fallback')
 
         const NestedInteropContainer = defineVaporComponent({
@@ -5141,7 +5742,7 @@ describe('component: slots', () => {
         const root = document.createElement('div')
         createApp(App).use(vaporInteropPlugin).mount(root)
         expect(localFallback).toHaveBeenCalledTimes(1)
-        expect(root.textContent).toBe('outer fallback')
+        expect(root.textContent).toBe('')
       })
 
       test('vdom local fallback should expose inherited fallback to nested interop vapor forwarded slots', async () => {
@@ -5159,7 +5760,7 @@ describe('component: slots', () => {
               NestedVdomSlot,
               null,
               {
-                bar: () => createSlot('bar', null),
+                bar: () => createInheritedSlotRoot('bar'),
               },
               true,
             )
@@ -5186,7 +5787,7 @@ describe('component: slots', () => {
         expect(root.textContent).toBe('outer fallback')
       })
 
-      test('vdom local fallback should keep nested inherited vapor fallback reactive after mount', async () => {
+      test('vdom local fallback keeps nested component slots isolated from inherited fallback', async () => {
         const fallbackText = ref('outer fallback')
 
         const VaporSlot = defineVaporComponent({
@@ -5229,12 +5830,12 @@ describe('component: slots', () => {
         const root = document.createElement('div')
         createApp(App).use(vaporInteropPlugin).mount(root)
         expect(localFallback).toHaveBeenCalledTimes(1)
-        expect(root.textContent).toBe('outer fallback')
+        expect(root.textContent).toBe('')
 
         fallbackText.value = 'updated outer fallback'
         await nextTick()
 
-        expect(root.textContent).toBe('updated outer fallback')
+        expect(root.textContent).toBe('')
       })
 
       test('vdom forwarded inherited vapor fallback should clean up old fallback effects', async () => {
@@ -5336,7 +5937,7 @@ describe('component: slots', () => {
               InnerVdomSlot,
               null,
               {
-                bar: () => createSlot('bar', null),
+                bar: () => createInheritedSlotRoot('bar'),
               },
               true,
             )
@@ -5349,7 +5950,7 @@ describe('component: slots', () => {
               OuterVdomSlot,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )
@@ -5424,7 +6025,7 @@ describe('component: slots', () => {
               InnerVdomSlot,
               null,
               {
-                bar: () => createSlot('bar', null),
+                bar: () => createInheritedSlotRoot('bar'),
               },
               true,
             )
@@ -5437,7 +6038,7 @@ describe('component: slots', () => {
               OuterVdomSlot,
               null,
               {
-                foo: () => createSlot('foo', null),
+                foo: () => createInheritedSlotRoot('foo'),
               },
               true,
             )

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -238,6 +238,27 @@ describe('component: slots', () => {
       expect(isValidBlock(frag)).toBe(true)
     })
 
+    test('slot root does not notify parent while exposed validity stays valid', () => {
+      const markDirty = vi.fn()
+      const parentBoundary: SlotBoundaryContext = {
+        parent: null,
+        getFallback: () => undefined,
+        run: fn => fn(),
+        markDirty,
+      }
+      const frag = withSlotBoundary(
+        parentBoundary,
+        () => new SlotFragment(true),
+      )
+      const fallback = () => document.createTextNode('fallback')
+
+      frag.updateSlot(() => [], fallback)
+      markDirty.mockClear()
+      frag.updateSlot(() => document.createTextNode('content'), fallback)
+
+      expect(markDirty).not.toHaveBeenCalled()
+    })
+
     test('slot fragment remove cleans active fallback and fallback scope', () => {
       const container = document.createElement('div')
       const stop = vi.fn()

--- a/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
@@ -132,7 +132,7 @@ describe('resolveDynamicAnchor', () => {
     expect(cleanup.cleanupUntil).toBe(footer)
   })
 
-  test('non-forwarded slot reuses the boundary close anchor', () => {
+  test('empty slot reuses the boundary close anchor', () => {
     const host = document.createElement('div')
     const start = document.createComment('[')
     const end = document.createComment(']')
@@ -149,26 +149,7 @@ describe('resolveDynamicAnchor', () => {
     expect(reuse.resetNodes).toBeUndefined()
   })
 
-  test('empty forwarded slot reuses the boundary close anchor', () => {
-    const host = document.createElement('div')
-    const start = document.createComment('[')
-    const end = document.createComment(']')
-    host.append(start, end)
-
-    const plan = resolveWithCursor(start, () =>
-      withHydratingSlotBoundary(() => {
-        const frag = new SlotFragment()
-        frag.forwarded = true
-        return resolveDynamicAnchor(frag, true)
-      }),
-    )
-
-    const reuse = expectKind(plan, 'reuse')
-    expect(reuse.node).toBe(end)
-    expect(reuse.resetNodes).toBeUndefined()
-  })
-
-  test('empty forwarded slot creates after an already reused boundary close anchor', () => {
+  test('empty slot creates after an already reused boundary close anchor', () => {
     const host = document.createElement('div')
     const start = document.createComment('[')
     const end = markHydrationAnchor(document.createComment(']'))
@@ -178,7 +159,6 @@ describe('resolveDynamicAnchor', () => {
     const plan = resolveWithCursor(start, () =>
       withHydratingSlotBoundary(() => {
         const frag = new SlotFragment()
-        frag.forwarded = true
         return resolveDynamicAnchor(frag, true)
       }),
     )

--- a/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
@@ -214,6 +214,30 @@ describe('resolveDynamicAnchor', () => {
     expect(pending.slotEnd).toBe(end)
   })
 
+  test('rendered invalid fragment waits for pending slot content decision', () => {
+    const host = document.createElement('div')
+    const start = document.createComment('[')
+    const end = document.createComment(']')
+    host.append(start, end)
+
+    const plan = resolveWithCursor(start, () =>
+      withHydratingSlotBoundary(() => {
+        const finish = startPendingSlotContent(start)
+        try {
+          const frag = new DynamicFragment('keyed', false, false)
+          frag.nodes = document.createComment('')
+          return resolveDynamicAnchor(frag, false)
+        } finally {
+          finish(false)
+        }
+      }),
+    )
+
+    const pending = expectKind(plan, 'pending')
+    expect(pending.parent).toBe(host)
+    expect(pending.slotEnd).toBe(end)
+  })
+
   test('nested invalid pending slot content preserves outer pending anchors', () => {
     const host = document.createElement('div')
     const start = document.createComment('[')

--- a/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/hydrateFragment.spec.ts
@@ -2,6 +2,7 @@ import { DynamicFragment, SlotFragment } from '../../src/fragment'
 import {
   hydrateNode,
   markHydrationAnchor,
+  setCurrentHydrationNode,
   setIsHydratingEnabled,
 } from '../../src/dom/hydration'
 import {
@@ -216,6 +217,30 @@ describe('resolveDynamicAnchor', () => {
     const pending = expectKind(plan, 'pending')
     expect(pending.parent).toBe(host)
     expect(pending.slotEnd).toBe(end)
+  })
+
+  test('rendered invalid fragment reuses its anchor after a markerless pending range', () => {
+    const host = document.createElement('div')
+    const anchor = document.createComment('keyed')
+    host.append(anchor)
+
+    const plan = resolveWithCursor(anchor, () =>
+      withHydratingSlotBoundary(() => {
+        const finish = startPendingSlotContent(anchor)
+        try {
+          setCurrentHydrationNode(null)
+          const frag = new DynamicFragment('keyed', false, false)
+          frag.nodes = anchor
+          return resolveDynamicAnchor(frag, false)
+        } finally {
+          finish(false)
+        }
+      }),
+    )
+
+    const reuse = expectKind(plan, 'reuse')
+    expect(reuse.node).toBe(anchor)
+    expect(reuse.resetNodes).toBe(true)
   })
 
   test('nested invalid pending slot content preserves outer pending anchors', () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4377,6 +4377,86 @@ describe('Vapor Mode hydration', () => {
       },
     )
 
+    test('forwarded keyed root slot tracks fallback across hydration and key updates', async () => {
+      const data = reactive({ show: false, key: 0 })
+      const { container } = await testHydration(
+        `<script setup>
+        const components = _components
+        const data = _data
+      </script>
+      <template>
+        <components.Carrier>
+          <span v-if="data.show">content</span>
+        </components.Carrier>
+      </template>`,
+        {
+          Receiver: `<template><slot><span>fallback</span></slot></template>`,
+          Carrier: `<script setup>
+          const components = _components
+          const data = _data
+        </script>
+        <template>
+          <components.Receiver>
+            <slot :key="data.key" />
+          </components.Receiver>
+        </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('fallback')
+      expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+
+      data.show = true
+      await nextTick()
+      expect(container.textContent).toBe('content')
+
+      data.key++
+      data.show = false
+      await nextTick()
+      expect(container.textContent).toBe('fallback')
+
+      data.show = true
+      await nextTick()
+      expect(container.textContent).toBe('content')
+    })
+
+    test('keyed dynamic slot root tracks fallback when remounted validity changes', async () => {
+      let view: string | null = 'span'
+      const data = reactive({
+        key: 0,
+        getView: () => view,
+      })
+      const { container } = await testHydration(
+        `<script setup>
+        const components = _components
+        const data = _data
+      </script>
+      <template>
+        <components.Receiver>
+          <component :is="data.getView()" :key="data.key">content</component>
+        </components.Receiver>
+      </template>`,
+        {
+          Receiver: `<template><slot><span>fallback</span></slot></template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('content')
+
+      view = null
+      data.key++
+      await nextTick()
+      expect(container.textContent).toBe('fallback')
+      expect(container.innerHTML).not.toContain('keyed')
+
+      view = 'span'
+      data.key++
+      await nextTick()
+      expect(container.textContent).toBe('content')
+    })
+
     test('forwarded slot with empty content', async () => {
       const data = reactive({
         foo: 'foo',

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5061,6 +5061,88 @@ describe('Vapor Mode hydration', () => {
       expect(container.textContent).toBe('AC')
     })
 
+    test('hydrated vdom content switches to local fallback after its sibling is removed', async () => {
+      const data = reactive({ showProvided: true, showTail: true })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #a>
+              <span v-if="data.showProvided">provided</span>
+            </template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><span>local fallback</span></slot>
+              <span v-if="data.showTail">tail</span>
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('providedtail')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showTail = false
+      await nextTick()
+      expect(container.textContent).toBe('provided')
+
+      data.showProvided = false
+      await nextTick()
+      expect(container.textContent).toBe('local fallback')
+
+      data.showProvided = true
+      await nextTick()
+      expect(container.textContent).toBe('provided')
+    })
+
+    test('hydrated vdom content switches inside a stable wrapper', async () => {
+      const data = reactive({ showProvided: true, showTail: true })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #a>
+              <span v-if="data.showProvided">provided</span>
+            </template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <div>
+                <slot name="a"><i>local fallback</i></slot>
+                <span v-if="data.showTail">tail</span>
+              </div>
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('providedtail')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showTail = false
+      await nextTick()
+      expect(container.textContent).toBe('provided')
+
+      data.showProvided = false
+      await nextTick()
+      expect(container.textContent).toBe('local fallback')
+
+      data.showProvided = true
+      await nextTick()
+      expect(container.textContent).toBe('provided')
+    })
+
     test('vdom nested hosts recover through a shared local fallback', async () => {
       const data = reactive({ showX: true, showY: false })
       const { container } = await testWithVDOMApp(

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4339,6 +4339,44 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test.each([
+      ['direct', `<slot />`],
+      ['v-if', `<slot v-if="true" />`],
+      ['v-for', `<slot v-for="n in [1]" :key="n" />`],
+    ])(
+      'forwarded %s root slot replaces receiver fallback when content becomes valid',
+      async (_, outlet) => {
+        const data = reactive({ show: false })
+        const { container } = await testHydration(
+          `<script setup>
+          const components = _components
+          const data = _data
+        </script>
+        <template>
+          <components.Carrier>
+            <span v-if="data.show">content</span>
+          </components.Carrier>
+        </template>`,
+          {
+            Receiver: `<template><slot><span>fallback</span></slot></template>`,
+            Carrier: `<script setup>const components = _components</script>
+            <template>
+              <components.Receiver>${outlet}</components.Receiver>
+            </template>`,
+          },
+          data,
+        )
+
+        expect(container.textContent).toBe('fallback')
+        expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+
+        data.show = true
+        await nextTick()
+
+        expect(container.textContent).toBe('content')
+      },
+    )
+
     test('forwarded slot with empty content', async () => {
       const data = reactive({
         foo: 'foo',

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -172,7 +172,7 @@ async function testHydration(
   }
 
   app.mount(container)
-  return { data, container, html }
+  return { data, container, html, app }
 }
 
 const triggerEvent = (type: string, el: Element) => {
@@ -4455,6 +4455,618 @@ describe('Vapor Mode hydration', () => {
       data.key++
       await nextTick()
       expect(container.textContent).toBe('content')
+    })
+
+    test.each([
+      {
+        initial: { showA: true, showB: false },
+        initialText: 'A',
+      },
+      {
+        initial: { showA: false, showB: false },
+        initialText: 'fallback',
+      },
+      {
+        initial: { showA: false, showB: true },
+        initialText: 'B',
+      },
+    ])(
+      'multiple forwarded roots resolve receiver fallback once from $initialText',
+      async ({ initial, initialText }) => {
+        const data = reactive({ ...initial })
+        const { container } = await testHydration(
+          `<script setup>
+        const components = _components
+        const data = _data
+      </script>
+      <template>
+        <components.Carrier>
+          <template #a><span v-if="data.showA">A</span></template>
+          <template #b><span v-if="data.showB">B</span></template>
+        </components.Carrier>
+      </template>`,
+          {
+            Receiver: `<template><slot><span>fallback</span></slot></template>`,
+            Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot name="a" />
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+          },
+          data,
+        )
+        expect(container.textContent).toBe(initialText)
+        expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+        if (initialText === 'A') {
+          data.showB = true
+        } else if (initialText === 'B') {
+          data.showA = true
+        }
+        if (initialText !== 'fallback') {
+          await nextTick()
+          expect(container.textContent).toBe('AB')
+        }
+
+        data.showA = false
+        data.showB = false
+        await nextTick()
+        expect(container.textContent).toBe('fallback')
+
+        data.showB = true
+        await nextTick()
+        expect(container.textContent).toBe('B')
+
+        data.showA = true
+        await nextTick()
+        expect(container.textContent).toBe('AB')
+
+        data.showA = false
+        data.showB = false
+        await nextTick()
+        expect(container.textContent).toBe('fallback')
+      },
+    )
+
+    test('multiple invalid forwarded roots hydrate fragment fallback without child anchors', async () => {
+      const data = reactive({ showA: false, showB: false, fallback: true })
+      const { container } = await testHydration(
+        `<script setup>
+        const components = _components
+        const data = _data
+      </script>
+      <template>
+        <components.Carrier>
+          <template #a><span v-if="data.showA">A</span></template>
+          <template #b><span v-if="data.showB">B</span></template>
+        </components.Carrier>
+      </template>`,
+        {
+          Receiver: `<script setup>const data = _data</script>
+          <template>
+            <slot>
+              <template v-if="data.fallback">
+                <span>fallback 1</span><span>fallback 2</span>
+              </template>
+            </slot>
+          </template>`,
+          Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot name="a" />
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('fallback 1fallback 2')
+      expect(container.innerHTML).not.toContain('<!--slot-->')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+    })
+
+    test('nested forwarded slot hydrates its own range inside stable content', async () => {
+      const data = reactive({ branch: true, show: false })
+      const { container } = await testHydration(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <span v-if="data.show">content</span>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <template v-if="data.branch"><div><slot /></div></template>
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.querySelector('div')!.textContent).toBe('')
+
+      data.show = true
+      await nextTick()
+      expect(container.querySelector('div')!.textContent).toBe('content')
+
+      data.branch = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+      expect(container.innerHTML.match(/<!--slot-->/g)).toHaveLength(1)
+    })
+
+    test('nested fallbacks stay within a shared boundary during hydration', async () => {
+      const data = reactive({ showX: false })
+      const { container } = await testHydration(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #x><span v-if="data.showX">X</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><span>receiver fallback</span></slot></template>`,
+          Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><slot name="x" /></slot>
+              <slot name="b"><slot name="y" /></slot>
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('receiver fallback')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showX = true
+      await nextTick()
+      expect(container.textContent).toBe('X')
+
+      data.showX = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+    })
+
+    test('v-once forwarded root shares fallback during hydration', async () => {
+      const data = reactive({ showB: false })
+      const { container } = await testHydration(
+        `<script setup>
+        const components = _components
+        const data = _data
+      </script>
+      <template>
+        <components.Carrier>
+          <template #a><span v-if="false">A</span></template>
+          <template #b><span v-if="data.showB">B</span></template>
+        </components.Carrier>
+      </template>`,
+        {
+          Receiver: `<template><slot><span>fallback</span></slot></template>`,
+          Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot v-once name="a" />
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('fallback')
+
+      data.showB = true
+      await nextTick()
+      expect(container.textContent).toBe('B')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+    })
+
+    test('shared local fallback participates in aggregate hydration', async () => {
+      const data = reactive({ localA: false })
+      const { container } = await testHydration(
+        `<script setup>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        {
+          Receiver: `<template><slot><b>receiver 1</b><b>receiver 2</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><span v-if="data.localA">local A</span></slot>
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('receiver 1receiver 2')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.localA = true
+      await nextTick()
+      expect(container.textContent).toBe('local A')
+    })
+
+    test('v-for restores slot boundary for roots created after hydration', async () => {
+      const data = reactive({ items: [] as number[], show: false })
+      const { container } = await testHydration(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <span v-if="data.show">content</span>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot v-for="item in data.items" :key="item" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('receiver fallback')
+
+      data.items.push(1)
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+
+      data.show = true
+      await nextTick()
+      expect(container.textContent).toBe('content')
+    })
+
+    test('slot-root v-for keeps its hydration anchor for empty component items', async () => {
+      const data = reactive({ items: [1], show: false })
+      const { container } = await testHydration(
+        `<script setup>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          EmptyItem: `<script setup>const data = _data</script>
+          <template><span v-if="data.show">item</span></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <components.EmptyItem
+                v-for="item in data.items"
+                :key="item"
+              />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('')
+      expect(container.textContent).not.toContain('receiver fallback')
+
+      data.items.push(2)
+      await nextTick()
+      data.show = true
+      await nextTick()
+      expect(container.textContent).toBe('itemitem')
+    })
+
+    test('vdom shared roots preserve hydration order and receiver fallback', async () => {
+      const data = reactive({ showA: false, showB: true })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #a><span v-if="data.showA">A</span></template>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot name="a" />
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('B')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showA = true
+      await nextTick()
+      expect(container.textContent).toBe('AB')
+
+      data.showA = false
+      data.showB = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+
+      data.showB = true
+      await nextTick()
+      expect(container.textContent).toBe('B')
+    })
+
+    test('vdom shared roots hydrate from receiver fallback', async () => {
+      const data = reactive({ mount: true, showA: false, showB: false })
+      const { app, container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier v-if="data.mount">
+            <template #a><span v-if="data.showA">A</span></template>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot name="a" />
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('receiver fallback')
+      const fallbackNodeCount = container.childNodes.length
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showB = true
+      await nextTick()
+      expect(container.textContent).toBe('B')
+
+      data.showA = true
+      await nextTick()
+      expect(container.textContent).toBe('AB')
+
+      data.showA = false
+      data.showB = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+      expect(container.childNodes).toHaveLength(fallbackNodeCount)
+
+      data.mount = false
+      await nextTick()
+      expect(container.textContent).toBe('')
+      app.unmount()
+    })
+
+    test('vdom shared roots leave fragment receiver fallback to the parent', async () => {
+      const data = reactive({ showA: false, showB: false })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #a><span v-if="data.showA">A</span></template>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template>
+            <slot>
+              <template v-if="true">
+                <b>receiver 1</b><b>receiver 2</b>
+              </template>
+            </slot>
+          </template>`,
+          Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot name="a" />
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('receiver 1receiver 2')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showB = true
+      await nextTick()
+      expect(container.textContent).toBe('B')
+    })
+
+    test('vdom shared local fallback participates in aggregate hydration', async () => {
+      const data = reactive({ localA: false, showB: false })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><span v-if="data.localA">local A</span></slot>
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('receiver fallback')
+      const fallbackNodeCount = container.childNodes.length
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.localA = true
+      await nextTick()
+      expect(container.textContent).toBe('local A')
+
+      data.localA = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+      expect(container.childNodes).toHaveLength(fallbackNodeCount)
+
+      data.showB = true
+      await nextTick()
+      expect(container.textContent).toBe('B')
+
+      data.showB = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+      expect(container.childNodes).toHaveLength(fallbackNodeCount)
+
+      data.localA = true
+      await nextTick()
+      expect(container.textContent).toBe('local A')
+    })
+
+    test('vdom shared local fallback does not claim fragment receiver fallback', async () => {
+      const data = reactive({ localA: false })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        {
+          Receiver: `<template>
+            <slot>
+              <template v-if="true">
+                <b>receiver 1</b><b>receiver 2</b>
+              </template>
+            </slot>
+          </template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><span v-if="data.localA">local A</span></slot>
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('receiver 1receiver 2')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.localA = true
+      await nextTick()
+      expect(container.textContent).toBe('local A')
+
+      data.localA = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver 1receiver 2')
+    })
+
+    test('vdom shared local fallback preserves sibling hydration order', async () => {
+      const data = reactive({ localA: false, showB: true })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><span v-if="data.localA">local A</span></slot>
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('B')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.localA = true
+      await nextTick()
+      expect(container.textContent).toBe('local AB')
+
+      data.localA = false
+      await nextTick()
+      expect(container.textContent).toBe('B')
+    })
+
+    test('vdom nested hosts recover through a shared local fallback', async () => {
+      const data = reactive({ showX: true, showY: false })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #x><span v-if="data.showX">X</span></template>
+            <template #y><span v-if="data.showY">Y</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><slot name="x" /><slot name="y" /></slot>
+              <slot name="b" />
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('X')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showX = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
+
+      data.showY = true
+      await nextTick()
+      expect(container.textContent).toBe('Y')
+    })
+
+    test('shared slot keeps its hydration position after a valid dynamic component', async () => {
+      const data = reactive({ showB: false, showC: true })
+      const { container } = await testHydration(
+        `<script setup>const components = _components; const data = _data</script>
+        <template>
+          <components.Carrier>
+            <template #b><span v-if="data.showB">B</span></template>
+          </components.Carrier>
+        </template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Item: `<template><span>A</span></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <component :is="components.Item" />
+              <slot name="b" />
+              <span v-if="data.showC">C</span>
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('AC')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.showB = true
+      await nextTick()
+      expect(container.textContent).toBe('ABC')
     })
 
     test('forwarded slot with empty content', async () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5002,6 +5002,65 @@ describe('Vapor Mode hydration', () => {
       expect(container.textContent).toBe('B')
     })
 
+    test('hydrated vdom shared local fallback restores before its sibling', async () => {
+      const data = reactive({ localA: true, showC: true })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><span v-if="data.localA">A</span></slot>
+              <span v-if="data.showC">C</span>
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('AC')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.localA = false
+      await nextTick()
+      expect(container.textContent).toBe('C')
+
+      data.localA = true
+      await nextTick()
+      expect(container.textContent).toBe('AC')
+    })
+
+    test('hydrated vdom local fallback restores before a stable sibling', async () => {
+      const data = reactive({ localA: true })
+      const { container } = await testWithVDOMApp(
+        `<script setup>const components = _components</script>
+        <template><components.Carrier /></template>`,
+        {
+          Receiver: `<template><slot><b>receiver fallback</b></slot></template>`,
+          Carrier: `<script setup>const components = _components; const data = _data</script>
+          <template>
+            <components.Receiver>
+              <slot name="a"><span v-if="data.localA">A</span></slot>
+              <span>C</span>
+            </components.Receiver>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(container.textContent).toBe('AC')
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+      data.localA = false
+      await nextTick()
+      expect(container.textContent).toBe('C')
+      data.localA = true
+      await nextTick()
+      expect(container.textContent).toBe('AC')
+    })
+
     test('vdom nested hosts recover through a shared local fallback', async () => {
       const data = reactive({ showX: true, showY: false })
       const { container } = await testWithVDOMApp(

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5238,6 +5238,38 @@ describe('Vapor Mode hydration', () => {
   })
 
   describe('transition', async () => {
+    test('hydrates a slot fallback without fragment markers', async () => {
+      const data = reactive({ show: false })
+      const { container } = await testHydration(
+        `<template>
+          <components.Child>
+            <template v-if="data.show">
+              <span>content</span>
+            </template>
+          </components.Child>
+        </template>`,
+        {
+          Child: `<template>
+            <Transition :css="false">
+              <slot><div>fallback</div></slot>
+            </Transition>
+          </template>`,
+        },
+        data,
+      )
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(container.textContent).toBe('fallback')
+
+      data.show = true
+      await nextTick()
+      expect(container.textContent).toBe('content')
+
+      data.show = false
+      await nextTick()
+      expect(container.textContent).toBe('fallback')
+    })
+
     test('transition appear', async () => {
       const { container } = await testHydration(
         `<template>

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -67,6 +67,8 @@ import {
 } from '../src'
 
 const define = makeInteropRender()
+const inheritedFallbackSlotRootFlags =
+  VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK
 
 describe('vdomInterop', () => {
   describe('key', () => {
@@ -1495,7 +1497,13 @@ describe('vdomInterop', () => {
             VDomInnerSlot as any,
             null,
             {
-              bar: () => createSlot('bar', null),
+              bar: () =>
+                createSlot(
+                  'bar',
+                  null,
+                  undefined,
+                  inheritedFallbackSlotRootFlags,
+                ),
             },
             true,
           )
@@ -4325,7 +4333,13 @@ describe('vdomInterop', () => {
                     VDomSlotOutlet as any,
                     null,
                     {
-                      default: () => createSlot('default'),
+                      default: () =>
+                        createSlot(
+                          'default',
+                          null,
+                          undefined,
+                          inheritedFallbackSlotRootFlags,
+                        ),
                     },
                     true,
                   ),

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -20,7 +20,7 @@ import {
   insert,
   insertFragment,
   insertNode,
-  isValidBlock,
+  isValidSlot,
   remove,
   removeFragment,
   removeNode,
@@ -69,6 +69,7 @@ import {
 } from './insertionState'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
 import { setBlockKey } from './helpers/setKey'
+import { currentSlotBoundary, setCurrentSlotBoundary } from './slotBoundary'
 
 type Source = any[] | Record<any, any> | number | Set<any> | Map<any, any>
 
@@ -147,6 +148,7 @@ export const createFor = (
   const isFragment = !!(flags & VaporVForFlags.IS_FRAGMENT)
 
   const slotOwner = currentSlotOwner
+  const slotBoundary = currentSlotBoundary
 
   if (__DEV__ && !instance) {
     warn('createFor() can only be used inside setup()')
@@ -543,7 +545,7 @@ export const createFor = (
         if (resolvedAnchor) {
           parentAnchor = resolvedAnchor
           pendingHydrationAnchor = true
-        } else if (slotFallbackRange && !isValidBlock(newBlocks)) {
+        } else if (slotFallbackRange && !isValidSlot(newBlocks)) {
           // Slot fallback can fall through an empty/invalid `v-for`. In that
           // case SSR only rendered the parent slot range, so this `v-for` has no
           // own `<!--]-->` to reuse. Keep its runtime anchor detached if
@@ -560,6 +562,7 @@ export const createFor = (
           parentAnchor = markHydrationAnchor(
             __DEV__ ? createComment('for') : createTextNode(),
           )
+          const hydrationAnchor = parentAnchor
           pendingHydrationAnchor = true
           if (
             currentHydrationNode === hydrationStart ||
@@ -567,15 +570,15 @@ export const createFor = (
           ) {
             setCurrentHydrationNode(hydrationStart)
           }
-          queuePendingSlotContentAnchor({
-            onContent: () => {
-              queuePostFlushCb(() => {
-                const parentNode = anchor.parentNode
-                if (parentNode) parentNode.insertBefore(parentAnchor, anchor)
-              })
-            },
+          const attachAnchor = () => {
+            const parentNode = anchor.parentNode
+            if (parentNode) parentNode.insertBefore(hydrationAnchor, anchor)
+          }
+          const queued = queuePendingSlotContentAnchor({
+            onContent: () => queuePostFlushCb(attachAnchor),
             onFallback: () => {},
           })
+          if (!queued) queuePostFlushCb(attachAnchor)
         } else {
           const close = locateHydrationBoundaryClose(currentHydrationNode!)
           reuseBoundaryClose(close)
@@ -640,9 +643,14 @@ export const createFor = (
     renderEffect(() => {
       if (!isMounted) return renderList()
       const prevOwner = setCurrentSlotOwner(slotOwner)
+      const restoreBoundary = currentSlotBoundary !== slotBoundary
+      const prevBoundary = restoreBoundary
+        ? setCurrentSlotBoundary(slotBoundary)
+        : null
       try {
         renderList()
       } finally {
+        if (restoreBoundary) setCurrentSlotBoundary(prevBoundary)
         setCurrentSlotOwner(prevOwner)
       }
     })

--- a/packages/runtime-vapor/src/apiCreateFragment.ts
+++ b/packages/runtime-vapor/src/apiCreateFragment.ts
@@ -1,4 +1,4 @@
-import { type Block, type BlockFn, insert } from './block'
+import { type Block, type BlockFn, insert, removeNode } from './block'
 import {
   type HydrationCursor,
   captureHydrationCursor,
@@ -23,7 +23,11 @@ import { renderEffect } from './renderEffect'
  *   <h1 :key="count">{{ count }}</h1>
  * </VaporTransition>
  */
-export function createKeyedFragment(key: () => any, render: BlockFn): Block {
+export function createKeyedFragment(
+  key: () => any,
+  render: BlockFn,
+  trackSlotBoundary: boolean = false,
+): Block {
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor
   if (!isHydrating) resetInsertionState()
@@ -35,8 +39,13 @@ export function createKeyedFragment(key: () => any, render: BlockFn): Block {
     __DEV__ ? 'keyed' : undefined,
     true,
     true,
-    false,
-    undefined,
+    trackSlotBoundary,
+    trackSlotBoundary
+      ? () => {
+          const parent = frag.anchor.parentNode
+          if (parent) removeNode(frag.anchor, parent)
+        }
+      : undefined,
     _insertionAnchor,
   )
 

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -296,6 +296,34 @@ export function remove(block: Block, parent?: ParentNode): void {
   }
 }
 
+// Detach a live block from `parent` without running fragment/component teardown.
+// Slot content uses this while an enclosing fallback temporarily owns the DOM.
+export function removeAttachedNodes(
+  block: Block,
+  parent: ParentNode,
+  removeAnchors: boolean = true,
+): void {
+  if (block instanceof Node) {
+    if (block.parentNode === parent) {
+      removeNode(block, parent)
+    }
+  } else if (isVaporComponent(block)) {
+    if (block.block) {
+      removeAttachedNodes(block.block, parent, removeAnchors)
+    }
+  } else if (isArray(block)) {
+    for (let i = 0; i < block.length; i++) {
+      removeAttachedNodes(block[i], parent, removeAnchors)
+    }
+  } else {
+    removeAttachedNodes(block.nodes, parent, removeAnchors)
+    const anchor = block.anchor
+    if (removeAnchors && anchor && anchor.parentNode === parent) {
+      removeNode(anchor, parent)
+    }
+  }
+}
+
 export function removeNode(block: Node, parent?: ParentNode): void {
   if (
     isTransitionEnabled &&

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -299,6 +299,7 @@ export function createSlot(
       slotRoot,
       sharedFallback,
       inheritFallback,
+      _insertionAnchor,
     )
   } else {
     if (isHydrating) hydrationCursor = captureHydrationCursor()

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -272,6 +272,8 @@ export function createSlot(
   const slotScopeIds = scopeId ? [`${scopeId}-s`] : null
   const once = !!(flags & VaporSlotFlags.ONCE)
   const slotRoot = !!(flags & VaporSlotFlags.SLOT_ROOT)
+  const sharedFallback = !!(flags & VaporSlotFlags.SHARED_FALLBACK)
+  const inheritFallback = !!(flags & VaporSlotFlags.INHERIT_FALLBACK)
   const slotProps = rawProps
     ? new Proxy(
         once ? snapshotRawProps(rawProps as RawProps) : rawProps,
@@ -295,6 +297,8 @@ export function createSlot(
       fallback,
       once,
       slotRoot,
+      sharedFallback,
+      inheritFallback,
     )
   } else {
     if (isHydrating) hydrationCursor = captureHydrationCursor()
@@ -309,7 +313,12 @@ export function createSlot(
       isCustomElementSlot,
     )
     const slotFragment = needsSlotFragment
-      ? new SlotFragment(slotRoot, _insertionAnchor)
+      ? new SlotFragment(
+          slotRoot,
+          sharedFallback,
+          inheritFallback,
+          _insertionAnchor,
+        )
       : undefined
     let dynamicFragment: DynamicFragment | undefined
     if (slotFragment) {
@@ -327,11 +336,6 @@ export function createSlot(
       )
       dynamicFragment.isSlot = true
       fragment = dynamicFragment
-    }
-
-    if (isHydrating) {
-      ;(fragment as DynamicFragment).forwarded =
-        currentSlotOwner != null && currentSlotOwner !== currentInstance
     }
 
     const isDynamicName = isFunction(name)

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -279,12 +279,12 @@ export function prepareDeferredHydrationAnchor(
 export type AnchorPlan =
   // Adopt an existing comment node as the fragment anchor.
   | { kind: 'reuse'; node: Node; resetNodes?: boolean }
-  // Delay an empty slot-content anchor until content/fallback is decided.
+  // Delay an invalid slot-content anchor until content/fallback is decided.
   // If fallback wins, the content anchor is created detached.
   | {
       kind: 'pending'
       parent: Node
-      slotEnd: Node
+      slotEnd: Node | null
     }
   // Insert a fresh runtime anchor before `next` once insertion flushes.
   // `mark` keeps an SSR node structural so boundary cleanup preserves it.
@@ -322,12 +322,17 @@ export function resolveDynamicAnchor(
   // pending just like an empty branch so fallback cleanup cannot detach the
   // insertion point before the runtime anchor is created.
   if (isPendingSlotContent() && (isEmpty || !isValidBlock(frag.nodes))) {
-    const slotEnd = getCurrentSlotEndAnchor()!
+    const slotEnd = getCurrentSlotEndAnchor()
     const node = currentHydrationNode || slotEnd
-    return {
-      kind: 'pending',
-      parent: getParentNode(node)!,
-      slotEnd,
+    if (node) {
+      const parent = getParentNode(node)
+      if (parent) {
+        return {
+          kind: 'pending',
+          parent,
+          slotEnd,
+        }
+      }
     }
   }
 
@@ -453,7 +458,7 @@ export function resolveDynamicAnchor(
   // The close marker is a valid stable anchor candidate: reuse it once, or
   // create a fresh runtime anchor after it when another fragment already did.
   if (
-    frag.isSlot ||
+    (frag.isSlot && slotAnchor) ||
     (anchorLabel === 'if' && isArray(frag.nodes) && frag.nodes.length > 1)
   ) {
     const anchor = locateHydrationBoundaryClose(
@@ -539,14 +544,16 @@ export function executeAnchorPlan(
               return
             }
             // Mismatch recovery can leave the cursor on fallback DOM instead
-            // of a reusable content anchor. Create this empty branch's
+            // of a reusable content anchor. Create this invalid branch's
             // runtime anchor before that DOM so later updates have a stable
             // insertion point.
-            const anchor = node && nodeParent === plan.parent ? node : slotEnd
-            const parentNode = getParentNode(anchor)
-            if (parentNode) {
-              parentNode.insertBefore(createRuntimeAnchor(), anchor)
-            }
+            const anchor =
+              node && nodeParent === plan.parent
+                ? node
+                : slotEnd && getParentNode(slotEnd) === plan.parent
+                  ? slotEnd
+                  : null
+            plan.parent.insertBefore(createRuntimeAnchor(), anchor)
           },
           onFallback: () => {
             // Match CSR by always creating the content fragment anchor, even

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -186,7 +186,7 @@ export function isPendingSlotContent(): boolean {
   return !!(state && state.pending)
 }
 
-function queueAnchorInsert(
+export function queueAnchorInsert(
   parentNode: Node,
   nextNode: Node | null,
   createAnchor: () => Node,

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -284,6 +284,19 @@ export function resolveDynamicAnchor(
   // truthiness check on the (possibly empty) label can't silently exclude one.
   const ownsDynamicAnchor = anchorLabel !== undefined || isNativeChildren
 
+  // A render function can still produce invalid slot content. Keep its anchor
+  // pending just like an empty branch so fallback cleanup cannot detach the
+  // insertion point before the runtime anchor is created.
+  if (isPendingSlotContent() && (isEmpty || !isValidBlock(frag.nodes))) {
+    const slotEnd = getCurrentSlotEndAnchor()!
+    const node = currentHydrationNode || slotEnd
+    return {
+      kind: 'pending',
+      parent: getParentNode(node)!,
+      slotEnd,
+    }
+  }
+
   // Native-children fragments get a runtime anchor injected by
   // createPlainElement when SSR rendered no default-slot content. Whenever the
   // cursor still points at that injected anchor — the branch stayed empty, or
@@ -300,15 +313,6 @@ export function resolveDynamicAnchor(
   // Empty fragments claim a current SSR anchor candidate directly. Later
   // fragments that need the same candidate create a fresh anchor after it.
   if (isEmpty) {
-    if (isPendingSlotContent()) {
-      const slotEnd = getCurrentSlotEndAnchor()!
-      const node = currentHydrationNode || slotEnd
-      return {
-        kind: 'pending',
-        parent: getParentNode(node)!,
-        slotEnd,
-      }
-    }
     if (isReusableAnchorCandidate(currentHydrationNode)) {
       return reuseOrCreateAfterAnchor(currentHydrationNode)
     }

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -39,16 +39,6 @@ interface PendingSlotContentAnchor {
   onFallback: () => void
 }
 
-function setCurrentHydratingSlotBoundaryState(
-  state: HydratingSlotBoundaryState | null,
-): HydratingSlotBoundaryState | null {
-  try {
-    return currentHydratingSlotBoundaryState
-  } finally {
-    currentHydratingSlotBoundaryState = state
-  }
-}
-
 export function getCurrentSlotEndAnchor(): Node | null {
   return currentHydratingSlotBoundaryState
     ? currentHydratingSlotBoundaryState.endAnchor
@@ -65,17 +55,59 @@ export function withHydratingSlotBoundary<R>(fn: () => R): R {
     setCurrentHydrationNode(currentHydrationNode.nextSibling)
     exitHydrationBoundary = enterHydrationBoundary(endAnchor)
   }
-  const prevState = setCurrentHydratingSlotBoundaryState({
+  const prevState = currentHydratingSlotBoundaryState
+  currentHydratingSlotBoundaryState = {
     endAnchor,
     pending: false,
     pendingAnchors: null,
-  })
+  }
 
   try {
     return fn()
   } finally {
-    setCurrentHydratingSlotBoundaryState(prevState)
+    currentHydratingSlotBoundaryState = prevState
     exitHydrationBoundary && exitHydrationBoundary()
+  }
+}
+
+export function withPendingHydratingSlotBoundary<R>(fn: () => R): R {
+  const pendingParent = currentHydratingSlotBoundaryState!
+  const contentStart = currentHydrationNode
+  let endAnchor = getCurrentSlotEndAnchor()
+  let exitHydrationBoundary: (() => void) | undefined
+
+  locateHydrationNode()
+  if (isComment(currentHydrationNode!, '[')) {
+    endAnchor = locateEndAnchor(currentHydrationNode)
+    setCurrentHydrationNode(currentHydrationNode.nextSibling)
+    exitHydrationBoundary = enterHydrationBoundary(endAnchor)
+  }
+  const state: HydratingSlotBoundaryState = {
+    endAnchor,
+    pending: true,
+    pendingAnchors: null,
+  }
+  currentHydratingSlotBoundaryState = state
+  let completed = false
+
+  try {
+    const result = fn()
+    completed = true
+    return result
+  } finally {
+    currentHydratingSlotBoundaryState = pendingParent
+    if (!completed) {
+      exitHydrationBoundary && exitHydrationBoundary()
+    } else if (state.pending) {
+      if (state.pendingAnchors) {
+        ;(pendingParent.pendingAnchors ||= []).push(...state.pendingAnchors)
+      }
+      setCurrentHydrationNode(contentStart)
+    } else {
+      exitHydrationBoundary && exitHydrationBoundary()
+      resolvePendingSlotContentAnchors(pendingParent, true)
+      pendingParent.pending = false
+    }
   }
 }
 
@@ -104,11 +136,13 @@ function resolvePendingSlotContentAnchors(
 
 export function queuePendingSlotContentAnchor(
   anchor: PendingSlotContentAnchor,
-): void {
+): boolean {
   const state = currentHydratingSlotBoundaryState
   if (state && state.pending) {
     ;(state.pendingAnchors ||= []).push(anchor)
+    return true
   }
+  return false
 }
 
 // Slot content with fallback is unresolved until it creates a valid node.

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -9,7 +9,10 @@ import {
   insert,
   isValidBlock,
   isValidSlot,
+  move,
   remove,
+  removeAttachedNodes,
+  removeNode,
 } from './block'
 import {
   type GenericComponentInstance,
@@ -37,6 +40,8 @@ import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
 import {
   type SlotBoundaryContext,
   currentSlotBoundary,
+  hasSlotFallback,
+  registerContentInvalid,
   setCurrentSlotBoundary,
   trackSlotBoundaryDirtying,
   withSlotBoundary,
@@ -45,12 +50,14 @@ import {
   getCurrentSlotEndAnchor,
   hydrateDynamicFragmentAnchor,
   prepareDeferredHydrationAnchor,
+  queuePendingSlotContentAnchor,
   startPendingSlotContent,
   withHydratingSlotBoundary,
 } from './dom/hydrateFragment'
 import {
   type SlotResolutionState,
   disposeSlotResolution,
+  invalidateExposedSlotContent,
   markSlotResolutionDirty,
   recheckSlotResolution,
 } from './slotFragment'
@@ -242,9 +249,6 @@ export class DynamicFragment extends RenderContextFragment {
   // pure marker consumed by the isSlotFragment predicate; the core update
   // pipeline never reads it.
   isSlot?: boolean
-  // Hydration-only marker for forwarded slots. They restore their own content
-  // anchor but leave inherited fallback resolution to the receiver slot.
-  forwarded?: boolean
   // Marks the generic dynamic fragment that createPlainElement creates for the
   // default-slot children of a dynamic element resolved to a native tag
   // (`rawSlots.$`). Unlike labeled control-flow fragments it has no
@@ -470,7 +474,6 @@ export class SlotFragment
 {
   isSlot = true
   private disposed = false
-  forwarded = false
   // Custom elements with `shadowRoot: false` replace their native slot outlet
   // after mount. Keep the live fallback block on the fragment so CE slot sync
   // can preserve block ownership after the outlet node is gone.
@@ -481,7 +484,7 @@ export class SlotFragment
   lastNodesValid?: boolean
   pendingRecheck = false
   pendingRecheckForce = false
-  isRenderingFallback = false
+  isReconciling = false
   private readonly onContentInvalid: (() => void)[] = []
   private content: Block = EMPTY_BLOCK
   private localFallback?: BlockFn
@@ -490,6 +493,8 @@ export class SlotFragment
   // Slot-root outlets expose their content validity to the enclosing boundary.
   constructor(
     private readonly notifyParentBoundary: boolean = false,
+    private readonly sharedFallback: boolean = false,
+    private readonly inheritFallback: boolean = false,
     adoptAnchor?: Node,
   ) {
     super(
@@ -500,6 +505,26 @@ export class SlotFragment
       undefined,
       adoptAnchor,
     )
+    if (sharedFallback) {
+      if (this.slotBoundary) {
+        registerContentInvalid(
+          this.slotBoundary,
+          () => {
+            invalidateExposedSlotContent(this)
+            const anchor = this.anchor
+            const parent = anchor.parentNode
+            if (parent) {
+              removeAttachedNodes(this.content, parent)
+              if (this.activeFallback) {
+                removeAttachedNodes(this.activeFallback, parent)
+              }
+              removeNode(anchor, parent)
+            }
+          },
+          this,
+        )
+      }
+    }
     if (!isHydrating) {
       this.insert = (parent, anchor, parentSuspense) =>
         this.insertSlot(parent, anchor, parentSuspense)
@@ -514,7 +539,7 @@ export class SlotFragment
 
   get boundary(): SlotBoundaryContext {
     return (this.ownBoundary ||= {
-      parent: this.slotBoundary,
+      parent: this.inheritFallback ? this.slotBoundary : null,
       getFallback: () => this.localFallback,
       run: (fn, scope) => this.runWithRenderCtx(fn, scope),
       markDirty: force => markSlotResolutionDirty(this, force),
@@ -576,7 +601,9 @@ export class SlotFragment
     const contentStart = currentHydrationNode
     let finish: ((contentValid: boolean) => void) | null = null
     try {
-      finish = startPendingSlotContent(contentStart)
+      if (this.sharedFallback || hasSlotFallback(this.boundary)) {
+        finish = startPendingSlotContent(contentStart)
+      }
       this.updateContent(render, key)
       const contentValid = isValidSlot(this.content)
       if (finish) {
@@ -608,18 +635,23 @@ export class SlotFragment
     try {
       const shouldForce = prevLocalFallback !== fallback
       if (isHydrating) {
-        // Forwarded content without local fallback must not run inherited
-        // fallback resolution itself. It only restores its own content anchor;
-        // the receiver slot boundary decides whether inherited fallback
-        // should run.
-        if (this.forwarded && !fallback) {
+        // Forwarded roots that do not own an inherited fallback restore only
+        // their exposed branch. The receiver decides its fallback after all
+        // shared roots have reported their final content/local-fallback result.
+        if (this.sharedFallback || (this.inheritFallback && !fallback)) {
           const { contentStart, contentValid } = this.updateHydratingContent(
             slotRender,
             key,
           )
-          this.syncNodes()
-          this.lastNodesValid = contentValid
-          if (contentValid) {
+          let exposedValid = contentValid
+          if (this.sharedFallback) {
+            recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)
+            exposedValid = isValidSlot(this.nodes)
+          } else {
+            this.syncNodes()
+            this.lastNodesValid = contentValid
+          }
+          if (exposedValid) {
             const end =
               contentStart && isComment(contentStart, '[')
                 ? locateEndAnchor(contentStart)
@@ -628,11 +660,60 @@ export class SlotFragment
               this.anchor = markHydrationAnchor(end)
               advanceHydrationNode(end)
             } else {
-              hydrateDynamicFragmentAnchor(this, !isValidBlock(this.content))
+              hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
+            }
+          } else if (this.sharedFallback) {
+            const slotEnd = getCurrentSlotEndAnchor()
+            const end =
+              contentStart && isComment(contentStart, '[')
+                ? locateEndAnchor(contentStart)
+                : null
+            if (end && end !== slotEnd) {
+              // Move past this candidate range so later sibling roots hydrate
+              // from their own position. The parent aggregate decision below
+              // determines whether this root actually owns the range.
+              advanceHydrationNode(end)
+            }
+            const anchor = markHydrationAnchor(
+              __DEV__
+                ? createComment(this.anchorLabel ?? '')
+                : createTextNode(),
+            )
+            this.anchor = anchor
+            const previous = slotEnd && slotEnd.previousSibling
+            if (previous && isComment(previous, ']')) {
+              markHydrationAnchor(previous)
+            }
+            const attachContent = () => {
+              const candidate = end && end !== slotEnd ? end : null
+              const insertionAnchor =
+                candidate ||
+                (contentStart && contentStart.parentNode
+                  ? contentStart
+                  : slotEnd)
+              const parent = insertionAnchor && insertionAnchor.parentNode
+              if (!parent) return
+
+              if (candidate) {
+                this.anchor = markHydrationAnchor(candidate)
+              } else {
+                parent.insertBefore(anchor, insertionAnchor)
+              }
+              move(this.nodes, parent, this.anchor)
+            }
+            const queued = queuePendingSlotContentAnchor({
+              onContent: attachContent,
+              onFallback: () => {},
+            })
+            if (!queued) {
+              if (end && end !== slotEnd) {
+                markHydrationAnchor(end)
+              }
+              queuePostFlushCb(attachContent)
             }
           } else {
-            // Empty forwarded content should not claim the receiver slot's SSR
-            // close marker. Queue its runtime anchor before that marker so
+            // Empty forwarded content should not claim the receiver slot's
+            // SSR close marker. Queue its runtime anchor before that marker so
             // fallback hydration can finish first and the final DOM matches CSR.
             const anchor = (this.anchor = markHydrationAnchor(
               __DEV__

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -2,11 +2,10 @@ import type { EffectScope } from '@vue/reactivity'
 import { type BlockFn, isValidSlot } from './block'
 import type { VaporFragment } from './fragment'
 
-// A slot boundary is one slot outlet's fallback-resolution point. Forwarded
-// slots chain boundaries through `parent`: when <Inner> renders a <slot>
-// inside <Outer>'s slot content, missing/invalid content resolves against
-// Inner's own fallback first, then Outer's, and so on outward
-// (renderSlotFallback in slotFragment.ts walks this chain).
+// A slot boundary is one slot outlet's fallback-resolution point. `parent` is
+// the next boundary this outlet is allowed to inherit from; ownership caps set
+// it to null even when another slot boundary physically encloses the outlet.
+// renderSlotFallback in slotFragment.ts walks this permitted chain.
 export interface SlotBoundaryContext {
   parent: SlotBoundaryContext | null
   getFallback: () => BlockFn | undefined

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -5,6 +5,7 @@ import {
   insert,
   isValidSlot,
   remove,
+  removeAttachedNodes,
 } from './block'
 import { isHydrating } from './dom/hydration'
 import {
@@ -34,6 +35,11 @@ import { setBlockKey } from './helpers/setKey'
 // slot implementations in vdomInterop.ts, which keep their per-slot state in
 // closures.
 
+interface RenderedSlotFallback {
+  block: Block
+  onContentInvalid: (() => void)[]
+}
+
 // Walks the boundary chain outward and renders fallbacks into `scope`. Returns:
 // - a valid block: the innermost fallback that rendered valid output;
 // - an invalid block: every boundary providing a fallback rendered invalid
@@ -44,8 +50,8 @@ import { setBlockKey } from './helpers/setKey'
 function renderSlotFallback(
   boundary: SlotBoundaryContext | null,
   scope: EffectScope,
-): Block | undefined {
-  let block: Block | undefined
+): RenderedSlotFallback | undefined {
+  let result: RenderedSlotFallback | undefined
 
   while (boundary) {
     const current = boundary
@@ -53,6 +59,7 @@ function renderSlotFallback(
 
     if (localFallback) {
       let selected = false
+      const onContentInvalid: (() => void)[] = []
       const content = current.run(
         () =>
           withSlotBoundary(
@@ -61,7 +68,7 @@ function renderSlotFallback(
               // Hide the local fallback while rendering it, so slot outlets inside
               // the fallback don't resolve to the same fallback again.
               getFallback: () => undefined,
-              onContentInvalid: [],
+              onContentInvalid,
               // Hidden invalid fallbacks in a forwarded fallback chain must
               // force a recheck when they become valid so the nearer fallback
               // can win again. The selected fallback only needs a normal
@@ -78,15 +85,15 @@ function renderSlotFallback(
       )
       if (isValidSlot(content)) {
         selected = true
-        return content
+        return { block: content, onContentInvalid }
       }
-      block = content
+      result = { block: content, onContentInvalid }
     }
 
     boundary = current.parent
   }
 
-  return block
+  return result
 }
 
 // Per-slot state the slot resolution machine operates on. Implemented by
@@ -97,6 +104,8 @@ export interface SlotResolutionState {
   boundary: SlotBoundaryContext
   // The committed fallback block, or null while content is exposed.
   activeFallback: Block | null
+  // Parking callbacks registered by hosts rendered in the active fallback.
+  activeFallbackInvalidCallbacks?: (() => void)[]
   // A committed fallback can be invalid and therefore remain detached.
   fallbackInserted: boolean
   // Detached scope owning the active fallback's effects (see
@@ -105,12 +114,12 @@ export interface SlotResolutionState {
   // Validity of the exposed branch as of the last recheck; undefined before
   // the first recheck. Flips trigger notifyExposedValidityChange.
   lastNodesValid?: boolean
-  // A dirty notification arrived while a fallback render or a host update
-  // was in flight; folded into the recheck that completes that operation.
+  // A dirty notification arrived during reconciliation or a host update;
+  // folded into the recheck that completes that operation.
   pendingRecheck: boolean
   pendingRecheckForce: boolean
-  // Reentrancy guard, set while renderSlotFallback runs user fallback code.
-  isRenderingFallback: boolean
+  // Reentrancy guard for one atomic content/fallback reconciliation.
+  isReconciling: boolean
   $transition?: VaporTransitionHooks
 
   getContent(): Block
@@ -129,10 +138,9 @@ export interface SlotResolutionState {
   notifyExposedValidityChange(): void
 }
 
-// Entry point for validity-change notifications (boundary.markDirty). While
-// user fallback code is rendering or the host is mid content update, the
-// notification is folded into pendingRecheck instead of recursing: the
-// in-flight operation ends with a recheck that subsumes it.
+// Entry point for validity-change notifications (boundary.markDirty). During
+// reconciliation or a host content update, fold notifications into the
+// in-flight operation instead of recursing.
 export function markSlotResolutionDirty(
   state: SlotResolutionState,
   force: boolean = false,
@@ -140,12 +148,23 @@ export function markSlotResolutionDirty(
   if (state.isDisposed()) {
     return
   }
-  if (state.isRenderingFallback || state.isBusy()) {
+  if (state.isReconciling || state.isBusy()) {
     state.pendingRecheck = true
     state.pendingRecheckForce = state.pendingRecheckForce || force
     return
   }
   recheckSlotResolution(state, force)
+}
+
+export function invalidateExposedSlotContent(state: SlotResolutionState): void {
+  const callbacks = state.activeFallback
+    ? state.activeFallbackInvalidCallbacks
+    : state.boundary.onContentInvalid
+  if (callbacks) {
+    for (let i = 0; i < callbacks.length; i++) {
+      callbacks[i]()
+    }
+  }
 }
 
 function clearSlotFallback(state: SlotResolutionState): void {
@@ -158,6 +177,7 @@ function clearSlotFallback(state: SlotResolutionState): void {
     state.activeFallback = null
     state.fallbackInserted = false
   }
+  state.activeFallbackInvalidCallbacks = undefined
   if (state.fallbackScope) {
     state.fallbackScope.stop()
     state.fallbackScope = undefined
@@ -183,17 +203,14 @@ export function leaveSlotFallback(
 // or right here when the render throws or yields nothing).
 function renderFallbackInScope(
   state: SlotResolutionState,
-): { block: Block; scope: EffectScope } | undefined {
+): (RenderedSlotFallback & { scope: EffectScope }) | undefined {
   const scope = new EffectScope(true)
-  let renderedFallback: Block | undefined
-  state.isRenderingFallback = true
+  let renderedFallback: RenderedSlotFallback | undefined
   try {
     renderedFallback = renderSlotFallback(state.boundary, scope)
   } catch (err) {
     scope.stop()
     throw err
-  } finally {
-    state.isRenderingFallback = false
   }
 
   if (!renderedFallback) {
@@ -202,7 +219,8 @@ function renderFallbackInScope(
   }
 
   return {
-    block: renderedFallback,
+    block: renderedFallback.block,
+    onContentInvalid: renderedFallback.onContentInvalid,
     scope,
   }
 }
@@ -227,9 +245,11 @@ function commitSlotFallback(
   state: SlotResolutionState,
   block: Block,
   scope: EffectScope,
+  onContentInvalid: (() => void)[],
   detachContent: boolean,
 ): void {
   state.activeFallback = block
+  state.activeFallbackInvalidCallbacks = onContentInvalid
   state.fallbackScope = scope
   state.fallbackInserted = isHydrating
   if (isTransitionEnabled) {
@@ -241,11 +261,13 @@ function commitSlotFallback(
     }
   }
   if (detachContent && !isHydrating) {
+    const parentNode = state.getParentNode()
     const contentInvalidCallbacks = state.boundary.onContentInvalid
-    if (contentInvalidCallbacks) {
-      for (let i = 0; i < contentInvalidCallbacks.length; i++) {
+    if (contentInvalidCallbacks)
+      for (let i = 0; i < contentInvalidCallbacks.length; i++)
         contentInvalidCallbacks[i]()
-      }
+    if (parentNode) {
+      removeAttachedNodes(state.getContent(), parentNode, false)
     }
   }
   insertActiveSlotFallback(state)
@@ -258,14 +280,13 @@ function renderAndCommitSlotFallback(
   const result = renderFallbackInScope(state)
   clearSlotFallback(state)
   if (result) {
-    commitSlotFallback(state, result.block, result.scope, !hadFallback)
-    // drain notifications folded into this fallback render/update window
-    if (state.pendingRecheck) {
-      const force = state.pendingRecheckForce
-      state.pendingRecheck = false
-      state.pendingRecheckForce = false
-      recheckSlotResolution(state, force)
-    }
+    commitSlotFallback(
+      state,
+      result.block,
+      result.scope,
+      result.onContentInvalid,
+      !hadFallback,
+    )
   }
 }
 
@@ -286,12 +307,31 @@ export function recheckSlotResolution(
   state: SlotResolutionState,
   force: boolean = false,
 ): void {
-  if (state.isRenderingFallback) {
+  if (state.isReconciling) {
     state.pendingRecheck = true
     state.pendingRecheckForce = state.pendingRecheckForce || force
     return
   }
 
+  let nextForce = force || state.pendingRecheckForce
+  do {
+    state.pendingRecheck = false
+    state.pendingRecheckForce = false
+    state.isReconciling = true
+    try {
+      recheckSlotResolutionNow(state, nextForce)
+    } finally {
+      state.isReconciling = false
+    }
+    if (!state.pendingRecheck) return
+    nextForce = state.pendingRecheckForce
+  } while (true)
+}
+
+function recheckSlotResolutionNow(
+  state: SlotResolutionState,
+  force: boolean,
+): void {
   const fallback = state.activeFallback
   const fallbackValid = fallback ? isValidSlot(fallback) : false
   const contentValid = state.isContentValid()

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -130,6 +130,7 @@ import {
   type VaporFragment,
   isFragment,
   isSlotFragment,
+  resolveFragmentAnchor,
   runWithFragmentCtxOnly,
   runWithRenderCtx,
 } from './fragment'
@@ -1517,6 +1518,7 @@ function renderVDOMSlot(
   slotRoot?: boolean,
   sharedFallback?: boolean,
   inheritFallback?: boolean,
+  adoptAnchor?: Node,
 ): VaporFragment {
   let suspense = currentParentSuspense || parentComponent.suspense
   const frag = createInteropFragment()
@@ -1793,6 +1795,15 @@ function renderVDOMSlot(
   frag.insert = (parentNode, anchor, parentSuspense) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
+    // A non-inherited local fallback can revive independently of sibling
+    // roots, so it needs an insertion point separate from the enclosing slot.
+    if (fallback && !inheritFallback && !frag.anchor) {
+      frag.anchor = resolveFragmentAnchor(adoptAnchor, undefined)
+      if (frag.anchor !== adoptAnchor) {
+        parentNode.insertBefore(frag.anchor, anchor)
+      }
+      anchor = frag.anchor
+    }
     const sharedContentParked = !!sharedContentStorage
     currentParentNode = parentNode
     currentAnchor = anchor
@@ -1911,7 +1922,7 @@ function renderVDOMSlot(
               const deferSharedContent =
                 sharedFallback && !slotContentValid && isPendingSlotContent()
               const localFallbackOwnsRange = !!(
-                sharedFallback &&
+                !inheritFallback &&
                 !slotContentValid &&
                 !deferSharedContent &&
                 localFallback &&
@@ -1997,6 +2008,12 @@ function renderVDOMSlot(
                 finishContentUpdate(true)
               }
               const exposedValid = isValidSlot(frag.nodes)
+              if (deferSharedContent && exposedValid && candidateEnd) {
+                // The local fallback won this candidate range. Keep its close
+                // marker as the host anchor for later invalid-to-valid updates.
+                frag.anchor = currentAnchor = markHydrationAnchor(candidateEnd)
+                currentParentNode = candidateEnd.parentNode as ParentNode
+              }
               if (
                 sharedFallback &&
                 exposedValid &&

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -153,6 +153,7 @@ import {
 import {
   getCurrentSlotEndAnchor,
   isPendingSlotContent,
+  queueAnchorInsert,
   queuePendingSlotContentAnchor,
   resolvePendingSlotContent,
   startPendingSlotContent,
@@ -2288,6 +2289,14 @@ function renderVDOMSlot(
     if (!currentParentNode) {
       currentAnchor = getCurrentSlotEndAnchor() || currentHydrationNode
       currentParentNode = currentAnchor!.parentNode as ParentNode
+    }
+    if (contentState.valid && fallback && !inheritFallback && !frag.anchor) {
+      // Insert an outlet-owned anchor after traversal so it cannot shift
+      // hydration indices.
+      queueAnchorInsert(currentParentNode, currentAnchor, () => {
+        return (frag.anchor = currentAnchor =
+          markHydrationAnchor(createTextNode()))
+      })
     }
     isMounted = true
   }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -119,6 +119,7 @@ import {
   isHydrating,
   isHydrationAnchor,
   locateEndAnchor,
+  markHydrationAnchor,
   setCurrentHydrationNode,
   hydrateNode as vaporHydrateNode,
 } from './dom/hydration'
@@ -143,14 +144,19 @@ import {
   type SlotResolutionState,
   disposeSlotResolution,
   insertActiveSlotFallback,
+  invalidateExposedSlotContent,
   leaveSlotFallback,
   markSlotResolutionDirty,
   recheckSlotResolution,
 } from './slotFragment'
 import {
   getCurrentSlotEndAnchor,
+  isPendingSlotContent,
+  queuePendingSlotContentAnchor,
+  resolvePendingSlotContent,
   startPendingSlotContent,
   withHydratingSlotBoundary,
+  withPendingHydratingSlotBoundary,
 } from './dom/hydrateFragment'
 import type { NodeRef } from './apiTemplateRef'
 import {
@@ -1509,6 +1515,8 @@ function renderVDOMSlot(
   fallback?: VaporSlot,
   once?: boolean,
   slotRoot?: boolean,
+  sharedFallback?: boolean,
+  inheritFallback?: boolean,
 ): VaporFragment {
   let suspense = currentParentSuspense || parentComponent.suspense
   const frag = createInteropFragment()
@@ -1525,6 +1533,7 @@ function renderVDOMSlot(
   }
   let currentParentNode: ParentNode | null = null
   let currentAnchor: Node | null = null
+  let sharedContentStorage: DocumentFragment | undefined
   let disposed = false
   let pendingInOutVNode: VNode | undefined
   let pendingOutIn:
@@ -1571,9 +1580,7 @@ function renderVDOMSlot(
       : contentState.valid
   }
   const boundary: SlotBoundaryContext = {
-    get parent() {
-      return slotBoundary
-    },
+    parent: inheritFallback ? slotBoundary : null,
     getFallback: (): BlockFn | undefined => localFallback,
     run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
     markDirty: force => markSlotResolutionDirty(slotResolutionState, force),
@@ -1585,7 +1592,7 @@ function renderVDOMSlot(
     fallbackInserted: false,
     pendingRecheck: false,
     pendingRecheckForce: false,
-    isRenderingFallback: false,
+    isReconciling: false,
     get $transition() {
       const transition = frag.$transition
       return transition && isVaporTransitionHooks(transition)
@@ -1610,8 +1617,33 @@ function renderVDOMSlot(
       }
     },
   }
+  if (sharedFallback && slotBoundary) {
+    registerContentInvalid(
+      slotBoundary,
+      () => {
+        if (!currentParentNode || sharedContentStorage) return
+        invalidateExposedSlotContent(slotResolutionState)
+        const storage = document.createDocumentFragment()
+        let anchor = frag.anchor
+        if (!anchor || anchor.parentNode !== currentParentNode) {
+          anchor = createTextNode()
+        }
+        storage.appendChild(anchor)
+        // VDOM Fragment ranges must keep a common parent while parked so the
+        // renderer can patch them before the aggregate fallback switches back.
+        insert(frag.nodes, storage, anchor, suspense)
+        sharedContentStorage = storage
+        currentParentNode = storage
+        currentAnchor = anchor
+      },
+      frag,
+    )
+  }
   if (slotRoot) {
-    trackSlotBoundaryDirtying(frag, cleanupInvalidContent)
+    trackSlotBoundaryDirtying(
+      frag,
+      sharedFallback ? undefined : cleanupInvalidContent,
+    )
   }
   localFallback = fallback
     ? once
@@ -1761,6 +1793,7 @@ function renderVDOMSlot(
   frag.insert = (parentNode, anchor, parentSuspense) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
+    const sharedContentParked = !!sharedContentStorage
     currentParentNode = parentNode
     currentAnchor = anchor
 
@@ -1768,7 +1801,13 @@ function renderVDOMSlot(
       scope.run(render)
       isMounted = true
     } else {
-      if (isVNode(contentState.rendered)) {
+      if (sharedContentParked) {
+        insert(frag.nodes, parentNode, anchor, suspense)
+        sharedContentStorage = undefined
+        if (slotResolutionState.activeFallback) {
+          slotResolutionState.fallbackInserted = true
+        }
+      } else if (isVNode(contentState.rendered)) {
         // move vdom content
         internals.m(
           contentState.rendered,
@@ -1783,14 +1822,17 @@ function renderVDOMSlot(
         insert(contentState.rendered, parentNode, anchor, suspense)
       }
 
-      insertActiveSlotFallback(slotResolutionState)
+      if (!sharedContentParked) {
+        insertActiveSlotFallback(slotResolutionState)
+      }
     }
 
     notifyUpdated()
   }
 
   frag.remove = parentNode => {
-    if (parentNode) {
+    const storage = sharedContentStorage
+    if (parentNode && !storage) {
       currentParentNode = parentNode
     }
     scope.stop()
@@ -1803,9 +1845,16 @@ function renderVDOMSlot(
       leavingElement && (leavingElement as TransitionElement)[leaveCbKey]
     if (leave) leave(true)
     if (contentState.rendered) {
-      removeRenderedContent(contentState.rendered, parentNode)
+      removeRenderedContent(contentState.rendered, storage || parentNode)
     }
     disposeSlotResolution(slotResolutionState)
+    if (storage) {
+      const anchor = frag.anchor
+      if (anchor && anchor.parentNode === storage) {
+        frag.anchor = undefined
+      }
+      sharedContentStorage = undefined
+    }
   }
 
   const render = () => {
@@ -1848,12 +1897,34 @@ function renderVDOMSlot(
             }
 
             if (isHydrating) {
+              if (slotContentValid && isPendingSlotContent()) {
+                resolvePendingSlotContent()
+              }
+              const contentStart = currentHydrationNode
+              const contentEnd =
+                contentStart && isComment(contentStart, '[')
+                  ? locateEndAnchor(contentStart)
+                  : null
+              const slotEnd = getCurrentSlotEndAnchor()
+              const candidateEnd =
+                contentEnd && contentEnd !== slotEnd ? contentEnd : null
+              const deferSharedContent =
+                sharedFallback && !slotContentValid && isPendingSlotContent()
+              const localFallbackOwnsRange = !!(
+                sharedFallback &&
+                !slotContentValid &&
+                !deferSharedContent &&
+                localFallback &&
+                candidateEnd
+              )
               // An empty VDOM slot fragment is still the hydration owner of the
               // SSR fragment markers when no fallback takes over. Keep hydrating
               // that content so later updates can patch inside the existing
               // range instead of mounting before it.
               const hydratedContent =
-                slotContent && (slotContentValid || !hasSlotFallback(boundary))
+                !deferSharedContent &&
+                slotContent &&
+                (slotContentValid || !hasSlotFallback(boundary))
                   ? slotContent
                   : undefined
               if (isVNode(hydratedContent)) {
@@ -1909,7 +1980,86 @@ function renderVDOMSlot(
                 frag.$key = undefined
                 setRenderedContent(null)
               }
-              finishContentUpdate(true)
+              if (deferSharedContent && localFallback && candidateEnd) {
+                // Resolve the local fallback inside its candidate range, but
+                // leave that range untouched if the parent aggregate still wins.
+                withPendingHydratingSlotBoundary(() =>
+                  finishContentUpdate(true),
+                )
+              } else if (localFallbackOwnsRange) {
+                // The candidate range belongs to the exposed local fallback,
+                // not to the invalid raw VDOM content or the parent aggregate.
+                withHydratingSlotBoundary(() => finishContentUpdate(true))
+                frag.anchor = currentAnchor = markHydrationAnchor(candidateEnd)
+                currentParentNode = candidateEnd.parentNode as ParentNode
+                advanceHydrationNode(candidateEnd)
+              } else {
+                finishContentUpdate(true)
+              }
+              const exposedValid = isValidSlot(frag.nodes)
+              if (
+                sharedFallback &&
+                exposedValid &&
+                candidateEnd &&
+                currentHydrationNode === candidateEnd
+              ) {
+                advanceHydrationNode(candidateEnd)
+              } else if (deferSharedContent && !exposedValid) {
+                if (candidateEnd && currentHydrationNode === candidateEnd) {
+                  advanceHydrationNode(candidateEnd)
+                }
+                const anchor = createTextNode()
+                const detachedParent = document.createDocumentFragment()
+                detachedParent.appendChild(anchor)
+                currentParentNode = detachedParent
+                currentAnchor = anchor
+                const previous = slotEnd && slotEnd.previousSibling
+                if (previous && isComment(previous, ']')) {
+                  markHydrationAnchor(previous)
+                }
+                const attachAnchor = () => {
+                  const insertionAnchor =
+                    candidateEnd ||
+                    (contentStart && contentStart.parentNode
+                      ? contentStart
+                      : slotEnd)
+                  const parent = insertionAnchor && insertionAnchor.parentNode
+                  if (parent) {
+                    if (candidateEnd) {
+                      frag.anchor = currentAnchor =
+                        markHydrationAnchor(candidateEnd)
+                      if (currentHydrationNode === contentStart) {
+                        advanceHydrationNode(candidateEnd)
+                      }
+                    } else {
+                      parent.insertBefore(anchor, insertionAnchor)
+                    }
+                    currentParentNode = parent
+                    move(frag.nodes, parent, currentAnchor)
+                  }
+                }
+                const queued = queuePendingSlotContentAnchor({
+                  onContent: () => {
+                    attachAnchor()
+                    // Keep the detached anchor out of the parent fragment's
+                    // boundary lookup until its hydration pass has finished.
+                    if (!candidateEnd) {
+                      queuePostFlushCb(() => {
+                        if (!disposed) frag.anchor = anchor
+                      })
+                    }
+                  },
+                  onFallback: () => {
+                    frag.anchor = anchor
+                  },
+                })
+                if (!queued) {
+                  queuePostFlushCb(() => {
+                    attachAnchor()
+                    if (!disposed && !candidateEnd) frag.anchor = anchor
+                  })
+                }
+              }
               return
             }
 
@@ -2375,7 +2525,7 @@ function renderVaporSlot(
       fallbackInserted: false,
       pendingRecheck: false,
       pendingRecheckForce: false,
-      isRenderingFallback: false,
+      isReconciling: false,
       getContent: () => contentNodes,
       getParentNode: () => currentParentNode,
       getAnchor: () => currentAnchor,

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -108,6 +108,12 @@ export enum VaporSlotFlags {
   // Per-slot function metadata. The slot root can start invalid or become
   // invalid, so fallback may be reachable and needs SlotFragment tracking.
   NON_STABLE = 1 << 3,
+  // Multiple independently invalid roots share one enclosing fallback
+  // decision instead of resolving that fallback from each root.
+  SHARED_FALLBACK = 1 << 4,
+  // The outlet is the only forwarded root, so it may resolve an enclosing
+  // fallback after its own local fallback is exhausted.
+  INHERIT_FALLBACK = 1 << 5,
 }
 
 export enum VaporDynamicComponentFlags {


### PR DESCRIPTION
Propagate exposed validity changes from forwarded root slot outlets so parent slot boundaries can re-resolve content and fallback correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot fallback resolution across nested, forwarded, conditional, loop, and dynamic content.
  * Fixed hydration of empty, invalid, keyed, and shared slot content, including correct anchors and cleanup.
  * Improved fallback updates, removal, reactivation, and stale-content cleanup.
  * Enhanced compatibility between Vapor and VDOM slots, including teleported content.
* **Tests**
  * Expanded coverage for slot rendering, fallback inheritance, hydration, keyed fragments, `v-once`, and transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->