### PR TITLE
fix(playground): default to TypeScript 6 (fix #15217)

### DIFF
--- a/packages-private/sfc-playground/src/App.vue
+++ b/packages-private/sfc-playground/src/App.vue
@@ -14,6 +14,8 @@ setVH()
 
 const useSSRMode = ref(false)
 
+const DEFAULT_TYPESCRIPT_VERSION = '6.0.3'
+
 const AUTO_SAVE_STORAGE_KEY = 'vue-sfc-playground-auto-save'
 const initAutoSave: boolean = JSON.parse(
   localStorage.getItem(AUTO_SAVE_STORAGE_KEY) ?? 'true',
@@ -69,6 +71,7 @@ const store = useStore(
   {
     builtinImportMap: importMap,
     vueVersion,
+    typescriptVersion: ref(DEFAULT_TYPESCRIPT_VERSION),
     sfcOptions,
   },
   hash,


### PR DESCRIPTION
## What changed

- Default new SFC Playground sessions to TypeScript 6.0.3 instead of the npm `latest` tag.
- Keep TypeScript versions serialized in shared Playground URLs authoritative over the default.

## Why

- The npm `latest` tag now resolves to TypeScript 7, which the Playground's Vue type support does not currently handle.
- This fixes #15217 while preserving explicitly selected versions.

## How tested

- Built the Vue compiler/runtime prerequisites and the SFC Playground production bundle successfully.
- Browser-tested a fresh Playground session: the TypeScript selector shows 6.0.3.
- Browser-tested an explicit selection: selecting 5.9.3 and reloading keeps 5.9.3.
- `git diff --check origin/main...HEAD`

Full `tsc --incremental --noEmit` is blocked in the local dependency snapshot by an unrelated existing mismatch: `vitest/browser` does not export `cdp` for `packages/vue/__tests__/e2e/e2eBrowserUtils.ts`.

## Risk and rollout

- Risk: Low. The change only affects the initial Playground default; shared URLs with an explicit TypeScript version continue to override it.
- Rollback: Revert the `typescriptVersion` store option.

## Notes for reviewers

- Duplicate audit covered open, closed, and merged PRs plus commits using: `15217`, the issue title, `playground TypeScript default`, `TypeScript version playground`, `typescriptVersion`, and `packages-private/sfc-playground/src/App.vue`.
- No matching implementation, linked branch, or existing PR was found. The issue's only comment is an unlinked offer to investigate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the playground to use TypeScript version 6.0.3 by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->