### PR TITLE
refactor(runtime-vapor): formalize fragment and interop boundaries

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -17,12 +17,7 @@ import type {
   ComponentPublicInstance,
 } from './componentPublicInstance'
 import { type Directive, validateDirectiveName } from './directives'
-import type {
-  ElementNamespace,
-  MoveType,
-  RootRenderFunction,
-  UnmountComponentFn,
-} from './renderer'
+import type { ElementNamespace, MoveType, RootRenderFunction } from './renderer'
 import type { InjectionKey } from './apiInject'
 import { warn } from './warning'
 import type { VNode } from './vnode'
@@ -182,7 +177,7 @@ export interface AppConfig extends GenericAppConfig {
 /**
  * The vapor in vdom implementation is in runtime-vapor/src/vdomInterop.ts
  */
-export interface VaporInteropInterface {
+export interface VaporInVdomInterface {
   mount(
     vnode: VNode,
     container: any,
@@ -251,16 +246,20 @@ export interface VaporInteropInterface {
     component: ComponentInternalInstance,
     transition: TransitionHooks,
   ): void
+}
 
-  vdomMount: (
+/**
+ * The vdom in vapor implementation is in runtime-vapor/src/vdomInterop.ts
+ */
+export interface VdomInVaporInterface {
+  mount: (
     component: ConcreteComponent,
     parentComponent: any,
     props?: any,
     slots?: any,
     once?: boolean,
   ) => any
-  vdomUnmount: UnmountComponentFn
-  vdomSlot: (
+  slot: (
     slots: any,
     name: string | (() => string),
     props: Record<string, any>,
@@ -272,7 +271,7 @@ export interface VaporInteropInterface {
     inheritFallback?: boolean,
     adoptAnchor?: Node,
   ) => any
-  vdomMountVNode: (
+  mountVNode: (
     vnode: VNode,
     parentComponent: any, // VaporComponentInstance
   ) => any
@@ -296,7 +295,11 @@ export interface GenericAppContext {
   /**
    * @internal vapor interop only
    */
-  vapor?: VaporInteropInterface
+  vapor?: VaporInVdomInterface
+  /**
+   * @internal vdom interop only
+   */
+  vdom?: VdomInVaporInterface
 }
 
 export interface AppContext extends GenericAppContext {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -521,7 +521,10 @@ export { type NormalizedPropsOptions } from './componentProps'
 /**
  * @internal
  */
-export { type VaporInteropInterface } from './apiCreateApp'
+export {
+  type VaporInVdomInterface,
+  type VdomInVaporInterface,
+} from './apiCreateApp'
 /**
  * @internal
  */

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -103,7 +103,7 @@ import { initFeatureFlags } from './featureFlags'
 import { isAsyncWrapper } from './apiAsyncComponent'
 import { isCompatEnabled } from './compat/compatConfig'
 import { DeprecationTypes } from './compat/compatConfig'
-import type { VaporInteropInterface } from './apiCreateApp'
+import type { VaporInVdomInterface } from './apiCreateApp'
 import { type TransitionHooks, leaveCbKey } from './components/BaseTransition'
 import type { ComponentCustomElementInterface } from './component'
 
@@ -2974,7 +2974,7 @@ export function performTransitionLeave(
 export function getVaporInterface(
   instance: ComponentInternalInstance | null,
   vnode: VNode,
-): VaporInteropInterface {
+): VaporInVdomInterface {
   const ctx = instance ? instance.appContext : vnode.appContext
   const res = ctx && ctx.vapor
   if (__DEV__ && !res) {

--- a/packages/runtime-vapor/__tests__/block.spec.ts
+++ b/packages/runtime-vapor/__tests__/block.spec.ts
@@ -1,3 +1,4 @@
+import { shallowRef } from '@vue/reactivity'
 import {
   insert,
   insertFragment,
@@ -7,7 +8,21 @@ import {
   removeFragment,
   removeNode,
 } from '../src/block'
-import { VaporFragment } from '../src/fragment'
+import {
+  DynamicFragment,
+  ForBlock,
+  ForFragment,
+  SlotFragment,
+  VaporFragment,
+  isDynamicFragment,
+  isForBlock,
+  isForFragment,
+  isFragment,
+  isInteropFragment,
+  isSlotFragment,
+} from '../src/fragment'
+import { TeleportFragment } from '../src/components/Teleport'
+import { isTeleportFragment } from '../src/teleport'
 
 const node1 = document.createTextNode('node1')
 const node2 = document.createTextNode('node2')
@@ -116,5 +131,45 @@ describe('block + node ops', () => {
     expect(() => remove(anchor, container)).toThrowError(
       'The node to be removed is not a child of this node.',
     )
+  })
+})
+
+describe('fragment protocol flags', () => {
+  test('identify constructor-owned roles without class or shape checks', () => {
+    const fragment = new VaporFragment(node1)
+    const dynamic = new DynamicFragment(undefined, false, false)
+    const slot = new SlotFragment()
+    const forFragment = new ForFragment([], false)
+    const forBlock = new ForBlock(
+      node2,
+      undefined,
+      shallowRef(0),
+      undefined,
+      undefined,
+      0,
+    )
+    const teleport = new TeleportFragment({ to: document.body })
+
+    for (const value of [
+      fragment,
+      dynamic,
+      slot,
+      forFragment,
+      forBlock,
+      teleport,
+    ]) {
+      expect(isFragment(value)).toBe(true)
+    }
+    expect(isDynamicFragment(dynamic)).toBe(true)
+    expect(isSlotFragment(slot)).toBe(true)
+    expect(isForFragment(forFragment)).toBe(true)
+    expect(isForBlock(forBlock)).toBe(true)
+    expect(isTeleportFragment(teleport)).toBe(true)
+
+    expect(isSlotFragment(dynamic)).toBe(false)
+    expect(isDynamicFragment(fragment)).toBe(false)
+    expect(isForFragment(forBlock)).toBe(false)
+    expect(isForBlock(forFragment)).toBe(false)
+    expect(isInteropFragment(fragment)).toBe(false)
   })
 })

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -56,7 +56,7 @@ import {
   setCurrentHydrationNode,
   setIsHydratingEnabled,
 } from '../src/dom/hydration'
-import { DynamicFragment, SlotFragment } from '../src/fragment'
+import { DynamicFragment, SlotFragment, isSlotFragment } from '../src/fragment'
 import {
   type SlotBoundaryContext,
   currentSlotBoundary,
@@ -1358,20 +1358,12 @@ describe('component: slots', () => {
       const instance = renderWithSlots({})
       const app = createApp({ render: () => null })
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
+      const vdom = (app._context as any).vdom
       const slotsRef = shallowRef({
         default: () => [h('div', text.value)],
       })
       const frag = withSlotBoundary(boundary, () =>
-        vapor.vdomSlot(
-          slotsRef,
-          'default',
-          {},
-          instance,
-          undefined,
-          false,
-          true,
-        ),
+        vdom.slot(slotsRef, 'default', {}, instance, undefined, false, true),
       )
       const host = document.createElement('div')
 
@@ -1396,12 +1388,12 @@ describe('component: slots', () => {
       const instance = renderWithSlots({})
       const app = createApp({ render: () => null })
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
+      const vdom = (app._context as any).vdom
       const slotsRef = shallowRef({
         default: () => [h('div', text.value)],
       })
       const frag = withSlotBoundary(boundary, () =>
-        vapor.vdomSlot(slotsRef, 'default', {}, instance),
+        vdom.slot(slotsRef, 'default', {}, instance),
       )
       const host = document.createElement('div')
 
@@ -1426,12 +1418,12 @@ describe('component: slots', () => {
       const instance = renderWithSlots({})
       const app = createApp({ render: () => null })
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
+      const vdom = (app._context as any).vdom
       const slotsRef = shallowRef({
         default: () => (show.value ? [h('div', 'content')] : []),
       })
       const frag = withSlotBoundary(boundary, () =>
-        vapor.vdomSlot(
+        vdom.slot(
           slotsRef,
           'default',
           {},
@@ -1763,20 +1755,12 @@ describe('component: slots', () => {
       const instance = renderWithSlots({})
       const app = createApp({ render: () => null })
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
+      const vdom = (app._context as any).vdom
       const slotsRef = shallowRef({
         default: () => (show.value ? [h('div', 'content')] : []),
       })
       const frag = withSlotBoundary(boundary, () =>
-        vapor.vdomSlot(
-          slotsRef,
-          'default',
-          {},
-          instance,
-          undefined,
-          false,
-          true,
-        ),
+        vdom.slot(slotsRef, 'default', {}, instance, undefined, false, true),
       )
       const host = document.createElement('div')
 
@@ -3866,6 +3850,7 @@ describe('component: slots', () => {
 
           expect(slotBlock).toBeInstanceOf(DynamicFragment)
           expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          expect(isSlotFragment(slotBlock)).toBe(true)
           expect(observedBoundary).toBe(null)
         })
 

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -39,6 +39,7 @@ import {
 import { VaporDynamicComponentFlags, VaporSlotFlags } from '@vue/shared'
 import { VaporSlot } from '../../runtime-core/src/vnode'
 import { compile, makeInteropRender } from './_utils'
+import { isInteropFragment } from '../src/fragment'
 import {
   type VaporComponentInstance,
   type VaporDirective,
@@ -72,7 +73,7 @@ const inheritedFallbackSlotRootFlags =
 
 describe('vdomInterop', () => {
   describe('key', () => {
-    test('preserves vnode key on blocks passed from vdom to vapor', () => {
+    test('marks vdom blocks as interop fragments and preserves keys', () => {
       const VDomChild = defineComponent({
         setup() {
           return () => h('div', 'vdom child')
@@ -81,16 +82,15 @@ describe('vdomInterop', () => {
 
       const app = createApp({ render: () => null })
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
+      const vdom = (app._context as any).vdom
 
-      const vnodeBlock = vapor.vdomMountVNode(
-        h(VDomChild, { key: 'foo' }),
-        null,
-      )
+      const vnodeBlock = vdom.mountVNode(h(VDomChild, { key: 'foo' }), null)
+      expect(isInteropFragment(vnodeBlock)).toBe(true)
       expect(vnodeBlock.$key).toBe('foo')
       expect(vnodeBlock.vnode.key).toBe('foo')
 
-      const componentBlock = vapor.vdomMount(VDomChild, null, { key: 'bar' })
+      const componentBlock = vdom.mount(VDomChild, null, { key: 'bar' })
+      expect(isInteropFragment(componentBlock)).toBe(true)
       expect(componentBlock.$key).toBe('bar')
       expect(componentBlock.vnode.key).toBe('bar')
     })
@@ -127,10 +127,10 @@ describe('vdomInterop', () => {
 
       const app = createApp(Parent)
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
-      const originalVdomSlot = vapor.vdomSlot
+      const vdom = (app._context as any).vdom
+      const originalVdomSlot = vdom.slot
       let frag: any
-      vapor.vdomSlot = (...args: any[]) => (frag = originalVdomSlot(...args))
+      vdom.slot = (...args: any[]) => (frag = originalVdomSlot(...args))
 
       const host = document.createElement('div')
       app.mount(host)
@@ -157,10 +157,10 @@ describe('vdomInterop', () => {
 
       const app = createApp({ render: () => null })
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
+      const vdom = (app._context as any).vdom
       const host = document.createElement('div')
 
-      const frag = vapor.vdomMount(VDomChild, null)
+      const frag = vdom.mount(VDomChild, null)
       insert(frag, host)
 
       expect(host.innerHTML).toBe('<!--v-if-->')
@@ -199,10 +199,10 @@ describe('vdomInterop', () => {
 
       const app = createApp(Parent)
       app.use(vaporInteropPlugin)
-      const vapor = (app._context as any).vapor
-      const originalVdomSlot = vapor.vdomSlot
+      const vdom = (app._context as any).vdom
+      const originalVdomSlot = vdom.slot
       let frag: any
-      vapor.vdomSlot = (...args: any[]) => (frag = originalVdomSlot(...args))
+      vdom.slot = (...args: any[]) => (frag = originalVdomSlot(...args))
 
       const host = document.createElement('div')
       app.mount(host)

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -92,7 +92,7 @@ export function createDynamicComponent(
       if (isBlock(value)) return value
 
       // Handles VNodes passed from VDOM components (e.g., `h(VaporComp)` from slots)
-      if (isInteropEnabled && appContext.vapor && isVNode(value)) {
+      if (isInteropEnabled && appContext.vdom && isVNode(value)) {
         if (isKeepAlive(currentInstance)) {
           enableKeepAlive()
           const frag = (
@@ -101,7 +101,7 @@ export function createDynamicComponent(
           if (frag) return frag
         }
 
-        const frag = appContext.vapor.vdomMountVNode(value, currentInstance)
+        const frag = appContext.vdom.mountVNode(value, currentInstance)
         if (isHydrating) {
           locateHydrationNode(shouldConsumeFragmentStart(value))
           frag.hydrate()

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -873,7 +873,3 @@ export function getRestElement(val: any, keys: string[]): any {
 export function getDefaultValue(val: any, getDefaultVal: () => any): any {
   return val === undefined ? getDefaultVal() : val
 }
-
-export function isForBlock(block: Block): block is ForBlock {
-  return block instanceof ForBlock
-}

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -130,6 +130,7 @@ import type {
   VaporRenderResult,
 } from './apiDefineComponent'
 import { DynamicFragment, isDynamicFragment, isFragment } from './fragment'
+import { SLOT } from './fragmentFlags'
 import { resolvePendingSlotContent } from './dom/hydrateFragment'
 import type { VaporElement } from './apiDefineCustomElement'
 import {
@@ -342,8 +343,8 @@ export function createComponent(
     }
 
     // vdom interop enabled and component is not an explicit vapor component
-    if (isInteropEnabled && appContext.vapor && !component.__vapor) {
-      const frag = appContext.vapor.vdomMount(
+    if (isInteropEnabled && appContext.vdom && !component.__vapor) {
+      const frag = appContext.vdom.mount(
         component as any,
         currentInstance as any,
         rawProps,
@@ -1558,7 +1559,7 @@ function applyFallthroughAttrs(
   const root = getRootElement(
     block,
     frag => {
-      if (frag.isSlot) {
+      if (frag.__vf & SLOT) {
         hasSlotFragment = true
       } else {
         ;(dynamicFragments ||= []).push(frag)
@@ -1574,7 +1575,7 @@ function applyFallthroughAttrs(
   if (fragmentsToRegister) {
     for (const frag of fragmentsToRegister) {
       // slot fragments warn instead of inheriting attrs, skip them
-      if (!frag.isSlot) {
+      if (!(frag.__vf & SLOT)) {
         // Nested dynamic fragments need their own fallthrough hook.
         registerDynamicFragmentFallthroughAttrs(
           frag,
@@ -1768,7 +1769,7 @@ function deferKeepAliveRenderEffects(
       let root = vaporOwner.block
       // Dynamic component and v-if roots use fragments in Vapor where VDOM
       // exposes the active component directly as `subTree.component`.
-      while (isDynamicFragment(root) && !root.isSlot) {
+      while (isDynamicFragment(root) && !(root.__vf & SLOT)) {
         root = root.nodes
       }
       if (root !== child) return

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -40,6 +40,7 @@ import {
   isAdoptedAnchor,
   isInteropFragment,
 } from './fragment'
+import { SLOT_FRAGMENT } from './fragmentFlags'
 import { currentSlotBoundary, withSlotBoundary } from './slotBoundary'
 import { createElement } from './dom/node'
 import { setDynamicProps } from './dom/prop'
@@ -289,7 +290,7 @@ export function createSlot(
   let isCustomElementSlot = false
   if (isRef(rawSlots._) && isInteropEnabled) {
     if (isHydrating) hydrationCursor = enterHydrationCursor()
-    fragment = instance.appContext.vapor!.vdomSlot(
+    fragment = instance.appContext.vdom!.slot(
       rawSlots._,
       name,
       slotProps,
@@ -334,8 +335,8 @@ export function createSlot(
         false,
         undefined,
         _insertionAnchor,
+        SLOT_FRAGMENT,
       )
-      dynamicFragment.isSlot = true
       fragment = dynamicFragment
     }
 

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -49,6 +49,7 @@ import type { DefineVaporSetupFnComponent } from '../apiDefineComponent'
 import type { RawSlots } from '../componentSlots'
 import { applyTransitionHooks, isTransitionEnabled } from '../transition'
 import { enableTeleport } from '../teleport'
+import { TELEPORT } from '../fragmentFlags'
 
 const VaporTeleportImpl = {
   name: 'VaporTeleport',
@@ -81,11 +82,6 @@ type TeleportMountState =
     }
 
 export class TeleportFragment extends RenderContextFragment {
-  /**
-   * @internal marker for duck typing to avoid direct instanceof check
-   * which prevents tree-shaking of TeleportFragment
-   */
-  readonly __tf = true
   anchor?: Node
   private resolvedProps?: TeleportProps
   private rawSlots?: RawSlots | null
@@ -110,7 +106,7 @@ export class TeleportFragment extends RenderContextFragment {
     slots?: RawSlots | null,
     adoptAnchor?: Node,
   ) {
-    super([])
+    super([], TELEPORT)
     this.rawSlots = slots
     // the main-view end anchor can adopt the template `<!>` placeholder the
     // teleport was anchored to, saving a runtime node

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -24,6 +24,7 @@ import {
 } from './node'
 import { EMPTY_BLOCK, findBlockBoundary, isValidBlock } from '../block'
 import type { DynamicFragment } from '../fragment'
+import { SLOT } from '../fragmentFlags'
 
 interface HydratingSlotBoundaryState {
   endAnchor: Node | null
@@ -244,7 +245,7 @@ export function prepareDeferredHydrationAnchor(
   const isRevivingDeferredBranch =
     isInDeferredHydrationBoundary() &&
     hasRender &&
-    !frag.isSlot &&
+    !(frag.__vf & SLOT) &&
     !isValidBlock(frag.nodes)
 
   const reusingDeferredAnchor =
@@ -374,7 +375,7 @@ export function resolveDynamicAnchor(
       }
     }
     if (
-      !frag.isSlot &&
+      !(frag.__vf & SLOT) &&
       ownsDynamicAnchor &&
       currentHydrationNode &&
       !isComment(currentHydrationNode, ']')
@@ -452,13 +453,14 @@ export function resolveDynamicAnchor(
   }
 
   const currentSlotEndAnchor = getCurrentSlotEndAnchor()
-  const slotAnchor = frag.isSlot ? currentSlotEndAnchor : null
+  const isSlot = !!(frag.__vf & SLOT)
+  const slotAnchor = isSlot ? currentSlotEndAnchor : null
 
   // SSR wraps slots and multi-root `v-if` branches with `<!--[-->...<!--]-->`.
   // The close marker is a valid stable anchor candidate: reuse it once, or
   // create a fresh runtime anchor after it when another fragment already did.
   if (
-    (frag.isSlot && slotAnchor) ||
+    (isSlot && slotAnchor) ||
     (anchorLabel === 'if' && isArray(frag.nodes) && frag.nodes.length > 1)
   ) {
     const anchor = locateHydrationBoundaryClose(

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -74,15 +74,24 @@ import {
   isVaporTransition,
   removeBranchWithLeave,
 } from './transition'
+import {
+  DYNAMIC,
+  FOR,
+  FOR_ITEM,
+  FRAGMENT,
+  SLOT,
+  SLOT_FRAGMENT,
+  VDOM,
+} from './fragmentFlags'
 
 export class VaporFragment<
   T extends Block = Block,
 > implements TransitionOptions {
   /**
-   * @internal marker for duck typing to avoid direct instanceof check
-   * which prevents tree-shaking of VaporFragment
+   * @internal fragment protocol flags. Role checks use a shared field instead
+   * of class references so unused fragment implementations remain tree-shakable.
    */
-  readonly __vf = true
+  readonly __vf: number
   $key?: any
   $transition?: VaporTransitionHooks | undefined
   nodes: T
@@ -111,8 +120,9 @@ export class VaporFragment<
   onBeforeUpdate?: (() => void)[]
   onUpdated?: ((nodes?: Block) => void)[]
 
-  constructor(nodes: T) {
+  constructor(nodes: T, flags: number = FRAGMENT) {
     this.nodes = nodes
+    this.__vf = flags
   }
 }
 
@@ -132,8 +142,8 @@ export class RenderContextFragment<
   readonly keepAliveCtx?: VaporKeepAliveContext | null
   readonly slotBoundary: SlotBoundaryContext | null = currentSlotBoundary
 
-  constructor(nodes: T) {
-    super(nodes)
+  constructor(nodes: T, flags: number = FRAGMENT) {
+    super(nodes, flags)
     if (isKeepAliveEnabled) {
       this.keepAliveCtx = getKeepAliveContext(currentInstance)
     }
@@ -194,7 +204,7 @@ export class ForFragment extends VaporFragment<Block[]> {
     trackSlotBoundary: boolean,
     onInvalid?: () => void,
   ) {
-    super(nodes)
+    super(nodes, FOR)
     if (trackSlotBoundary) trackSlotBoundaryDirtying(this, onInvalid)
   }
 
@@ -222,7 +232,7 @@ export class ForBlock extends VaporFragment {
     index: ShallowRef<number | undefined> | undefined,
     renderKey: any,
   ) {
-    super(nodes)
+    super(nodes, FOR_ITEM)
     this.scope = scope
     this.itemRef = item
     this.keyRef = key
@@ -232,11 +242,6 @@ export class ForBlock extends VaporFragment {
 }
 
 export class DynamicFragment extends RenderContextFragment {
-  /**
-   * @internal marker for duck typing to avoid direct instanceof check
-   * which prevents tree-shaking of DynamicFragment
-   */
-  readonly __df = true
   // @ts-expect-error - assigned in the constructor or hydrateDynamicFragmentAnchor()
   anchor: Node
   scope: EffectScope | undefined
@@ -246,9 +251,6 @@ export class DynamicFragment extends RenderContextFragment {
   pending?: { render?: BlockFn; key: any; noScope: boolean }
   anchorLabel?: string
   keyed?: boolean
-  // pure marker consumed by the isSlotFragment predicate; the core update
-  // pipeline never reads it.
-  isSlot?: boolean
   // Marks the generic dynamic fragment that createPlainElement creates for the
   // default-slot children of a dynamic element resolved to a native tag
   // (`rawSlots.$`). Unlike labeled control-flow fragments it has no
@@ -272,8 +274,9 @@ export class DynamicFragment extends RenderContextFragment {
     trackSlotBoundary: boolean = false,
     onInvalid?: () => void,
     adoptAnchor?: Node,
+    flags: number = DYNAMIC,
   ) {
-    super(EMPTY_BLOCK)
+    super(EMPTY_BLOCK, flags)
     if (keyed) this.keyed = true
     if (
       isTransitionEnabled &&
@@ -472,7 +475,6 @@ export class SlotFragment
   extends DynamicFragment
   implements SlotResolutionState
 {
-  isSlot = true
   private disposed = false
   // Custom elements with `shadowRoot: false` replace their native slot outlet
   // after mount. Keep the live fallback block on the fragment so CE slot sync
@@ -504,6 +506,7 @@ export class SlotFragment
       false,
       undefined,
       adoptAnchor,
+      SLOT_FRAGMENT,
     )
     if (sharedFallback) {
       if (this.slotBoundary) {
@@ -835,21 +838,21 @@ export type InteropFragment<T extends Block = Block> = VaporFragment<T> & {
 }
 
 export function isInteropFragment(val: unknown): val is InteropFragment {
-  return isFragment(val) && val.vnode !== undefined
+  return !!(val && (val as any).__vf & VDOM)
 }
 
 export function isDynamicFragment(val: unknown): val is DynamicFragment {
-  return !!(val && (val as any).__df)
+  return !!(val && (val as any).__vf & DYNAMIC)
 }
 
 export function isForFragment(val: unknown): val is ForFragment {
-  return isFragment(val) && typeof (val as ForFragment).onReset === 'function'
+  return !!(val && (val as any).__vf & FOR)
 }
 
 export function isForBlock(val: unknown): val is ForBlock {
-  return isFragment(val) && (val as ForBlock).itemRef !== undefined
+  return !!(val && (val as any).__vf & FOR_ITEM)
 }
 
 export function isSlotFragment(val: unknown): val is SlotFragment {
-  return isDynamicFragment(val) && !!val.isSlot
+  return !!(val && (val as any).__vf & SLOT)
 }

--- a/packages/runtime-vapor/src/fragmentFlags.ts
+++ b/packages/runtime-vapor/src/fragmentFlags.ts
@@ -1,0 +1,9 @@
+export const FRAGMENT: number = 1
+export const DYNAMIC: number = 1 << 1
+export const SLOT: number = 1 << 2
+export const FOR: number = 1 << 3
+export const FOR_ITEM: number = 1 << 4
+export const TELEPORT: number = 1 << 5
+export const VDOM: number = 1 << 6
+
+export const SLOT_FRAGMENT: number = DYNAMIC | SLOT

--- a/packages/runtime-vapor/src/teleport.ts
+++ b/packages/runtime-vapor/src/teleport.ts
@@ -1,6 +1,7 @@
 import type { LooseRawProps } from './component'
 import type { RawSlots } from './componentSlots'
 import type { TeleportFragment } from './components/Teleport'
+import { TELEPORT } from './fragmentFlags'
 
 type VaporTeleportLike = {
   process(
@@ -22,5 +23,5 @@ export function isVaporTeleport(value: unknown): value is VaporTeleportLike {
 }
 
 export function isTeleportFragment(value: unknown): value is TeleportFragment {
-  return !!(value && (value as any).__tf)
+  return !!(value && (value as any).__vf & TELEPORT)
 }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -20,8 +20,9 @@ import {
   type VNode,
   type VNodeArrayChildren,
   type VNodeNormalizedRef,
-  type VaporInteropInterface,
+  type VaporInVdomInterface,
   VaporSlot as VaporSlotVNode,
+  type VdomInVaporInterface,
   callWithAsyncErrorHandling,
   createCommentVNode,
   createInternalObject,
@@ -134,6 +135,7 @@ import {
   runWithFragmentCtxOnly,
   runWithRenderCtx,
 } from './fragment'
+import { VDOM } from './fragmentFlags'
 import {
   type SlotBoundaryContext,
   hasSlotFallback,
@@ -309,10 +311,7 @@ function unmountVaporInteropWithParentSuspense(
 }
 
 // mounting vapor components and slots in vdom
-const vaporInteropImpl: Omit<
-  VaporInteropInterface,
-  'vdomMount' | 'vdomUnmount' | 'vdomSlot' | 'vdomMountVNode'
-> = {
+const vaporInteropImpl: VaporInVdomInterface = {
   mount(
     vnode,
     container,
@@ -2375,15 +2374,13 @@ export const vaporInteropPlugin: Plugin = app => {
     getInteropTransitionElement,
   )
   setInteropEnabled()
+  app._context.vapor = vaporInteropImpl
   const internals = ensureRenderer().internals
-  // Keep the shared base implementation immutable; renderer-bound methods must
-  // be per-app so installing the plugin cannot overwrite another app's bridge.
-  app._context.vapor = extend({}, vaporInteropImpl, {
-    vdomMount: createVDOMComponent.bind(null, internals),
-    vdomUnmount: internals.umt,
-    vdomSlot: renderVDOMSlot.bind(null, internals),
-    vdomMountVNode: mountVNode.bind(null, internals),
-  })
+  app._context.vdom = {
+    mount: createVDOMComponent.bind(null, internals),
+    slot: renderVDOMSlot.bind(null, internals),
+    mountVNode: mountVNode.bind(null, internals),
+  } satisfies VdomInVaporInterface
   const mount = app.mount
   app.mount = ((...args) => {
     optimizePropertyLookup()
@@ -3317,7 +3314,7 @@ function createInteropFragment(
   nodes: Block = EMPTY_BLOCK,
   vnode: VNode | null = null,
 ): RenderContextFragment<Block> {
-  const frag = new RenderContextFragment<Block>(nodes)
+  const frag = new RenderContextFragment<Block>(nodes, VDOM)
   frag.vnode = vnode
   return frag
 }


### PR DESCRIPTION
Use explicit fragment role flags and separate the internal bridge interfaces without changing the unified interop plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved interoperability between VDOM and Vapor rendering.
  * Added clearer fragment classification for slots, loops, teleports, dynamic content, and VDOM content.

* **Bug Fixes**
  * Improved slot detection, hydration handling, and dynamic component mounting.
  * Preserved fragment keys during VDOM–Vapor interoperation.

* **Refactor**
  * Unified fragment identification through shared flags.
  * Updated public interop APIs with clearer VDOM and Vapor separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->