### PR TITLE
fix(hydration): handle moving unresolved async fragment

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1639,6 +1639,45 @@ describe('SSR hydration', () => {
     resolve({})
   })
 
+  test('move async wrapper before load (fragment)', async () => {
+    let resolve: any
+    const Comp = vi.fn(() => [h('i', 'one'), h('b', 'two')])
+    const AsyncComp = defineAsyncComponent(
+      () =>
+        new Promise(r => {
+          resolve = r
+        }),
+    )
+
+    const reverse = ref(false)
+    const root = document.createElement('div')
+    root.innerHTML =
+      '<div><span>tail</span><!--[--><i>one</i><b>two</b><!--]--></div>'
+
+    createSSRApp({
+      render() {
+        const asyncComp = h(AsyncComp, { key: 'async' })
+        const sibling = h('span', { key: 'sibling' }, 'tail')
+        return h(
+          'div',
+          reverse.value ? [asyncComp, sibling] : [sibling, asyncComp],
+        )
+      },
+    }).mount(root)
+
+    reverse.value = true
+    await nextTick()
+    expect(root.innerHTML).toBe(
+      '<div><!--[--><i>one</i><b>two</b><!--]--><span>tail</span></div>',
+    )
+    resolve(Comp)
+    await new Promise(r => setTimeout(r))
+    expect(Comp).toHaveBeenCalled()
+    expect(root.innerHTML).toBe(
+      '<div><!--[--><i>one</i><b>two</b><!--]--><span>tail</span></div>',
+    )
+  })
+
   test('elements with camel-case in svg ', () => {
     const { vnode, container } = mountWithHydration(
       '<animateTransform></animateTransform>',

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -315,7 +315,9 @@ export function createHydrationFunctions(
           ) {
             let subTree
             if (isFragmentStart) {
-              subTree = createVNode(Fragment)
+              // the async component has no child vnodes yet, so represent its
+              // adopted DOM as an opaque range that can be moved or removed
+              subTree = createVNode(Static)
               subTree.anchor = nextNode
                 ? nextNode.previousSibling
                 : container.lastChild


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration of unresolved asynchronous components rendered as fragments.
  * Preserved correct DOM order when async content is moved before a sibling, both before and after resolution.
  * Improved handling of placeholder content during hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->