### PR TITLE
fix(types): prevent infer Exposed as JSX.Element for defineVaporComponent

### DIFF
--- a/packages-private/dts-test/vapor/defineVaporComponent.test-d.tsx
+++ b/packages-private/dts-test/vapor/defineVaporComponent.test-d.tsx
@@ -574,6 +574,7 @@ describe('extract instance type', () => {
       },
       c: Number,
     },
+    setup: () => <div></div>,
   })
 
   const compA = {} as InstanceType<typeof CompA>
@@ -581,6 +582,7 @@ describe('extract instance type', () => {
   expectType<boolean | undefined>(compA.props.a)
   expectType<string>(compA.props.b)
   expectType<number | undefined>(compA.props.c)
+  expectType<Record<string, any> | null>(compA.exposed)
 
   //  @ts-expect-error
   compA.props.a = true

--- a/packages/runtime-vapor/src/apiDefineComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineComponent.ts
@@ -210,7 +210,7 @@ export function defineVaporComponent<
   ResolvedEmits,
   RuntimeEmitsKeys,
   Slots,
-  Exposed extends Block ? Record<string, any> : Exposed,
+  Block extends Exposed ? Record<string, any> : Exposed,
   TypeBlock,
   TypeRefs,
   // MakeDefaultsOptional - if TypeProps is provided, set to false to use

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -202,7 +202,9 @@ export interface VaporComponentOptions<
     },
   ) => TypeBlock | Exposed | Promise<Exposed> | void
   render?(
-    ctx: Exposed extends Block ? undefined : ShallowUnwrapRef<Exposed>,
+    ctx: Block extends Exposed
+      ? Record<string, any>
+      : ShallowUnwrapRef<Exposed>,
     props: Readonly<InferredProps>,
     emit: EmitFn<Emits>,
     attrs: any,
@@ -768,7 +770,9 @@ export class VaporComponentInstance<
   effectCount = 0
 
   // dev only
-  setupState?: Exposed extends Block ? undefined : ShallowUnwrapRef<Exposed>
+  setupState?: Block extends Exposed
+    ? Record<string, any>
+    : ShallowUnwrapRef<Exposed>
   devtoolsRawSetupState?: any
   hmrRerender?: () => void
   hmrReload?: (newComp: VaporComponent) => void


### PR DESCRIPTION
JSX.Element is a `VNode | Block` type, don't extends `Block`, so use `Block extends Exposed` insteaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for exposed Vapor component instances.
  * Corrected render-context and setup-state typing for components with compatible exposed types.
  * Added coverage to verify the exposed instance type is correctly recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->