### PR TITLE
fix(runtime-vapor): clean up teleport targets on scope disposal

### DIFF
--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -7082,5 +7082,58 @@ describe('component: slots', () => {
       await nextTick()
       expect(instance.slots).toEqual({})
     })
+
+    test('should remove teleported content when a dynamic v-for slot is removed', async () => {
+      const cats = ref(['a', 'b'])
+      const unmounted = vi.fn()
+      const Modal = compile(
+        `<script setup vapor>
+        import { onUnmounted } from 'vue'
+        onUnmounted(_components.unmounted)
+        </script>
+        <template>
+          <Teleport to="body">
+            <div id="teleported">teleported</div>
+          </Teleport>
+        </template>`,
+        cats,
+        { unmounted },
+      )
+      const Host = compile(
+        `<template>
+          <div v-for="c in data" :key="c">
+            <slot :name="c" />
+          </div>
+        </template>`,
+        cats,
+      )
+      const App = compile(
+        `<template>
+          <components.Host>
+            <template v-for="c in data" :key="c" #[c]>
+              <components.Modal v-if="c === 'a'" />
+            </template>
+          </components.Host>
+        </template>`,
+        cats,
+        { Host, Modal },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+
+      try {
+        app.mount(root)
+        expect(document.body.querySelectorAll('#teleported')).toHaveLength(1)
+
+        cats.value = ['b']
+        await nextTick()
+
+        expect(unmounted).toHaveBeenCalledOnce()
+        expect(document.body.querySelectorAll('#teleported')).toHaveLength(0)
+      } finally {
+        app.unmount()
+        document.querySelectorAll('#teleported').forEach(node => node.remove())
+      }
+    })
   })
 })

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -7135,5 +7135,64 @@ describe('component: slots', () => {
         document.querySelectorAll('#teleported').forEach(node => node.remove())
       }
     })
+
+    test('should leave disabled teleport content to its main-view owner', async () => {
+      const cats = ref(['a', 'b'])
+      let leaveDone: (() => void) | undefined
+      const onLeave = vi.fn((_el: Element, done: () => void) => {
+        leaveDone = done
+      })
+      const target = document.createElement('div')
+      const Modal = compile(
+        `<template>
+          <Teleport :to="components.target" disabled>
+            <span>teleported</span>
+          </Teleport>
+        </template>`,
+        cats,
+        { target },
+      )
+      const Host = compile(
+        `<template>
+          <TransitionGroup :css="false" @leave="components.onLeave">
+            <div v-for="c in data" :key="c">
+              <slot :name="c" />
+            </div>
+          </TransitionGroup>
+        </template>`,
+        cats,
+        { onLeave },
+      )
+      const App = compile(
+        `<template>
+          <components.Host>
+            <template v-for="c in data" :key="c" #[c]>
+              <components.Modal v-if="c === 'a'" />
+            </template>
+          </components.Host>
+        </template>`,
+        cats,
+        { Host, Modal },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+
+      try {
+        app.mount(root)
+        cats.value = ['b']
+        await nextTick()
+
+        expect(onLeave).toHaveBeenCalledOnce()
+        expect(root.textContent).toContain('teleported')
+
+        leaveDone!()
+        await nextTick()
+
+        expect(root.textContent).not.toContain('teleported')
+      } finally {
+        leaveDone?.()
+        app.unmount()
+      }
+    })
   })
 })

--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -26,6 +26,7 @@ import {
 import { makeRender } from '../_utils'
 import {
   defineComponent,
+  effectScope,
   h,
   nextTick,
   onActivated,
@@ -33,6 +34,7 @@ import {
   onDeactivated,
   onMounted,
   onUnmounted,
+  queuePostFlushCb,
   reactive,
   ref,
   renderSlot,
@@ -202,6 +204,38 @@ describe('renderer: VaporTeleport', () => {
       show.value = false
       await nextTick()
 
+      expect(target.innerHTML).toBe('')
+    })
+
+    test('should not initialize deferred children after owner scope stops', () => {
+      const root = document.createElement('div')
+      const target = document.createElement('div')
+      const mounted = vi.fn()
+      const Probe = defineVaporComponent(() => {
+        onMounted(mounted)
+        return template('<div>teleported</div>')()
+      })
+      const { mount } = define({
+        setup() {
+          const scope = effectScope()
+          const teleport = scope.run(() =>
+            createComp(
+              VaporTeleport,
+              {
+                to: () => target,
+                defer: () => true,
+              },
+              { default: () => createComp(Probe) },
+            ),
+          )!
+          queuePostFlushCb(() => scope.stop(), -1)
+          return teleport
+        },
+      }).create()
+
+      mount(root)
+
+      expect(mounted).not.toHaveBeenCalled()
       expect(target.innerHTML).toBe('')
     })
   })

--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -23,7 +23,7 @@ import {
   vaporInteropPlugin,
   withVaporDirectives,
 } from '@vue/runtime-vapor'
-import { makeRender } from '../_utils'
+import { compile, makeRender } from '../_utils'
 import {
   defineComponent,
   effectScope,
@@ -1791,6 +1791,44 @@ function runSharedTests(deferMode: boolean): void {
     expect(beforeEnter).toHaveBeenCalledTimes(0)
   })
 }
+
+test('should dispose target after v-for fast remove clears it', async () => {
+  const items = ref([1])
+  const App = compile(
+    `<template>
+      <div id="teleport-fast-remove-target">
+        <template v-for="item in data" :key="item">
+          <Teleport to="#teleport-fast-remove-target">
+            <span>teleported</span>
+          </Teleport>
+          <i>item</i>
+        </template>
+      </div>
+    </template>`,
+    items,
+  )
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const app = createVaporApp(App)
+
+  try {
+    app.mount(root)
+    await nextTick()
+    expect(
+      root.querySelector('#teleport-fast-remove-target')!.textContent,
+    ).toContain('teleported')
+
+    items.value = []
+    await nextTick()
+
+    expect(
+      root.querySelector('#teleport-fast-remove-target')!.textContent,
+    ).toBe('')
+  } finally {
+    app.unmount()
+    root.remove()
+  }
+})
 
 test('should clean up old anchors when target changes', async () => {
   const targetA = document.createElement('div')

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -1553,6 +1553,89 @@ describe('Transition', () => {
     expect(host.querySelector('span')?.textContent).toBe('second')
   })
 
+  test('teleport root should respect out-in transition mode', async () => {
+    let leaveDone: (() => void) | undefined
+    const target = document.createElement('div')
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({ show: true, target, onEnter, onLeave })
+    const App = compile(
+      `<template>
+        <Transition
+          mode="out-in"
+          :css="false"
+          @enter="data.onEnter"
+          @leave="data.onLeave"
+        >
+          <template #default v-if="data.show">
+            <Teleport :to="data.target"><div>A</div></Teleport>
+          </template>
+          <template #default v-else>
+            <Teleport :to="data.target"><div>B</div></Teleport>
+          </template>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { app } = define(App).render()
+
+    try {
+      data.value.show = false
+      await nextTick()
+
+      expect(onLeave).toHaveBeenCalledOnce()
+      expect(onEnter).not.toHaveBeenCalled()
+      expect(target.textContent).toBe('A')
+
+      leaveDone!()
+      await nextTick()
+
+      expect(onEnter).toHaveBeenCalledOnce()
+      expect(target.textContent).toBe('B')
+    } finally {
+      leaveDone?.()
+      app.unmount()
+    }
+  })
+
+  test('disabled teleport should leave with its main-view owner', async () => {
+    let leaveDone: (() => void) | undefined
+    const target = document.createElement('div')
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      leaveDone = done
+    })
+    const data = ref({ show: true, target, onLeave })
+    const App = compile(
+      `<template>
+        <Transition :css="false" @leave="data.onLeave">
+          <div v-if="data.show">
+            <Teleport :to="data.target" disabled><span>A</span></Teleport>
+          </div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { app, host } = define(App).render()
+
+    try {
+      data.value.show = false
+      await nextTick()
+
+      expect(onLeave).toHaveBeenCalledOnce()
+      expect(host.textContent).toBe('A')
+
+      leaveDone!()
+      await nextTick()
+
+      expect(host.textContent).toBe('')
+    } finally {
+      leaveDone?.()
+      app.unmount()
+    }
+  })
+
   test('slot fallback should trigger enter hooks when slot content becomes empty', async () => {
     const onBeforeEnter = vi.fn()
     const onEnter = vi.fn()

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -360,9 +360,15 @@ export function createComponent(
         normalizeRawSlots(rawSlots),
         _insertionAnchor,
       )
-      // Teleport target-side state can outlive DOM-only teardown of an
-      // enclosing block, so always bind it to the creating scope.
-      onScopeDispose(() => frag.dispose(), true)
+      if (_insertionParent) {
+        // Teleports mounted via insertion state are not part of the returned
+        // block tree, so scope disposal must tear down their target-side state.
+        onScopeDispose(() => frag.disposeTarget(), true)
+      } else {
+        // Give normal block removal (and Transition leave preparation) the
+        // current stack before falling back to target-side cleanup.
+        onScopeDispose(() => frag.scheduleTargetDispose(), true)
+      }
       if (!isHydrating) {
         if (_insertionParent) {
           insert(frag, _insertionParent, _insertionAnchor, parentSuspense)

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -360,11 +360,9 @@ export function createComponent(
         normalizeRawSlots(rawSlots),
         _insertionAnchor,
       )
-      if (_insertionParent) {
-        // Teleports mounted via insertion state are not part of the returned
-        // block tree, so scope disposal must tear down their target-side state.
-        onScopeDispose(() => frag.dispose(), true)
-      }
+      // Teleport target-side state can outlive DOM-only teardown of an
+      // enclosing block, so always bind it to the creating scope.
+      onScopeDispose(() => frag.dispose(), true)
       if (!isHydrating) {
         if (_insertionParent) {
           insert(frag, _insertionParent, _insertionAnchor, parentSuspense)

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -410,7 +410,11 @@ export class TeleportFragment extends RenderContextFragment {
 
     const mountState = this.mountState
     if (this.nodes && mountState.location === TeleportMountLocation.Target) {
-      remove(this.nodes, mountState.container)
+      const targetParent =
+        (this.targetStart && parentNode(this.targetStart)) ||
+        (this.targetAnchor && parentNode(this.targetAnchor)) ||
+        undefined
+      remove(this.nodes, targetParent)
       this.nodes = []
       this.mountState = { location: TeleportMountLocation.None }
     }

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -12,6 +12,7 @@ import {
   isTeleportDeferred,
   isTeleportDisabled,
   logMismatchError,
+  queuePostFlushCb,
   queuePostRenderEffect,
   resolveTeleportTarget,
   restoreCurrentInstance,
@@ -397,20 +398,22 @@ export class TeleportFragment extends RenderContextFragment {
     }
   }
 
-  dispose = (): void => {
+  private cancelMountToTarget(): void {
     if (this.mountToTargetJob) {
       this.mountToTargetJob.flags! |= SchedulerJobFlags.DISPOSED
       this.mountToTargetJob = undefined
     }
+  }
 
-    // remove nodes
+  disposeTarget(): void {
+    this.cancelMountToTarget()
+
     const mountState = this.mountState
-    if (this.nodes && mountState.location !== TeleportMountLocation.None) {
+    if (this.nodes && mountState.location === TeleportMountLocation.Target) {
       remove(this.nodes, mountState.container)
       this.nodes = []
+      this.mountState = { location: TeleportMountLocation.None }
     }
-
-    this.mountState = { location: TeleportMountLocation.None }
 
     // remove anchors
     if (this.targetStart) {
@@ -423,6 +426,23 @@ export class TeleportFragment extends RenderContextFragment {
     }
 
     this.target = undefined
+  }
+
+  scheduleTargetDispose(): void {
+    // A deferred target mount may already be ahead of the fallback in the
+    // post-flush queue, so cancel it synchronously with scope teardown.
+    this.cancelMountToTarget()
+    queuePostFlushCb(() => this.disposeTarget())
+  }
+
+  dispose = (): void => {
+    const mountState = this.mountState
+    if (this.nodes && mountState.location === TeleportMountLocation.Main) {
+      remove(this.nodes, mountState.container)
+      this.nodes = []
+    }
+    this.disposeTarget()
+    this.mountState = { location: TeleportMountLocation.None }
   }
 
   remove = (_parent?: ParentNode): void => {


### PR DESCRIPTION
Closes #15236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed teleported content not being properly removed when dynamically generated slot items are deleted.
  * Ensured associated modals are unmounted and their DOM elements removed correctly.

* **Tests**
  * Added regression coverage for conditional teleported content inside keyed slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->