### PR TITLE
fix(compiler-sfc): scope nested rules under mixed :deep() selector lists

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -514,6 +514,24 @@ color: red
         }"
       `)
     })
+
+    // a `:slotted()` member gets its own `-s` attribute handling in
+    // rewriteSelector, which the branch wrapper cannot reproduce
+    test('a :slotted() member is left alone', () => {
+      expect(
+        compileScoped(
+          `.a,
+.b :deep(.c),
+:slotted(.e) { > span { color: blue; } }`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a,
+        .b[data-v-test] .c,[data-v-test].e[data-v-test-s] {
+        > span { color: blue;
+        }
+        }"
+      `)
+    })
   })
 
   test('::v-slotted', () => {

--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -196,63 +196,297 @@ color: red
   })
 
   // #15205
-  test(':deep() in a selector list with nested rules', () => {
-    const code = compileScoped(
-      `.a,
+  describe(':deep() in a selector list with nested rules', () => {
+    test('plain and :deep() members get their own copy of the body', () => {
+      expect(
+        compileScoped(
+          `.a,
 .b :deep(.c) {
   color: red;
   > span { color: blue; }
 }`,
-    )
-    // the plain member keeps normal scoped nesting semantics:
-    // .a[data-v-test] and .a > span[data-v-test]
-    expect(code).toContain('&[data-v-test]')
-    expect(code).toContain('> span[data-v-test]')
-    // the :deep() member keeps deep semantics:
-    // .b[data-v-test] .c and .b[data-v-test] .c > span
-    expect(code).toContain('.b[data-v-test] .c')
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a,
+        .b[data-v-test] .c {
+        &:where(.a) {
+        &[data-v-test] {
+          color: red;
+        }
+        > span[data-v-test] { color: blue;
+        }
+        }
+        &:where(.b[data-v-test] .c) {
+          color: red;
+        > span { color: blue;
+        }
+        }
+        }"
+      `)
+    })
 
-    // the position of the :deep() member in the list must not matter
-    const reversed = compileScoped(
-      `.b :deep(.c),
+    test('the position of the :deep() member does not matter', () => {
+      expect(
+        compileScoped(
+          `.b :deep(.c),
 .a {
   color: red;
   > span { color: blue; }
 }`,
-    )
-    expect(reversed).toContain('&[data-v-test]')
-    expect(reversed).toContain('> span[data-v-test]')
-    expect(reversed).toContain('.b[data-v-test] .c')
+        ),
+      ).toMatchInlineSnapshot(`
+        ".b[data-v-test] .c,
+        .a {
+        &:where(.b[data-v-test] .c) {
+          color: red;
+        > span { color: blue;
+        }
+        }
+        &:where(.a) {
+        &[data-v-test] {
+          color: red;
+        }
+        > span[data-v-test] { color: blue;
+        }
+        }
+        }"
+      `)
+    })
 
-    // plain members are grouped together, wherever they sit in the list
-    const threeMembers = compileScoped(
-      `.a,
+    test('plain members are grouped, wherever they sit in the list', () => {
+      expect(
+        compileScoped(
+          `.a,
 .b :deep(.c),
 .d {
   color: red;
   > span { color: blue; }
 }`,
-    )
-    expect(threeMembers).toContain('.a,\n.d {')
-    expect(threeMembers).toContain('> span[data-v-test]')
-    expect(threeMembers).toContain('.b[data-v-test] .c')
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a,
+        .b[data-v-test] .c,
+        .d {
+        &:where(.a, .d) {
+        &[data-v-test] {
+          color: red;
+        }
+        > span[data-v-test] { color: blue;
+        }
+        }
+        &:where(.b[data-v-test] .c) {
+          color: red;
+        > span { color: blue;
+        }
+        }
+        }"
+      `)
+    })
 
-    // nested rules below an at-rule count as nested rules too
-    const withAtRule = compileScoped(
-      `.a,
+    test('nested rules below an at-rule count as nested rules', () => {
+      expect(
+        compileScoped(
+          `.a,
 .b :deep(.c) {
   @media (min-width: 100px) {
     .z { color: pink; }
   }
 }`,
-    )
-    expect(withAtRule).toContain('.z[data-v-test]')
-    expect(withAtRule).toContain('.b[data-v-test] .c')
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a,
+        .b[data-v-test] .c {
+        &:where(.a) {
+        @media (min-width: 100px) {
+        .z[data-v-test] { color: pink;
+        }
+        }
+        }
+        &:where(.b[data-v-test] .c) {
+        @media (min-width: 100px) {
+        .z { color: pink;
+        }
+        }
+        }
+        }"
+      `)
+    })
 
-    // without nested rules there is nothing to disambiguate, so no split
-    expect(compileScoped(`.a, .b :deep(.c) { color: red; }`)).toMatch(
-      `.a[data-v-test], .b[data-v-test] .c { color: red;`,
-    )
+    // per the CSS nesting spec the specificity of `&` is the largest
+    // specificity in the parent selector list, so the list is kept whole and
+    // the branches are narrowed with `:where()`, which adds nothing on top.
+    // here `&` stays at (1,2,0) - the specificity of `#b[data-v-test] .c` -
+    // for both branches, and the only change to a nested rule is the scope
+    // attribute it is supposed to get
+    test('nesting specificity of the selector list is preserved', () => {
+      expect(
+        compileScoped(
+          `.a,
+#b :deep(.c) {
+  > span { color: blue; }
+}`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a,
+        #b[data-v-test] .c {
+        &:where(.a) {
+        > span[data-v-test] { color: blue;
+        }
+        }
+        &:where(#b[data-v-test] .c) {
+        > span { color: blue;
+        }
+        }
+        }"
+      `)
+    })
+
+    test('no nested rules - nothing to disambiguate, rule is left alone', () => {
+      expect(compileScoped(`.a, .b :deep(.c) { color: red; }`))
+        .toMatchInlineSnapshot(`
+        ".a[data-v-test], .b[data-v-test] .c { color: red;
+        }"
+      `)
+    })
+
+    test('every member is :deep() - rule is left alone', () => {
+      expect(
+        compileScoped(
+          `.a :deep(.x),
+.b :deep(.c) {
+  > span { color: blue; }
+}`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a[data-v-test] .x,
+        .b[data-v-test] .c {
+        > span { color: blue;
+        }
+        }"
+      `)
+    })
+
+    test('a mixed list below a :deep() rule stays deep', () => {
+      expect(
+        compileScoped(
+          `:deep(.p) {
+  .a,
+  .b :deep(.c) { > span { color: blue; } }
+}`,
+        ),
+      ).toMatchInlineSnapshot(`
+        "[data-v-test] .p {
+        .a,
+          .b[data-v-test] .c {
+        > span { color: blue;
+        }
+        }
+        }"
+      `)
+    })
+
+    // `:where()` is a forgiving selector list: it drops arguments it cannot
+    // parse instead of invalidating the rule, so a branch that cannot be
+    // expressed as a `:where()` argument is left alone rather than silently
+    // reduced to matching nothing
+    test('a member with a pseudo element is left alone', () => {
+      expect(
+        compileScoped(
+          `.a::before,
+.b :deep(.c) { > span { color: blue; } }`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a::before,
+        .b[data-v-test] .c {
+        > span { color: blue;
+        }
+        }"
+      `)
+      expect(
+        compileScoped(
+          `.a:before,
+.b :deep(.c) { > span { color: blue; } }`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a:before,
+        .b[data-v-test] .c {
+        > span { color: blue;
+        }
+        }"
+      `)
+    })
+
+    // inside a branch `&` would resolve against the mixed list itself instead
+    // of against the rule the member was written against
+    test('a member built on & is left alone', () => {
+      expect(
+        compileScoped(
+          `.p {
+  &.a,
+  &.b :deep(.c) { > span { color: blue; } }
+}`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".p {
+        &.a,
+          &.b[data-v-test] .c {
+        > span { color: blue;
+        }
+        }
+        }"
+      `)
+    })
+
+    test('a member expanding into several selectors is left alone', () => {
+      expect(
+        compileScoped(
+          `:is(:deep(.foo), .bar) .baz,
+.a { > span { color: blue; } }`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ":is([data-v-test] .foo)[data-v-test] .baz, :is(.bar) .baz[data-v-test],
+        .a[data-v-test] {
+        > span { color: blue;
+        }
+        }"
+      `)
+    })
+
+    test('a :global() member is left alone', () => {
+      expect(
+        compileScoped(
+          `:global(.a),
+.b :deep(.c) { > span { color: blue; } }`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a,
+        .b[data-v-test] .c {
+        > span { color: blue;
+        }
+        }"
+      `)
+    })
+
+    test('keyframes do not count as nested rules', () => {
+      expect(
+        compileScoped(
+          `.a,
+.b :deep(.c) {
+  @keyframes x { from { opacity: 0; } to { opacity: 1; } }
+}`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ".a[data-v-test],
+        .b[data-v-test] .c {
+        @keyframes x-test {
+        from { opacity: 0;
+        }
+        to { opacity: 1;
+        }
+        }
+        }"
+      `)
+    })
   })
 
   test('::v-slotted', () => {

--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -467,6 +467,33 @@ color: red
       `)
     })
 
+    test('a member with :global() buried in a functional pseudo is left alone', () => {
+      expect(
+        compileScoped(
+          `:is(:global(.b)) :deep(.c),
+.a { > span { color: blue; } }`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ":is(.b) .c,
+        .a[data-v-test] {
+        > span { color: blue;
+        }
+        }"
+      `)
+      expect(
+        compileScoped(
+          `:is(:global(.b)) .x,
+.b :deep(.c) { > span { color: blue; } }`,
+        ),
+      ).toMatchInlineSnapshot(`
+        ":is(:global(.b)) .x,
+        .b[data-v-test] .c {
+        > span { color: blue;
+        }
+        }"
+      `)
+    })
+
     test('keyframes do not count as nested rules', () => {
       expect(
         compileScoped(

--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -195,6 +195,54 @@ color: red
     `)
   })
 
+  // #15205
+  test(':deep() in a selector list with nested rules', () => {
+    const code = compileScoped(
+      `.a,
+.b :deep(.c) {
+  color: red;
+  > span { color: blue; }
+}`,
+    )
+    // the plain member keeps normal scoped nesting semantics:
+    // .a[data-v-test] and .a > span[data-v-test]
+    expect(code).toContain('&[data-v-test]')
+    expect(code).toContain('> span[data-v-test]')
+    // the :deep() member keeps deep semantics:
+    // .b[data-v-test] .c and .b[data-v-test] .c > span
+    expect(code).toContain('.b[data-v-test] .c')
+
+    // the position of the :deep() member in the list must not matter
+    const reversed = compileScoped(
+      `.b :deep(.c),
+.a {
+  color: red;
+  > span { color: blue; }
+}`,
+    )
+    expect(reversed).toContain('&[data-v-test]')
+    expect(reversed).toContain('> span[data-v-test]')
+    expect(reversed).toContain('.b[data-v-test] .c')
+
+    // plain members are grouped together, wherever they sit in the list
+    const threeMembers = compileScoped(
+      `.a,
+.b :deep(.c),
+.d {
+  color: red;
+  > span { color: blue; }
+}`,
+    )
+    expect(threeMembers).toContain('.a,\n.d {')
+    expect(threeMembers).toContain('> span[data-v-test]')
+    expect(threeMembers).toContain('.b[data-v-test] .c')
+
+    // without nested rules there is nothing to disambiguate, so no split
+    expect(compileScoped(`.a, .b :deep(.c) { color: red; }`)).toMatch(
+      `.a[data-v-test], .b[data-v-test] .c { color: red;`,
+    )
+  })
+
   test('::v-slotted', () => {
     expect(compileScoped(`:slotted(.foo) { color: red; }`))
       .toMatchInlineSnapshot(`

--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -237,6 +237,18 @@ color: red
     expect(threeMembers).toContain('> span[data-v-test]')
     expect(threeMembers).toContain('.b[data-v-test] .c')
 
+    // nested rules below an at-rule count as nested rules too
+    const withAtRule = compileScoped(
+      `.a,
+.b :deep(.c) {
+  @media (min-width: 100px) {
+    .z { color: pink; }
+  }
+}`,
+    )
+    expect(withAtRule).toContain('.z[data-v-test]')
+    expect(withAtRule).toContain('.b[data-v-test] .c')
+
     // without nested rules there is nothing to disambiguate, so no split
     expect(compileScoped(`.a, .b :deep(.c) { color: red; }`)).toMatch(
       `.a[data-v-test], .b[data-v-test] .c { color: red;`,

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -140,6 +140,9 @@ function splitMixedDeepRuleBody(id: string, rule: Rule): boolean {
       // a `:global()` member is neither scoped nor deep, so it belongs to
       // neither branch
       selector.some(isGlobalSelector) ||
+      // a `:slotted()` member gets its own `-s` attribute handling in
+      // rewriteSelector, which the branch wrapper cannot reproduce
+      selector.some(isSlottedSelector) ||
       // a member written on `&` refers to the selector list of the rule that
       // contains this one, but inside a branch wrapper it would resolve
       // against the mixed list itself
@@ -520,6 +523,19 @@ function isGlobalSelector(node: selectorParser.Node): boolean {
   return !!(
     node as selectorParser.Node & { nodes?: selectorParser.Node[] }
   ).nodes?.some(child => isGlobalSelector(child))
+}
+
+function isSlottedSelector(node: selectorParser.Node): boolean {
+  if (
+    node.type === 'pseudo' &&
+    (node.value === ':slotted' || node.value === '::v-slotted')
+  ) {
+    return true
+  }
+
+  return !!(
+    node as selectorParser.Node & { nodes?: selectorParser.Node[] }
+  ).nodes?.some(child => isSlottedSelector(child))
 }
 
 function isDeepContainerPseudo(

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -510,10 +510,16 @@ function isDeepSelector(node: selectorParser.Node): boolean {
 }
 
 function isGlobalSelector(node: selectorParser.Node): boolean {
-  return (
+  if (
     node.type === 'pseudo' &&
     (node.value === ':global' || node.value === '::v-global')
-  )
+  ) {
+    return true
+  }
+
+  return !!(
+    node as selectorParser.Node & { nodes?: selectorParser.Node[] }
+  ).nodes?.some(child => isGlobalSelector(child))
 }
 
 function isDeepContainerPseudo(

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -95,6 +95,21 @@ function processRule(id: string, rule: Rule) {
 }
 
 /**
+ * Whether the node has nested rules, including ones sitting below at-rules
+ * such as `@media`. Keyframes are skipped: their `from` / `to` children are
+ * not nested style rules.
+ */
+function hasNestedRule(node: Rule | AtRule): boolean {
+  return !!node.nodes?.some(
+    child =>
+      child.type === 'rule' ||
+      (child.type === 'atrule' &&
+        !keyframesRE.test(child.name) &&
+        hasNestedRule(child)),
+  )
+}
+
+/**
  * A selector list can mix `:deep()` members with plain ones, but the rule body
  * is shared by all of them. When the rule also has nested rules, the two kinds
  * need the scope id in different places (`.a > span[id]` vs
@@ -102,7 +117,7 @@ function processRule(id: string, rule: Rule) {
  * that each kind gets its own copy of the body.
  */
 function splitMixedDeepSelectorList(rule: Rule): boolean {
-  if (!rule.nodes || !rule.nodes.some(node => node.type === 'rule')) {
+  if (!hasNestedRule(rule)) {
     return false
   }
   const selectorRoot = selectorParser().astSync(rule.selector)

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -84,11 +84,54 @@ function processRule(id: string, rule: Rule) {
     }
     parent = parent.parent
   }
+  if (!deep && splitMixedDeepSelectorList(rule)) {
+    return
+  }
   rule.selector = selectorParser(selectorRoot => {
     selectorRoot.each(selector => {
       rewriteSelector(id, rule, selector, selectorRoot, deep)
     })
   }).processSync(rule.selector)
+}
+
+/**
+ * A selector list can mix `:deep()` members with plain ones, but the rule body
+ * is shared by all of them. When the rule also has nested rules, the two kinds
+ * need the scope id in different places (`.a > span[id]` vs
+ * `.b[id] .c > span`), which a single rule cannot express. Split the rule so
+ * that each kind gets its own copy of the body.
+ */
+function splitMixedDeepSelectorList(rule: Rule): boolean {
+  if (!rule.nodes || !rule.nodes.some(node => node.type === 'rule')) {
+    return false
+  }
+  const selectorRoot = selectorParser().astSync(rule.selector)
+  if (selectorRoot.nodes.length < 2) {
+    return false
+  }
+  const deepSelectors: string[] = []
+  const plainSelectors: string[] = []
+  let deepComesFirst = false
+  selectorRoot.each(selector => {
+    const target = selector.some(isDeepSelector)
+      ? deepSelectors
+      : plainSelectors
+    if (!deepSelectors.length && !plainSelectors.length) {
+      deepComesFirst = target === deepSelectors
+    }
+    target.push(String(selector).trim())
+  })
+  if (!deepSelectors.length || !plainSelectors.length) {
+    return false
+  }
+  const deepRule = rule.clone({ selector: deepSelectors.join(',\n') })
+  const plainRule = rule.clone({ selector: plainSelectors.join(',\n') })
+  const [first, second] = deepComesFirst
+    ? [deepRule, plainRule]
+    : [plainRule, deepRule]
+  second.raws.before = '\n'
+  rule.replaceWith(first, second)
+  return true
 }
 
 function rewriteSelector(

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -11,6 +11,7 @@ import { warn } from '../warn'
 const animationNameRE = /^(?:-\w+-)?animation-name$/
 const animationRE = /^(?:-\w+-)?animation$/
 const keyframesRE = /^(?:-\w+-)?keyframes$/
+const pseudoElementRE = /^(?:::|:(?:before|after|first-line|first-letter)$)/
 
 const scopedPlugin: PluginCreator<string> = (id = '') => {
   const keyframes = Object.create(null)
@@ -68,6 +69,8 @@ const processedRules = new WeakSet<Rule>()
 function processRule(id: string, rule: Rule) {
   if (
     processedRules.has(rule) ||
+    // branch wrappers are generated with their final selector
+    (rule as any).__branch ||
     (rule.parent &&
       rule.parent.type === 'atrule' &&
       keyframesRE.test((rule.parent as AtRule).name))
@@ -84,7 +87,7 @@ function processRule(id: string, rule: Rule) {
     }
     parent = parent.parent
   }
-  if (!deep && splitMixedDeepSelectorList(rule)) {
+  if (!deep && splitMixedDeepRuleBody(id, rule)) {
     return
   }
   rule.selector = selectorParser(selectorRoot => {
@@ -113,10 +116,17 @@ function hasNestedRule(node: Rule | AtRule): boolean {
  * A selector list can mix `:deep()` members with plain ones, but the rule body
  * is shared by all of them. When the rule also has nested rules, the two kinds
  * need the scope id in different places (`.a > span[id]` vs
- * `.b[id] .c > span`), which a single rule cannot express. Split the rule so
- * that each kind gets its own copy of the body.
+ * `.b[id] .c > span`), which a single rule cannot express. Give each kind its
+ * own copy of the body, wrapped in `&:where(<members of that kind>)`.
+ *
+ * The selector list itself is left whole, because per the CSS nesting spec the
+ * specificity of `&` is the largest specificity in the parent selector list.
+ * Splitting the list into two rules would evaluate each branch against a
+ * smaller list and could change which declaration wins the cascade;
+ * `&:where()` narrows what a branch matches while adding no specificity of its
+ * own, so nested rules keep the weight they have without the split.
  */
-function splitMixedDeepSelectorList(rule: Rule): boolean {
+function splitMixedDeepRuleBody(id: string, rule: Rule): boolean {
   if (!hasNestedRule(rule)) {
     return false
   }
@@ -124,29 +134,113 @@ function splitMixedDeepSelectorList(rule: Rule): boolean {
   if (selectorRoot.nodes.length < 2) {
     return false
   }
-  const deepSelectors: string[] = []
-  const plainSelectors: string[] = []
-  let deepComesFirst = false
-  selectorRoot.each(selector => {
-    const target = selector.some(isDeepSelector)
-      ? deepSelectors
-      : plainSelectors
-    if (!deepSelectors.length && !plainSelectors.length) {
-      deepComesFirst = target === deepSelectors
+  const members: { deep: boolean; scoped: string }[] = []
+  for (const selector of selectorRoot.nodes) {
+    if (
+      // a `:global()` member is neither scoped nor deep, so it belongs to
+      // neither branch
+      selector.some(isGlobalSelector) ||
+      // a member written on `&` refers to the selector list of the rule that
+      // contains this one, but inside a branch wrapper it would resolve
+      // against the mixed list itself
+      hasNestingSelector(selector)
+    ) {
+      return false
     }
-    target.push(String(selector).trim())
-  })
-  if (!deepSelectors.length || !plainSelectors.length) {
+    const scoped = rewriteMemberSelector(id, String(selector).trim())
+    if (scoped === null) {
+      return false
+    }
+    members.push({ deep: selector.some(isDeepSelector), scoped })
+  }
+  const deepMembers = members.filter(member => member.deep)
+  if (!deepMembers.length || deepMembers.length === members.length) {
     return false
   }
-  const deepRule = rule.clone({ selector: deepSelectors.join(',\n') })
-  const plainRule = rule.clone({ selector: plainSelectors.join(',\n') })
-  const [first, second] = deepComesFirst
-    ? [deepRule, plainRule]
-    : [plainRule, deepRule]
-  second.raws.before = '\n'
-  rule.replaceWith(first, second)
+  const plainMembers = members.filter(member => !member.deep)
+
+  const deepBranch = createBranchRule(rule, deepMembers)
+  const plainBranch = createBranchRule(rule, plainMembers)
+  // deep mode is carried by the deep branch instead of by the rule holding the
+  // mixed list
+  ;(deepBranch as any).__deep = true
+
+  rule.selector = members.map(member => member.scoped).join(',\n')
+  rule.removeAll()
+  rule.append(
+    members[0].deep ? [deepBranch, plainBranch] : [plainBranch, deepBranch],
+  )
+
+  // mirror what rewriteSelector does for a non-deep rule with nested rules:
+  // declarations move into `&` so that they get the scope id
+  extractAndWrapNodes(plainBranch)
+  for (const node of plainBranch.nodes) {
+    if (node.type === 'atrule') {
+      extractAndWrapNodes(node)
+    }
+  }
   return true
+}
+
+/**
+ * Rewrite one member of a selector list on its own, so that a branch wrapper
+ * can select on the final, scoped form of the members it stands for. Returns
+ * null for a member that cannot be used inside `:where()`.
+ */
+function rewriteMemberSelector(id: string, selector: string): string | null {
+  // rewriteSelector looks at the rule to decide where the scope id goes, and
+  // for a rule with nested rules it goes on those rather than on the member
+  // itself - stand in for the rule being processed so that its body, which is
+  // about to be moved into the branches, is left alone
+  const stub = new Rule({
+    selector,
+    nodes: [new Rule({ selector: '&', nodes: [] })],
+  })
+  const scoped = selectorParser(memberRoot => {
+    memberRoot.each(memberSelector =>
+      rewriteSelector(id, stub, memberSelector, memberRoot, false),
+    )
+  }).processSync(selector)
+  const scopedRoot = selectorParser().astSync(scoped)
+  // `:where()` drops any argument it cannot parse, and pseudo elements are not
+  // valid there; a member that expanded into several selectors cannot be
+  // attributed to a single branch either
+  if (scopedRoot.nodes.length > 1 || hasPseudoElement(scopedRoot)) {
+    return null
+  }
+  return scoped
+}
+
+function createBranchRule(rule: Rule, members: { scoped: string }[]): Rule {
+  const branch = new Rule({
+    selector: `&:where(${members.map(member => member.scoped).join(', ')})`,
+    nodes: rule.nodes.map(node => node.clone()),
+    raws: { before: '\n', between: ' ' },
+  })
+  // the branch selector is generated in its final form, so processRule must
+  // leave it alone
+  ;(branch as any).__branch = true
+  return branch
+}
+
+function hasNestingSelector(selector: selectorParser.Selector): boolean {
+  let found = false
+  selector.walk(node => {
+    if (node.type === 'nesting') {
+      found = true
+    }
+  })
+  return found
+}
+
+function hasPseudoElement(selectorRoot: selectorParser.Root): boolean {
+  let found = false
+  selectorRoot.walkPseudos(pseudo => {
+    if (pseudoElementRE.test(pseudo.value)) {
+      found = true
+    }
+  })
+  return found
 }
 
 function rewriteSelector(
@@ -413,6 +507,13 @@ function isDeepSelector(node: selectorParser.Node): boolean {
   return !!(
     node as selectorParser.Node & { nodes?: selectorParser.Node[] }
   ).nodes?.some(child => isDeepSelector(child))
+}
+
+function isGlobalSelector(node: selectorParser.Node): boolean {
+  return (
+    node.type === 'pseudo' &&
+    (node.value === ':global' || node.value === '::v-global')
+  )
 }
 
 function isDeepContainerPseudo(


### PR DESCRIPTION
Closes #15205.

### Problem

When a scoped rule has a comma-separated selector list where one member uses `:deep()`, **and** the rule contains nested rules, the scope id is placed wrongly for the plain members. Depending on where the `:deep()` member sits, a plain member either loses the id entirely or keeps it while its nested rules go unscoped.

`__deep` is stored on the rule, but "is this deep?" is a property of an individual list member. Two things are inherently per-rule and cannot distinguish members: the one-shot `extractAndWrapNodes(rule)`, and the deep-ness that nested rules inherit by walking `rule.parent`.

### Approach

Per the spec in https://github.com/vuejs/core/issues/15205#issuecomment-5176407629, each list member must keep its own scoped nesting semantics:

```css
.a[data-v-xxx],
.b[data-v-xxx] .c { color: red; }

.a > span[data-v-xxx],          /* not .a[data-v-xxx] > span */
.b[data-v-xxx] .c > span { color: blue; }
```

That needs the id in **different positions inside the same body**, which one shared body cannot express. So `processRule` gives each kind of member its own copy of the body, wrapped in `&:where(<members of that kind>)`, and the existing code paths process each branch unchanged — no new scoping logic.

The selector list itself stays whole. Per [css-nesting](https://drafts.csswg.org/css-nesting/#nest-selector) the specificity of `&` is the largest specificity in the parent selector list, so splitting the list into two rules would evaluate each branch against a smaller list and could change which declaration wins the cascade (see [review](https://github.com/vuejs/core/pull/15270#pullrequestreview-4911995544)). `&:where()` narrows what a branch matches while adding no specificity of its own, so nested rules keep exactly the weight they have today, plus the scope attribute they are supposed to get.

Input:

```css
.a,
.b :deep(.c) { color: red; > span { color: blue; } }
```

Output:

```css
.a,
.b[data-v-test] .c {
&:where(.a) {
&[data-v-test] { color: red; }
> span[data-v-test] { color: blue; }
}
&:where(.b[data-v-test] .c) {
  color: red;
> span { color: blue; }
}
}
```

`:where()` is Chrome 88 / Safari 14 / Firefox 78; the native nesting this code path already emits is Chrome 112 / Safari 16.5 / Firefox 117, so any browser that can parse the output supports `:where()`.

The change is narrowly gated: it only fires when the body has a nested rule (including one below an at-rule such as `@media`; `@keyframes` are excluded), the list has more than one member, and the list mixes deep and plain members.

Because `:where()` is a forgiving selector list — it drops an argument it cannot parse instead of invalidating the rule — a rule is left exactly as it is on `main` whenever a member cannot be a `:where()` argument: members with pseudo elements, members written on `&` (inside a branch it would resolve against the mixed list itself), `:global()` members, and members that expand into several selectors such as `:is(:deep(.foo), .bar) .baz`. Each bail-out has a test asserting unchanged output.

### Relation to #15206

#15206 resolves `rule.__deep` up-front. That fixes the reported "`.a` is unscoped" symptom, but the nested rule then yields `.a[data-v-xxx] > span` — the shape explicitly called out as wrong in the issue, and visible in that PR's own inline snapshot. Pre-computing the flag cannot get to `.a > span[data-v-xxx]`, because the body is still shared.

### Not covered

One related case stays as it is on `main`, and can be a follow-up:

- `:is(.a, :deep(.c))` with nested rules, which goes through `splitSelectorForNestedDeep`

### Trade-off

The body is duplicated in the output for mixed lists — unavoidable if each branch needs its own id placement.

### Tests

Added to `compileStyle.spec.ts` as exact inline snapshots: the reported case, the reversed order, a three-member list, a nested rule below `@media`, a case with an id member pinning the preserved nesting specificity, and controls asserting unchanged output for lists without nested rules, all-deep lists, and every bail-out above. `vitest run --project unit --project unit-jsdom`: 181 test files, 3675 tests passed, 5 skipped.

Cascade behavior verified in Chrome by mounting the compiled output against a competing `.q.q.q.q.q.q.q.q > span` rule — specificity `(0,8,1)`: the nested rule keeps winning, the `:deep()` branch applies, and nothing leaks outside the component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved scoped styling for `:deep()` selectors used alongside regular selectors in nested rules.
* Preserved selector order, grouping, specificity, and formatting when separating deep and standard selectors.
* Improved handling of nested at-rules, pseudo-elements, `:global()`, keyframes, and other complex selector combinations.
* Maintained existing behavior when selector separation is unnecessary.

## Tests

* Added comprehensive regression coverage for mixed selector lists, nested rules, at-rules, and related selector scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->