### PR TITLE
fix(compiler-sfc): scope non-:deep() members in selector list with nesting

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -195,6 +195,29 @@ color: red
     `)
   })
 
+  test(':deep() with selector list + nesting (issue #15205)', () => {
+    // Non-:deep() members of a comma selector list should retain scope
+    // even when another member uses :deep(). See #15205.
+    expect(
+      compileScoped(`
+.a,
+.b :deep(.c) {
+  color: red;
+  > span { color: blue; }
+}
+`),
+    ).toMatchInlineSnapshot(`
+      "
+      .a[data-v-test],
+      .b[data-v-test] .c {
+        color: red;
+      > span { color: blue;
+      }
+      }
+      "
+    `)
+  })
+
   test('::v-slotted', () => {
     expect(compileScoped(`:slotted(.foo) { color: red; }`))
       .toMatchInlineSnapshot(`

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -84,6 +84,17 @@ function processRule(id: string, rule: Rule) {
     }
     parent = parent.parent
   }
+  // Pre-scan: if any selector in this rule contains :deep(), set rule.__deep
+  // before processing individual selectors. This prevents non-:deep() members
+  // of a comma selector list from being processed with stale __deep state.
+  // See #15205.
+  selectorParser(root => {
+    root.walkPseudos(n => {
+      if (n.value === ':deep' || n.value === '::v-deep') {
+        ;(rule as any).__deep = true
+      }
+    })
+  }).processSync(rule.selector)
   rule.selector = selectorParser(selectorRoot => {
     selectorRoot.each(selector => {
       rewriteSelector(id, rule, selector, selectorRoot, deep)


### PR DESCRIPTION
## Description

When a `<style scoped>` rule has a comma-separated selector list where one member uses `:deep()` and the rule contains nested child rules, non-` :deep()` members lose their `[data-v-xxx]` scope attribute.

### Reproduction

```css
.a,
.b :deep(.c) {
  color: red;
  > span { color: blue; }
}
```

**Before (bug):** `.a` is unscoped — it leaks globally:

```css
.a,
.b[data-v-xxx] .c {
  color: red;
  > span { color: blue; }
}
```

**After (fix):** `.a` retains its scope:

```css
.a[data-v-xxx],
.b[data-v-xxx] .c {
  color: red;
  > span { color: blue; }
}
```

### Root cause

`rule.__deep` is set per-rule (by any selector containing `:deep()`) but read per-selector in `rewriteSelector`. When `.a` is processed before `.b :deep(.c)`, `rule.__deep` is still `false`, causing `extractAndWrapNodes` to run and wrap declarations in a `& {}` block. Then `.b :deep(.c)` sets `rule.__deep = true`, and the subsequent `shouldInject = rule.__deep` overwrites the per-selector decision for `.a`, causing scope injection to be skipped.

### Fix

Pre-scan the rule's selector for `:deep()` before processing individual selectors, setting `rule.__deep` upfront so all selectors see consistent state. This ensures non-`:deep()` members get scope injected on the selector itself, matching the behavior of non-nested selector lists.

Note: nested child rules (`> span`) inside a `:deep()` rule do not receive scope, which is consistent with existing `:deep()` nesting behavior (see existing test for `:deep(.foo) { color: red; .bar { color: red; } }`).

Closes #15205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scoped CSS compilation for comma-separated selectors containing deep selectors.
  * Ensured regular selectors retain their scope attributes while nested declarations and deep selectors compile correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->