### PR TITLE
fix(runtime-vapor): respect inheritAttrs ownership for component roots

### DIFF
--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1672,4 +1672,62 @@ describe('attribute fallthrough', () => {
     await nextTick()
     expect(host.innerHTML).toBe('<div><i>two</i></div><!--dynamic-component-->')
   })
+
+  // #15277
+  it('should pass fallthrough attrs to declared props with inheritAttrs: false', () => {
+    const Child = compile(
+      `<script setup vapor>
+        const { class: className } = defineProps({ class: String })
+        defineOptions({ inheritAttrs: false })
+      </script>
+      <template>
+        <div :class="className">class prop = {{ className ?? 'DROPPED' }}</div>
+      </template>`,
+      ref(null),
+    )
+    const Middle = compile(
+      `<template><components.Child /></template>`,
+      ref(null),
+      { Child },
+    )
+    const App = compile(
+      `<template><components.Middle class="forwarded-marker" /></template>`,
+      ref(null),
+      { Middle },
+    )
+
+    const { host } = define(App).render()
+    expect(host.innerHTML).toBe(
+      '<div class="forwarded-marker">class prop = forwarded-marker</div>',
+    )
+  })
+
+  it('should not pass attrs through a component with inheritAttrs: false', () => {
+    const Child = compile(
+      `<script setup vapor>
+        const { class: className } = defineProps({ class: String })
+      </script>
+      <template>
+        <div :class="className">class prop = {{ className ?? 'DROPPED' }}</div>
+      </template>`,
+      ref(null),
+    )
+    const Middle = compile(
+      `<script setup vapor>
+        const Child = _components.Child
+        defineOptions({ inheritAttrs: false })
+      </script>
+      <template><Child /></template>`,
+      ref(null),
+      { Child },
+    )
+    const App = compile(
+      `<template><components.Middle class="forwarded-marker" /></template>`,
+      ref(null),
+      { Middle },
+    )
+
+    const { host } = define(App).render()
+    expect(host.innerHTML).toBe('<div>class prop = DROPPED</div>')
+  })
 })

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -311,8 +311,8 @@ export function createComponent(
         (isTransitionEnabled
           ? currentInstance && isVaporTransition(currentInstance!.type)
           : false)) &&
-      component.inheritAttrs !== false &&
       isVaporComponent(currentInstance) &&
+      currentInstance.type.inheritAttrs !== false &&
       currentInstance.hasFallthrough
     ) {
       // check if we are the single root of the parent


### PR DESCRIPTION
close #15277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attribute fallthrough for compiled Vapor components when declared class props are forwarded.
  * Ensured components configured to disable attribute inheritance correctly prevent attributes from reaching child components.
  * Improved handling of attribute inheritance across nested components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->