### PR TITLE
fix(compiler-vapor): propagate component root through Transition

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`compiler: transition > basic 1`] = `
 "import { VaporTransition as _VaporTransition, applyVShow as _applyVShow, createComponent as _createComponent, template as _template } from 'vue';
-const t0 = _template("<h1>foo")
+const t0 = _template("<h1>foo", 1)
 
 export function render(_ctx) {
   const n1 = _createComponent(_VaporTransition, { persisted: "" }, () => {
@@ -16,7 +16,7 @@ export function render(_ctx) {
 
 exports[`compiler: transition > inject persisted when child has v-show 1`] = `
 "import { VaporTransition as _VaporTransition, applyVShow as _applyVShow, createComponent as _createComponent, template as _template } from 'vue';
-const t0 = _template("<div>")
+const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n1 = _createComponent(_VaporTransition, { persisted: "" }, () => {
@@ -30,10 +30,10 @@ export function render(_ctx) {
 
 exports[`compiler: transition > the v-if/else-if/else branches in Transition should ignore comments 1`] = `
 "import { VaporTransition as _VaporTransition, setInsertionState as _setInsertionState, createIf as _createIf, extend as _extend, createComponent as _createComponent, template as _template } from 'vue';
-const t0 = _template("<div>hey", 2)
+const t0 = _template("<div>hey", 3)
 const t1 = _template("<p>", 2)
 const t2 = _template("<!-- this should not be ignored -->", 2)
-const t3 = _template("<div>")
+const t3 = _template("<div>", 1)
 
 export function render(_ctx) {
   const n17 = _createComponent(_VaporTransition, null, _extend(() => {
@@ -64,7 +64,7 @@ export function render(_ctx) {
 
 exports[`compiler: transition > v-show + appear 1`] = `
 "import { VaporTransition as _VaporTransition, applyVShow as _applyVShow, createComponent as _createComponent, template as _template } from 'vue';
-const t0 = _template("<h1>foo")
+const t0 = _template("<h1>foo", 1)
 
 export function render(_ctx) {
   const n1 = _createComponent(_VaporTransition, {
@@ -81,7 +81,7 @@ export function render(_ctx) {
 
 exports[`compiler: transition > work with dynamic keyed children 1`] = `
 "import { VaporTransition as _VaporTransition, createKeyedFragment as _createKeyedFragment, createComponent as _createComponent, template as _template } from 'vue';
-const t0 = _template("<h1>foo", 2)
+const t0 = _template("<h1>foo", 3)
 
 export function render(_ctx) {
   const n2 = _createComponent(_VaporTransition, null, () => {
@@ -97,7 +97,7 @@ export function render(_ctx) {
 
 exports[`compiler: transition > work with v-if 1`] = `
 "import { VaporTransition as _VaporTransition, createIf as _createIf, extend as _extend, createComponent as _createComponent, template as _template } from 'vue';
-const t0 = _template("<h1>foo", 2)
+const t0 = _template("<h1>foo", 3)
 
 export function render(_ctx) {
   const n3 = _createComponent(_VaporTransition, null, _extend(() => {

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -31,7 +31,11 @@ import {
   type VaporDirectiveNode,
   isBlockOperation,
 } from './ir'
-import { isConstantExpression, isStaticExpression } from './utils'
+import {
+  isConstantExpression,
+  isStaticExpression,
+  isTransitionNode,
+} from './utils'
 import { newBlock, newDynamic } from './transforms/utils'
 import type { ImportItem } from '@vue/compiler-core'
 
@@ -422,7 +426,8 @@ export class TransformContext<T extends AllNode = AllNode> {
 
     return (
       this.node.type === NodeTypes.ELEMENT &&
-      this.node.tagType === ElementTypes.TEMPLATE &&
+      (this.node.tagType === ElementTypes.TEMPLATE ||
+        isTransitionNode(this.node)) &&
       !!this.parent &&
       this.isSingleRoot
     )

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -1852,4 +1852,43 @@ describe('Transition', () => {
     await nextTick()
     expect(el.className).toBe('b-leave-from b-leave-active')
   })
+
+  // #15274
+  test('should merge fallthrough class with a transition child root', async () => {
+    const data = ref({
+      internalClass: 'internal-box',
+      externalClass: 'external-class',
+    })
+    const Child = compile(
+      `<template>
+        <Transition>
+          <div class="box" :class="data.internalClass">child</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<template>
+        <components.Child :class="data.externalClass" />
+      </template>`,
+      data,
+      { Child },
+    )
+    const { host } = define(App as any).render()
+    const el = host.querySelector('div')!
+
+    expect([...el.classList]).toEqual(
+      expect.arrayContaining(['external-class', 'box', 'internal-box']),
+    )
+    expect(el.classList).toHaveLength(3)
+
+    data.value.internalClass = 'internal-next'
+    data.value.externalClass = 'external-next'
+    await nextTick()
+
+    expect([...el.classList]).toEqual(
+      expect.arrayContaining(['external-next', 'box', 'internal-next']),
+    )
+    expect(el.classList).toHaveLength(3)
+  })
 })


### PR DESCRIPTION
Close #15274

Treat a root Transition as transparent when determining its single-root child so fallthrough class and style bindings use root merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class merging for components whose root content is wrapped in a transition.
  * Preserved static classes while correctly applying initial and reactive external and internal class updates.

* **Tests**
  * Added regression coverage for transition-wrapped child roots and dynamic class updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->