### PR TITLE
fix(compiler-vapor): preserve optional chaining in cached member expressions

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
@@ -305,6 +305,15 @@ describe('compiler: expression', () => {
       expect(code).contains('_setProp(n0, "id", _obj?.foo + _obj?.bar)')
     })
 
+    test('repeated optional chaining', () => {
+      const { code } = compileWithExpression(
+        `<div :id="obj?.foo" :title="obj?.foo"></div>`,
+      )
+      expect(code).contains('const _obj_foo = _ctx.obj?.foo')
+      expect(code).contains('_setProp(n0, "id", _obj_foo)')
+      expect(code).contains('_setProp(n0, "title", _obj_foo)')
+    })
+
     test('TSNonNullExpression', () => {
       const { code } = compileWithExpression(
         `<div :id="obj!.foo + obj!.bar"></div>`,

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -1023,9 +1023,10 @@ function extractMemberExpression(
     case 'MemberExpression': // foo[bar.baz]
     case 'OptionalMemberExpression': // foo?.bar
       const object = extractMemberExpression(exp.object, onIdentifier)
+      const optional = exp.type === 'OptionalMemberExpression' && exp.optional
       const prop = exp.computed
-        ? `[${extractMemberExpression(exp.property, onIdentifier)}]`
-        : `.${extractMemberExpression(exp.property, NOOP)}`
+        ? `${optional ? '?.' : ''}[${extractMemberExpression(exp.property, onIdentifier)}]`
+        : `${optional ? '?.' : '.'}${extractMemberExpression(exp.property, NOOP)}`
       return `${object}${prop}`
     case 'TSNonNullExpression': // foo!.bar
       return `${extractMemberExpression(exp.expression, onIdentifier)}`


### PR DESCRIPTION
close #15226