### PR TITLE
fix(runtime-vapor): avoid redundant transition block resolution

### DIFF
--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -184,16 +184,18 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
           shouldCaptureVShow && !isMounted,
           () => frag.update(slots.default),
         )
-        let hasStructuralRoot = false
-        const root = resolveTransitionBlock(frag.nodes, fragment => {
-          hasStructuralRoot ||= isStructuralTransitionFragment(fragment)
-        })
-        applyPendingVShows(
-          frag.$transition!,
-          root,
-          pendingVShows,
-          hasStructuralRoot,
-        )
+        if (pendingVShows && pendingVShows.length) {
+          let hasStructuralRoot = false
+          const root = resolveTransitionBlock(frag.nodes, fragment => {
+            hasStructuralRoot ||= isStructuralTransitionFragment(fragment)
+          })
+          applyPendingVShows(
+            frag.$transition!,
+            root,
+            pendingVShows,
+            hasStructuralRoot,
+          )
+        }
         if (!isMounted && shouldPerformAppear) performAppear(frag.$transition!)
         isMounted = true
       })
@@ -661,8 +663,6 @@ function collectArrayTransitionBlocks(
   let hasFound = false
   for (const c of block) {
     if (c instanceof Comment) continue
-    const nested: ResolvedTransitionBlock[] = []
-    collectTransitionBlocks(c, onFragment, nested)
     if (__DEV__ && hasFound) {
       // warn more than one non-comment child
       warn(
@@ -671,6 +671,8 @@ function collectArrayTransitionBlocks(
       )
       break
     }
+    const nested: ResolvedTransitionBlock[] = []
+    collectTransitionBlocks(c, onFragment, nested)
     if (nested.length) children.push(nested[0])
     hasFound = true
     if (!__DEV__) break


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic transition handling for `v-show` content.
  * Prevented unnecessary transition processing when no pending entries or additional children exist.
  * Reduced avoidable development warnings during transition rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->