### PR TITLE
fix(compiler-vapor): preserve modifiers on merged event handlers

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -610,6 +610,16 @@ describe('compiler: element transform', () => {
   ]`)
     })
 
+    test('props merging: event handlers with modifiers', () => {
+      const { code } = compileWithElementTransform(
+        `<Foo @keydown.enter.prevent="a" @keydown.esc.prevent="b" />`,
+      )
+      expect(code).contains(`onKeydown: () => [
+    _withKeys(_withModifiers(_ctx.a, ["prevent"]), ["enter"]),
+    _withKeys(_withModifiers(_ctx.b, ["prevent"]), ["esc"])
+  ]`)
+    })
+
     test('props merging: inline event handlers', () => {
       const { code } = compileWithElementTransform(
         `<Foo @click.foo="e => a(e)" @click.bar="e => b(e)" />`,

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -1255,7 +1255,10 @@ function dedupeProperties(results: DirectiveTransformResult[]): IRProp[] {
     // prop names and event handler names can be the same but serve different purposes
     // e.g. `:appear="true"` is a prop while `@appear="handler"` is an event handler
     if (existing && existing.handler === prop.handler) {
-      if (name === 'style' || name === 'class' || prop.handler) {
+      if (prop.handler) {
+        // keep modifiers associated with each handler; codegen merges matching keys
+        deduped.push(prop)
+      } else if (name === 'style' || name === 'class') {
         mergePropValues(existing, prop)
       }
       // unexpected duplicate, should have emitted error during parse


### PR DESCRIPTION
close #15264 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved separate component event handlers when multiple handlers use different modifiers.
  * Ensured key modifiers such as Enter and Escape work correctly alongside modifiers like Prevent.
  * Continued merging duplicate class and style attributes as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->