### PR TITLE
fix(types): type Options API computed arguments (fix #13103)

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -2,6 +2,7 @@ import {
   type Component,
   type ComponentOptions,
   type ComponentPublicInstance,
+  type ComputedOptions,
   type PropType,
   type SetupContext,
   type Slots,
@@ -507,6 +508,30 @@ describe('type inference w/ options API', () => {
       expectType<() => number | undefined>(this.returnSomething)
     },
   })
+})
+
+// #13103
+describe('type inference for computed previous value w/ options API', () => {
+  const computed: ComputedOptions = {
+    doubled(vm, previous: number | undefined): number {
+      expectType<ComponentPublicInstance>(vm)
+      expectType<false>({} as IsAny<typeof vm>)
+      expectType<number | undefined>(previous)
+      return 2
+    },
+    writable: {
+      get(vm, previous: number | undefined): number {
+        expectType<ComponentPublicInstance>(vm)
+        expectType<false>({} as IsAny<typeof vm>)
+        expectType<number | undefined>(previous)
+        return 1
+      },
+      set(value: number) {
+        expectType<number>(value)
+      },
+    },
+  }
+  expectType<ComputedOptions>(computed)
 })
 
 // #4051

--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1,5 +1,7 @@
 import {
   type Component,
+  type ComponentComputedGetter,
+  type ComponentComputedOptions,
   type ComponentOptions,
   type ComponentPublicInstance,
   type ComputedOptions,
@@ -512,26 +514,29 @@ describe('type inference w/ options API', () => {
 
 // #13103
 describe('type inference for computed previous value w/ options API', () => {
-  const computed: ComputedOptions = {
-    doubled(vm, previous: number | undefined): number {
+  const doubled: ComponentComputedGetter<number> = (vm, previous) => {
+    expectType<ComponentPublicInstance>(vm)
+    expectType<false>({} as IsAny<typeof vm>)
+    expectType<number | undefined>(previous)
+    expectType<false>({} as IsAny<typeof previous>)
+    return 2
+  }
+
+  const writable: ComponentComputedOptions<number> = {
+    get(vm, previous) {
       expectType<ComponentPublicInstance>(vm)
       expectType<false>({} as IsAny<typeof vm>)
       expectType<number | undefined>(previous)
-      return 2
+      expectType<false>({} as IsAny<typeof previous>)
+      return 1
     },
-    writable: {
-      get(vm, previous: number | undefined): number {
-        expectType<ComponentPublicInstance>(vm)
-        expectType<false>({} as IsAny<typeof vm>)
-        expectType<number | undefined>(previous)
-        return 1
-      },
-      set(value: number) {
-        expectType<number>(value)
-      },
+    set(value) {
+      expectType<number>(value)
+      expectType<false>({} as IsAny<typeof value>)
     },
   }
-  expectType<ComputedOptions>(computed)
+
+  expectType<ComputedOptions>({ doubled, writable })
 })
 
 // #4051

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -44,11 +44,7 @@ import {
   onUnmounted,
   onUpdated,
 } from './apiLifecycle'
-import {
-  type ComputedGetter,
-  type WritableComputedOptions,
-  reactive,
-} from '@vue/reactivity'
+import { type ComputedSetter, reactive } from '@vue/reactivity'
 import type {
   ComponentObjectPropsOptions,
   ComponentPropsOptions,
@@ -315,9 +311,19 @@ export type ComponentOptionsMixin = ComponentOptionsBase<
   any
 >
 
+export type ComponentComputedGetter<T = any> = (
+  vm: ComponentPublicInstance,
+  previous?: T,
+) => T
+
+export interface ComponentComputedOptions<T = any, S = T> {
+  get: ComponentComputedGetter<T>
+  set: ComputedSetter<S>
+}
+
 export type ComputedOptions = Record<
   string,
-  ComputedGetter<any> | WritableComputedOptions<any>
+  ComponentComputedGetter<any> | ComponentComputedOptions<any>
 >
 
 export interface MethodOptions {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -282,6 +282,8 @@ export type {
   ComponentProvideOptions,
   RenderFunction,
   MethodOptions,
+  ComponentComputedGetter,
+  ComponentComputedOptions,
   ComputedOptions,
   RuntimeCompilerOptions,
   ComponentInjectOptions,


### PR DESCRIPTION
## What changed

- add Options API-specific computed getter types that model the runtime arguments as `(componentInstance, previousValue)`
- use that getter shape for both shorthand and writable computed options
- export the component getter and writable-option types alongside `ComputedOptions`
- add dts coverage that verifies contextual inference for the component instance, previous value, and writable setter without widening to `any`

## Why

Options API computed getters are bound with the public component instance as their first argument before reactivity supplies the previous value. The existing `ComputedOptions` type reused the Composition API `ComputedGetter`, so it incorrectly described the previous value as the first argument.

Fixes #13103.

## How tested

- `tsc -p tsconfig.build.json --noCheck`
- `rollup -c rollup.dts.config.js`
- `tsc -p packages-private/dts-built-test/tsconfig.json`
- `tsc -p packages-private/dts-test/tsconfig.test.json`
- ESLint on all three changed files
- Prettier 3.9.6 check on all three changed files
- `git diff --check`
- GitHub CI: lint/dts, Linux and Windows unit tests, release, size, and deployment checks pass on the current head

The focused runtime test could not start locally because the shared dependency snapshot does not contain `@vitest/browser-playwright`. A full source `tsc --incremental --noEmit` likewise reaches an unrelated existing dependency mismatch where `vitest/browser` does not export `cdp`. The declaration build and both complete dts suites pass locally.

The initial GitHub CI run passed e2e. After the type-test-only follow-up, e2e hit an unrelated transition timing failure in `Transition.spec.ts:1706`: the expected element still had its enter classes. This PR does not change runtime code, and fork authors cannot rerun upstream jobs, so the failed job needs a maintainer rerun.

## Risk and rollout

- Risk: low; this is a type-only change, the two new exports are additive, and zero-argument computed getters remain compatible
- Rollback: revert these commits to restore the previous Options API computed type alias

## Notes for reviewers

- Runtime behavior is unchanged; the new type mirrors the existing `opt.bind(publicThis, publicThis)` call.
- Duplicate audit searched #13103, the issue title/behavior, `ComponentComputedGetter`, Options API computed previous-value wording, file paths, and related commits across open, closed, and merged work. No core PR or commit covers this fix.
- CodeRabbit surfaced #15107 after the initial publication. I reviewed its files and patch: it is a broad migration of the dts assertion helper and does not change `componentOptions.ts`, the computed argument contract, or #13103. It may touch the same test file but is not an implementation duplicate. The only issue-linked work remains vuejs/docs#3206, which corrected the documentation example without changing core types.
