### PR TITLE
fix(compiler-vapor): keep the space after a quoted attribute value

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/templateTransformSrcset.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/templateTransformSrcset.spec.ts.snap
@@ -18,16 +18,16 @@ exports[`compiler sfc: transform srcset > transform srcset 1`] = `
 "import { template as _template } from 'vue';
 import _imports_0 from './logo.png';
 import _imports_1 from '/logo.png';
-const t0 = _template("<img src=\\"" + _imports_0 + "\\"srcset>", 2)
-const t1 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + "\\">", 2)
-const t2 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x' + "\\">", 2)
-const t3 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
-const t4 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + "\\">", 2)
-const t5 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
-const t6 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
-const t7 = _template("<img src=\\"" + _imports_1 + "\\"srcset=\\"" + _imports_1 + ', ' + _imports_1 + ' 2x' + "\\">", 2)
+const t0 = _template("<img src=\\"" + _imports_0 + "\\" srcset>", 2)
+const t1 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + "\\">", 2)
+const t2 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x' + "\\">", 2)
+const t3 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
+const t4 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + "\\">", 2)
+const t5 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
+const t6 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
+const t7 = _template("<img src=\\"" + _imports_1 + "\\" srcset=\\"" + _imports_1 + ', ' + _imports_1 + ' 2x' + "\\">", 2)
 const t8 = _template("<img src=https://example.com/logo.png srcset=\\"https://example.com/logo.png, https://example.com/logo.png 2x\\">", 2)
-const t9 = _template("<img src=\\"" + _imports_1 + "\\"srcset=\\"" + _imports_1 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
+const t9 = _template("<img src=\\"" + _imports_1 + "\\" srcset=\\"" + _imports_1 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
 const t10 = _template("<img src=data:image/png;base64,i srcset=\\"data:image/png;base64,i 1x, data:image/png;base64,i 2x\\">", 2)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
@@ -58,9 +58,9 @@ const t3 = _template("<img src=/foo/logo.png srcset=\\"/foo/logo.png, /foo/logo.
 const t4 = _template("<img src=/foo/logo.png srcset=\\"/foo/logo.png 2x, /foo/logo.png\\">", 2)
 const t5 = _template("<img src=/foo/logo.png srcset=\\"/foo/logo.png 2x, /foo/logo.png 3x\\">", 2)
 const t6 = _template("<img src=/foo/logo.png srcset=\\"/foo/logo.png, /foo/logo.png 2x, /foo/logo.png 3x\\">", 2)
-const t7 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
+const t7 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
 const t8 = _template("<img src=https://example.com/logo.png srcset=\\"https://example.com/logo.png, https://example.com/logo.png 2x\\">", 2)
-const t9 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_1 + ' 2x' + "\\">", 2)
+const t9 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_1 + ' 2x' + "\\">", 2)
 const t10 = _template("<img src=data:image/png;base64,i srcset=\\"data:image/png;base64,i 1x, data:image/png;base64,i 2x\\">", 2)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
@@ -84,16 +84,16 @@ exports[`compiler sfc: transform srcset > transform srcset w/ includeAbsolute: t
 "import { template as _template } from 'vue';
 import _imports_0 from './logo.png';
 import _imports_1 from '/logo.png';
-const t0 = _template("<img src=\\"" + _imports_0 + "\\"srcset>", 2)
-const t1 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + "\\">", 2)
-const t2 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x' + "\\">", 2)
-const t3 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
-const t4 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + "\\">", 2)
-const t5 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
-const t6 = _template("<img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
-const t7 = _template("<img src=\\"" + _imports_1 + "\\"srcset=\\"" + _imports_1 + ', ' + _imports_1 + ' 2x' + "\\">", 2)
+const t0 = _template("<img src=\\"" + _imports_0 + "\\" srcset>", 2)
+const t1 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + "\\">", 2)
+const t2 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x' + "\\">", 2)
+const t3 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
+const t4 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + "\\">", 2)
+const t5 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
+const t6 = _template("<img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\">", 2)
+const t7 = _template("<img src=\\"" + _imports_1 + "\\" srcset=\\"" + _imports_1 + ', ' + _imports_1 + ' 2x' + "\\">", 2)
 const t8 = _template("<img src=https://example.com/logo.png srcset=\\"https://example.com/logo.png, https://example.com/logo.png 2x\\">", 2)
-const t9 = _template("<img src=\\"" + _imports_1 + "\\"srcset=\\"" + _imports_1 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
+const t9 = _template("<img src=\\"" + _imports_1 + "\\" srcset=\\"" + _imports_1 + ', ' + _imports_0 + ' 2x' + "\\">", 2)
 const t10 = _template("<img src=data:image/png;base64,i srcset=\\"data:image/png;base64,i 1x, data:image/png;base64,i 2x\\">", 2)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
@@ -117,7 +117,7 @@ exports[`compiler sfc: transform srcset > transform srcset w/ stringify 1`] = `
 "import { template as _template } from 'vue';
 import _imports_0 from './logo.png';
 import _imports_1 from '/logo.png';
-const t0 = _template("<div><img src=\\"" + _imports_0 + "\\"srcset><img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + "\\"><img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x' + "\\"><img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x' + "\\"><img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\"><img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + "\\"><img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\"><img src=\\"" + _imports_0 + "\\"srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\"><img src=\\"" + _imports_1 + "\\"srcset=\\"" + _imports_1 + ', ' + _imports_1 + ' 2x' + "\\"><img src=https://example.com/logo.png srcset=\\"https://example.com/logo.png, https://example.com/logo.png 2x\\"><img src=\\"" + _imports_1 + "\\"srcset=\\"" + _imports_1 + ', ' + _imports_0 + ' 2x' + "\\"><img src=data:image/png;base64,i srcset=\\"data:image/png;base64,i 1x, data:image/png;base64,i 2x\\">", 3)
+const t0 = _template("<div><img src=\\"" + _imports_0 + "\\" srcset><img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + "\\"><img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x' + "\\"><img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x' + "\\"><img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x' + "\\"><img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + "\\"><img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\"><img src=\\"" + _imports_0 + "\\" srcset=\\"" + _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x' + "\\"><img src=\\"" + _imports_1 + "\\" srcset=\\"" + _imports_1 + ', ' + _imports_1 + ' 2x' + "\\"><img src=https://example.com/logo.png srcset=\\"https://example.com/logo.png, https://example.com/logo.png 2x\\"><img src=\\"" + _imports_1 + "\\" srcset=\\"" + _imports_1 + ', ' + _imports_0 + ' 2x' + "\\"><img src=data:image/png;base64,i srcset=\\"data:image/png;base64,i 1x, data:image/png;base64,i 2x\\">", 3)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -1077,7 +1077,7 @@ export function render(_ctx) {
 
 exports[`compiler: element transform > static props quoting > mixed quoting with boolean attribute 1`] = `
 "import { template as _template } from 'vue';
-const t0 = _template("<div title=\\"has whitespace\\"inert data-targets=\\"foo>bar\\">", 3)
+const t0 = _template("<div title=\\"has whitespace\\" inert data-targets=\\"foo>bar\\">", 3)
 
 export function render(_ctx) {
   const n0 = t0()
@@ -1145,9 +1145,9 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: element transform > static props quoting > space omitted after quoted attribute 1`] = `
+exports[`compiler: element transform > static props quoting > space kept after quoted attribute 1`] = `
 "import { template as _template } from 'vue';
-const t0 = _template("<div title=\\"has whitespace\\"alt=\\"&quot;contains quotes&quot;\\"data-targets=\\"foo>bar\\">", 3)
+const t0 = _template("<div title=\\"has whitespace\\" alt=\\"&quot;contains quotes&quot;\\" data-targets=\\"foo>bar\\">", 3)
 
 export function render(_ctx) {
   const n0 = t0()

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -1792,19 +1792,19 @@ describe('compiler: element transform', () => {
       )
 
       const template =
-        '<div title="has whitespace"inert data-targets="foo>bar">'
+        '<div title="has whitespace" inert data-targets="foo>bar">'
       expect(code).toMatchSnapshot()
       expect(code).contains(JSON.stringify(template))
       expect([...ir.template.keys()]).toMatchObject([template])
     })
 
-    test('space omitted after quoted attribute', () => {
+    test('space kept after quoted attribute', () => {
       const { code, ir } = compileWithElementTransform(
         `<div title="has whitespace" alt='"contains quotes"' data-targets="foo>bar" />`,
       )
 
       const template =
-        '<div title="has whitespace"alt="&quot;contains quotes&quot;"data-targets="foo>bar">'
+        '<div title="has whitespace" alt="&quot;contains quotes&quot;" data-targets="foo>bar">'
       expect(code).toMatchSnapshot()
       expect(code).contains(JSON.stringify(template))
       expect([...ir.template.keys()]).toMatchObject([template])

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -417,26 +417,20 @@ function transformNativeElement(
       getEffectIndex,
     )
   } else {
-    // tracks if previous attribute was quoted, allowing space omission
-    // e.g. `class="foo"id="bar"` is valid, `class=foo id=bar` needs space
-    let prevWasQuoted = false
     const appendTemplateProp = (
       key: string,
       value: string = '',
       generated: boolean = false,
     ) => {
-      if (!prevWasQuoted) template += ` `
-      template += key
+      template += ` ${key}`
 
       if (value) {
         const escapedValue = generated
           ? escapeGeneratedAttrValue(value)
           : value.replace(/"/g, '&quot;')
-        template += (prevWasQuoted = NEEDS_QUOTES_RE.test(value))
+        template += NEEDS_QUOTES_RE.test(value)
           ? `="${escapedValue}"`
           : `=${escapedValue}`
-      } else {
-        prevWasQuoted = false
       }
     }
 
@@ -452,11 +446,9 @@ function transformNativeElement(
           values[0].content.includes(imported.exp.content),
         )
       ) {
-        if (!prevWasQuoted) template += ` `
         // add start and end markers to the import expression, so it can be replaced
         // with string concatenation in the generator, see genTemplates
-        template += `${key.content}="${IMPORT_EXP_START}${values[0].content}${IMPORT_EXP_END}"`
-        prevWasQuoted = true
+        template += ` ${key.content}="${IMPORT_EXP_START}${values[0].content}${IMPORT_EXP_END}"`
       } else if (
         canStringifyAttrName &&
         values.length === 1 &&


### PR DESCRIPTION
close #15257

The static template string dropped the separator after any attribute whose value was quoted, so `<div class="a b" title="c">` compiled to `_template("<div class=\"a b\"title=c>")`. That is a `missing-whitespace-between-attributes` parse error: the "after attribute value (quoted)" state only accepts whitespace, `/` or `>`. Browsers recover from it, but anything stricter that re-parses the generated string does not.

There is no case where the separator can be dropped, so `prevWasQuoted` is gone and the space is always emitted. Unquoted values are unaffected, they already kept theirs.