### PR TITLE
fix(runtime-vapor): isolate cached component props and dynamic slots

### DIFF
--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1699,12 +1699,20 @@ describe('VaporKeepAlive', () => {
     })
 
     test('should isolate props between cached dynamic components', async () => {
+      const fooCalls: Array<[number, number]> = []
       const Foo = compile(
         `<script setup vapor>
+          import { watch } from 'vue'
+          const calls = _data
           const props = defineProps(['n'])
+          watch(
+            () => props.n,
+            (value, oldValue) => calls.push([value, oldValue]),
+            { flush: 'sync' },
+          )
         </script>
         <template><div>foo {{ props.n }}</div></template>`,
-        ref(),
+        fooCalls as any,
       )
       const Bar = compile(
         `<script setup vapor>
@@ -1732,45 +1740,63 @@ describe('VaporKeepAlive', () => {
       data.value = { current: Bar, n: 1 }
       await nextTick()
       expect(html()).toBe(`<div>bar 1</div><!--dynamic-component-->`)
+      expect(fooCalls).toEqual([])
 
       data.value = { current: Foo, n: 2 }
       await nextTick()
       expect(html()).toBe(`<div>foo 2</div><!--dynamic-component-->`)
+      expect(fooCalls).toEqual([[2, 0]])
     })
 
-    test('should preserve raw prop source precedence', async () => {
+    test('should preserve raw prop source precedence across reactivation', async () => {
       const Child = compile(
         `<script setup vapor>
-          const props = defineProps(['fooBar'])
+          const props = defineProps(['fooBar', 'stale', 'bar'])
         </script>
-        <template><div>{{ props.fooBar }}</div></template>`,
+        <template><div>{{ props.fooBar }}|{{ props.stale }}|{{ props.bar }}</div></template>`,
         ref(),
       )
-      const data = ref<{ fooBar?: string }>({ fooBar: 'b' })
+      const Other = compile(
+        `<script setup vapor>
+          defineProps(['fooBar', 'stale', 'bar'])
+        </script>
+        <template><div>other</div></template>`,
+        ref(),
+      )
+      const current = shallowRef<VaporComponent>(Child)
+      const data = reactive<{
+        fooBar?: string
+        stale?: string
+        bar?: string
+      }>({ fooBar: 'b', stale: 'stale' })
       const App = compile(
         `<script setup vapor>
-          const data = _data
-          const Child = _components.Child
+          const current = _data.current
+          const data = _data.data
         </script>
         <template>
           <KeepAlive>
-            <Child foo-bar="a" v-bind="data" />
+            <component :is="current" foo-bar="a" v-bind="data" />
           </KeepAlive>
         </template>`,
-        data,
-        { Child },
+        { current, data } as any,
       )
 
       const { html } = define(App).render()
-      expect(html()).toBe(`<div>b</div>`)
+      expect(html()).toBe(`<div>b|stale|</div><!--dynamic-component-->`)
 
-      delete data.value.fooBar
+      current.value = Other
       await nextTick()
-      expect(html()).toBe(`<div>a</div>`)
+      expect(html()).toBe(`<div>other</div><!--dynamic-component-->`)
 
-      data.value.fooBar = 'c'
+      delete data.fooBar
+      delete data.stale
+      data.bar = 'bar'
       await nextTick()
-      expect(html()).toBe(`<div>c</div>`)
+
+      current.value = Child
+      await nextTick()
+      expect(html()).toBe(`<div>a||bar</div><!--dynamic-component-->`)
     })
 
     // #15228

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1697,6 +1697,177 @@ describe('VaporKeepAlive', () => {
       await nextTick()
       expect(html()).toBe(`<div>1</div><!--if-->`)
     })
+
+    test('should isolate props between cached dynamic components', async () => {
+      const Foo = compile(
+        `<script setup vapor>
+          const props = defineProps(['n'])
+        </script>
+        <template><div>foo {{ props.n }}</div></template>`,
+        ref(),
+      )
+      const Bar = compile(
+        `<script setup vapor>
+          const props = defineProps(['n'])
+        </script>
+        <template><div>bar {{ props.n }}</div></template>`,
+        ref(),
+      )
+      const data = shallowRef({ current: Foo, n: 0 })
+      const App = compile(
+        `<script setup vapor>
+          const data = _data
+        </script>
+        <template>
+          <KeepAlive>
+            <component :is="data.current" :n="data.n" />
+          </KeepAlive>
+        </template>`,
+        data,
+      )
+      const { html } = define(App).render()
+
+      expect(html()).toBe(`<div>foo 0</div><!--dynamic-component-->`)
+
+      data.value = { current: Bar, n: 1 }
+      await nextTick()
+      expect(html()).toBe(`<div>bar 1</div><!--dynamic-component-->`)
+
+      data.value = { current: Foo, n: 2 }
+      await nextTick()
+      expect(html()).toBe(`<div>foo 2</div><!--dynamic-component-->`)
+    })
+
+    test('should preserve raw prop source precedence', async () => {
+      const Child = compile(
+        `<script setup vapor>
+          const props = defineProps(['fooBar'])
+        </script>
+        <template><div>{{ props.fooBar }}</div></template>`,
+        ref(),
+      )
+      const data = ref<{ fooBar?: string }>({ fooBar: 'b' })
+      const App = compile(
+        `<script setup vapor>
+          const data = _data
+          const Child = _components.Child
+        </script>
+        <template>
+          <KeepAlive>
+            <Child foo-bar="a" v-bind="data" />
+          </KeepAlive>
+        </template>`,
+        data,
+        { Child },
+      )
+
+      const { html } = define(App).render()
+      expect(html()).toBe(`<div>b</div>`)
+
+      delete data.value.fooBar
+      await nextTick()
+      expect(html()).toBe(`<div>a</div>`)
+
+      data.value.fooBar = 'c'
+      await nextTick()
+      expect(html()).toBe(`<div>c</div>`)
+    })
+
+    // #15228
+    test('should not expose uncommitted props to a cached component', async () => {
+      const watcherCalls: Array<[string, string]> = []
+      const Hero = compile(
+        `<script setup vapor>
+          const props = defineProps({ item: { type: Object, required: true } })
+        </script>
+        <template><span>{{ props.item.id }}</span></template>`,
+        ref(),
+      )
+      const Child = compile(
+        `<script setup vapor>
+          import { watch } from 'vue'
+          const calls = _data
+          const Hero = _components.Hero
+          const props = defineProps({ item: { type: Object, required: true } })
+          watch(
+            () => props.item.id,
+            (value, oldValue) => calls.push([value, oldValue]),
+            { flush: 'sync' },
+          )
+        </script>
+        <template><p>pane: {{ props.item.id }}</p><Hero :item="props.item" /></template>`,
+        watcherCalls as any,
+        { Hero },
+      )
+      const selected = ref<{ id: string } | undefined>({ id: 'A' })
+      const App = compile(
+        `<script setup vapor>
+          const selected = _data
+          const Child = _components.Child
+        </script>
+        <template>
+          <KeepAlive>
+            <Child v-if="selected" :item="selected" />
+          </KeepAlive>
+        </template>`,
+        selected,
+        { Child },
+      )
+      const { html } = define(App).render()
+
+      expect(html()).toBe(`<p>pane: A</p><span>A</span><!--if-->`)
+
+      selected.value = undefined
+      await nextTick()
+      expect(html()).toBe(`<!--if-->`)
+      expect(watcherCalls).toEqual([])
+
+      selected.value = { id: 'B' }
+      await nextTick()
+      expect(html()).toBe(`<p>pane: B</p><span>B</span><!--if-->`)
+      expect(watcherCalls).toEqual([['B', 'A']])
+      expect('type check failed for prop "item"').not.toHaveBeenWarned()
+    })
+
+    test('should preserve props when an async component resolves while deactivated', async () => {
+      let resolve!: (comp: VaporComponent) => void
+      const AsyncChild = defineVaporAsyncComponent(
+        () => new Promise<VaporComponent>(r => (resolve = r)),
+      )
+      const Child = compile(
+        `<script setup vapor>
+          const props = defineProps({ item: { type: Object, required: true } })
+        </script>
+        <template><p>{{ props.item.id }}</p></template>`,
+        ref(),
+      )
+      const selected = ref<{ id: string } | undefined>({ id: 'A' })
+      const App = compile(
+        `<script setup vapor>
+          const selected = _data
+          const AsyncChild = _components.AsyncChild
+        </script>
+        <template>
+          <KeepAlive>
+            <AsyncChild v-if="selected" :item="selected" />
+          </KeepAlive>
+        </template>`,
+        selected,
+        { AsyncChild },
+      )
+      const { html } = define(App).render()
+
+      selected.value = undefined
+      await nextTick()
+      resolve(Child)
+      await timeout()
+      expect(html()).toBe(`<!--if-->`)
+      expect('type check failed for prop "item"').not.toHaveBeenWarned()
+
+      selected.value = { id: 'B' }
+      await nextTick()
+      expect(html()).toBe(`<p>B</p><!--async component--><!--if-->`)
+    })
   })
 
   test('should work with async component', async () => {

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -4429,4 +4429,56 @@ describe('VaporKeepAlive', () => {
       name: 'B',
     })
   })
+
+  test('should isolate dynamic slots accessed by a cached component', async () => {
+    const trigger = ref(0)
+    const slotKeys: string[][] = []
+    const Child = compile(
+      `<script setup vapor>
+        import { useSlots, watchEffect } from 'vue'
+        const trigger = _data.trigger
+        const slotKeys = _data.slotKeys
+        const slots = useSlots()
+        watchEffect(() => {
+          trigger.value
+          slotKeys.push(Object.keys(slots))
+        })
+      </script>
+      <template><div>child</div></template>`,
+      { trigger, slotKeys } as any,
+    )
+    const selected = ref<{ name: string } | undefined>({ name: 'a' })
+    const App = compile(
+      `<script setup vapor>
+        const selected = _data
+        const Child = _components.Child
+      </script>
+      <template>
+        <KeepAlive>
+          <Child v-if="selected">
+            <template #[selected.name]>content</template>
+          </Child>
+        </KeepAlive>
+      </template>`,
+      selected,
+      { Child },
+    )
+    const { html } = define(App).render()
+
+    expect(html()).toBe(`<div>child</div><!--if-->`)
+    expect(slotKeys).toEqual([['a']])
+
+    selected.value = undefined
+    await nextTick()
+    expect(html()).toBe(`<!--if-->`)
+
+    trigger.value++
+    await nextTick()
+    expect(slotKeys).toEqual([['a'], ['a']])
+
+    selected.value = { name: 'b' }
+    await nextTick()
+    expect(html()).toBe(`<div>child</div><!--if-->`)
+    expect(slotKeys[slotKeys.length - 1]).toEqual(['b'])
+  })
 })

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -69,6 +69,7 @@ import {
 import {
   type DynamicPropsSource,
   type RawProps,
+  createKeepAliveRawProps,
   getKeysFromRawProps,
   getPropsProxyHandlers,
   hasFallthroughAttrs,
@@ -115,7 +116,11 @@ import {
   isVaporTeleport,
 } from './teleport'
 import type { KeepAliveInstance } from './components/KeepAlive'
-import { getKeepAliveContext, isKeepAliveEnabled } from './keepAlive'
+import {
+  type VaporKeepAliveContext,
+  getKeepAliveContext,
+  isKeepAliveEnabled,
+} from './keepAlive'
 import {
   insertionAnchor,
   insertionParent,
@@ -320,6 +325,7 @@ export function createComponent(
       }
     }
 
+    let keepAliveCtx: VaporKeepAliveContext | null = null
     // keep-alive
     if (
       isKeepAliveEnabled &&
@@ -327,9 +333,9 @@ export function createComponent(
       currentInstance.vapor &&
       isKeepAlive(currentInstance)
     ) {
-      const cached = (
-        currentInstance as KeepAliveInstance
-      ).ctx.getCachedComponent(component)
+      const ctx = (currentInstance as KeepAliveInstance).ctx
+      keepAliveCtx = ctx
+      const cached = ctx.getCachedComponent(component)
       // @ts-expect-error
       if (cached) return cached
     }
@@ -382,6 +388,13 @@ export function createComponent(
       return frag as any
     }
 
+    if (rawProps && keepAliveCtx) {
+      // The cached component keeps its detached scope active, so commit only
+      // its direct inputs through the KeepAlive branch scope. Descendants read
+      // from the same committed props and need no additional isolation.
+      rawProps = createKeepAliveRawProps(rawProps as RawProps)
+    }
+
     const instance = new VaporComponentInstance(
       component,
       rawProps as RawProps,
@@ -394,7 +407,7 @@ export function createComponent(
     // Async wrappers are skipped here: their DynamicFragment resolves the outer
     // KeepAlive context from the wrapper's parent chain during setup.
     if (isKeepAliveEnabled && !isAsyncWrapper(instance)) {
-      const keepAliveCtx = getKeepAliveContext(currentInstance)
+      keepAliveCtx ||= getKeepAliveContext(currentInstance)
       if (keepAliveCtx) keepAliveCtx.processShapeFlag(instance)
     }
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -69,7 +69,6 @@ import {
 import {
   type DynamicPropsSource,
   type RawProps,
-  createKeepAliveRawProps,
   getKeysFromRawProps,
   getPropsProxyHandlers,
   hasFallthroughAttrs,
@@ -392,7 +391,7 @@ export function createComponent(
       // The cached component keeps its detached scope active, so commit only
       // its direct inputs through the KeepAlive branch scope. Descendants read
       // from the same committed props and need no additional isolation.
-      rawProps = createKeepAliveRawProps(rawProps as RawProps)
+      rawProps = keepAliveCtx.isolateRawProps(rawProps as RawProps)
     }
 
     const instance = new VaporComponentInstance(

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -391,7 +391,9 @@ export function createComponent(
       // The cached component keeps its detached scope active, so commit only
       // its direct inputs through the KeepAlive branch scope. Descendants read
       // from the same committed inputs and need no additional isolation.
-      if (rawProps) {
+      // v-once snapshots raw props in the instance constructor, so it does not
+      // need a live commit effect after creation.
+      if (rawProps && !once) {
         rawProps = keepAliveCtx.isolatePropSources(rawProps as RawProps)
       }
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -387,11 +387,20 @@ export function createComponent(
       return frag as any
     }
 
-    if (rawProps && keepAliveCtx) {
+    if (keepAliveCtx) {
       // The cached component keeps its detached scope active, so commit only
       // its direct inputs through the KeepAlive branch scope. Descendants read
-      // from the same committed props and need no additional isolation.
-      rawProps = keepAliveCtx.isolateRawProps(rawProps as RawProps)
+      // from the same committed inputs and need no additional isolation.
+      if (rawProps) {
+        rawProps = keepAliveCtx.isolatePropSources(rawProps as RawProps)
+      }
+
+      // Static slots are fixed function entries. Only `$` contains live slot
+      // descriptor sources that useSlots() can re-resolve while cached; slot
+      // function execution retains its existing closure semantics.
+      if (rawSlots && (rawSlots as RawSlots).$) {
+        rawSlots = keepAliveCtx.isolateSlotSources(rawSlots as RawSlots)
+      }
     }
 
     const instance = new VaporComponentInstance(

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -1,5 +1,6 @@
 import {
   EMPTY_ARR,
+  EMPTY_OBJ,
   NO,
   camelize,
   hasOwn,
@@ -30,6 +31,7 @@ import {
   ReactiveFlags,
   computed,
   onScopeDispose,
+  shallowReactive,
 } from '@vue/reactivity'
 import { normalizeEmitsOptions } from './componentEmits'
 import { renderEffect } from './renderEffect'
@@ -44,6 +46,137 @@ export type RawProps = Record<string, unknown> & {
 export type DynamicPropsSource =
   | (() => Record<string, unknown>)
   | Record<string, unknown>
+
+export function createKeepAliveRawProps(rawProps: RawProps): RawProps {
+  // Static values cannot change while cached and need no commit boundary.
+  let hasFunctionSource = false
+  for (const key in rawProps) {
+    if (key !== '$' && isFunction(rawProps[key])) hasFunctionSource = true
+  }
+  const dynamicSources = rawProps.$
+  if (dynamicSources && !hasFunctionSource) {
+    for (let i = 0; i < dynamicSources.length; i++) {
+      const source = dynamicSources[i]
+      if (isFunction(source)) {
+        hasFunctionSource = true
+        break
+      } else {
+        for (const key in source) {
+          if (isFunction(source[key])) {
+            hasFunctionSource = true
+            break
+          }
+        }
+        if (hasFunctionSource) break
+      }
+    }
+  }
+  if (!hasFunctionSource) return rawProps
+
+  const isolated: RawProps = Object.create(null)
+  let committed: Record<string, unknown> | undefined
+  for (const key in rawProps) {
+    if (key === '$') continue
+    const source = rawProps[key]
+    if (isFunction(source)) {
+      const target =
+        committed || (committed = shallowReactive<Record<string, unknown>>({}))
+      isolated[key] = () => target[key]
+    } else {
+      isolated[key] = source
+    }
+  }
+
+  let committedDynamicSources:
+    | (Record<string, unknown> | undefined)[]
+    | undefined
+  let previousDynamicSources: Record<string, unknown>[] | undefined
+  if (dynamicSources) {
+    const isolatedDynamicSources: DynamicPropsSource[] & {
+      [interopKey]?: boolean
+    } = []
+    committedDynamicSources = []
+    previousDynamicSources = []
+    for (let i = 0; i < dynamicSources.length; i++) {
+      const source = dynamicSources[i]
+      if (isFunction(source)) {
+        const target = (committedDynamicSources[i] = shallowReactive<
+          Record<string, unknown>
+        >({}))
+        previousDynamicSources[i] = {}
+        isolatedDynamicSources[i] = () => target
+      } else {
+        const isolatedSource: Record<string, unknown> = Object.create(null)
+        let target: Record<string, unknown> | undefined
+        for (const key in source) {
+          const value = source[key]
+          if (isFunction(value)) {
+            if (!target) {
+              target = committedDynamicSources[i] = shallowReactive<
+                Record<string, unknown>
+              >({})
+            }
+            const committedSource = target
+            isolatedSource[key] = () => committedSource[key]
+          } else {
+            isolatedSource[key] = value
+          }
+        }
+        isolatedDynamicSources[i] = target ? isolatedSource : source
+      }
+    }
+    const symbols = Object.getOwnPropertySymbols(dynamicSources)
+    for (let i = 0; i < symbols.length; i++) {
+      ;(isolatedDynamicSources as any)[symbols[i]] = (dynamicSources as any)[
+        symbols[i]
+      ]
+    }
+    isolated.$ = isolatedDynamicSources
+  }
+
+  // Each source keeps its original position and key spelling so prop/attr
+  // precedence is unchanged. The writer belongs to the KeepAlive branch scope,
+  // so deactivation pauses parent updates without pausing the component.
+  // Source invalidations while this effect is paused still leave it dirty.
+  // Resuming the branch scope therefore schedules one commit with the latest
+  // raw props, while an unchanged cache entry needs no work on activation.
+  renderEffect(() => {
+    if (committed) {
+      for (const key in rawProps) {
+        if (key !== '$' && isFunction(rawProps[key])) {
+          committed[key] = resolveSource(rawProps[key])
+        }
+      }
+    }
+    if (dynamicSources) {
+      for (let i = 0; i < dynamicSources.length; i++) {
+        const source = dynamicSources[i]
+        const target = committedDynamicSources![i]
+        if (!target) continue
+        if (isFunction(source)) {
+          const next = resolveFunctionSource(source) || EMPTY_OBJ
+          const previous = previousDynamicSources![i]
+          for (const key in previous) {
+            if (!hasOwn(next, key)) {
+              delete target[key]
+              delete previous[key]
+            }
+          }
+          for (const key in next) {
+            target[key] = previous[key] = next[key]
+          }
+        } else {
+          for (const key in source) {
+            if (isFunction(source[key])) {
+              target[key] = resolveSource(source[key])
+            }
+          }
+        }
+      }
+    }
+  }, true)
+  return isolated
+}
 
 export function resolveSource<T>(source: T | (() => T)): T {
   return isFunction(source) ? resolveFunctionSource(source as () => T) : source

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -47,7 +47,7 @@ export type DynamicPropsSource =
   | (() => Record<string, unknown>)
   | Record<string, unknown>
 
-export function createKeepAliveRawProps(rawProps: RawProps): RawProps {
+export function isolatePropSources(rawProps: RawProps): RawProps {
   // Static values cannot change while cached and need no commit boundary.
   let hasFunctionSource = false
   for (const key in rawProps) {

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -27,12 +27,13 @@ import {
   type VaporComponentInstance,
   isVaporComponent,
 } from '../component'
-import { createKeepAliveRawProps } from '../componentProps'
+import { isolatePropSources, resolveFunctionSource } from '../componentProps'
+import type { DynamicSlotFn, RawSlots } from '../componentSlots'
 import {
   type DefineVaporComponent,
   defineVaporComponent,
 } from '../apiDefineComponent'
-import { ShapeFlags, invokeArrayFns, isArray } from '@vue/shared'
+import { ShapeFlags, invokeArrayFns, isArray, isFunction } from '@vue/shared'
 import { createElement } from '../dom/node'
 import { unsetRef } from '../refCleanup'
 import {
@@ -42,8 +43,9 @@ import {
   isFragment,
   isInteropFragment,
 } from '../fragment'
-import { EffectScope } from '@vue/reactivity'
+import { EffectScope, shallowReactive } from '@vue/reactivity'
 import { isInteropEnabled } from '../vdomInteropState'
+import { renderEffect } from '../renderEffect'
 import {
   type VaporKeepAliveContext,
   currentCacheKey,
@@ -375,7 +377,8 @@ const VaporKeepAliveImpl = defineVaporComponent({
     })
 
     const keepAliveCtx: KeepAliveInstance['ctx'] = {
-      isolateRawProps: createKeepAliveRawProps,
+      isolatePropSources,
+      isolateSlotSources,
       getStorageContainer: () => storageContainer,
       getCachedComponent: (comp, key) => {
         if (isInteropEnabled && isVNode(comp)) {
@@ -660,4 +663,37 @@ export function deactivate(
   if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
     devtoolsComponentAdded(instance)
   }
+}
+
+function isolateSlotSources(rawSlots: RawSlots): RawSlots {
+  const dynamicSources = rawSlots.$!
+
+  const isolatedSources = dynamicSources.slice()
+  const committedSources = shallowReactive<
+    Array<ReturnType<DynamicSlotFn> | undefined>
+  >([])
+  let hasFunctionSource = false
+  for (let i = 0; i < dynamicSources.length; i++) {
+    const source = dynamicSources[i]
+    if (isFunction(source)) {
+      hasFunctionSource = true
+      isolatedSources[i] = (() => committedSources[i]) as DynamicSlotFn
+    }
+  }
+  if (!hasFunctionSource) return rawSlots
+
+  const isolated = { ...rawSlots, $: isolatedSources } as RawSlots
+  // VDOM materializes dynamic slots before caching a child. Commit Vapor's
+  // live slot descriptors through the branch scope so useSlots() observes the
+  // same last-patched slot table while deactivated. Slot functions themselves
+  // remain unchanged and retain their existing closure semantics.
+  renderEffect(() => {
+    for (let i = 0; i < dynamicSources.length; i++) {
+      const source = dynamicSources[i]
+      if (isFunction(source)) {
+        committedSources[i] = resolveFunctionSource(source as DynamicSlotFn)
+      }
+    }
+  }, true)
+  return isolated
 }

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -27,6 +27,7 @@ import {
   type VaporComponentInstance,
   isVaporComponent,
 } from '../component'
+import { createKeepAliveRawProps } from '../componentProps'
 import {
   type DefineVaporComponent,
   defineVaporComponent,
@@ -374,6 +375,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
     })
 
     const keepAliveCtx: KeepAliveInstance['ctx'] = {
+      isolateRawProps: createKeepAliveRawProps,
       getStorageContainer: () => storageContainer,
       getCachedComponent: (comp, key) => {
         if (isInteropEnabled && isVNode(comp)) {

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -405,13 +405,18 @@ const VaporKeepAliveImpl = defineVaporComponent({
           scope.stop()
           return false
         }
+        // Component scopes are detached from this DynamicFragment scope.
+        // Pausing it freezes branch-owned input commits without pausing the
+        // cached component's own effects; those effects keep reading the last
+        // committed inputs, like a cached VNode whose props are not patched.
+        scope.pause()
         cacheScope(cacheKey, frag.current, scope)
         return true
       },
       runBranchRender(frag, fn, useScope, removePrevious) {
-        frag.scope = useScope
-          ? deleteScope(frag.current) || new EffectScope()
-          : undefined
+        const cachedScope = useScope ? deleteScope(frag.current) : undefined
+        frag.scope = useScope ? cachedScope || new EffectScope() : undefined
+        if (cachedScope) cachedScope.resume()
         let incomingCacheKey: CacheKey | false = false
         const run = () => {
           try {

--- a/packages/runtime-vapor/src/keepAlive.ts
+++ b/packages/runtime-vapor/src/keepAlive.ts
@@ -6,8 +6,10 @@ import {
 import type { EffectScope } from '@vue/reactivity'
 import type { Block } from './block'
 import type { DynamicFragment } from './fragment'
+import type { RawProps } from './componentProps'
 
 export interface VaporKeepAliveContext {
+  isolateRawProps(rawProps: RawProps): RawProps
   // caches or stops the outgoing branch scope and returns whether its DOM
   // removal must wait for the incoming cache decision
   prepareBranchRemoval(frag: DynamicFragment, scope: EffectScope): boolean

--- a/packages/runtime-vapor/src/keepAlive.ts
+++ b/packages/runtime-vapor/src/keepAlive.ts
@@ -7,9 +7,11 @@ import type { EffectScope } from '@vue/reactivity'
 import type { Block } from './block'
 import type { DynamicFragment } from './fragment'
 import type { RawProps } from './componentProps'
+import type { RawSlots } from './componentSlots'
 
 export interface VaporKeepAliveContext {
-  isolateRawProps(rawProps: RawProps): RawProps
+  isolatePropSources(rawProps: RawProps): RawProps
+  isolateSlotSources(rawSlots: RawSlots): RawSlots
   // caches or stops the outgoing branch scope and returns whether its DOM
   // removal must wait for the incoming cache decision
   prepareBranchRemoval(frag: DynamicFragment, scope: EffectScope): boolean

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -39,7 +39,8 @@ export class RenderEffect extends ReactiveEffect {
     }
 
     const job: SchedulerJob = () => {
-      if (this.dirty) {
+      // The job may already be queued when its owning scope is paused.
+      if (!(this.flags & EffectFlags.PAUSED) && this.dirty) {
         // A pending KeepAlive async root defers updates along its root chain.
         const deferred =
           __FEATURE_SUSPENSE__ &&


### PR DESCRIPTION
Closes #15228

Vapor component props can retain lazy subscriptions to live parent sources. When the same parent value controls a `v-if` branch and is passed as a prop, a cached component can observe a transient value before the branch is deactivated. This can run render effects and `flush: 'sync'` watchers with invalid props, unlike VDOM where a cached vnode retains its last patched inputs.

Commit dynamic raw prop sources through an effect owned by the KeepAlive branch scope. Cached components read the committed shallow values instead of subscribing directly to the parent sources. When the branch is removed, its scope is paused before queued commit jobs run, so the cached component continues to observe its last committed props. Activation resumes the scope and synchronizes the latest values.

Keep component scopes and their local effects active, preserve raw source ordering and key spelling, reconcile dynamic key additions and removals, and skip the commit bridge for `v-once` components that already snapshot their raw props.

Apply the same commit boundary to dynamic slot descriptors so cached components using `useSlots()` retain their last committed slot table while deactivated. Static slot entries and slot function closure semantics remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KeepAlive behavior when switching between cached and inactive components.
  * Prevented stale or uncommitted prop and slot updates from appearing during deactivation and reactivation.
  * Preserved component props when asynchronous components resolve while inactive.
  * Ensured queued updates remain paused until their associated component is reused.
* **Tests**
  * Added regression coverage for prop and slot isolation, update precedence, suppression, and preservation in KeepAlive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->