### PR TITLE
(fix #15276) preserve keyed Vapor v-for slot state

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -68,14 +68,14 @@ const t0 = _template(" ")
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, {
     $: [
-      () => (_createForSlots(_ctx.list, (item) => ({
-        name: item,
-        fn: (_slotProps0) => {
+      () => (_createForSlots(_ctx.list, (_for_item0) => ({
+        name: _for_item0.value,
+        fn: (_slotProps1) => {
           const n0 = t0()
-          _renderEffect(() => _setText(n0, _toDisplayString(_slotProps0.bar)))
+          _renderEffect(() => _setText(n0, _toDisplayString(_slotProps1.bar)))
           return n0
         }
-      })))
+      }), (item) => (item)))
     ]
   }, true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -468,13 +468,16 @@ describe('compiler: transform slot', () => {
   test('dynamic slots name w/ v-for', () => {
     const { ir, code } = compileWithSlots(
       `<Comp>
-        <template v-for="item in list" #[item]="{ bar }">{{ bar }}</template>
+        <template v-for="item in list" :key="item" #[item]="{ bar }">{{ bar }}</template>
       </Comp>`,
     )
     expect(code).toMatchSnapshot()
 
-    expect(code).contains(`fn: (_slotProps0) =>`)
-    expect(code).contains(`_setText(n0, _toDisplayString(_slotProps0.bar))`)
+    expect(code).contains(`fn: (_slotProps1) =>`)
+    expect(code).contains(`_setText(n0, _toDisplayString(_slotProps1.bar))`)
+    expect(code).contains(`(_for_item0) =>`)
+    expect(code).contains(`_for_item0.value`)
+    expect(code).contains(`(item) => (item)`)
 
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.CREATE_COMPONENT_NODE,
@@ -487,6 +490,7 @@ describe('compiler: transform slot', () => {
             isStatic: false,
           },
           fn: { type: IRNodeTypes.BLOCK },
+          keyProp: { content: 'item' },
           loop: {
             source: { content: 'list' },
             value: { content: 'item' },

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -694,6 +694,9 @@ function genLoopSlot(
   slot: IRSlotDynamicLoop,
   context: CodegenContext,
 ): CodeFragment[] {
+  const { keyProp } = slot
+  if (keyProp) return genKeyedLoopSlot(slot, context, keyProp)
+
   const { name, fn, loop } = slot
   const { value, key, index, source } = loop
   const rawValue = value && value.content
@@ -727,6 +730,81 @@ function genLoopSlot(
         ...slotExpr,
         ')',
       ],
+    ),
+  ]
+}
+
+function genKeyedLoopSlot(
+  { name, fn, loop }: IRSlotDynamicLoop,
+  context: CodegenContext,
+  keyProp: SimpleExpressionNode,
+): CodeFragment[] {
+  const { value, key, index, source } = loop
+  const rawValue = value && value.content
+  const rawKey = key && key.content
+  const rawIndex = index && index.content
+  const idToPathMap = parseValueDestructure(value, context)
+  const [depth, exitScope] = context.enterScope()
+  const itemVar = `_for_item${depth}`
+  const idMap = buildDestructureIdMap(
+    idToPathMap,
+    `${itemVar}.value`,
+    context.options.expressionPlugins,
+  )
+  idMap[itemVar] = null
+  const args = [itemVar]
+  if (rawKey) {
+    const keyVar = `_for_key${depth}`
+    args.push(keyVar)
+    idMap[rawKey] = `${keyVar}.value`
+    idMap[keyVar] = null
+  } else if (rawIndex) {
+    args.push('_')
+  }
+  if (rawIndex) {
+    const indexVar = `_for_index${depth}`
+    args.push(indexVar)
+    idMap[rawIndex] = `${indexVar}.value`
+    idMap[indexVar] = null
+  }
+  const slotExpr = genMulti(
+    DELIMITERS_OBJECT_NEWLINE,
+    ['name: ', ...context.withId(() => genExpression(name, context), idMap)],
+    [
+      'fn: ',
+      ...context.withId(() => genSlotBlockWithProps(fn, context, false), idMap),
+    ],
+  )
+  exitScope()
+
+  const renderSlot = [
+    ...genMulti(['(', ')', ', '], ...args),
+    ' => (',
+    ...slotExpr,
+    ')',
+  ]
+  const rawIdMap: Record<string, null> = {}
+  if (rawKey) rawIdMap[rawKey] = null
+  if (rawIndex) rawIdMap[rawIndex] = null
+  idToPathMap.forEach((_, id) => (rawIdMap[id] = null))
+  const getKey = [
+    ...genMulti(
+      ['(', ')', ', '],
+      rawValue ? rawValue : rawKey || rawIndex ? '_' : undefined,
+      rawKey ? rawKey : rawIndex ? '__' : undefined,
+      rawIndex,
+    ),
+    ' => (',
+    ...context.withId(() => genExpression(keyProp, context), rawIdMap),
+    ')',
+  ]
+
+  return [
+    ...genCall(
+      context.helper('createForSlots'),
+      genExpression(source, context),
+      renderSlot,
+      getKey,
     ),
   ]
 }

--- a/packages/compiler-vapor/src/ir/component.ts
+++ b/packages/compiler-vapor/src/ir/component.ts
@@ -52,6 +52,7 @@ export interface IRSlotDynamicLoop {
   name: SimpleExpressionNode
   fn: SlotBlockIRNode
   loop: IRFor
+  keyProp?: SimpleExpressionNode
 }
 export interface IRSlotDynamicConditional {
   slotType: IRSlotType.CONDITIONAL

--- a/packages/compiler-vapor/src/transforms/vSlot.ts
+++ b/packages/compiler-vapor/src/transforms/vSlot.ts
@@ -23,7 +23,12 @@ import {
   type SlotBlockIRNode,
   type VaporDirectiveNode,
 } from '../ir'
-import { findDir, resolveExpression } from '../utils'
+import {
+  findDir,
+  findProp,
+  propToExpression,
+  resolveExpression,
+} from '../utils'
 import { markNonTemplate } from './transformText'
 import { ignoreComment } from './transformComment'
 
@@ -197,11 +202,13 @@ function transformTemplateSlot(
     }
   } else if (vFor) {
     if (vFor.forParseResult) {
+      const keyProp = findProp(node, 'key')
       registerDynamicSlot(slots, {
         slotType: IRSlotType.LOOP,
         name: arg!,
         fn: block,
         loop: vFor.forParseResult as IRFor,
+        keyProp: keyProp && propToExpression(keyProp),
       })
     } else {
       context.options.onError(

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -6849,6 +6849,61 @@ describe('component: slots', () => {
       expect(instance.slots).not.toHaveProperty('1')
     })
 
+    // #15276
+    test('should preserve keyed slot content when source identities change', async () => {
+      const items = shallowRef([
+        { name: 'a', label: 'A' },
+        { name: 'b', label: 'B' },
+      ])
+      const Content = compile(
+        `<script setup vapor>
+        import { ref } from 'vue'
+        defineProps(['label'])
+        const count = ref(0)
+        </script>
+        <template>
+          <button @click="count++">{{ label }}:{{ count }}</button>
+        </template>`,
+        items,
+      )
+      const Child = compile(
+        `<template><slot name="a" /><slot name="b" /></template>`,
+        items,
+      )
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template
+              v-for="item in data"
+              :key="item.name"
+              #[item.name]
+            >
+              <components.Content :label="item.label" />
+            </template>
+          </components.Child>
+        </template>`,
+        items,
+        { Child, Content },
+      )
+
+      const { host } = define(App).render()
+      const firstButton = host.querySelector('button')!
+      firstButton.click()
+      firstButton.click()
+      await nextTick()
+
+      expect(firstButton.textContent).toBe('A:2')
+
+      items.value = [
+        { name: 'a', label: 'A updated' },
+        { name: 'b', label: 'B updated' },
+      ]
+      await nextTick()
+
+      expect(host.querySelector('button')).toBe(firstButton)
+      expect(firstButton.textContent).toBe('A updated:2')
+    })
+
     test('should cache dynamic slot source result', async () => {
       const items = ref([1, 2, 3])
       let callCount = 0

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -70,6 +70,10 @@ import {
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
 import { setBlockKey } from './helpers/setKey'
 import { currentSlotBoundary, setCurrentSlotBoundary } from './slotBoundary'
+import {
+  type KeyedForSlotMetadata,
+  setKeyedForSlotMetadata,
+} from './componentProps'
 
 type Source = any[] | Record<any, any> | number | Set<any> | Map<any, any>
 
@@ -790,11 +794,30 @@ function stopBlockScopes(blocks: ForBlock[]): void {
 
 export function createForSlots(
   rawSource: Source,
-  getSlot: (item: any, key: any, index?: number) => DynamicSlot,
+  getSlot: (item: any, key: any, index?: any) => DynamicSlot,
+  getKey?: (item: any, key: any, index?: number) => any,
 ): DynamicSlot[] {
   const source = normalizeSource(rawSource)
   const sourceLength = source.values.length
   const slots = new Array<DynamicSlot>(sourceLength)
+  if (getKey) {
+    const metadata = new Array<KeyedForSlotMetadata>(sourceLength)
+    const needKey = getSlot.length > 1
+    const needIndex = getSlot.length > 2
+    for (let i = 0; i < sourceLength; i++) {
+      const item = getItem(source, i)
+      const refs: ShallowRef[] = [shallowRef(item[0])]
+      if (needKey) refs.push(shallowRef(item[1]))
+      if (needIndex) refs.push(shallowRef(item[2]))
+      slots[i] = getSlot(refs[0], refs[1], refs[2])
+      metadata[i] = {
+        key: getKey(...item),
+        refs,
+      }
+    }
+    setKeyedForSlotMetadata(slots, metadata)
+    return slots
+  }
   for (let i = 0; i < sourceLength; i++) {
     slots[i] = getSlot(...getItem(source, i))
   }

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -29,6 +29,7 @@ import {
 import {
   type ComputedRef,
   ReactiveFlags,
+  type ShallowRef,
   computed,
   onScopeDispose,
   shallowReactive,
@@ -46,6 +47,22 @@ export type RawProps = Record<string, unknown> & {
 export type DynamicPropsSource =
   | (() => Record<string, unknown>)
   | Record<string, unknown>
+
+export interface KeyedForSlotMetadata {
+  key: unknown
+  refs: ShallowRef[]
+}
+
+// Keep compiler-emitted slot descriptors public-shape compatible while giving
+// dynamic source stabilization enough state to advance keyed loop aliases.
+const keyedForSlotMetadata = new WeakMap<unknown[], KeyedForSlotMetadata[]>()
+
+export function setKeyedForSlotMetadata(
+  slots: unknown[],
+  metadata: KeyedForSlotMetadata[],
+): void {
+  keyedForSlotMetadata.set(slots, metadata)
+}
 
 export function isolatePropSources(rawProps: RawProps): RawProps {
   // Static values cannot change while cached and need no commit boundary.
@@ -267,6 +284,19 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
 }
 
 function stabilizeDynamicSourceValue<T>(oldValue: T | undefined, value: T): T {
+  if (isArray(oldValue) && isArray(value)) {
+    const oldMetadata = keyedForSlotMetadata.get(oldValue)
+    const newMetadata = keyedForSlotMetadata.get(value)
+    if (oldMetadata && newMetadata) {
+      return stabilizeKeyedForSlots(
+        oldValue,
+        value,
+        oldMetadata,
+        newMetadata,
+      ) as T
+    }
+  }
+
   if (!isPlainObject(oldValue) || !isPlainObject(value)) {
     return value
   }
@@ -291,6 +321,57 @@ function stabilizeDynamicSourceValue<T>(oldValue: T | undefined, value: T): T {
   }
 
   return oldValue
+}
+
+function stabilizeKeyedForSlots(
+  oldSlots: unknown[],
+  newSlots: unknown[],
+  oldMetadata: KeyedForSlotMetadata[],
+  newMetadata: KeyedForSlotMetadata[],
+): unknown[] {
+  const oldIndexes = new Map<unknown, number>()
+  for (let i = 0; i < oldMetadata.length; i++) {
+    oldIndexes.set(oldMetadata[i].key, i)
+  }
+
+  const slots = new Array(newSlots.length)
+  const metadata = new Array<KeyedForSlotMetadata>(newSlots.length)
+  let unchanged = oldSlots.length === newSlots.length
+
+  for (let i = 0; i < newSlots.length; i++) {
+    const newEntry = newMetadata[i]
+    const oldIndex = oldIndexes.get(newEntry.key)
+    if (oldIndex === undefined) {
+      slots[i] = newSlots[i]
+      metadata[i] = newEntry
+      unchanged = false
+      continue
+    }
+
+    oldIndexes.delete(newEntry.key)
+    const oldEntry = oldMetadata[oldIndex]
+    for (let j = 0; j < oldEntry.refs.length; j++) {
+      updateForSlotRef(oldEntry.refs[j], newEntry.refs[j])
+    }
+
+    const oldSlot = oldSlots[oldIndex] as { name: unknown }
+    const newSlot = newSlots[i] as { name: unknown }
+    if (!Object.is(oldSlot.name, newSlot.name)) {
+      oldSlot.name = newSlot.name
+      unchanged = false
+    }
+    if (oldIndex !== i) unchanged = false
+    slots[i] = oldSlot
+    metadata[i] = oldEntry
+  }
+
+  if (unchanged) return oldSlots
+  keyedForSlotMetadata.set(slots, metadata)
+  return slots
+}
+
+function updateForSlotRef(ref: ShallowRef, newRef: ShallowRef): void {
+  if (!Object.is(ref.value, newRef.value)) ref.value = newRef.value
 }
 
 export function getPropsProxyHandlers(


### PR DESCRIPTION
## What changed

- preserve `:key` from compiler-vapor slot `v-for` templates and generate stable loop refs for keyed slot descriptors
- reconcile keyed descriptors while updating their loop refs, so unchanged keys retain slot-function identity and mounted state
- keep the existing unkeyed `createForSlots` path unchanged
- add compiler output coverage and a compiled-SFC regression test that verifies both DOM identity/state preservation and fresh prop values

## Why

Fixes #15276.

A keyed dynamic slot loop currently creates fresh slot closures whenever its source identity changes. Since the template key is dropped, slot outlets treat those closures as new branches and remount their content. Reusing by key alone would leave stale loop closures, so this change also advances shallow refs for the reused loop aliases.

## How tested

- `vp test packages/runtime-vapor --run` — 47 files; 1734 passed, 2 expected failures, 15 todo
- `vp test packages/compiler-vapor --run` — 24 files; 663 passed
- `vp run check`
- `vp run lint`
- `vp run build runtime-vapor compiler-vapor`
- `vp fmt --check` on all changed TypeScript/test files
- `git diff --check`

The checkout-wide `vp run format-check` was also attempted, but this Windows worktree reports 972 unchanged files because of its line-ending baseline. All changed source/test files pass the targeted format check and only the expected snapshot is changed.

## Risk and rollout

- Risk: limited to dynamic slot loops that explicitly provide `:key`. Reused keys now keep their slot function while loop aliases update through shallow refs. Added/removed keys still mount/unmount, and name/order changes still publish a new descriptor array.
- Rollback: revert this commit; the previous function-identity remount behavior is restored.

## Notes for reviewers

Duplicate audit was run before implementation and again immediately before push.

- Searched PRs/issues/commits/branches for: `#15276`, `dynamic slots v-for remount`, `createForSlots key`, `createForSlots identity`, `componentSlots DynamicFragment function identity`, and the affected file/API names.
- No open PR, linked branch, issue comment, or commit covers this root cause.
- Related but distinct work:
  - [#14176](https://github.com/vuejs/core/pull/14176) caches repeated evaluation of one dynamic slot source; it does not stabilize newly generated loop descriptors.
  - [#14912](https://github.com/vuejs/core/pull/14912) caches VDOM-to-Vapor interop wrappers; it does not cover compiler-vapor slot loops.
  - [#15051](https://github.com/vuejs/core/pull/15051) fixes compiler-core slot-outlet branch-key leakage; it is the opposite slot direction and not Vapor loop reuse.
  - [#15251](https://github.com/vuejs/core/pull/15251) isolates KeepAlive slot-source commits; it intentionally retains existing slot closure semantics.
