### PR TITLE
fix(runtime-vapor): pause KeepAlive scopes when deactivated

### DIFF
--- a/packages/reactivity/__tests__/effectScope.spec.ts
+++ b/packages/reactivity/__tests__/effectScope.spec.ts
@@ -324,6 +324,30 @@ describe('reactivity/effect/scope', () => {
     expect(fnSpy).toHaveBeenCalledTimes(3)
   })
 
+  it('should pause effects created in a paused scope', () => {
+    const count = ref(0)
+    const effectSpy = vi.fn(() => count.value)
+    const nestedEffectSpy = vi.fn(() => count.value)
+    const scope = effectScope()
+
+    scope.pause()
+    scope.run(() => {
+      effect(effectSpy)
+      effectScope().run(() => effect(nestedEffectSpy))
+    })
+
+    expect(effectSpy).toHaveBeenCalledOnce()
+    expect(nestedEffectSpy).toHaveBeenCalledOnce()
+
+    count.value++
+    expect(effectSpy).toHaveBeenCalledOnce()
+    expect(nestedEffectSpy).toHaveBeenCalledOnce()
+
+    scope.resume()
+    expect(effectSpy).toHaveBeenCalledTimes(2)
+    expect(nestedEffectSpy).toHaveBeenCalledTimes(2)
+  })
+
   test('removing a watcher while stopping its effectScope', async () => {
     const count = ref(0)
     const scope = effectScope()

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -89,6 +89,8 @@ export class ReactiveEffect<T = any>
     }
     if (activeEffectScope) {
       link(this, activeEffectScope)
+      // pause() only visits existing effects, so inherit the current state.
+      this.flags |= activeEffectScope.flags & EffectFlags.PAUSED
     }
   }
 

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -23,6 +23,8 @@ export class EffectScope implements ReactiveNode {
   constructor(detached = false) {
     if (!detached && activeEffectScope) {
       link(this, activeEffectScope)
+      // pause() only visits existing child scopes, so inherit the current state.
+      this.flags |= activeEffectScope.flags & EffectFlags.PAUSED
     }
   }
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -159,7 +159,8 @@ class RenderWatcherEffect extends WatcherEffect {
     super(source, cb, options)
 
     const job: SchedulerJob = () => {
-      if (this.dirty) {
+      // The job may have been queued before its scope was paused.
+      if (!(this.flags & EffectFlags.PAUSED) && this.dirty) {
         this.run()
       }
     }

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1738,8 +1738,9 @@ describe('VaporKeepAlive', () => {
     expect('type check failed for prop "item"').not.toHaveBeenWarned()
   })
 
-  test('should pause nested cached component effects', async () => {
+  test('should pause effects under nested KeepAlive boundaries', async () => {
     const toggle = ref(true)
+    const innerToggle = ref(true)
     const count = ref(0)
     const render = vi.fn()
     const watcher = vi.fn()
@@ -1757,7 +1758,13 @@ describe('VaporKeepAlive', () => {
     })
     const CachedRoot = defineVaporComponent({
       setup() {
-        return createComponent(NestedChild)
+        return createComponent(VaporKeepAlive, null, {
+          default: () =>
+            createIf(
+              () => innerToggle.value,
+              () => createComponent(NestedChild),
+            ),
+        })
       },
     })
     const { html } = define({
@@ -1782,9 +1789,16 @@ describe('VaporKeepAlive', () => {
     expect(render).toHaveBeenCalledTimes(1)
     expect(watcher).not.toHaveBeenCalled()
 
+    innerToggle.value = false
+    await nextTick()
+    innerToggle.value = true
+    await nextTick()
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(watcher).not.toHaveBeenCalled()
+
     toggle.value = true
     await nextTick()
-    expect(html()).toBe(`<div>2</div><!--if-->`)
+    expect(html()).toBe(`<div>2</div><!--if--><!--if-->`)
     expect(render).toHaveBeenCalledTimes(2)
     expect(watcher).toHaveBeenCalledOnce()
   })
@@ -1792,14 +1806,34 @@ describe('VaporKeepAlive', () => {
   test('should pause component effects created while cached', async () => {
     let resolve: (comp: VaporComponent) => void
     let increment: () => void
+    const loadingCount = ref(0)
+    const loadingRender = vi.fn()
     const render = vi.fn()
     const watcher = vi.fn()
-    const AsyncComp = defineVaporAsyncComponent(
-      () =>
+    const LoadingComp = defineVaporComponent({
+      setup() {
+        const n0 = template(`<span> </span>`)() as any
+        const x0 = child(n0) as any
+        renderEffect(() => {
+          loadingRender()
+          setText(x0, String(loadingCount.value))
+        })
+        return n0
+      },
+    })
+    const AsyncComp = defineVaporAsyncComponent({
+      loader: () =>
         new Promise(r => {
           resolve = r as any
         }),
-    )
+      loadingComponent: LoadingComp,
+      delay: 0,
+    })
+    const CachedRoot = defineVaporComponent({
+      setup() {
+        return createComponent(AsyncComp)
+      },
+    })
     const toggle = ref(true)
     const { html } = define({
       setup() {
@@ -1807,14 +1841,19 @@ describe('VaporKeepAlive', () => {
           default: () =>
             createIf(
               () => toggle.value,
-              () => createComponent(AsyncComp),
+              () => createComponent(CachedRoot),
             ),
         })
       },
     }).render()
 
+    expect(loadingRender).toHaveBeenCalledOnce()
+
     toggle.value = false
     await nextTick()
+    loadingCount.value++
+    await nextTick()
+    expect(loadingRender).toHaveBeenCalledOnce()
 
     resolve!(
       defineVaporComponent({

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -12,6 +12,7 @@ import {
   ref,
   shallowRef,
   vModelText,
+  watch,
   withDirectives,
 } from 'vue'
 import {
@@ -1697,6 +1698,166 @@ describe('VaporKeepAlive', () => {
       await nextTick()
       expect(html()).toBe(`<div>1</div><!--if-->`)
     })
+  })
+
+  test('should not update a cached child while deactivating it', async () => {
+    const Child = compile(
+      `<script setup vapor>
+        defineProps({ item: { type: Object, required: true } })
+      </script>
+      <template><p>child: {{ item.id }}</p></template>`,
+      ref(),
+    )
+    const selected = ref<{ id: string } | undefined>({ id: 'A' })
+    const App = compile(
+      `<script setup vapor>
+        const selected = _data
+        const Child = _components.Child
+      </script>
+      <template>
+        <KeepAlive>
+          <Child v-if="selected" :item="selected" />
+        </KeepAlive>
+      </template>`,
+      selected,
+      { Child },
+    )
+    const { host } = define(App).render()
+
+    expect(host.textContent).toBe('child: A')
+
+    for (const id of ['B', 'A', 'B']) {
+      selected.value = undefined
+      await nextTick()
+      expect(host.innerHTML).toBe('<!--if-->')
+
+      selected.value = { id }
+      await nextTick()
+      expect(host.textContent).toBe(`child: ${id}`)
+    }
+    expect('type check failed for prop "item"').not.toHaveBeenWarned()
+  })
+
+  test('should pause nested cached component effects', async () => {
+    const toggle = ref(true)
+    const count = ref(0)
+    const render = vi.fn()
+    const watcher = vi.fn()
+    const NestedChild = defineVaporComponent({
+      setup() {
+        watch(count, watcher)
+        const n0 = template(`<div> </div>`)() as any
+        const x0 = child(n0) as any
+        renderEffect(() => {
+          render()
+          setText(x0, String(count.value))
+        })
+        return n0
+      },
+    })
+    const CachedRoot = defineVaporComponent({
+      setup() {
+        return createComponent(NestedChild)
+      },
+    })
+    const { html } = define({
+      setup() {
+        return createComponent(VaporKeepAlive, null, {
+          default: () =>
+            createIf(
+              () => toggle.value,
+              () => createComponent(CachedRoot),
+            ),
+        })
+      },
+    }).render()
+
+    expect(render).toHaveBeenCalledTimes(1)
+
+    count.value = 1
+    toggle.value = false
+    await nextTick()
+    count.value = 2
+    await nextTick()
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(watcher).not.toHaveBeenCalled()
+
+    toggle.value = true
+    await nextTick()
+    expect(html()).toBe(`<div>2</div><!--if-->`)
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(watcher).toHaveBeenCalledOnce()
+  })
+
+  test('should pause component effects created while cached', async () => {
+    let resolve: (comp: VaporComponent) => void
+    let increment: () => void
+    const render = vi.fn()
+    const watcher = vi.fn()
+    const AsyncComp = defineVaporAsyncComponent(
+      () =>
+        new Promise(r => {
+          resolve = r as any
+        }),
+    )
+    const toggle = ref(true)
+    const { html } = define({
+      setup() {
+        return createComponent(VaporKeepAlive, null, {
+          default: () =>
+            createIf(
+              () => toggle.value,
+              () => createComponent(AsyncComp),
+            ),
+        })
+      },
+    }).render()
+
+    toggle.value = false
+    await nextTick()
+
+    resolve!(
+      defineVaporComponent({
+        setup() {
+          const count = ref(0)
+          increment = () => count.value++
+          watch(count, watcher)
+          const n0 = template(`<p> </p>`)() as any
+          const x0 = child(n0) as any
+          renderEffect(() => {
+            render()
+            setText(x0, String(count.value))
+          })
+          return n0
+        },
+      }),
+    )
+    await timeout()
+    expect(render).toHaveBeenCalledOnce()
+
+    increment!()
+    await nextTick()
+    expect(render).toHaveBeenCalledOnce()
+    expect(watcher).not.toHaveBeenCalled()
+
+    toggle.value = true
+    await nextTick()
+    expect(html()).toBe('<p>1</p><!--async component--><!--if-->')
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(watcher).toHaveBeenCalledOnce()
+
+    toggle.value = false
+    await nextTick()
+    increment!()
+    await nextTick()
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(watcher).toHaveBeenCalledOnce()
+
+    toggle.value = true
+    await nextTick()
+    expect(html()).toBe('<p>2</p><!--async component--><!--if-->')
+    expect(render).toHaveBeenCalledTimes(3)
+    expect(watcher).toHaveBeenCalledTimes(2)
   })
 
   test('should work with async component', async () => {

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1726,15 +1726,113 @@ describe('VaporKeepAlive', () => {
 
     expect(host.textContent).toBe('child: A')
 
-    for (const id of ['B', 'A', 'B']) {
-      selected.value = undefined
-      await nextTick()
-      expect(host.innerHTML).toBe('<!--if-->')
+    selected.value = undefined
+    await nextTick()
+    expect(host.innerHTML).toBe('<!--if-->')
 
-      selected.value = { id }
-      await nextTick()
-      expect(host.textContent).toBe(`child: ${id}`)
-    }
+    selected.value = { id: 'B' }
+    await nextTick()
+    expect(host.textContent).toBe('child: B')
+    expect('type check failed for prop "item"').not.toHaveBeenWarned()
+  })
+
+  test('should not update a nested KeepAlive slot while its owner is cached', async () => {
+    const Child = compile(
+      `<script setup vapor>
+        defineProps({ item: { type: Object, required: true } })
+      </script>
+      <template><p>child: {{ item.id }}</p></template>`,
+      ref(),
+    )
+    const Nested = compile(
+      `<script setup vapor>
+        defineProps({ item: { type: Object, required: true } })
+        const Child = _components.Child
+      </script>
+      <template>
+        <KeepAlive>
+          <Child v-if="item.visible" :item="item" />
+        </KeepAlive>
+      </template>`,
+      ref(),
+      { Child },
+    )
+    const selected = ref<{ id: string; visible: boolean } | undefined>({
+      id: 'A',
+      visible: true,
+    })
+    const App = compile(
+      `<script setup vapor>
+        const selected = _data
+        const Nested = _components.Nested
+      </script>
+      <template>
+        <KeepAlive>
+          <Nested v-if="selected" :item="selected" />
+        </KeepAlive>
+      </template>`,
+      selected,
+      { Nested },
+    )
+    const { host } = define(App).render()
+
+    expect(host.textContent).toBe('child: A')
+
+    selected.value = undefined
+    await nextTick()
+    expect(host.innerHTML).toBe('<!--if-->')
+
+    selected.value = { id: 'B', visible: true }
+    await nextTick()
+    expect(host.textContent).toBe('child: B')
+    expect('type check failed for prop "item"').not.toHaveBeenWarned()
+  })
+
+  test('should defer resolving a cached async component until activation', async () => {
+    let resolve: (comp: VaporComponent) => void
+    const setups = ref(0)
+    const Child = compile(
+      `<script setup vapor>
+        const setups = _data
+        setups.value++
+        defineProps({ item: { type: Object, required: true } })
+      </script>
+      <template><p>child: {{ item.id }}</p></template>`,
+      setups,
+    )
+    const AsyncChild = defineVaporAsyncComponent(
+      () =>
+        new Promise(r => {
+          resolve = r as any
+        }),
+    )
+    const selected = ref<{ id: string } | undefined>({ id: 'A' })
+    const App = compile(
+      `<script setup vapor>
+        const selected = _data
+        const AsyncChild = _components.AsyncChild
+      </script>
+      <template>
+        <KeepAlive>
+          <AsyncChild v-if="selected" :item="selected" />
+        </KeepAlive>
+      </template>`,
+      selected,
+      { AsyncChild },
+    )
+    const { host } = define(App).render()
+
+    selected.value = undefined
+    await nextTick()
+    resolve!(Child)
+    await timeout()
+
+    expect(setups.value).toBe(0)
+
+    selected.value = { id: 'B' }
+    await nextTick()
+    expect(setups.value).toBe(1)
+    expect(host.textContent).toBe('child: B')
     expect('type check failed for prop "item"').not.toHaveBeenWarned()
   })
 
@@ -1744,6 +1842,7 @@ describe('VaporKeepAlive', () => {
     const count = ref(0)
     const render = vi.fn()
     const watcher = vi.fn()
+    const providerWatcher = vi.fn()
     const NestedChild = defineVaporComponent({
       setup() {
         watch(count, watcher)
@@ -1758,6 +1857,14 @@ describe('VaporKeepAlive', () => {
     })
     const CachedRoot = defineVaporComponent({
       setup() {
+        watch(
+          count,
+          value => {
+            providerWatcher()
+            if (value === 2) innerToggle.value = false
+          },
+          { flush: 'sync' },
+        )
         return createComponent(VaporKeepAlive, null, {
           default: () =>
             createIf(
@@ -1787,6 +1894,7 @@ describe('VaporKeepAlive', () => {
     count.value = 2
     await nextTick()
     expect(render).toHaveBeenCalledTimes(1)
+    expect(providerWatcher).toHaveBeenCalledOnce()
     expect(watcher).not.toHaveBeenCalled()
 
     innerToggle.value = false
@@ -1798,105 +1906,16 @@ describe('VaporKeepAlive', () => {
 
     toggle.value = true
     await nextTick()
+    expect(html()).toBe(`<!--if--><!--if-->`)
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(providerWatcher).toHaveBeenCalledTimes(2)
+    expect(watcher).not.toHaveBeenCalled()
+
+    innerToggle.value = true
+    await nextTick()
     expect(html()).toBe(`<div>2</div><!--if--><!--if-->`)
     expect(render).toHaveBeenCalledTimes(2)
     expect(watcher).toHaveBeenCalledOnce()
-  })
-
-  test('should pause component effects created while cached', async () => {
-    let resolve: (comp: VaporComponent) => void
-    let increment: () => void
-    const loadingCount = ref(0)
-    const loadingRender = vi.fn()
-    const render = vi.fn()
-    const watcher = vi.fn()
-    const LoadingComp = defineVaporComponent({
-      setup() {
-        const n0 = template(`<span> </span>`)() as any
-        const x0 = child(n0) as any
-        renderEffect(() => {
-          loadingRender()
-          setText(x0, String(loadingCount.value))
-        })
-        return n0
-      },
-    })
-    const AsyncComp = defineVaporAsyncComponent({
-      loader: () =>
-        new Promise(r => {
-          resolve = r as any
-        }),
-      loadingComponent: LoadingComp,
-      delay: 0,
-    })
-    const CachedRoot = defineVaporComponent({
-      setup() {
-        return createComponent(AsyncComp)
-      },
-    })
-    const toggle = ref(true)
-    const { html } = define({
-      setup() {
-        return createComponent(VaporKeepAlive, null, {
-          default: () =>
-            createIf(
-              () => toggle.value,
-              () => createComponent(CachedRoot),
-            ),
-        })
-      },
-    }).render()
-
-    expect(loadingRender).toHaveBeenCalledOnce()
-
-    toggle.value = false
-    await nextTick()
-    loadingCount.value++
-    await nextTick()
-    expect(loadingRender).toHaveBeenCalledOnce()
-
-    resolve!(
-      defineVaporComponent({
-        setup() {
-          const count = ref(0)
-          increment = () => count.value++
-          watch(count, watcher)
-          const n0 = template(`<p> </p>`)() as any
-          const x0 = child(n0) as any
-          renderEffect(() => {
-            render()
-            setText(x0, String(count.value))
-          })
-          return n0
-        },
-      }),
-    )
-    await timeout()
-    expect(render).toHaveBeenCalledOnce()
-
-    increment!()
-    await nextTick()
-    expect(render).toHaveBeenCalledOnce()
-    expect(watcher).not.toHaveBeenCalled()
-
-    toggle.value = true
-    await nextTick()
-    expect(html()).toBe('<p>1</p><!--async component--><!--if-->')
-    expect(render).toHaveBeenCalledTimes(2)
-    expect(watcher).toHaveBeenCalledOnce()
-
-    toggle.value = false
-    await nextTick()
-    increment!()
-    await nextTick()
-    expect(render).toHaveBeenCalledTimes(2)
-    expect(watcher).toHaveBeenCalledOnce()
-
-    toggle.value = true
-    await nextTick()
-    expect(html()).toBe('<p>2</p><!--async component--><!--if-->')
-    expect(render).toHaveBeenCalledTimes(3)
-    expect(watcher).toHaveBeenCalledTimes(2)
   })
 
   test('should work with async component', async () => {

--- a/packages/runtime-vapor/__tests__/renderEffect.spec.ts
+++ b/packages/runtime-vapor/__tests__/renderEffect.spec.ts
@@ -137,6 +137,20 @@ describe('renderEffect', () => {
     expect(dummy).toBe(3)
   })
 
+  test('defers the initial run in a paused scope', async () => {
+    const scope = new EffectScope()
+    const render = vi.fn()
+    scope.pause()
+
+    scope.run(() => renderEffect(render))
+    expect(render).not.toHaveBeenCalled()
+
+    scope.resume()
+    await nextTick()
+    expect(render).toHaveBeenCalledOnce()
+    scope.stop()
+  })
+
   test('should run with the scheduling order', async () => {
     const calls: string[] = []
 

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -40,6 +40,7 @@ import { VaporDynamicComponentFlags, VaporSlotFlags } from '@vue/shared'
 import { VaporSlot } from '../../runtime-core/src/vnode'
 import { compile, makeInteropRender } from './_utils'
 import {
+  type VaporComponent,
   type VaporComponentInstance,
   type VaporDirective,
   VaporKeepAlive,
@@ -4378,11 +4379,76 @@ describe('vdomInterop', () => {
   })
 
   describe('Suspense', () => {
-    function deferred() {
-      let resolve!: () => void
-      const promise = new Promise<void>(r => (resolve = r))
+    function deferred<T = void>() {
+      let resolve!: (value: T) => void
+      const promise = new Promise<T>(r => (resolve = r))
       return { promise, resolve }
     }
+
+    test('defers resolving an async component while its KeepAlive branch is deactivated', async () => {
+      const pending = deferred<VaporComponent>()
+      const setups = vi.fn()
+      const data = ref({
+        selected: { id: 'A' } as { id: string } | undefined,
+        setups,
+      })
+      const Child = compile(
+        `<script vapor>
+          const data = _data
+          data.value.setups()
+          defineProps({ item: { type: Object, required: true } })
+        </script>
+        <template><p>child: {{ item.id }}</p></template>`,
+        data,
+      )
+      const AsyncChild = defineVaporAsyncComponent(() => pending.promise)
+      const VaporParent = compile(
+        `<script setup vapor>
+          const data = _data
+          const AsyncChild = _components.AsyncChild
+          const VaporKeepAlive = _components.VaporKeepAlive
+        </script>
+        <template>
+          <VaporKeepAlive>
+            <AsyncChild v-if="data.selected" :item="data.selected" />
+          </VaporKeepAlive>
+        </template>`,
+        data,
+        { AsyncChild, VaporKeepAlive },
+      )
+      const host = document.createElement('div')
+      const app = createApp({
+        render: () =>
+          h(Suspense, null, {
+            default: () => h(VaporParent),
+            fallback: () => h('p', 'pending'),
+          }),
+      })
+      app.use(vaporInteropPlugin)
+
+      try {
+        app.mount(host)
+        data.value.selected = undefined
+        await nextTick()
+
+        pending.resolve(Child)
+        await flushResolution(pending.promise)
+        await new Promise(r => setTimeout(r))
+
+        expect(setups).not.toHaveBeenCalled()
+
+        data.value.selected = { id: 'B' }
+        await nextTick()
+        expect(setups).toHaveBeenCalledOnce()
+        expect(host.textContent).toBe('child: B')
+        expect('type check failed for prop "item"').not.toHaveBeenWarned()
+      } finally {
+        pending.resolve(Child)
+        await flushResolution(pending.promise)
+        app.unmount()
+        host.remove()
+      }
+    })
 
     async function flushResolution(promise: Promise<unknown>) {
       await promise

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -9,6 +9,7 @@ import {
   performAsyncHydrate,
   restoreCurrentInstance,
   setCurrentInstance,
+  shallowRef,
   useAsyncComponentState,
 } from '@vue/runtime-dom'
 import { defineVaporComponent } from './apiDefineComponent'
@@ -134,18 +135,33 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
       }
 
       if (__FEATURE_SUSPENSE__ && suspensible && instance.suspense) {
+        // Resolve the loader independently, but create its rendered branch
+        // through the wrapper scope so KeepAlive can defer or pause that work.
+        const asyncRender = instance.keepAliveBranchState
+          ? shallowRef<() => VaporComponentInstance>()
+          : undefined
+        if (asyncRender) {
+          renderEffect(() => {
+            const render = asyncRender.value
+            if (render) frag.update(render)
+          })
+        }
+        const update = (render: () => VaporComponentInstance) => {
+          if (asyncRender) asyncRender.value = render
+          else frag.update(render)
+        }
         return load()
           .then(() => {
             resolvedComp = getResolvedComp()
             if (resolvedComp) {
-              frag.update(() => createInnerComp(resolvedComp!, instance))
+              update(() => createInnerComp(resolvedComp!, instance))
             }
             return frag
           })
           .catch(err => {
             onError(err)
             if (errorComponent) {
-              frag.update(() => createErrorComp(errorComponent, instance, err))
+              update(() => createErrorComp(errorComponent, instance, err))
             }
             return frag
           })

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -3,6 +3,7 @@ import {
   type VaporComponentInstance,
   currentInstance,
   getExposed,
+  isKeepAliveBranchDeactivated,
   isVaporComponent,
 } from './component'
 import {
@@ -134,8 +135,16 @@ function setTemplateRefWithState(
     ;(frag.onUpdated ||= []).push(() => {
       // KeepAlive clears refs on deactivation but keeps this fragment update
       // callback alive. Skip re-applying refs for async/offscreen updates
-      // until the component is activated again.
-      if (isVaporComponent(el) && el.isDeactivated) return
+      // until the component is activated again. The branch state changes
+      // synchronously on activation; isDeactivated is cleared post-render.
+      if (
+        isVaporComponent(el) &&
+        el.isDeactivated &&
+        (!el.keepAliveBranchState ||
+          isKeepAliveBranchDeactivated(el.keepAliveBranchState))
+      ) {
+        return
+      }
       state.oldRef = setRef(
         instance,
         state.suspense,

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -668,6 +668,11 @@ export const emptyContext: GenericAppContext = {
   provides: /*@__PURE__*/ Object.create(null),
 }
 
+interface KeepAliveScopeState {
+  scopes: Set<EffectScope>
+  paused: boolean
+}
+
 export class VaporComponentInstance<
   Props extends Record<string, any> = {},
   Emits extends EmitsOptions = {},
@@ -734,6 +739,7 @@ export class VaporComponentInstance<
   // for keep-alive
   shapeFlag?: number
   $key?: any
+  keepAliveScopeState?: KeepAliveScopeState
   // Share deferred updates across async roots on the KeepAlive component-root
   // chain so A(pending) -> B -> A renders only the final branch, matching VDOM.
   deferredKeepAliveUpdates?: DeferredKeepAliveUpdates
@@ -819,6 +825,34 @@ export class VaporComponentInstance<
 
     this.block = null! // to be set
     this.scope = new EffectScope(true)
+
+    if (isKeepAliveEnabled) {
+      // Unlike VDOM, effects in a cached Vapor branch can directly track
+      // reactive sources owned by its parent (for example, a compiled prop
+      // getter). Moving the branch into storage does not detach those
+      // subscriptions, so its effects must be paused while deactivated.
+      //
+      // VDOM child props are updated through vnode patching instead. Once a
+      // vnode is deactivated it leaves the active patch path, and activation
+      // explicitly patches the cached instance with the latest vnode.
+      //
+      // Component scopes are detached in both runtimes. Since Vapor needs to
+      // pause the whole cached subtree, collect each component scope explicitly
+      // so descendants are included.
+      const parent = this.parent
+      const keepAliveScopeState =
+        !isKeepAlive(this) && parent && parent.vapor
+          ? isKeepAlive(parent)
+            ? { scopes: new Set<EffectScope>(), paused: false }
+            : (parent as VaporComponentInstance).keepAliveScopeState
+          : undefined
+      if (keepAliveScopeState) {
+        this.keepAliveScopeState = keepAliveScopeState
+        keepAliveScopeState.scopes.add(this.scope)
+        if (keepAliveScopeState.paused) this.scope.pause()
+      }
+    }
+
     this.isOnce = !!once
 
     this.emit = emit.bind(null, this) as EmitFn<Emits>
@@ -1318,6 +1352,11 @@ export function unmountComponent(
     invalidateMount(instance.a)
     if (instance.bum) {
       invokeArrayFns(instance.bum)
+    }
+
+    if (isKeepAliveEnabled) {
+      const scopeState = instance.keepAliveScopeState
+      if (scopeState) scopeState.scopes.delete(instance.scope)
     }
 
     instance.scope.stop()

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -668,9 +668,11 @@ export const emptyContext: GenericAppContext = {
   provides: /*@__PURE__*/ Object.create(null),
 }
 
-interface KeepAliveScopeState {
-  scopes: Set<EffectScope>
-  paused: boolean
+interface KeepAliveBranchState {
+  instances: Set<VaporComponentInstance>
+  parent?: KeepAliveBranchState
+  children?: Set<KeepAliveBranchState>
+  deactivated: boolean
 }
 
 export class VaporComponentInstance<
@@ -739,7 +741,7 @@ export class VaporComponentInstance<
   // for keep-alive
   shapeFlag?: number
   $key?: any
-  keepAliveScopeState?: KeepAliveScopeState
+  keepAliveBranchState?: KeepAliveBranchState
   // Share deferred updates across async roots on the KeepAlive component-root
   // chain so A(pending) -> B -> A renders only the final branch, matching VDOM.
   deferredKeepAliveUpdates?: DeferredKeepAliveUpdates
@@ -837,19 +839,42 @@ export class VaporComponentInstance<
       // explicitly patches the cached instance with the latest vnode.
       //
       // Component scopes are detached in both runtimes. Since Vapor needs to
-      // pause the whole cached subtree, collect each component scope explicitly
-      // so descendants are included.
+      // pause the whole cached subtree, track each component instance and link
+      // nested KeepAlive boundaries so an ancestor pause reaches them without
+      // merging their independent cache lifecycles.
       const parent = this.parent
-      const keepAliveScopeState =
-        !isKeepAlive(this) && parent && parent.vapor
-          ? isKeepAlive(parent)
-            ? { scopes: new Set<EffectScope>(), paused: false }
-            : (parent as VaporComponentInstance).keepAliveScopeState
-          : undefined
-      if (keepAliveScopeState) {
-        this.keepAliveScopeState = keepAliveScopeState
-        keepAliveScopeState.scopes.add(this.scope)
-        if (keepAliveScopeState.paused) this.scope.pause()
+      const vaporParent =
+        parent && parent.vapor ? (parent as VaporComponentInstance) : undefined
+      const parentBranch = vaporParent && vaporParent.keepAliveBranchState
+      let branchState = parentBranch
+      if (vaporParent && isKeepAlive(vaporParent)) {
+        branchState = {
+          instances: new Set(),
+          parent: parentBranch,
+          deactivated: false,
+        }
+        if (parentBranch) {
+          ;(parentBranch.children ||= new Set()).add(branchState)
+        }
+      }
+      if (branchState) {
+        this.keepAliveBranchState = branchState
+        branchState.instances.add(this)
+        let currentBranch: KeepAliveBranchState | undefined = branchState
+        while (currentBranch) {
+          if (currentBranch.deactivated) {
+            // KeepAlive and unresolved async wrappers must keep advancing their
+            // boundary state. Their rendered children still start paused.
+            if (
+              !isKeepAlive(this) &&
+              (!isAsyncWrapper(this) || this.type.__asyncResolved)
+            ) {
+              this.scope.pause()
+            }
+            break
+          }
+          currentBranch = currentBranch.parent
+        }
       }
     }
 
@@ -1355,8 +1380,16 @@ export function unmountComponent(
     }
 
     if (isKeepAliveEnabled) {
-      const scopeState = instance.keepAliveScopeState
-      if (scopeState) scopeState.scopes.delete(instance.scope)
+      const branchState = instance.keepAliveBranchState
+      if (branchState) {
+        branchState.instances.delete(instance)
+        const parentBranch = branchState.parent
+        if (!branchState.instances.size && parentBranch) {
+          const children = parentBranch.children!
+          children.delete(branchState)
+          if (!children.size) parentBranch.children = undefined
+        }
+      }
     }
 
     instance.scope.stop()

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -668,11 +668,21 @@ export const emptyContext: GenericAppContext = {
   provides: /*@__PURE__*/ Object.create(null),
 }
 
-interface KeepAliveBranchState {
+export interface KeepAliveBranchState {
   instances: Set<VaporComponentInstance>
   parent?: KeepAliveBranchState
   children?: Set<KeepAliveBranchState>
   deactivated: boolean
+}
+
+export function isKeepAliveBranchDeactivated(
+  branchState?: KeepAliveBranchState,
+): boolean {
+  while (branchState) {
+    if (branchState.deactivated) return true
+    branchState = branchState.parent
+  }
+  return false
 }
 
 export class VaporComponentInstance<
@@ -860,20 +870,8 @@ export class VaporComponentInstance<
       if (branchState) {
         this.keepAliveBranchState = branchState
         branchState.instances.add(this)
-        let currentBranch: KeepAliveBranchState | undefined = branchState
-        while (currentBranch) {
-          if (currentBranch.deactivated) {
-            // KeepAlive and unresolved async wrappers must keep advancing their
-            // boundary state. Their rendered children still start paused.
-            if (
-              !isKeepAlive(this) &&
-              (!isAsyncWrapper(this) || this.type.__asyncResolved)
-            ) {
-              this.scope.pause()
-            }
-            break
-          }
-          currentBranch = currentBranch.parent
+        if (isKeepAliveBranchDeactivated(branchState)) {
+          this.scope.pause()
         }
       }
     }
@@ -1826,6 +1824,16 @@ function deferKeepAliveRenderEffects(
     deferred = state
   } else {
     deferred.pendingRoot = instance
+  }
+
+  // The async root may own work that materializes its resolved branch. Attach
+  // it to the same state so owner removal runs before that work.
+  if (
+    isAsyncWrapper(instance) &&
+    instance.deferredKeepAliveUpdates !== deferred
+  ) {
+    instance.deferredKeepAliveUpdates = deferred
+    deferred.owners.push(instance)
   }
 
   for (let i = 0; i < owners.length; i++) {

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -612,6 +612,11 @@ export function activate(
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
   move(instance, parentNode, anchor, MoveType.ENTER, instance, parentSuspense)
+  const scopeState = instance.keepAliveScopeState
+  if (scopeState) {
+    scopeState.paused = false
+    scopeState.scopes.forEach(scope => scope.resume())
+  }
 
   queuePostRenderEffect(
     () => {
@@ -632,6 +637,16 @@ export function deactivate(
   container: ParentNode,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
+  const scopeState = instance.keepAliveScopeState
+  if (scopeState) {
+    scopeState.paused = true
+    // Let an unresolved async wrapper finish resolving. The component it
+    // creates inherits scopeState.paused and starts paused while cached.
+    if (!isAsyncWrapper(instance) || instance.type.__asyncResolved) {
+      scopeState.scopes.forEach(scope => scope.pause())
+    }
+  }
+
   // Clear refs before deactivation, matching VDOM core's unmount path
   // which calls setRef(null) before the deactivation check.
   unsetRef(instance)

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -11,6 +11,7 @@ import {
   getComponentName,
   invalidateMount,
   isAsyncWrapper,
+  isKeepAlive,
   isVNode,
   matches,
   onBeforeUnmount,
@@ -605,6 +606,32 @@ function getInstanceFromCache(
   }
 }
 
+type KeepAliveBranchState = NonNullable<
+  VaporComponentInstance['keepAliveBranchState']
+>
+
+function pauseKeepAliveBranch(branchState: KeepAliveBranchState): void {
+  branchState.instances.forEach(instance => {
+    // KeepAlive and unresolved async wrappers must keep advancing their
+    // boundary state. Their rendered children remain paused while cached.
+    if (
+      !isKeepAlive(instance) &&
+      (!isAsyncWrapper(instance) || instance.type.__asyncResolved)
+    ) {
+      instance.scope.pause()
+    }
+  })
+  const children = branchState.children
+  if (children) children.forEach(pauseKeepAliveBranch)
+}
+
+function resumeKeepAliveBranch(branchState: KeepAliveBranchState): void {
+  if (branchState.deactivated) return
+  branchState.instances.forEach(instance => instance.scope.resume())
+  const children = branchState.children
+  if (children) children.forEach(resumeKeepAliveBranch)
+}
+
 export function activate(
   instance: VaporComponentInstance,
   parentNode: ParentNode,
@@ -612,10 +639,14 @@ export function activate(
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
   move(instance, parentNode, anchor, MoveType.ENTER, instance, parentSuspense)
-  const scopeState = instance.keepAliveScopeState
-  if (scopeState) {
-    scopeState.paused = false
-    scopeState.scopes.forEach(scope => scope.resume())
+  const branchState = instance.keepAliveBranchState
+  if (branchState) {
+    branchState.deactivated = false
+    // A nested boundary can reactivate while an ancestor is still deactivated.
+    // Keep its local state active, but defer effects until the ancestor resumes.
+    let ancestor = branchState.parent
+    while (ancestor && !ancestor.deactivated) ancestor = ancestor.parent
+    if (!ancestor) resumeKeepAliveBranch(branchState)
   }
 
   queuePostRenderEffect(
@@ -637,14 +668,10 @@ export function deactivate(
   container: ParentNode,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
-  const scopeState = instance.keepAliveScopeState
-  if (scopeState) {
-    scopeState.paused = true
-    // Let an unresolved async wrapper finish resolving. The component it
-    // creates inherits scopeState.paused and starts paused while cached.
-    if (!isAsyncWrapper(instance) || instance.type.__asyncResolved) {
-      scopeState.scopes.forEach(scope => scope.pause())
-    }
+  const branchState = instance.keepAliveBranchState
+  if (branchState) {
+    branchState.deactivated = true
+    pauseKeepAliveBranch(branchState)
   }
 
   // Clear refs before deactivation, matching VDOM core's unmount path

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -24,8 +24,10 @@ import {
 } from '@vue/runtime-dom'
 import { type Block, findBlockBoundary, move, remove } from '../block'
 import {
+  type KeepAliveBranchState,
   type VaporComponent,
   type VaporComponentInstance,
+  isKeepAliveBranchDeactivated,
   isVaporComponent,
 } from '../component'
 import {
@@ -44,6 +46,7 @@ import {
 } from '../fragment'
 import { EffectScope } from '@vue/reactivity'
 import { isInteropEnabled } from '../vdomInteropState'
+import { RenderEffect } from '../renderEffect'
 import {
   type VaporKeepAliveContext,
   currentCacheKey,
@@ -606,28 +609,31 @@ function getInstanceFromCache(
   }
 }
 
-type KeepAliveBranchState = NonNullable<
-  VaporComponentInstance['keepAliveBranchState']
->
-
 function pauseKeepAliveBranch(branchState: KeepAliveBranchState): void {
   branchState.instances.forEach(instance => {
-    // KeepAlive and unresolved async wrappers must keep advancing their
-    // boundary state. Their rendered children remain paused while cached.
-    if (
-      !isKeepAlive(instance) &&
-      (!isAsyncWrapper(instance) || instance.type.__asyncResolved)
-    ) {
-      instance.scope.pause()
-    }
+    instance.scope.pause()
   })
   const children = branchState.children
   if (children) children.forEach(pauseKeepAliveBranch)
 }
 
+function resumeKeepAliveScope(scope: EffectScope): void {
+  scope.resume()
+  // Watchers resumed above may change the selected branch. Reconcile it now,
+  // before child branches resume, so stale children never become active.
+  for (let link = scope.deps; link; link = link.nextDep) {
+    if (link.dep instanceof RenderEffect) link.dep.runIfDirty()
+  }
+}
+
 function resumeKeepAliveBranch(branchState: KeepAliveBranchState): void {
   if (branchState.deactivated) return
-  branchState.instances.forEach(instance => instance.scope.resume())
+  branchState.instances.forEach(instance => {
+    if (!isKeepAlive(instance)) instance.scope.resume()
+  })
+  branchState.instances.forEach(instance => {
+    if (isKeepAlive(instance)) resumeKeepAliveScope(instance.scope)
+  })
   const children = branchState.children
   if (children) children.forEach(resumeKeepAliveBranch)
 }
@@ -644,9 +650,9 @@ export function activate(
     branchState.deactivated = false
     // A nested boundary can reactivate while an ancestor is still deactivated.
     // Keep its local state active, but defer effects until the ancestor resumes.
-    let ancestor = branchState.parent
-    while (ancestor && !ancestor.deactivated) ancestor = ancestor.parent
-    if (!ancestor) resumeKeepAliveBranch(branchState)
+    if (!isKeepAliveBranchDeactivated(branchState)) {
+      resumeKeepAliveBranch(branchState)
+    }
   }
 
   queuePostRenderEffect(

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -39,7 +39,8 @@ export class RenderEffect extends ReactiveEffect {
     }
 
     const job: SchedulerJob = () => {
-      if (this.dirty) {
+      // The job may have been queued before its scope was paused.
+      if (!(this.flags & EffectFlags.PAUSED) && this.dirty) {
         // A pending KeepAlive async root defers updates along its root chain.
         const deferred =
           __FEATURE_SUSPENSE__ &&

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -1,7 +1,9 @@
 import { EffectFlags, type EffectScope, ReactiveEffect } from '@vue/reactivity'
 import {
+  ErrorCodes,
   type SchedulerJob,
   SchedulerJobFlags,
+  callWithErrorHandling,
   currentInstance,
   endMeasure,
   queueJob,
@@ -135,6 +137,16 @@ export class RenderEffect extends ReactiveEffect {
       queueJob(this.job, this.i ? this.i.uid : undefined, false, this.order)
     }
   }
+
+  runIfDirty(): void {
+    if (this.dirty) {
+      callWithErrorHandling(
+        () => this.run(),
+        this.i,
+        ErrorCodes.COMPONENT_UPDATE,
+      )
+    }
+  }
 }
 
 export function renderEffect(fn: () => void, noLifecycle = false): void {
@@ -142,5 +154,5 @@ export function renderEffect(fn: () => void, noLifecycle = false): void {
   if (inOnceSlot) return fn()
 
   const effect = new RenderEffect(fn, noLifecycle)
-  effect.run()
+  if (!(effect.flags & EffectFlags.PAUSED)) effect.run()
 }


### PR DESCRIPTION
Closes #15228

Vapor effects can continue tracking parent-owned reactive sources after a cached branch is moved into storage. This allows render and watcher jobs to consume transient values while the branch is inactive.

Collect the detached component scopes within each KeepAlive boundary and pause them on deactivation, then resume dirty effects on activation. Ensure effects and child scopes created under an already-paused scope inherit its state, and prevent jobs queued before deactivation from running.

Allow unresolved async wrappers to finish resolving while ensuring their resolved component effects start paused when the branch is cached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cached component behavior so inactive `KeepAlive` content no longer runs render effects or watchers unnecessarily.
  - Cached components now correctly pause reactive updates while inactive and resume when reactivated.
  - Ensured updates queued before deactivation do not execute until the component becomes active again.
  - Preserved valid cached props during deactivation.
  - Async components can finish resolving while cached, while their effects remain paused until activation.

- **Tests**
  - Added regression coverage for nested scopes, watchers, render effects, and async cached components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->