### PR TITLE
fix(server-renderer): reject CR in attribute names

### DIFF
--- a/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
@@ -118,6 +118,17 @@ describe('ssr: renderAttrs', () => {
       ),
     ).toBe(` viewBox="foo"`)
   })
+
+  test('ignore attr names containing carriage returns', () => {
+    expect(
+      ssrRenderAttrs({
+        id: 'safe',
+        ['x\rautofocus\ronfocus']: 'alert(1)',
+      }),
+    ).toBe(` id="safe"`)
+    expect(`unsafe attribute name`).toHaveBeenWarned()
+    expect(`Skipped rendering unsafe attribute name`).toHaveBeenWarned()
+  })
 })
 
 describe('ssr: renderAttr', () => {

--- a/packages/shared/src/domAttrConfig.ts
+++ b/packages/shared/src/domAttrConfig.ts
@@ -33,7 +33,7 @@ export function includeBooleanAttr(value: unknown): boolean {
   return !!value || value === ''
 }
 
-const unsafeAttrCharRE = /[>/="'\u0009\u000a\u000c\u0020]/
+const unsafeAttrCharRE = /[>/="'\u0009\u000a\u000c\u000d\u0020]/
 const attrValidationCache: Record<string, boolean> = {}
 
 export function isSSRSafeAttrName(name: string): boolean {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered output by rejecting attribute names containing carriage returns.
  * Safe attributes continue to render correctly while unsafe attributes are skipped with warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->