### PR TITLE
fix(runtime-vapor): align app unmount lifecycle with vdom

### DIFF
--- a/packages/runtime-vapor/__tests__/apiLifecycle.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiLifecycle.spec.ts
@@ -18,6 +18,7 @@ import {
   provide,
   reactive,
   ref,
+  watch,
 } from '@vue/runtime-dom'
 import {
   createComponent,
@@ -29,7 +30,7 @@ import {
   template,
 } from '../src'
 import { makeRender } from './_utils'
-import { ITERATE_KEY } from '@vue/reactivity'
+import { ITERATE_KEY, onScopeDispose } from '@vue/reactivity'
 import { setElementText } from '../src/dom/prop'
 
 const define = makeRender<any>()
@@ -246,6 +247,7 @@ describe('api: lifecycle hooks', () => {
         onUpdated(() => calls.push('root onUpdated'))
         onBeforeUnmount(() => calls.push('root onBeforeUnmount'))
         onUnmounted(() => calls.push('root onUnmounted'))
+        onScopeDispose(() => calls.push('root onScopeDispose'))
 
         const n0 = createIf(
           () => toggle.value,
@@ -264,6 +266,7 @@ describe('api: lifecycle hooks', () => {
         onUpdated(() => calls.push('mid onUpdated'))
         onBeforeUnmount(() => calls.push('mid onBeforeUnmount'))
         onUnmounted(() => calls.push('mid onUnmounted'))
+        onScopeDispose(() => calls.push('mid onScopeDispose'))
 
         const n0 = createComponent(Child, { count: () => props.count })
         return n0
@@ -279,6 +282,7 @@ describe('api: lifecycle hooks', () => {
         onUpdated(() => calls.push('child onUpdated'))
         onBeforeUnmount(() => calls.push('child onBeforeUnmount'))
         onUnmounted(() => calls.push('child onUnmounted'))
+        onScopeDispose(() => calls.push('child onScopeDispose'))
 
         const t0 = template('<div></div>')
         const n0 = t0()
@@ -310,15 +314,37 @@ describe('api: lifecycle hooks', () => {
 
     // unmount
     ctx.app.unmount()
-    await nextTick()
     expect(calls).toEqual([
       'root onBeforeUnmount',
       'mid onBeforeUnmount',
+      'mid onScopeDispose',
       'child onBeforeUnmount',
+      'child onScopeDispose',
+      'root onScopeDispose',
       'child onUnmounted',
       'mid onUnmounted',
       'root onUnmounted',
     ])
+  })
+
+  it('does not flush pre watchers from another app on unmount', async () => {
+    const source = ref(0)
+    const cb = vi.fn()
+    const app = define({ setup: () => [] }).render().app
+    const otherApp = define({
+      setup() {
+        watch(source, cb)
+        return []
+      },
+    }).render(undefined, document.createElement('div')).app
+
+    source.value++
+    app.unmount()
+    expect(cb).not.toHaveBeenCalled()
+
+    await nextTick()
+    expect(cb).toHaveBeenCalledOnce()
+    otherApp.unmount()
   })
 
   it('onRenderTracked', async () => {

--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -828,6 +828,73 @@ describe('effects in pending branches', () => {
     app.unmount()
   })
 
+  test.each(['branch removal', 'app unmount'] as const)(
+    'Vapor-owned VDOM hooks use the %s context',
+    async operation => {
+      const asyncSetup = deferred()
+      const show = ref(true)
+      const order: string[] = []
+      const data = ref({ order })
+      const Child = compile(
+        `<script setup>
+          import { onUnmounted } from 'vue'
+          const data = _data
+          onUnmounted(() => data.value.order.push('child'))
+        </script>
+        <template><span>child</span></template>`,
+        data,
+        {},
+        { vapor: false },
+      )
+      const Parent = compile(
+        `<script vapor>
+          const components = _components
+        </script>
+        <template><components.Child /></template>`,
+        data,
+        { Child },
+      )
+      const AsyncSibling = defineComponent({
+        async setup() {
+          await asyncSetup.promise
+          return () => h('span', 'async')
+        },
+      })
+      const Root = defineComponent({
+        setup: () => () =>
+          h(Suspense, null, {
+            default: () =>
+              h('div', [
+                show.value ? h(Parent as any) : h('span', 'gone'),
+                h(AsyncSibling),
+              ]),
+            fallback: () => h('span', 'loading'),
+          }),
+      })
+      const app = createApp(Root)
+      app.use(vaporInteropPlugin)
+      const container = document.createElement('div')
+      app.mount(container)
+
+      await nextTick()
+      expect(container.textContent).toBe('loading')
+      if (operation === 'app unmount') {
+        app.unmount()
+        expect(order).toEqual(['child'])
+        return
+      }
+
+      show.value = false
+      await nextTick()
+      expect(order).toEqual([])
+
+      asyncSetup.resolve()
+      await flushResolution(asyncSetup.promise)
+      expect(order).toEqual(['child'])
+      app.unmount()
+    },
+  )
+
   test('keep-alive lifecycle and vnode hooks wait for the branch to resolve', async () => {
     const asyncSetup = deferred()
     const current = ref<'A' | 'B'>('A')

--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -289,6 +289,12 @@ async function flushResolution(promise: Promise<void>) {
 }
 
 describe('effects in pending branches', () => {
+  const Pending = defineComponent({
+    async setup() {
+      await new Promise(() => {})
+    },
+  })
+
   test('updated hook waits for the branch to resolve', async () => {
     const asyncSetup = deferred()
     const value = ref(0)
@@ -648,6 +654,179 @@ describe('effects in pending branches', () => {
       app.unmount()
     },
   )
+
+  test.each(['vdom', 'vapor', 'vapor-slot'] as const)(
+    '%s nested unmount hooks run when a pending boundary is removed by app unmount',
+    kind => {
+      const order: string[] = []
+      const vapor = kind !== 'vdom'
+      const script = vapor ? '<script vapor>' : '<script setup>'
+      const data = ref({ order })
+      const Child = compile(
+        `${script}
+          import { onBeforeUnmount, onScopeDispose, onUnmounted } from 'vue'
+          const data = _data
+          onBeforeUnmount(() => data.value.order.push('child before'))
+          onScopeDispose(() => data.value.order.push('child scope'))
+          onUnmounted(() => data.value.order.push('child'))
+        </script>
+        <template><span>child</span></template>`,
+        data,
+        {},
+        { vapor },
+      )
+      const Parent = compile(
+        `${script}
+          import { onBeforeUnmount, onScopeDispose, onUnmounted } from 'vue'
+          const data = _data
+          const components = _components
+          onBeforeUnmount(() => data.value.order.push('parent before'))
+          onScopeDispose(() => data.value.order.push('parent scope'))
+          onUnmounted(() => data.value.order.push('parent'))
+        </script>
+        <template><components.Child /></template>`,
+        data,
+        { Child },
+        { vapor },
+      )
+      const VDomHost = compile(
+        `<script setup>
+          const components = _components
+        </script>
+        <template>
+          <Suspense>
+            <div>
+              ${kind === 'vapor-slot' ? '<slot />' : '<components.Parent />'}
+              <components.Pending />
+            </div>
+            <template #fallback><span>loading</span></template>
+          </Suspense>
+        </template>`,
+        data,
+        { Parent, Pending },
+        { vapor: false },
+      )
+      const VaporRoot = compile(
+        kind === 'vapor-slot'
+          ? `<script vapor>
+              const components = _components
+            </script>
+            <template>
+              <components.VDomHost><components.Parent /></components.VDomHost>
+            </template>`
+          : `<script vapor>
+              const components = _components
+            </script>
+            <template><components.VDomHost /></template>`,
+        data,
+        { Parent, VDomHost },
+      )
+      const container = document.createElement('div')
+      const app = runtimeVapor.createVaporApp(VaporRoot)
+      app.use(vaporInteropPlugin)
+      app.mount(container)
+
+      expect(container.textContent).toBe('loading')
+      app.unmount()
+      expect(order).toEqual([
+        'parent before',
+        'parent scope',
+        'child before',
+        'child scope',
+        'child',
+        'parent',
+      ])
+    },
+  )
+
+  test('pending unmount context does not leak through another app', async () => {
+    const outerAsyncSetup = deferred()
+    const showInner = ref(true)
+    const afterUnmounted = vi.fn()
+    const otherUnmounted = vi.fn()
+    const data = ref<{
+      otherApp?: { unmount(): void }
+      afterUnmounted: () => void
+      otherUnmounted: () => void
+    }>({ afterUnmounted, otherUnmounted })
+    const OtherChild = compile(
+      `<script vapor>
+        import { onUnmounted } from 'vue'
+        const data = _data
+        onUnmounted(data.value.otherUnmounted)
+      </script>
+      <template><span>other child</span></template>`,
+      data,
+    )
+    const OtherRoot = compile(
+      `<script vapor>
+        const components = _components
+      </script>
+      <template><components.OtherChild /></template>`,
+      data,
+      { OtherChild },
+    )
+    const otherApp = runtimeVapor.createVaporApp(OtherRoot)
+    data.value.otherApp = otherApp
+    otherApp.mount(document.createElement('div'))
+
+    const After = compile(
+      `<script vapor>
+        import { onUnmounted } from 'vue'
+        const data = _data
+        onUnmounted(data.value.afterUnmounted)
+      </script>
+      <template><span>after</span></template>`,
+      data,
+    )
+    const Trigger = compile(
+      `<script vapor>
+        import { onScopeDispose } from 'vue'
+        const data = _data
+        const components = _components
+        onScopeDispose(() => data.value.otherApp.unmount())
+      </script>
+      <template><components.After /></template>`,
+      data,
+      { After },
+    )
+    const OuterPending = defineComponent({
+      async setup() {
+        await outerAsyncSetup.promise
+        return () => h('span', 'outer content')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () =>
+            h('div', [
+              showInner.value
+                ? h(Suspense, null, {
+                    default: () => h('div', [h(Trigger as any), h(Pending)]),
+                    fallback: () => h('span', 'inner loading'),
+                  })
+                : h('span', 'gone'),
+              h(OuterPending),
+            ]),
+          fallback: () => h('span', 'outer loading'),
+        }),
+    })
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(document.createElement('div'))
+
+    await nextTick()
+    showInner.value = false
+    await nextTick()
+
+    expect(otherUnmounted).toHaveBeenCalledOnce()
+    expect(afterUnmounted).not.toHaveBeenCalled()
+    outerAsyncSetup.resolve()
+    await flushResolution(outerAsyncSetup.promise)
+    expect(afterUnmounted).toHaveBeenCalledOnce()
+    app.unmount()
+  })
 
   test('keep-alive lifecycle and vnode hooks wait for the branch to resolve', async () => {
     const asyncSetup = deferred()

--- a/packages/runtime-vapor/src/apiCreateApp.ts
+++ b/packages/runtime-vapor/src/apiCreateApp.ts
@@ -92,6 +92,7 @@ const unmountApp: AppUnmountFn = app => {
   const instance = ((__DEV__ && app._instance) ||
     rootInstances.get(app)!) as VaporComponentInstance
   unmountComponent(instance, app._container)
+  flushOnAppMount(instance)
   rootInstances.delete(app)
 }
 

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -22,7 +22,7 @@ import {
 import { isTeleportEnabled, isTeleportFragment } from './teleport'
 import { isTransitionEnabled } from './transition'
 import { isInteropEnabled } from './vdomInteropState'
-import { isSuspenseEnabled } from './suspense'
+import { currentUnmountSuspense, isSuspenseEnabled } from './suspense'
 
 export interface VaporTransitionHooks extends TransitionHooks {
   __vapor: true
@@ -286,7 +286,16 @@ export function remove(block: Block, parent?: ParentNode): void {
   if (block instanceof Node) {
     removeNode(block, parent)
   } else if (isVaporComponent(block)) {
-    unmountComponent(block, parent)
+    if (
+      __FEATURE_SUSPENSE__ &&
+      isSuspenseEnabled &&
+      isInteropEnabled &&
+      currentUnmountSuspense !== undefined
+    ) {
+      unmountComponent(block, parent, currentUnmountSuspense)
+    } else {
+      unmountComponent(block, parent)
+    }
   } else if (isArray(block)) {
     for (let i = 0; i < block.length; i++) {
       remove(block[i], parent)

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -133,8 +133,10 @@ import { DynamicFragment, isDynamicFragment, isFragment } from './fragment'
 import { resolvePendingSlotContent } from './dom/hydrateFragment'
 import type { VaporElement } from './apiDefineCustomElement'
 import {
+  currentUnmountSuspense,
   isSuspenseEnabled,
   parentSuspense,
+  setCurrentUnmountSuspense,
   setParentSuspense,
 } from './suspense'
 import { isInteropEnabled } from './vdomInteropState'
@@ -501,7 +503,15 @@ export function createComponent(
         hasParentSuspense = false
       }
     }
-    onScopeDispose(() => unmountComponent(instance), true)
+    onScopeDispose(
+      () =>
+        __FEATURE_SUSPENSE__ &&
+        isInteropEnabled &&
+        currentUnmountSuspense !== undefined
+          ? unmountComponent(instance, undefined, currentUnmountSuspense)
+          : unmountComponent(instance),
+      true,
+    )
 
     if (!managedMount && (_insertionParent || isHydrating)) {
       mountComponent(instance, _insertionParent!, _insertionAnchor)
@@ -1314,6 +1324,16 @@ export function unmountComponent(
   parentNode?: ParentNode,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
+  if (
+    __FEATURE_SUSPENSE__ &&
+    isSuspenseEnabled &&
+    isInteropEnabled &&
+    currentUnmountSuspense !== parentSuspense
+  ) {
+    unmountComponentWithParentSuspense(instance, parentNode, parentSuspense)
+    return
+  }
+
   // Skip unmount for kept-alive components - deactivate if called from remove()
   if (
     isKeepAliveEnabled &&
@@ -1386,6 +1406,19 @@ export function unmountComponent(
   if (pendingAsyncSetup) {
     instance.restoreAsyncContext = undefined
     instance.deferredHydrationBoundary = undefined
+  }
+}
+
+function unmountComponentWithParentSuspense(
+  instance: VaporComponentInstance,
+  parentNode: ParentNode | undefined,
+  parentSuspense: SuspenseBoundary | null,
+): void {
+  const prev = setCurrentUnmountSuspense(parentSuspense)
+  try {
+    unmountComponent(instance, parentNode, parentSuspense)
+  } finally {
+    setCurrentUnmountSuspense(prev)
   }
 }
 

--- a/packages/runtime-vapor/src/suspense.ts
+++ b/packages/runtime-vapor/src/suspense.ts
@@ -2,6 +2,12 @@ import type { SuspenseBoundary } from '@vue/runtime-dom'
 
 export let isSuspenseEnabled = false
 export let parentSuspense: SuspenseBoundary | null = null
+// `instance.suspense` is the boundary a component was mounted in, but an
+// ancestor boundary may be removed under a different parent Suspense. Carry
+// that effective parent through synchronous scope-owned teardown, where VDOM's
+// explicit `parentSuspense` argument would otherwise be lost. `undefined`
+// means there is no active unmount operation.
+export let currentUnmountSuspense: SuspenseBoundary | null | undefined
 
 export function enableSuspense(): void {
   isSuspenseEnabled = true
@@ -19,5 +25,15 @@ export function setParentSuspense(
     return parentSuspense
   } finally {
     parentSuspense = suspense
+  }
+}
+
+export function setCurrentUnmountSuspense(
+  suspense: SuspenseBoundary | null | undefined,
+): SuspenseBoundary | null | undefined {
+  try {
+    return currentUnmountSuspense
+  } finally {
+    currentUnmountSuspense = suspense
   }
 }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -181,8 +181,10 @@ import {
 } from './keepAlive'
 import {
   parentSuspense as currentParentSuspense,
+  currentUnmountSuspense,
   enableSuspense,
   isSuspenseEnabled,
+  setCurrentUnmountSuspense,
   setParentSuspense,
 } from './suspense'
 
@@ -291,6 +293,19 @@ function filterReservedProps(props: VNode['props']): VNode['props'] {
     }
   }
   return filtered
+}
+
+function unmountVaporInteropWithParentSuspense(
+  vnode: VNode,
+  doRemove: boolean | undefined,
+  parentSuspense: SuspenseBoundary | null,
+): void {
+  const prev = setCurrentUnmountSuspense(parentSuspense)
+  try {
+    vaporInteropImpl.unmount(vnode, doRemove, parentSuspense)
+  } finally {
+    setCurrentUnmountSuspense(prev)
+  }
 }
 
 // mounting vapor components and slots in vdom
@@ -446,6 +461,15 @@ const vaporInteropImpl: Omit<
   },
 
   unmount(vnode, doRemove, parentSuspense) {
+    if (
+      __FEATURE_SUSPENSE__ &&
+      isSuspenseEnabled &&
+      currentUnmountSuspense !== parentSuspense
+    ) {
+      unmountVaporInteropWithParentSuspense(vnode, doRemove, parentSuspense)
+      return
+    }
+
     const container = doRemove ? vnode.anchor!.parentNode : undefined
     const instance = vnode.component as any as VaporComponentInstance
     let slotStartAnchor: Node | null = null

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1023,6 +1023,14 @@ function createVNodeFragment(vnode: VNode): {
   return { frag, syncNodes }
 }
 
+function resolveUnmountSuspense(
+  suspense: SuspenseBoundary | null,
+): SuspenseBoundary | null {
+  return currentUnmountSuspense === undefined
+    ? suspense
+    : currentUnmountSuspense
+}
+
 /**
  * Mount VNode in vapor
  */
@@ -1031,19 +1039,20 @@ function mountVNode(
   vnode: VNode,
   parentComponent: VaporComponentInstance | null,
 ): VaporFragment {
-  const suspense =
+  let suspense =
     currentParentSuspense || (parentComponent && parentComponent.suspense)
   const { frag, syncNodes } = createVNodeFragment(vnode)
 
   let isMounted = false
   const unmount = (parentNode?: ParentNode, transition?: TransitionHooks) => {
     if (transition) setVNodeTransitionHooks(vnode, transition)
+    const parentSuspense = resolveUnmountSuspense(suspense)
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
       const keepAliveCtx = (parentComponent as KeepAliveInstance).ctx
       keepAliveCtx.clearCurrent!(frag)
       const storageContainer = keepAliveCtx.getStorageContainer()
       if ((vnode.type as any).__vapor) {
-        deactivate(vnode.component as any, storageContainer)
+        deactivate(vnode.component as any, storageContainer, parentSuspense)
         // Move the VNode-owned end anchor with the inner Vapor block.
         insert(vnode.anchor as Node, storageContainer)
       } else {
@@ -1052,11 +1061,11 @@ function mountVNode(
           storageContainer,
           internals,
           parentComponent as any,
-          null,
+          parentSuspense,
         )
       }
     } else {
-      internals.um(vnode, parentComponent as any, null, !!parentNode)
+      internals.um(vnode, parentComponent as any, parentSuspense, !!parentNode)
     }
 
     if (vnode.anchor && parentNode && vnode.anchor.parentNode === parentNode) {
@@ -1080,8 +1089,8 @@ function mountVNode(
     moveType = MoveType.REORDER,
   ) => {
     if (isHydrating) return
-    const operationSuspense =
-      parentSuspense === undefined ? suspense : parentSuspense
+    if (parentSuspense !== undefined) suspense = parentSuspense
+    const operationSuspense = suspense
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_KEPT_ALIVE) {
       if ((vnode.type as any).__vapor) {
         activate(vnode.component as any, parentNode, anchor, operationSuspense)
@@ -1259,6 +1268,7 @@ function createVDOMComponent(
     // unset ref
     if (rawRef) vdomSetRef(rawRef, null, null, vnode, true)
     if (transition) setVNodeTransitionHooks(vnode, transition)
+    const parentSuspense = resolveUnmountSuspense(suspense)
     if (vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
       keepAliveCtx!.clearCurrent!(frag)
       vdomDeactivate(
@@ -1266,13 +1276,13 @@ function createVDOMComponent(
         keepAliveCtx!.getStorageContainer(),
         internals,
         parentComponent as any,
-        null,
+        parentSuspense,
       )
       return
     }
     isUnmounted = true
     isMounted = false
-    internals.umt(vnode.component!, null, !!parentNode)
+    internals.umt(vnode.component!, parentSuspense, !!parentNode)
     // VDOM transitions own their leaving DOM until the leave finishes.
     if (!transition) removeDom(parentNode)
   }
@@ -1598,7 +1608,12 @@ function renderVDOMSlot(
           NOOP,
         )
       }
-      internals.um(pending, parentComponent as any, null, true)
+      internals.um(
+        pending,
+        parentComponent as any,
+        resolveUnmountSuspense(suspense),
+        true,
+      )
       return
     }
     if (currentParentNode) {
@@ -1779,7 +1794,7 @@ function renderVDOMSlot(
       internals.um(
         rendered,
         parentComponent as any,
-        null,
+        resolveUnmountSuspense(suspense),
         !contentDetached && !!parentNode,
       )
     } else {
@@ -3078,8 +3093,9 @@ function createVNodeChildrenFragment(
 
   frag.remove = parentNode => {
     scope.stop()
+    const parentSuspense = resolveUnmountSuspense(suspense)
     currentChildren.forEach(vnode => {
-      internals.um(vnode, parentComponent, null, !!parentNode)
+      internals.um(vnode, parentComponent, parentSuspense, !!parentNode)
     })
   }
 


### PR DESCRIPTION
close #15234

Flush lifecycle jobs after Vapor app teardown so onUnmounted hooks run synchronously before app.unmount() returns, while preserving pre-flush isolation between apps.

Propagate the effective parent Suspense through synchronous interop teardown so nested Vapor components queue their unmount hooks on the correct surviving boundary, matching VDOM's explicit propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component cleanup when unmounting applications with pending Suspense branches.
  * Preserved parent–child unmount hook ordering across VDOM, Vapor, and Vapor-slot scenarios.
  * Prevented Suspense cleanup state from leaking between separate applications.
  * Ensured unmounting one application does not prematurely run watchers belonging to another application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->