### PR TITLE
fix(runtime-vapor): defer cached branch effects until activation

### DIFF
--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1697,6 +1697,54 @@ describe('VaporKeepAlive', () => {
       await nextTick()
       expect(html()).toBe(`<div>1</div><!--if-->`)
     })
+
+    test('should not update cached component with a nullish v-if prop', async () => {
+      const rendered: Array<string | undefined> = []
+      const Child = defineVaporComponent({
+        props: { item: { type: Object, required: true } },
+        setup(props: any) {
+          const n0 = template(`<div> </div>`)() as any
+          const x0 = child(n0) as any
+          renderEffect(() => {
+            const item = props.item as { id: string } | undefined
+            rendered.push(item?.id)
+            setText(x0, item?.id ?? '')
+          })
+          return n0
+        },
+      })
+
+      const items = [{ id: 'A' }, { id: 'B' }]
+      const selected = ref<(typeof items)[number] | undefined>(items[0])
+      const { html } = define({
+        setup() {
+          return createComponent(VaporKeepAlive, null, {
+            default: () =>
+              createIf(
+                () => selected.value,
+                () =>
+                  createComponent(Child, {
+                    item: () => selected.value,
+                  }),
+              ),
+          })
+        },
+      }).render()
+
+      expect(html()).toBe(`<div>A</div><!--if-->`)
+      expect(rendered).toEqual(['A'])
+
+      selected.value = undefined
+      await nextTick()
+      expect(html()).toBe(`<!--if-->`)
+      expect(rendered).toEqual(['A'])
+      expect('type check failed for prop "item"').not.toHaveBeenWarned()
+
+      selected.value = items[1]
+      await nextTick()
+      expect(html()).toBe(`<div>B</div><!--if-->`)
+      expect(rendered).toEqual(['A', 'B'])
+    })
   })
 
   test('should work with async component', async () => {

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1745,6 +1745,133 @@ describe('VaporKeepAlive', () => {
       expect(html()).toBe(`<div>B</div><!--if-->`)
       expect(rendered).toEqual(['A', 'B'])
     })
+
+    test('should replay parent removal before a deferred child update', async () => {
+      const selected = ref<{ id: string } | undefined>({ id: 'A' })
+      const childDirty = ref(0)
+      const show = ref(true)
+      const rendered: Array<string | undefined> = []
+
+      const Child = defineVaporComponent({
+        props: { item: { type: Object, required: true } },
+        setup(props: any) {
+          const n0 = template(`<div> </div>`)() as any
+          const x0 = child(n0) as any
+          renderEffect(() => {
+            void childDirty.value
+            rendered.push(props.item?.id)
+            setText(x0, props.item?.id ?? '')
+          })
+          return n0
+        },
+      })
+
+      const Pane = defineVaporComponent({
+        setup() {
+          return createIf(
+            () => selected.value,
+            () =>
+              createComponent(Child, {
+                item: () => selected.value,
+              }),
+          )
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return createComponent(VaporKeepAlive, null, {
+            default: () =>
+              createIf(
+                () => show.value,
+                () => createComponent(Pane),
+              ),
+          })
+        },
+      }).render()
+
+      expect(html()).toBe(`<div>A</div><!--if--><!--if-->`)
+      expect(rendered).toEqual(['A'])
+
+      show.value = false
+      await nextTick()
+
+      childDirty.value++
+      await nextTick()
+      selected.value = undefined
+      await nextTick()
+
+      show.value = true
+      await nextTick()
+
+      expect(html()).toBe(`<!--if--><!--if-->`)
+      expect(rendered).toEqual(['A'])
+      expect('type check failed for prop "item"').not.toHaveBeenWarned()
+    })
+  })
+
+  test('should activate async component once when resolved while deactivated', async () => {
+    let resolve: (comp: VaporComponent) => void
+    const activated = vi.fn()
+    const deactivated = vi.fn()
+    const mounted = vi.fn()
+    const AsyncComp = defineVaporAsyncComponent(
+      () =>
+        new Promise<VaporComponent>(r => {
+          resolve = r
+        }),
+    )
+    const show = ref(true)
+
+    const { html } = define({
+      setup() {
+        return createComponent(VaporKeepAlive, null, {
+          default: () =>
+            createIf(
+              () => show.value,
+              () => createComponent(AsyncComp),
+            ),
+        })
+      },
+    }).render()
+
+    expect(html()).toBe(`<!--async component--><!--if-->`)
+
+    show.value = false
+    await nextTick()
+
+    resolve!(
+      defineVaporComponent({
+        setup() {
+          onMounted(mounted)
+          onActivated(activated)
+          onDeactivated(deactivated)
+          return template(`<div>resolved</div>`)()
+        },
+      }),
+    )
+    await timeout()
+    await nextTick()
+
+    expect(html()).toBe(`<!--if-->`)
+    expect(mounted).not.toHaveBeenCalled()
+    expect(activated).not.toHaveBeenCalled()
+
+    show.value = true
+    await nextTick()
+
+    expect(html()).toBe(`<div>resolved</div><!--async component--><!--if-->`)
+    expect(mounted).toHaveBeenCalledTimes(1)
+    expect(activated).toHaveBeenCalledTimes(1)
+
+    show.value = false
+    await nextTick()
+    expect(deactivated).toHaveBeenCalledTimes(1)
+
+    show.value = true
+    await nextTick()
+    expect(mounted).toHaveBeenCalledTimes(1)
+    expect(activated).toHaveBeenCalledTimes(2)
   })
 
   test('should work with async component', async () => {

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -135,7 +135,13 @@ function setTemplateRefWithState(
       // KeepAlive clears refs on deactivation but keeps this fragment update
       // callback alive. Skip re-applying refs for async/offscreen updates
       // until the component is activated again.
-      if (isVaporComponent(el) && el.isDeactivated) return
+      if (
+        isVaporComponent(el) &&
+        el.isDeactivated &&
+        el.keepAliveUpdatePaused !== false
+      ) {
+        return
+      }
       state.oldRef = setRef(
         instance,
         state.suspense,
@@ -179,7 +185,13 @@ export function setStaticTemplateRef(
     // Static refs do not need old-ref tracking, but async/dynamic component
     // targets still need to re-apply the same ref after their fragment updates.
     ;(frag.onUpdated ||= []).push(() => {
-      if (isVaporComponent(el) && el.isDeactivated) return
+      if (
+        isVaporComponent(el) &&
+        el.isDeactivated &&
+        el.keepAliveUpdatePaused !== false
+      ) {
+        return
+      }
       setRef(instance, suspense, el, ref, oldRef, refFor, refKey)
     })
   }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -734,6 +734,8 @@ export class VaporComponentInstance<
   // for keep-alive
   shapeFlag?: number
   $key?: any
+  keepAliveUpdatePaused?: boolean
+  deferredKeepAliveEffects?: Set<RenderEffect>
   // Share deferred updates across async roots on the KeepAlive component-root
   // chain so A(pending) -> B -> A renders only the final branch, matching VDOM.
   deferredKeepAliveUpdates?: DeferredKeepAliveUpdates

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -1,11 +1,13 @@
 import {
   type AsyncComponentInternalOptions,
+  ErrorCodes,
   type GenericComponent,
   type GenericComponentInstance,
   type KeepAliveProps,
   MoveType,
   type SuspenseBoundary,
   type VNode,
+  callWithErrorHandling,
   currentInstance,
   devtoolsComponentAdded,
   getComponentName,
@@ -611,7 +613,30 @@ export function activate(
   anchor?: Node | null,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
+  instance.keepAliveUpdatePaused = false
+  // Deferred effects may update async fragments and their template refs while
+  // the branch is being restored, so expose the active state before replay.
+  if (isAsyncWrapper(instance)) instance.isDeactivated = false
   move(instance, parentNode, anchor, MoveType.ENTER, instance, parentSuspense)
+
+  const deferredEffects = instance.deferredKeepAliveEffects
+  if (deferredEffects) {
+    instance.deferredKeepAliveEffects = undefined
+    deferredEffects.forEach(effect => {
+      let current: GenericComponentInstance | null = effect.i
+      while (current) {
+        if (isVaporComponent(current) && current.keepAliveUpdatePaused) {
+          ;(current.deferredKeepAliveEffects ||= new Set()).add(effect)
+          return
+        }
+        current = current.parent
+      }
+      if (effect.active) {
+        callWithErrorHandling(effect.job, effect.i, ErrorCodes.COMPONENT_UPDATE)
+      }
+      effect.resume()
+    })
+  }
 
   queuePostRenderEffect(
     () => {
@@ -632,6 +657,11 @@ export function deactivate(
   container: ParentNode,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
+  // Parent-owned prop sources remain reactive after the branch is cached.
+  // Block their queued render effects until activation so the cached subtree
+  // cannot observe an intermediate value that made its v-if branch inactive.
+  instance.keepAliveUpdatePaused = true
+
   // Clear refs before deactivation, matching VDOM core's unmount path
   // which calls setRef(null) before the deactivation check.
   unsetRef(instance)

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -614,15 +614,16 @@ export function activate(
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
   instance.keepAliveUpdatePaused = false
-  // Deferred effects may update async fragments and their template refs while
-  // the branch is being restored, so expose the active state before replay.
-  if (isAsyncWrapper(instance)) instance.isDeactivated = false
   move(instance, parentNode, anchor, MoveType.ENTER, instance, parentSuspense)
 
   const deferredEffects = instance.deferredKeepAliveEffects
   if (deferredEffects) {
     instance.deferredKeepAliveEffects = undefined
-    deferredEffects.forEach(effect => {
+    const effects = [...deferredEffects]
+    if (effects.length > 1) {
+      effects.sort((a, b) => a.job.order! - b.job.order!)
+    }
+    effects.forEach(effect => {
       let current: GenericComponentInstance | null = effect.i
       while (current) {
         if (isVaporComponent(current) && current.keepAliveUpdatePaused) {

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -1,5 +1,6 @@
 import { EffectFlags, type EffectScope, ReactiveEffect } from '@vue/reactivity'
 import {
+  type GenericComponentInstance,
   type SchedulerJob,
   SchedulerJobFlags,
   currentInstance,
@@ -58,6 +59,14 @@ export class RenderEffect extends ReactiveEffect {
           settleDeferredKeepAliveUpdates(deferred, this.job)
           return
         }
+
+        const keepAliveRoot = this.i && findPausedKeepAliveRoot(this.i)
+        if (keepAliveRoot) {
+          this.pause()
+          ;(keepAliveRoot.deferredKeepAliveEffects ||= new Set()).add(this)
+          return
+        }
+
         this.run()
       }
     }
@@ -142,4 +151,16 @@ export function renderEffect(fn: () => void, noLifecycle = false): void {
 
   const effect = new RenderEffect(fn, noLifecycle)
   effect.run()
+}
+
+function findPausedKeepAliveRoot(
+  instance: VaporComponentInstance,
+): VaporComponentInstance | undefined {
+  let current: GenericComponentInstance | null = instance
+  while (current) {
+    if (isVaporComponent(current) && current.keepAliveUpdatePaused) {
+      return current
+    }
+    current = current.parent
+  }
 }

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -21,6 +21,7 @@ import {
 import { inOnceSlot } from './componentSlots'
 import { invokeArrayFns } from '@vue/shared'
 import { isSuspenseEnabled } from './suspense'
+import { isKeepAliveEnabled } from './keepAlive'
 
 export class RenderEffect extends ReactiveEffect {
   i: VaporComponentInstance | null
@@ -60,7 +61,8 @@ export class RenderEffect extends ReactiveEffect {
           return
         }
 
-        const keepAliveRoot = this.i && findPausedKeepAliveRoot(this.i)
+        const keepAliveRoot =
+          isKeepAliveEnabled && this.i && findPausedKeepAliveRoot(this.i)
         if (keepAliveRoot) {
           this.pause()
           ;(keepAliveRoot.deferredKeepAliveEffects ||= new Set()).add(this)


### PR DESCRIPTION
## Summary

- pause cached Vapor branch render effects after KeepAlive deactivation so they cannot consume transient parent prop values
- synchronously replay the latest dirty effects on activation, including nested KeepAlive and async-wrapper cases
- add a regression test covering the nullish guarded-prop tick and fresh-value reactivation

## Tests

- `pnpm test --project unit-jsdom packages/runtime-vapor`
- `pnpm test --project unit-jsdom packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts`
- `pnpm check`
- targeted lint and format checks for the changed files

Closes #15228