### PR TITLE
fix(runtime-vapor): flush unmounted hooks on app unmount

### DIFF
--- a/packages/runtime-vapor/__tests__/apiLifecycle.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiLifecycle.spec.ts
@@ -310,7 +310,6 @@ describe('api: lifecycle hooks', () => {
 
     // unmount
     ctx.app.unmount()
-    await nextTick()
     expect(calls).toEqual([
       'root onBeforeUnmount',
       'mid onBeforeUnmount',

--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -649,6 +649,87 @@ describe('effects in pending branches', () => {
     },
   )
 
+  test.each(['vdom', 'vapor'] as const)(
+    '%s nested unmounted hooks run when a pending boundary is removed by app unmount',
+    async kind => {
+      const asyncSetup = deferred()
+      const order: string[] = []
+      const vapor = kind === 'vapor'
+      const script = vapor ? '<script vapor>' : '<script setup>'
+      const data = ref({ asyncSetup, order })
+      const Child = compile(
+        `${script}
+          import { onUnmounted } from 'vue'
+          const data = _data
+          onUnmounted(() => data.value.order.push('child'))
+        </script>
+        <template><span>child</span></template>`,
+        data,
+        {},
+        { vapor },
+      )
+      const Parent = compile(
+        `${script}
+          import { onUnmounted } from 'vue'
+          const data = _data
+          const components = _components
+          onUnmounted(() => data.value.order.push('parent'))
+        </script>
+        <template><components.Child /></template>`,
+        data,
+        { Child },
+        { vapor },
+      )
+      const AsyncSibling = compile(
+        `<script setup>
+          const data = _data
+          await data.value.asyncSetup.promise
+        </script>
+        <template><span>async</span></template>`,
+        data,
+        {},
+        { vapor: false },
+      )
+      const VDomHost = compile(
+        `<script setup>
+          const components = _components
+        </script>
+        <template>
+          <Suspense>
+            <div>
+              <components.Parent />
+              <components.AsyncSibling />
+            </div>
+            <template #fallback><span>loading</span></template>
+          </Suspense>
+        </template>`,
+        data,
+        { Parent, AsyncSibling },
+        { vapor: false },
+      )
+      const VaporRoot = compile(
+        `<script vapor>
+          const components = _components
+        </script>
+        <template><components.VDomHost /></template>`,
+        data,
+        { VDomHost },
+      )
+      const container = document.createElement('div')
+      const app = runtimeVapor.createVaporApp(VaporRoot)
+      app.use(vaporInteropPlugin)
+      app.mount(container)
+
+      expect(container.textContent).toBe('loading')
+
+      app.unmount()
+
+      expect(order).toEqual(['child', 'parent'])
+      asyncSetup.resolve()
+      await flushResolution(asyncSetup.promise)
+    },
+  )
+
   test('keep-alive lifecycle and vnode hooks wait for the branch to resolve', async () => {
     const asyncSetup = deferred()
     const current = ref<'A' | 'B'>('A')

--- a/packages/runtime-vapor/src/apiCreateApp.ts
+++ b/packages/runtime-vapor/src/apiCreateApp.ts
@@ -92,6 +92,7 @@ const unmountApp: AppUnmountFn = app => {
   const instance = ((__DEV__ && app._instance) ||
     rootInstances.get(app)!) as VaporComponentInstance
   unmountComponent(instance, app._container)
+  flushOnAppMount(instance)
   rootInstances.delete(app)
 }
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1278,10 +1278,36 @@ export function mountComponent(
   }
 }
 
+// Propagate boundary-removal context through nested scope teardown.
+// `undefined` means there is no active override.
+let currentUnmountSuspense: SuspenseBoundary | null | undefined
+
 export function unmountComponent(
   instance: VaporComponentInstance,
   parentNode?: ParentNode,
-  parentSuspense: SuspenseBoundary | null = instance.suspense,
+  parentSuspense: SuspenseBoundary | null = __FEATURE_SUSPENSE__ &&
+  isSuspenseEnabled &&
+  currentUnmountSuspense !== undefined
+    ? currentUnmountSuspense
+    : instance.suspense,
+): void {
+  if (__FEATURE_SUSPENSE__ && isSuspenseEnabled) {
+    const prevUnmountSuspense = currentUnmountSuspense
+    currentUnmountSuspense = parentSuspense
+    try {
+      unmountComponentImpl(instance, parentNode, parentSuspense)
+    } finally {
+      currentUnmountSuspense = prevUnmountSuspense
+    }
+  } else {
+    unmountComponentImpl(instance, parentNode, parentSuspense)
+  }
+}
+
+function unmountComponentImpl(
+  instance: VaporComponentInstance,
+  parentNode: ParentNode | undefined,
+  parentSuspense: SuspenseBoundary | null,
 ): void {
   // Skip unmount for kept-alive components - deactivate if called from remove()
   if (


### PR DESCRIPTION
## Summary

- flush Vapor post-render hooks before `app.unmount()` returns, matching the VDOM root teardown path
- make the existing lifecycle-order test verify root and descendant `onUnmounted` hooks synchronously

## Root cause

`unmountComponent()` queues `onUnmounted` through `queuePostRenderEffect()`, but Vapor's `unmountApp()` did not flush the post-render queue. The hook could run on a later scheduler flush, while VDOM root unmount already calls `flushOnAppMount(instance)` before returning. The test's `await nextTick()` masked this difference.

Passing the root instance to `flushOnAppMount()` also preserves the existing cross-app pre-flush isolation used by the VDOM path.

## Testing

- `vp run test runtime-vapor` (47 files, 1709 passed, 2 expected failures, 15 todo)
- `vp run check`
- `vp run lint`
- `vp fmt --check packages/runtime-vapor/src/apiCreateApp.ts packages/runtime-vapor/__tests__/apiLifecycle.spec.ts`

Closes #15234
