### PR TITLE
fix(vapor): resolve props declared via extends/mixins on VDOM child of vapor parent

### DIFF
--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -571,6 +571,115 @@ describe('vdomInterop', () => {
         'vnode updated',
       ])
     })
+
+    // https://github.com/vuejs/core/issues/15254
+    test('should resolve props declared via extends on a VDOM child of a vapor parent', () => {
+      const base = {
+        props: {
+          modelValue: { type: Boolean, default: false },
+        },
+        emits: ['update:modelValue'],
+      }
+
+      const ExtendsChild = defineComponent({
+        extends: base,
+        setup(props: any) {
+          return () =>
+            h(
+              'div',
+              `${typeof props.modelValue}:${String(props.modelValue)}`,
+            )
+        },
+      })
+
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(ExtendsChild as any, {
+            modelValue: () => false,
+          })
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporParent as any)
+        },
+      }).render()
+
+      expect(html()).toBe('<div>boolean:false</div>')
+    })
+
+    // https://github.com/vuejs/core/issues/15254
+    test('should resolve props declared via mixins on a VDOM child of a vapor parent', () => {
+      const base = {
+        props: {
+          modelValue: { type: Boolean, default: false },
+        },
+        emits: ['update:modelValue'],
+      }
+
+      const MixinsChild = defineComponent({
+        mixins: [base],
+        setup(props: any) {
+          return () =>
+            h(
+              'div',
+              `${typeof props.modelValue}:${String(props.modelValue)}`,
+            )
+        },
+      })
+
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(MixinsChild as any, {
+            modelValue: () => false,
+          })
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporParent as any)
+        },
+      }).render()
+
+      expect(html()).toBe('<div>boolean:false</div>')
+    })
+
+    // https://github.com/vuejs/core/issues/15254
+    test('should apply props defaults declared via extends on a VDOM child of a vapor parent', () => {
+      const base = {
+        props: {
+          modelValue: { type: Boolean, default: false },
+        },
+        emits: ['update:modelValue'],
+      }
+
+      const ExtendsChild = defineComponent({
+        extends: base,
+        setup(props: any) {
+          return () =>
+            h(
+              'div',
+              `${typeof props.modelValue}:${String(props.modelValue)}`,
+            )
+        },
+      })
+
+      const VaporParent = defineVaporComponent({
+        setup() {
+          return createComponent(ExtendsChild as any)
+        },
+      })
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporParent as any)
+        },
+      }).render()
+
+      expect(html()).toBe('<div>boolean:false</div>')
+    })
   })
 
   describe('v-model', () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -585,10 +585,7 @@ describe('vdomInterop', () => {
         extends: base,
         setup(props: any) {
           return () =>
-            h(
-              'div',
-              `${typeof props.modelValue}:${String(props.modelValue)}`,
-            )
+            h('div', `${typeof props.modelValue}:${String(props.modelValue)}`)
         },
       })
 
@@ -622,10 +619,7 @@ describe('vdomInterop', () => {
         mixins: [base],
         setup(props: any) {
           return () =>
-            h(
-              'div',
-              `${typeof props.modelValue}:${String(props.modelValue)}`,
-            )
+            h('div', `${typeof props.modelValue}:${String(props.modelValue)}`)
         },
       })
 
@@ -659,10 +653,7 @@ describe('vdomInterop', () => {
         extends: base,
         setup(props: any) {
           return () =>
-            h(
-              'div',
-              `${typeof props.modelValue}:${String(props.modelValue)}`,
-            )
+            h('div', `${typeof props.modelValue}:${String(props.modelValue)}`)
         },
       })
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1,10 +1,14 @@
 import {
   type App,
+  type AppContext,
   type ComponentInternalInstance,
+  type ComponentOptions,
+  type ComponentPropsOptions,
   type ConcreteComponent,
   ErrorCodes,
   Fragment,
   type FunctionalComponent,
+  type GenericAppContext,
   type HydrationRenderer,
   type KeepAliveContext,
   MoveType,
@@ -1117,6 +1121,59 @@ function mountVNode(
 }
 
 /**
+ * Merge the props declared on a VDOM component through its `extends` /
+ * `mixins` chain (and global mixins), mirroring how runtime-core resolves a
+ * component's props options. The interop wrapper only knows about the props
+ * directly present on the component, so props declared on an extended base
+ * or a mixin would otherwise be treated as attrs and resolve to `undefined`.
+ * See https://github.com/vuejs/core/issues/15254
+ */
+function resolveInteropComponentProps(
+  component: ConcreteComponent,
+  appContext?: GenericAppContext,
+): ComponentPropsOptions | undefined {
+  const merged: Record<string, any> = {}
+  let hasProps = false
+
+  const merge = (raw: ComponentOptions | undefined): void => {
+    if (!raw || isFunction(raw)) return
+    if (raw.extends) merge(raw.extends)
+    if (raw.mixins) {
+      for (let i = 0; i < raw.mixins.length; i++) {
+        merge(raw.mixins[i])
+      }
+    }
+    const props = raw.props
+    if (props) {
+      if (isArray(props)) {
+        for (let i = 0; i < props.length; i++) {
+          if (isString(props[i])) {
+            merged[props[i]] = null
+            hasProps = true
+          }
+        }
+      } else if (isObject(props)) {
+        hasProps = true
+        for (const key in props) {
+          merged[key] = props[key]
+        }
+      }
+    }
+  }
+
+  // global mixins have the lowest priority, matching runtime-core
+  const globalMixins = appContext && (appContext as AppContext).mixins
+  if (globalMixins) {
+    for (let i = 0; i < globalMixins.length; i++) {
+      merge(globalMixins[i])
+    }
+  }
+  merge(component as ComponentOptions)
+
+  return hasProps ? merged : undefined
+}
+
+/**
  * Mount vdom component in vapor
  */
 function createVDOMComponent(
@@ -1157,7 +1214,14 @@ function createVDOMComponent(
   }
 
   const wrapper = new VaporComponentInstance<Record<string, unknown>>(
-    useBridge ? (comp as any) : { props: component.props },
+    useBridge
+      ? (comp as any)
+      : {
+          props: resolveInteropComponentProps(
+            component,
+            parentComponent ? parentComponent.appContext : undefined,
+          ),
+        },
     rawProps as RawProps,
     rawSlots as RawSlots,
     parentComponent ? parentComponent.appContext : undefined,


### PR DESCRIPTION
## Summary

Fixes #15254

When a vapor parent renders a VDOM child whose props are declared via `extends` / `mixins` (e.g. an options-API component extending a `BaseComponent`), the props resolve to `undefined` inside the child, and their declared `default` values are not applied.

### Root cause

The vapor<->VDOM interop (`packages/runtime-vapor/src/vdomInterop.ts`) mounts a VDOM child by wrapping it in a `VaporComponentInstance` whose type is `{ props: component.props }`. The vapor props proxy then resolves props only against the props *directly* declared on the component (`component.props`). Props declared on an `extends` base or a `mixins` entry are part of the component's *resolved* props options in VDOM (runtime-core's `normalizePropsOptions` walks the `extends`/`mixins` chain plus global mixins), but they are invisible to the interop wrapper, so they are treated as attrs and fall through. `props.modelValue` (and any other inherited prop) resolves to `undefined`, and its default is skipped.

### Fix

`createVDOMComponent` now builds the wrapper's props options by merging the props declared through the component's `extends` / `mixins` chain (and global mixins), mirroring how runtime-core resolves props options for non-vapor components (`normalizePropsOptions`). This keeps prop resolution (including defaults) consistent between the vapor->VDOM interop boundary and plain VDOM.

### Test

Added three tests to `packages/runtime-vapor/__tests__/vdomInterop.spec.ts` covering props declared via `extends`, via `mixins`, and application of a declared default through `extends`, on a VDOM child of a vapor parent. On the pristine code they fail (`undefined:undefined`); with the fix they pass.

### Scope note

Vapor mode (`3.6.0-rc.x`) is experimental. This is a correctness fix at the vapor<->VDOM interop boundary and does not touch VDOM behavior. It targets the `minor` branch, where the vapor compiler/runtime live (`main` is the 3.5.x stable line).

Full `pnpm exec vp test --project unit-jsdom packages/runtime-vapor` passes (1721 passed, 2 expected fail, 15 todo).