### PR TITLE
fix(runtime-dom): warn when in-DOM template container contains a shadow root

### DIFF
--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -121,6 +121,9 @@ export const createApp = ((...args) => {
       // The user must make sure the in-DOM template is trusted. If it's
       // rendered by the server, the template should not contain any user data.
       component.template = container.innerHTML
+      if (__DEV__ && container.nodeType === 1) {
+        warnShadowRootLoss(container as Element)
+      }
       // 2.x compat check
       if (__COMPAT__ && __DEV__ && container.nodeType === 1) {
         for (let i = 0; i < (container as Element).attributes.length; i++) {
@@ -181,6 +184,30 @@ function resolveRootNamespace(
     container instanceof MathMLElement
   ) {
     return 'mathml'
+  }
+}
+
+// dev only
+// `innerHTML` does not serialize shadow roots, so shadow DOM inside the mount
+// container - most notably declarative shadow DOM parsed by the browser from
+// `<template shadowrootmode>` - is absent from the in-DOM template and is
+// destroyed when the container is cleared before mounting.
+// https://github.com/vuejs/core/issues/12813
+function warnShadowRootLoss(container: Element) {
+  const descendants = container.querySelectorAll('*')
+  for (let i = 0; i < descendants.length; i++) {
+    const el = descendants[i]
+    if (el.shadowRoot) {
+      warn(
+        `Mount container contains <${el.tagName.toLowerCase()}> with a shadow ` +
+          `root. Shadow roots are not serialized by \`innerHTML\`, so they are ` +
+          `not part of the in-DOM template and are discarded when the ` +
+          `container is cleared before mounting. Use the \`template\` or ` +
+          `\`render\` option instead of relying on the in-DOM template, or ` +
+          `mount into a container that has no shadow roots inside it.`,
+      )
+      break
+    }
   }
 }
 

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -177,6 +177,38 @@ describe('compiler + runtime integration', () => {
     expect(container.innerHTML).toBe('hello')
   })
 
+  // #12813
+  it('should warn when in-DOM template container contains a shadow root', () => {
+    const container = document.createElement('div')
+    const host = document.createElement('div')
+    // this is what the HTML parser produces for
+    // `<div><template shadowrootmode="open">Shadow content</template>Light content</div>`
+    host.attachShadow({ mode: 'open' }).textContent = 'Shadow content'
+    host.textContent = 'Light content'
+    container.appendChild(host)
+
+    createApp({}).mount(container)
+
+    expect(
+      '[Vue warn]: Mount container contains <div> with a shadow root.',
+    ).toHaveBeenWarned()
+    // the shadow root is not part of the in-DOM template and the host element
+    // is re-created from scratch, so it is gone
+    expect(container.innerHTML).toBe('<div>Light content</div>')
+    expect(container.firstElementChild!.shadowRoot).toBe(null)
+  })
+
+  it('should not warn about shadow roots when template option is provided', () => {
+    const container = document.createElement('div')
+    const host = document.createElement('div')
+    host.attachShadow({ mode: 'open' }).textContent = 'Shadow content'
+    container.appendChild(host)
+
+    createApp({ template: `<span>ok</span>` }).mount(container)
+
+    expect('shadow root').not.toHaveBeenWarned()
+  })
+
   it('should support selector of rootContainer', () => {
     const container = document.createElement('div')
     const origin = document.querySelector


### PR DESCRIPTION
close #12813

### Problem

`createApp({}).mount(el)` silently destroys declarative shadow DOM inside the mount container.

`packages/runtime-dom/src/index.ts`:

```ts
component.template = container.innerHTML
...
// clear content before mounting
if (container.nodeType === 1) {
  container.textContent = ''
}
```

The HTML parser turns `<template shadowrootmode="open">` into a real shadow root and removes the `<template>` from the light DOM before any script runs. `innerHTML` does not serialize shadow roots, so the in-DOM template Vue compiles has no trace of it; `container.textContent = ''` then discards the host node along with its shadow root, and Vue re-creates the host from the compiled template. Net effect: the shadow content disappears and the light content is rendered instead, with no diagnostic of any kind.

Reproduced identically on 3.4.38, 3.5.41 and 3.6.0-rc.3.

### What this PR does

It does **not** add declarative shadow DOM support — that needs both `getHTML({ shadowRoots })` for serialization and a new renderer step to call `attachShadow()` for `<template shadowrootmode>`, which is a design decision rather than a bug fix (see the issue for the analysis).

It turns the silent data loss into a diagnosable warning. On the in-DOM-template path only, in dev only:

```
[Vue warn]: Mount container contains <div> with a shadow root. Shadow roots are
not serialized by `innerHTML`, so they are not part of the in-DOM template and
are discarded when the container is cleared before mounting. Use the `template`
or `render` option instead of relying on the in-DOM template, or mount into a
container that has no shadow roots inside it.
```

Details:

- Guarded by `__DEV__`, tree-shaken in production, same pattern as the neighbouring `injectNativeTagCheck` / `injectCompilerOptionsCheck`.
- Runs only inside the `!component.render && !component.template` branch, i.e. exactly where the loss happens. No cost when `template`/`render` is provided.
- Checks descendants only, not the container itself: a container that is itself a shadow host projects its light children through `<slot>` and works correctly, so warning there would be a false positive.
- Breaks on the first match, so one message rather than one per host.
- No new imports; `warn` is already imported in the file.

Known limitation, matching what the issue says: `el.shadowRoot` is only exposed for `mode: 'open'`, so closed shadow roots cannot be detected.

### Tests

Two tests in `packages/vue/__tests__/index.spec.ts`: one asserting the warning and the resulting shadow-root loss, one asserting no warning when a `template` option is provided. The DOM state is built with `attachShadow` + light text, which is what the parser produces for `<div><template shadowrootmode="open">Shadow content</template>Light content</div>`.

`vitest run --project unit-jsdom`: 32 files, 397 passed, 1 skipped. The new test fails without the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development builds now warn when in-DOM templates contain shadow roots.
  * Shadow-root content is excluded from the template and removed when the mount container is cleared.
  * Explicit templates avoid warnings about existing shadow roots.

* **Tests**
  * Added coverage for shadow-root handling during application mounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->