### PR TITLE
fix(runtime-vapor): normalize class prop passed to components

### DIFF
--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -618,6 +618,29 @@ describe('component: props', () => {
     expect(cb).not.toHaveBeenCalled()
   })
 
+  // #15227
+  test('declared class prop should be normalized', () => {
+    let props: any
+    const { render } = define({
+      props: { class: { type: String } },
+      setup(_props: any) {
+        props = _props
+        return []
+      },
+    })
+
+    render({ class: () => ['a', { b: true, c: false }] })
+    expect(props.class).toBe('a b')
+
+    render({ class: () => '  a  b ' })
+    expect(props.class).toBe('  a  b ')
+
+    render()
+    expect(props.class).toBeUndefined()
+
+    expect('Invalid prop').not.toHaveBeenWarned()
+  })
+
   describe('dynamic props source caching', () => {
     test('v-bind object should be cached when child accesses multiple props', () => {
       let sourceCallCount = 0

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -16,7 +16,7 @@ import {
   template,
 } from '../src'
 import { resolveDynamicProps } from '../src/componentProps'
-import { makeRender } from './_utils'
+import { compile, makeRender } from './_utils'
 import { setElementText } from '../src/dom/prop'
 
 const define = makeRender<any>()
@@ -620,24 +620,64 @@ describe('component: props', () => {
 
   // #15227
   test('declared class prop should be normalized', () => {
+    const data = ref({ skin: { b: true, c: false } })
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps({ class: { type: String } })
+      </script>
+      <template><div>{{ props.class }}</div></template>`,
+      data,
+    )
+    const Parent = compile(
+      `<script setup vapor>
+        const data = _data
+        const Child = _components.Child
+      </script>
+      <template><Child class="a" :class="data.skin" /></template>`,
+      data,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe('<div>a b</div>')
+    expect('Invalid prop').not.toHaveBeenWarned()
+  })
+
+  test('class prop should only normalize the value that was passed', () => {
     let props: any
+    const fallback = ['a', 'b']
     const { render } = define({
-      props: { class: { type: String } },
+      props: { class: { default: () => fallback } },
       setup(_props: any) {
         props = _props
         return []
       },
     })
 
-    render({ class: () => ['a', { b: true, c: false }] })
-    expect(props.class).toBe('a b')
-
     render({ class: () => '  a  b ' })
     expect(props.class).toBe('  a  b ')
 
+    // class is absent or empty here, so the default is used as-is
     render()
-    expect(props.class).toBeUndefined()
+    expect(props.class).toBe(fallback)
 
+    render({ class: () => undefined })
+    expect(props.class).toBe(fallback)
+  })
+
+  test('class prop should be normalized before Boolean casting', () => {
+    let props: any
+    const { render } = define({
+      props: { class: { type: Boolean } },
+      setup(_props: any) {
+        props = _props
+        return []
+      },
+    })
+
+    // `<Child class />` casts to true and must stay true
+    render({ class: () => '' })
+    expect(props.class).toBe(true)
     expect('Invalid prop').not.toHaveBeenWarned()
   })
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -7,6 +7,7 @@ import {
   isFunction,
   isPlainObject,
   isString,
+  normalizeClass,
 } from '@vue/shared'
 import type { VaporComponent, VaporComponentInstance } from './component'
 import {
@@ -185,11 +186,7 @@ export function getPropsProxyHandlers(
           !isEmitListener(emitsOptions, key)
       : (key: string | symbol) => isString(key)
 
-  const getProp = (instance: VaporComponentInstance, key: string | symbol) => {
-    // this enables direct watching of props and prevents `Invalid watch source` DEV warnings.
-    if (key === ReactiveFlags.IS_REACTIVE) return true
-
-    if (!isProp(key)) return
+  const resolveProp = (instance: VaporComponentInstance, key: string) => {
     const rawProps = instance.rawProps
     const dynamicSources = rawProps.$
     if (dynamicSources) {
@@ -235,6 +232,17 @@ export function getPropsProxyHandlers(
       resolveDefault,
       true,
     )
+  }
+
+  const getProp = (instance: VaporComponentInstance, key: string | symbol) => {
+    // this enables direct watching of props and prevents `Invalid watch source` DEV warnings.
+    if (key === ReactiveFlags.IS_REACTIVE) return true
+
+    if (!isProp(key)) return
+    const value = resolveProp(instance, key)
+    return key === 'class' && value && !isString(value)
+      ? normalizeClass(value)
+      : value
   }
 
   const withOnceCache = <

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -186,7 +186,16 @@ export function getPropsProxyHandlers(
           !isEmitListener(emitsOptions, key)
       : (key: string | symbol) => isString(key)
 
-  const resolveProp = (instance: VaporComponentInstance, key: string) => {
+  // vdom normalizes class on the vnode, so prop resolution already receives a
+  // normalized value. Match that order here.
+  const normalizeRawProp = (key: string, value: unknown) =>
+    key === 'class' && value && !isString(value) ? normalizeClass(value) : value
+
+  const getProp = (instance: VaporComponentInstance, key: string | symbol) => {
+    // this enables direct watching of props and prevents `Invalid watch source` DEV warnings.
+    if (key === ReactiveFlags.IS_REACTIVE) return true
+
+    if (!isProp(key)) return
     const rawProps = instance.rawProps
     const dynamicSources = rawProps.$
     if (dynamicSources) {
@@ -205,7 +214,10 @@ export function getPropsProxyHandlers(
             return resolvePropValue(
               propsOptions!,
               key,
-              isDynamic ? source[rawKey] : resolveSource(source[rawKey]),
+              normalizeRawProp(
+                key,
+                isDynamic ? source[rawKey] : resolveSource(source[rawKey]),
+              ),
               instance,
               resolveDefault,
             )
@@ -218,7 +230,7 @@ export function getPropsProxyHandlers(
         return resolvePropValue(
           propsOptions!,
           key,
-          resolveSource(rawProps[rawKey]),
+          normalizeRawProp(key, resolveSource(rawProps[rawKey])),
           instance,
           resolveDefault,
         )
@@ -232,17 +244,6 @@ export function getPropsProxyHandlers(
       resolveDefault,
       true,
     )
-  }
-
-  const getProp = (instance: VaporComponentInstance, key: string | symbol) => {
-    // this enables direct watching of props and prevents `Invalid watch source` DEV warnings.
-    if (key === ReactiveFlags.IS_REACTIVE) return true
-
-    if (!isProp(key)) return
-    const value = resolveProp(instance, key)
-    return key === 'class' && value && !isString(value)
-      ? normalizeClass(value)
-      : value
   }
 
   const withOnceCache = <


### PR DESCRIPTION
close #15227

When a component declares `class` as a prop, Vapor passes the raw compiler output through, so `class="a" :class="skin"` arrives as `["a", skin]` and a `class: String` declaration fails its type check. VDOM does not hit this because `createBaseVNode` normalizes `props.class` while building the vnode.

Normalize the resolved value in the declared prop getter, using the same guard.