### PR TITLE
chore: remove outdated configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,3 @@ peerDependencyRules:
     '@typescript-eslint/utils>eslint': '^9.0.0'
 
 minimumReleaseAge: 1440
-minimumReleaseAgeExclude:
-  # Renovate security update: postcss@8.5.23
-  - postcss@8.5.23


### PR DESCRIPTION
Over time, postcss@8.5.23 is no longer affected by the minimumReleaseAge configuration so that it can be safely removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package release policy settings to apply the minimum release age requirement consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->