### PR TITLE
fix(runtime-vapor): skip node removal when the node is already detached

### DIFF
--- a/packages/runtime-vapor/__tests__/block.spec.ts
+++ b/packages/runtime-vapor/__tests__/block.spec.ts
@@ -113,8 +113,8 @@ describe('block + node ops', () => {
     remove(frag, container)
     expect(Array.from(container.childNodes)).toEqual([node2])
 
-    expect(() => remove(anchor, container)).toThrowError(
-      'The node to be removed is not a child of this node.',
-    )
+    const detached = document.createTextNode('detached')
+    expect(() => remove(detached, container)).not.toThrow()
+    expect(Array.from(container.childNodes)).toEqual([node2])
   })
 })

--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -1016,6 +1016,34 @@ function runSharedTests(deferMode: boolean): void {
     testUnmount({ to: () => null, disabled: () => true })
   })
 
+  test('should not throw when teleported children are detached outside of Vue', async () => {
+    const target = document.createElement('div')
+    const root = document.createElement('div')
+
+    const { app } = define({
+      setup() {
+        const n0 = createComponent(
+          VaporTeleport,
+          {
+            to: () => target,
+          },
+          {
+            default: () => template('<div>teleported</div>')(),
+          },
+        )
+        const n1 = template('<div>root</div>')()
+        return [n0, n1]
+      },
+    }).create()
+
+    app.mount(root)
+    expect(target.innerHTML).toBe('<div>teleported</div>')
+
+    target.children[0].remove()
+    expect(() => app.unmount()).not.toThrow()
+    expect(target.innerHTML).toBe('')
+  })
+
   test('component with multi roots should be removed when unmounted', async () => {
     const target = document.createElement('div')
     const root = document.createElement('div')

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -297,6 +297,7 @@ export function remove(block: Block, parent?: ParentNode): void {
 }
 
 export function removeNode(block: Node, parent?: ParentNode): void {
+  // `parent` only signals whether to detach: the node may have moved since
   if (
     isTransitionEnabled &&
     (block as TransitionBlock).$transition &&
@@ -305,10 +306,10 @@ export function removeNode(block: Node, parent?: ParentNode): void {
     performTransitionLeave(
       block,
       (block as TransitionBlock).$transition as TransitionHooks,
-      () => parent && parent.removeChild(block),
+      () => parent && block.remove(),
     )
   } else {
-    parent && parent.removeChild(block)
+    parent && (block as ChildNode).remove()
   }
 }
 


### PR DESCRIPTION
close #15221

`removeNode` called `parent.removeChild(block)` with the parent the caller remembered earlier. `TeleportFragment` passes the container recorded at mount time, so if anything outside Vue has already taken the teleported node out of the DOM, that throws `NotFoundError`. It happens inside `EffectScope.stop`, so it also aborts the rest of the unmount.

The node now detaches itself, the same as `runtime-dom`'s `nodeOps.remove` deriving the parent from the child. `parent` is still what decides whether to detach at all, since callers pass `undefined` to mean tear down without detaching. This covers `handleChildrenUpdate` too, not just unmount.

The `block.spec.ts` assertion that removing a non-child throws is updated to the new no-op behavior.