### PR TITLE
types(runtime-dom): allow null native attribute values (fix #8600)

### DIFF
--- a/packages-private/dts-test/tsx.test-d.tsx
+++ b/packages-private/dts-test/tsx.test-d.tsx
@@ -16,6 +16,11 @@ expectType<JSX.Element>(<div>hello</div>)
 expectType<JSX.Element>(<input value="foo" />)
 expectType<JSX.Element>(<textarea value={null} />)
 
+// #8600
+expectType<JSX.Element>(<div id={null} aria-label={null} />)
+expectType<JSX.Element>(<input disabled={null} />)
+expectType<JSX.Element>(<svg viewBox={null} />)
+
 // @ts-expect-error style css property validation
 ;<div style={{ unknown: 123 }} />
 

--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -1501,7 +1501,13 @@ export interface ReservedProps {
   ref_key?: string | undefined
 }
 
+type NativeElementProps<T> = {
+  [K in keyof T]: T[K] | null
+}
+
 export type NativeElements = {
-  [K in keyof IntrinsicElementAttributes]: IntrinsicElementAttributes[K] &
+  [K in keyof IntrinsicElementAttributes]: NativeElementProps<
+    IntrinsicElementAttributes[K]
+  > &
     ReservedProps
 }


### PR DESCRIPTION
## Summary

- allow `null` for native HTML, SVG, and ARIA binding values
- apply nullability at the `NativeElements` boundary so component prop contracts remain unchanged
- add declaration tests for global, ARIA, boolean, and SVG attributes

## Root cause

Vue removes or resets native DOM attributes and properties when their runtime value is `null`, but `NativeElements` exposed the underlying attribute types without including `null`. Template tooling and TSX therefore rejected values that the runtime supports.

## Validation

- reproduced the original `TS2322` errors on `main` for `id`, `aria-label`, `disabled`, and `viewBox`
- `pnpm run build-dts`
- `pnpm run test-dts-only`
- `pnpm run check`
- ESLint and Prettier checks for the changed files

Closes #8600.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JSX typing so `null` is accepted for native element properties, including ARIA attributes, input boolean attributes, and SVG attributes.
  * Improved type compatibility when using nullable values with intrinsic elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->