### PR TITLE
fix(compiler-vapor): keep optional chaining when caching member access

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/expression.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/expression.spec.ts.snap
@@ -198,6 +198,51 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: expression > cache expressions > optional chaining with repeated computed member access 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => {
+    const _obj_key = _ctx.obj?.[_ctx.key]
+    _setProp(n0, "id", _obj_key)
+    _setProp(n0, "title", _obj_key)
+  })
+  return n0
+}"
+`;
+
+exports[`compiler: expression > cache expressions > optional chaining with repeated member access 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => {
+    const _obj_foo = _ctx.obj?.foo
+    _setProp(n0, "id", _obj_foo)
+    _setProp(n0, "title", _obj_foo)
+  })
+  return n0
+}"
+`;
+
+exports[`compiler: expression > cache expressions > optional chaining with repeated mixed member access 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _renderEffect(() => {
+    const _obj_foo_bar = _ctx.obj?.foo.bar
+    _setProp(n0, "id", _obj_foo_bar)
+    _setProp(n0, "title", _obj_foo_bar)
+  })
+  return n0
+}"
+`;
+
 exports[`compiler: expression > cache expressions > overlapping repeated expressions avoid stale declarations 1`] = `
 "import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>")

--- a/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
@@ -305,6 +305,33 @@ describe('compiler: expression', () => {
       expect(code).contains('_setProp(n0, "id", _obj?.foo + _obj?.bar)')
     })
 
+    test('optional chaining with repeated member access', () => {
+      const { code } = compileWithExpression(
+        `<div :id="obj?.foo" :title="obj?.foo"></div>`,
+      )
+      expect(code).matchSnapshot()
+      expect(code).contains('const _obj_foo = _ctx.obj?.foo')
+      expect(code).contains('_setProp(n0, "id", _obj_foo)')
+    })
+
+    test('optional chaining with repeated computed member access', () => {
+      const { code } = compileWithExpression(
+        `<div :id="obj?.[key]" :title="obj?.[key]"></div>`,
+      )
+      expect(code).matchSnapshot()
+      expect(code).contains('const _obj_key = _ctx.obj?.[_ctx.key]')
+      expect(code).contains('_setProp(n0, "id", _obj_key)')
+    })
+
+    test('optional chaining with repeated mixed member access', () => {
+      const { code } = compileWithExpression(
+        `<div :id="obj?.foo.bar" :title="obj?.foo.bar"></div>`,
+      )
+      expect(code).matchSnapshot()
+      expect(code).contains('const _obj_foo_bar = _ctx.obj?.foo.bar')
+      expect(code).contains('_setProp(n0, "id", _obj_foo_bar)')
+    })
+
     test('TSNonNullExpression', () => {
       const { code } = compileWithExpression(
         `<div :id="obj!.foo + obj!.bar"></div>`,

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -1023,9 +1023,10 @@ function extractMemberExpression(
     case 'MemberExpression': // foo[bar.baz]
     case 'OptionalMemberExpression': // foo?.bar
       const object = extractMemberExpression(exp.object, onIdentifier)
+      const optional = exp.type === 'OptionalMemberExpression' && exp.optional
       const prop = exp.computed
-        ? `[${extractMemberExpression(exp.property, onIdentifier)}]`
-        : `.${extractMemberExpression(exp.property, NOOP)}`
+        ? `${optional ? '?.' : ''}[${extractMemberExpression(exp.property, onIdentifier)}]`
+        : `${optional ? '?.' : '.'}${extractMemberExpression(exp.property, NOOP)}`
       return `${object}${prop}`
     case 'TSNonNullExpression': // foo!.bar
       return `${extractMemberExpression(exp.expression, onIdentifier)}`


### PR DESCRIPTION
When the same optional member access appears more than once in a render function, Vapor hoists it into a local. The string it builds for that local came from `extractMemberExpression`, which handles `MemberExpression` and `OptionalMemberExpression` in the same branch and always writes a plain `.`, so `obj?.foo` was cached as `const _obj_foo = _ctx.obj.foo` and threw once `obj` was nullish.

#13519 fixed the case where the cached value is the object itself (`_obj?.foo + _obj?.bar`); this covers the case where the whole access is cached.

The branch now reads the node's own `optional` flag, so only the links that were optional in the source keep `?.` and `a?.b.c` still caches as `_ctx.a?.b.c`.

close #15226