### PR TITLE
fix(hydration): handle async component unmount before lazy hydration

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1245,6 +1245,79 @@ describe('SSR hydration', () => {
     assertSkipLazyHydration,
   )
 
+  test('unmount a lazily hydrated component that has not hydrated yet', async () => {
+    const Comp = { render: () => h('p', 'hello') }
+    const AsyncComp = defineAsyncComponent({
+      loader: () => Promise.resolve(Comp),
+      // a lazy hydration strategy that has not fired yet, e.g. hydrateOnVisible()
+      // on content that was never scrolled into view
+      hydrate: () => {},
+    })
+
+    const show = ref(true)
+    // the async component is unmounted as part of a parent subtree, which is
+    // what happens on a route change
+    const App = () => h('div', show.value ? [h(AsyncComp)] : [])
+
+    const container = document.createElement('div')
+    container.innerHTML = await renderToString(h(App))
+    document.body.appendChild(container)
+    createSSRApp(App).mount(container)
+
+    // the strategy never fired, so instance.subTree is still null
+    show.value = false
+    await expect(nextTick()).resolves.not.toThrow()
+    // the server-rendered DOM of the never-hydrated component is removed
+    expect(container.innerHTML).toBe('<div></div>')
+  })
+
+  // the #15091 guard skips hydration when the SSR node is detached, which
+  // leaves subTree unset in the same way
+  test('unmount after lazy hydration was skipped for a detached node', async () => {
+    let observer!: IntersectionObserver
+    let observerCallback!: IntersectionObserverCallback
+    const originalIntersectionObserver = globalThis.IntersectionObserver
+    globalThis.IntersectionObserver = class {
+      constructor(callback: IntersectionObserverCallback) {
+        observer = this as any
+        observerCallback = callback
+      }
+      disconnect() {}
+      observe() {}
+    } as any
+
+    try {
+      const Comp = vi.fn(() => h('p', 'hello'))
+      const AsyncComp = defineAsyncComponent({
+        loader: () => Promise.resolve(Comp),
+        hydrate: hydrateOnVisible(),
+      })
+      const show = ref(true)
+      const App = () => h('div', show.value ? [h(AsyncComp)] : [])
+
+      const container = document.createElement('div')
+      container.innerHTML = await renderToString(h(App))
+      document.body.appendChild(container)
+      Comp.mockClear()
+      createSSRApp(App).mount(container)
+
+      // detach, then let the observer fire: hydration bails out
+      const el: Element = container.querySelector('p')!
+      el.remove()
+      observerCallback(
+        [{ isIntersecting: true, target: el } as IntersectionObserverEntry],
+        observer,
+      )
+      await nextTick()
+      expect(Comp).not.toHaveBeenCalled()
+
+      show.value = false
+      await expect(nextTick()).resolves.not.toThrow()
+    } finally {
+      globalThis.IntersectionObserver = originalIntersectionObserver
+    }
+  })
+
   test('update async wrapper before resolve', async () => {
     const Comp = {
       render() {

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -11,7 +11,7 @@ import {
   normalizeVNode,
 } from './vnode'
 import { flushPostFlushCbs } from './scheduler'
-import type { ComponentInternalInstance, ComponentOptions } from './component'
+import type { ComponentInternalInstance } from './component'
 import { invokeDirectiveHook } from './directives'
 import { warn } from './warning'
 import {
@@ -309,10 +309,12 @@ export function createHydrationFunctions(
           // if component is async, it may get moved / unmounted before its
           // inner component is loaded, so we need to give it a placeholder
           // vnode that matches its adopted DOM.
-          if (
-            isAsyncWrapper(vnode) &&
-            !(vnode.type as ComponentOptions).__asyncResolved
-          ) {
+          //
+          // This covers two cases, both of which leave subTree unset:
+          // - the component has not resolved yet
+          // - the component has resolved, but uses a lazy hydration strategy
+          //   that has not fired yet, so hydrating its subtree was deferred
+          if (isAsyncWrapper(vnode) && !vnode.component!.subTree) {
             let subTree
             if (isFragmentStart) {
               subTree = createVNode(Fragment)


### PR DESCRIPTION
### Summary

An async component that uses a lazy hydration strategy crashes when it is unmounted before its strategy has fired:

```
TypeError: Cannot destructure property 'type' of 'vnode' as it is null.
    at unmount
    at unmountComponent
    at unmount
    at unmountChildren
    at unmount
```

This happens with any strategy that legitimately may never fire — `hydrateOnVisible()` on content that is never scrolled into view, `hydrateOnInteraction()` that is never interacted with, or `hydrateOnMediaQuery()` whose query does not match.

Reproduces on 3.5.21, 3.5.41 and 3.6.0-rc.2, and on `main` (f897565).

### Reproduction

https://github.com/tandler5/vue-lazy-hydration-unmount-crash

- `npm run dev` → click the button (real SSR + hydration in a browser)
- `npm run repro:headless` → same crash without a browser

Minimal case:

```js
const AsyncLazy = defineAsyncComponent({
  loader: () => Promise.resolve(Comp),
  hydrate: () => {}, // a strategy that has not fired yet
})

const show = ref(true)
const App = () => h('div', show.value ? [h(AsyncLazy)] : [])

// SSR render, hydrate, then:
show.value = false // 💥
```

### Cause

When hydrating an async wrapper that has a hydration strategy, `setupRenderEffect` defers `hydrateSubTree()` — the only place that assigns `instance.subTree`:

```js
if (isAsyncWrapperVNode && type.__asyncHydrate) {
  type.__asyncHydrate(el, instance, hydrateSubTree) // deferred; subTree stays null
} else {
  hydrateSubTree()
}
```

`instance.job` is assigned unconditionally before `update()`, so the component ends up with `job` set and `subTree` still `null`. `unmountComponent` only guards on `job`, so it calls `unmount(null)`.

Hydration already handles exactly this situation: since #3787 it assigns a placeholder subtree that matches the adopted DOM, precisely so an async component can be moved or unmounted before its inner component is available. But the condition only covered the *unresolved* case:

```js
if (isAsyncWrapper(vnode) && !(vnode.type as ComponentOptions).__asyncResolved) {
```

A lazily hydrated component can be **resolved and still un-hydrated**, so it was skipped and got no placeholder.

Note that this needs the component to be resolved *before* hydration — which is the normal case in an SSR framework, where the chunk for an SSR-rendered component is preloaded or bundled. If the loader only resolves after hydration, the resulting re-render mounts the component normally and assigns `subTree`, which hides the bug.

### Fix

Key off the missing `subTree` instead of `__asyncResolved`. This covers both cases that leave it unset and needs no extra condition:

```js
if (isAsyncWrapper(vnode) && !vnode.component!.subTree) {
```

I first tried guarding `unmount(subTree)` in `unmountComponent`. That stops the throw, but it is the wrong layer: nothing then removes the server-rendered DOM, so unmounting leaks the markup (the added test asserts against this). Reusing the existing placeholder mechanism fixes the crash *and* removes the DOM, consistent with what already happens for unresolved async components.

### Tests

Two cases added to `hydration.spec.ts`, next to the existing #15091 lazy-hydration tests. Both fail on `main` with the exact error above and pass with the fix:

1. a strategy that has not fired yet — also asserts the server-rendered DOM is actually removed, not just that nothing throws
2. the #15091 detached-node path (see below)

Full unit suite passes (3267 tests).

### Notes

- No breaking change, no API surface change.
- Perf/size: swaps one property read for another in a hydration-only branch — the placeholder is now also created for resolved-but-not-yet-hydrated wrappers, which is the case that previously crashed.
- **This also covers the aftermath of #15091.** That fix guards `performHydrate`:

  ```js
  if (!el.parentNode || (wasConnected && !el.isConnected)) return
  ```

  It prevents the `nodeType` crash, but it returns *without hydrating*, which leaves `subTree` unset in exactly the same way — so any later unmount of that component hit this crash. The second added test covers this: detach the SSR node, let the observer fire so the guard bails, then unmount. It throws on `main` and passes with this fix.

  Note the two are otherwise distinct: #15091 crashes during hydration when the strategy *did* fire on a detached node; this one crashes during unmount when the strategy never fired at all.
- The same null `subTree` also crashes `getNextHostNode` (`Cannot read properties of null (reading 'shapeFlag')`) when the lazy component has a following sibling; this fix resolves that too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when lazily hydrated asynchronous components are removed before hydration begins.
  * Prevented errors during unmounting and ensured server-rendered content is removed correctly.
  * Avoided invoking asynchronous components when hydration is skipped because their server-rendered nodes are detached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->