### PR TITLE
fix(compiler-vapor): wrap custom directive value in parens

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -65,7 +65,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => _ctx.msg]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg)]])
   return n0
 }"
 `;
@@ -76,7 +76,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => _ctx.msg, _ctx.foo]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), _ctx.foo]])
   return n0
 }"
 `;
@@ -87,7 +87,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => _ctx.msg, void 0, { bar: true }]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), void 0, { bar: true }]])
   return n0
 }"
 `;
@@ -103,13 +103,32 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 }"
 `;
 
+exports[`compile > directives > custom directive > object literal binding value 1`] = `
+"import { withVaporDirectives as _withVaporDirectives, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx, $props, $emit, $attrs, $slots) {
+  const n0 = t0()
+  _withVaporDirectives(n0, [[_ctx.vExample, () => ({ value: _ctx.msg, other: 1 })]])
+  return n0
+}"
+`;
+
+exports[`compile > directives > custom directive > object literal binding value w/ inline mode 1`] = `
+"
+  const n0 = t0()
+  _withVaporDirectives(n0, [[vExample, () => ({ value: msg.value })]])
+  return n0
+"
+`;
+
 exports[`compile > directives > custom directive > static parameters 1`] = `
 "import { withVaporDirectives as _withVaporDirectives, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => _ctx.msg, "foo"]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), "foo"]])
   return n0
 }"
 `;
@@ -120,7 +139,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => _ctx.msg, "foo", { bar: true }]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), "foo", { bar: true }]])
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -116,6 +116,32 @@ describe('compile', () => {
         expect(code).matchSnapshot()
       })
 
+      test('object literal binding value', () => {
+        const code = compile(
+          `<div v-example="{ value: msg, other: 1 }"></div>`,
+          {
+            bindingMetadata: {
+              msg: BindingTypes.SETUP_REF,
+              vExample: BindingTypes.SETUP_CONST,
+            },
+          },
+        )
+        expect(code).matchSnapshot()
+        expect(code).contains('() => ({ value: _ctx.msg, other: 1 })')
+      })
+
+      test('object literal binding value w/ inline mode', () => {
+        const code = compile(`<div v-example="{ value: msg }"></div>`, {
+          inline: true,
+          bindingMetadata: {
+            msg: BindingTypes.SETUP_REF,
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
+        expect(code).contains('() => ({ value: msg.value })')
+      })
+
       test('static parameters', () => {
         const code = compile(`<div v-example:foo="msg"></div>`, {
           bindingMetadata: {

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -66,7 +66,11 @@ function genCustomDirectives(
           extend(createSimpleExpression(name, false), { ast: null }),
           context,
         )
-    const value = dir.exp && ['() => ', ...genExpression(dir.exp, context)]
+    const value = dir.exp && [
+      '() => (',
+      ...genExpression(dir.exp, context),
+      ')',
+    ]
     const argument = dir.arg && genExpression(dir.arg, context)
     const modifiers = !!dir.modifiers.length && [
       '{ ',


### PR DESCRIPTION
close #15253

The vapor codegen wrapped a custom directive's value with `() => ` and no parens, so an inline object literal came out as an arrow with a block body: `() => { value: msg }`. With a single property that quietly returns undefined, with two or more it's a SyntaxError at build time. Wrapping the expression in parens, the way the other vapor getters already do, fixes both shapes, and inline mode too since it goes through the same code path.