### PR TITLE
chore(playground): disable unsupported ts7 and eliminate vite warn

### DIFF
--- a/packages-private/sfc-playground/src/VersionSelect.vue
+++ b/packages-private/sfc-playground/src/VersionSelect.vue
@@ -91,6 +91,7 @@ onMounted(() => {
         class="versions-item"
         :class="{
           active: ver === version || (version === 'latest' && index === 0),
+          disabled: pkg === 'typescript' && ver.startsWith('7.')
         }"
       >
         <a @click="setVersion(ver)">v{{ ver }}</a>
@@ -140,6 +141,12 @@ onMounted(() => {
 
 .versions .active a {
   color: var(--green);
+}
+
+.versions .disabled a, .versions .disabled a:hover {
+  color: #a8abb2;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .versions .versions-item {

--- a/packages-private/sfc-playground/src/VersionSelect.vue
+++ b/packages-private/sfc-playground/src/VersionSelect.vue
@@ -143,10 +143,13 @@ onMounted(() => {
   color: var(--green);
 }
 
-.versions .disabled a,
-.versions .disabled a:hover {
-  color: #a8abb2;
+.versions .versions-item.disabled {
   cursor: not-allowed;
+}
+
+.versions .versions-item.disabled a,
+.versions .versions-item.disabled a:hover {
+  color: #a8abb2;
   pointer-events: none;
 }
 

--- a/packages-private/sfc-playground/src/VersionSelect.vue
+++ b/packages-private/sfc-playground/src/VersionSelect.vue
@@ -91,7 +91,7 @@ onMounted(() => {
         class="versions-item"
         :class="{
           active: ver === version || (version === 'latest' && index === 0),
-          disabled: pkg === 'typescript' && ver.startsWith('7.')
+          disabled: pkg === 'typescript' && ver.startsWith('7.'),
         }"
       >
         <a @click="setVersion(ver)">v{{ ver }}</a>
@@ -143,7 +143,8 @@ onMounted(() => {
   color: var(--green);
 }
 
-.versions .disabled a, .versions .disabled a:hover {
+.versions .disabled a,
+.versions .disabled a:hover {
   color: #a8abb2;
   cursor: not-allowed;
   pointer-events: none;

--- a/packages-private/sfc-playground/vite.config.ts
+++ b/packages-private/sfc-playground/vite.config.ts
@@ -34,7 +34,11 @@ function copyVuePlugin(): Plugin {
     name: 'copy-vue',
     generateBundle() {
       const copyFile = (file: string) => {
-        const filePath = path.resolve(__dirname, '../../packages', file)
+        const filePath = path.resolve(
+          import.meta.dirname,
+          '../../packages',
+          file,
+        )
         const basename = path.basename(file)
         if (!fs.existsSync(filePath)) {
           throw new Error(


### PR DESCRIPTION
refs https://github.com/vitejs/vite/pull/22850

TypeScript 7 does not support Vue, and the path is incorrect after switching to TypeScript 7, so TypeScript 7 is temporarily disabled. Alternatively, we can migrate to https://github.com/johnsoncodehk/typescript-native-bridge later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TypeScript 7.x versions are now clearly marked as unavailable in the version selector.
  * Unavailable versions appear disabled, use a not-allowed cursor, and cannot be selected.
  * Version selection remains available for supported TypeScript releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->