### PR TITLE
fix(vapor): preserve dynamic v-for slot state

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -7,14 +7,11 @@ const t0 = _template(" ")
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, {
     $: [
-      () => (_createForSlots(_ctx.list, (item) => ({
-        name: "default",
-        fn: () => {
-          const n0 = t0()
-          _renderEffect(() => _setText(n0, _toDisplayString(item)))
-          return n0
-        }
-      })))
+      _createForSlots(() => (_ctx.list), (_for_item0) => () => {
+        const n0 = t0()
+        _renderEffect(() => _setText(n0, _toDisplayString(_for_item0.value)))
+        return n0
+      }, (item) => ("default"))
     ]
   }, true)
   return n2
@@ -61,6 +58,24 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: transform slot > dynamic slots name w/ keyed v-for 1`] = `
+"import { toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createForSlots as _createForSlots, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template(" ")
+
+export function render(_ctx) {
+  const n2 = _createAssetComponent("Comp", null, {
+    $: [
+      _createForSlots(() => (_ctx.list), (_for_item0) => () => {
+        const n0 = t0()
+        _renderEffect(() => _setText(n0, _toDisplayString(_for_item0.value.label)))
+        return n0
+      }, (item) => (item.name), (item) => (item.id))
+    ]
+  }, true)
+  return n2
+}"
+`;
+
 exports[`compiler: transform slot > dynamic slots name w/ v-for 1`] = `
 "import { toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createForSlots as _createForSlots, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template(" ")
@@ -68,14 +83,11 @@ const t0 = _template(" ")
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, {
     $: [
-      () => (_createForSlots(_ctx.list, (item) => ({
-        name: item,
-        fn: (_slotProps0) => {
-          const n0 = t0()
-          _renderEffect(() => _setText(n0, _toDisplayString(_slotProps0.bar)))
-          return n0
-        }
-      })))
+      _createForSlots(() => (_ctx.list), (_for_item0) => (_slotProps1) => {
+        const n0 = t0()
+        _renderEffect(() => _setText(n0, _toDisplayString(_slotProps1.bar)))
+        return n0
+      }, (item) => (item))
     ]
   }, true)
   return n2
@@ -89,13 +101,10 @@ const t0 = _template("foo", 2)
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, {
     $: [
-      () => (_createForSlots(_ctx.list, (_, __, index) => ({
-        name: index,
-        fn: () => {
-          const n0 = t0()
-          return n0
-        }
-      })))
+      _createForSlots(() => (_ctx.list), (_for_item0, _, _for_index0) => () => {
+        const n0 = t0()
+        return n0
+      }, (_, __, index) => (index))
     ]
   }, true)
   return n2
@@ -470,13 +479,10 @@ exports[`compiler: transform slot > slot owner context > dynamic slot source wit
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, {
     $: [
-      () => (_createForSlots(_ctx.slots, (_, name) => ({
-        name: name,
-        fn: () => {
-          const n0 = _createSlot(() => (name), null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
-          return n0
-        }
-      })))
+      _createForSlots(() => (_ctx.slots), (_for_item0, _for_key0) => () => {
+        const n0 = _createSlot(() => (_for_key0.value), null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+        return n0
+      }, (_, name) => (name))
     ]
   }, true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -136,7 +136,7 @@ describe('compiler: transform slot', () => {
     expect(ir.block.dynamic).toMatchObject({
       children: [{ id: 2 }],
     })
-    expect(code).contains(`name: "default",`)
+    expect(code).contains(`(item) => ("default")`)
   })
 
   test('on-component default slot', () => {
@@ -473,8 +473,8 @@ describe('compiler: transform slot', () => {
     )
     expect(code).toMatchSnapshot()
 
-    expect(code).contains(`fn: (_slotProps0) =>`)
-    expect(code).contains(`_setText(n0, _toDisplayString(_slotProps0.bar))`)
+    expect(code).contains(`(_slotProps1) =>`)
+    expect(code).contains(`_setText(n0, _toDisplayString(_slotProps1.bar))`)
 
     expect(ir.block.dynamic.children[0].operation).toMatchObject({
       type: IRNodeTypes.CREATE_COMPONENT_NODE,
@@ -492,6 +492,29 @@ describe('compiler: transform slot', () => {
             value: { content: 'item' },
             index: undefined,
           },
+        },
+      ],
+    })
+  })
+
+  test('dynamic slots name w/ keyed v-for', () => {
+    const { ir, code } = compileWithSlots(
+      `<Comp>
+        <template v-for="item in list" :key="item.id" #[item.name]>{{ item.label }}</template>
+      </Comp>`,
+    )
+    expect(code).toMatchSnapshot()
+    expect(ir.block.dynamic.children[0].operation).toMatchObject({
+      type: IRNodeTypes.CREATE_COMPONENT_NODE,
+      tag: 'Comp',
+      slots: [
+        {
+          name: { content: 'item.name' },
+          loop: {
+            source: { content: 'list' },
+            value: { content: 'item' },
+          },
+          keyProp: { content: 'item.id' },
         },
       ],
     })
@@ -1068,8 +1091,8 @@ describe('compiler: transform slot', () => {
         </Comp>
       `)
       expect(code).toContain(`$: [
-      () => (_createForSlots`)
-      expect(code).toContain(`fn: () =>`)
+      _createForSlots`)
+      expect(code).toContain(`=> () =>`)
       expect(code).toMatchSnapshot()
     })
 

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -651,7 +651,7 @@ function genDynamicSlots(
         ? genStaticSlots(slot, context)
         : slot.slotType === IRSlotType.EXPRESSION
           ? slot.slots.content
-          : genDynamicSlot(slot, context, true),
+          : genDynamicSlot(slot, context, slot.slotType !== IRSlotType.LOOP),
     ),
   )
 }
@@ -694,39 +694,75 @@ function genLoopSlot(
   slot: IRSlotDynamicLoop,
   context: CodegenContext,
 ): CodeFragment[] {
-  const { name, fn, loop } = slot
+  const { name, fn, loop, keyProp } = slot
   const { value, key, index, source } = loop
   const rawValue = value && value.content
   const rawKey = key && key.content
   const rawIndex = index && index.content
 
-  const idMap: Record<string, string> = {}
-  if (rawValue) idMap[rawValue] = rawValue
-  if (rawKey) idMap[rawKey] = rawKey
-  if (rawIndex) idMap[rawIndex] = rawIndex
-  const slotExpr = genMulti(
-    DELIMITERS_OBJECT_NEWLINE,
-    ['name: ', ...context.withId(() => genExpression(name, context), idMap)],
-    [
-      'fn: ',
-      ...context.withId(() => genSlotBlockWithProps(fn, context, false), idMap),
-    ],
+  const idToPathMap = parseValueDestructure(value, context)
+  const [depth, exitScope] = context.enterScope()
+  const itemVar = `_for_item${depth}`
+  const idMap = buildDestructureIdMap(
+    idToPathMap,
+    `${itemVar}.value`,
+    context.options.expressionPlugins,
   )
+  idMap[itemVar] = null
+
+  const args = [itemVar]
+  if (rawKey) {
+    const keyVar = `_for_key${depth}`
+    args.push(keyVar)
+    idMap[rawKey] = `${keyVar}.value`
+    idMap[keyVar] = null
+  } else if (rawIndex) {
+    args.push('_')
+  }
+  if (rawIndex) {
+    const indexVar = `_for_index${depth}`
+    args.push(indexVar)
+    idMap[rawIndex] = `${indexVar}.value`
+    idMap[indexVar] = null
+  }
+
+  const renderSlot = [
+    ...genMulti(['(', ')', ', '], ...args),
+    ' => ',
+    ...context.withId(() => genSlotBlockWithProps(fn, context, false), idMap),
+  ]
+  exitScope()
+
+  const rawIdMap: Record<string, null> = {}
+  if (rawKey) rawIdMap[rawKey] = null
+  if (rawIndex) rawIdMap[rawIndex] = null
+  idToPathMap.forEach((_, id) => (rawIdMap[id] = null))
+  const rawParams = genMulti(
+    ['(', ')', ', '],
+    rawValue ? rawValue : rawKey || rawIndex ? '_' : undefined,
+    rawKey ? rawKey : rawIndex ? '__' : undefined,
+    rawIndex,
+  )
+  const getName = [
+    ...rawParams,
+    ' => (',
+    ...context.withId(() => genExpression(name, context), rawIdMap),
+    ')',
+  ]
+  const getKey = keyProp && [
+    ...rawParams,
+    ' => (',
+    ...context.withId(() => genExpression(keyProp, context), rawIdMap),
+    ')',
+  ]
+
   return [
     ...genCall(
       context.helper('createForSlots'),
-      genExpression(source, context),
-      [
-        ...genMulti(
-          ['(', ')', ', '],
-          rawValue ? rawValue : rawKey || rawIndex ? '_' : undefined,
-          rawKey ? rawKey : rawIndex ? '__' : undefined,
-          rawIndex,
-        ),
-        ' => (',
-        ...slotExpr,
-        ')',
-      ],
+      ['() => (', ...genExpression(source, context), ')'],
+      renderSlot,
+      getName,
+      getKey,
     ),
   ]
 }

--- a/packages/compiler-vapor/src/ir/component.ts
+++ b/packages/compiler-vapor/src/ir/component.ts
@@ -52,6 +52,7 @@ export interface IRSlotDynamicLoop {
   name: SimpleExpressionNode
   fn: SlotBlockIRNode
   loop: IRFor
+  keyProp?: SimpleExpressionNode
 }
 export interface IRSlotDynamicConditional {
   slotType: IRSlotType.CONDITIONAL

--- a/packages/compiler-vapor/src/transforms/vSlot.ts
+++ b/packages/compiler-vapor/src/transforms/vSlot.ts
@@ -23,7 +23,12 @@ import {
   type SlotBlockIRNode,
   type VaporDirectiveNode,
 } from '../ir'
-import { findDir, resolveExpression } from '../utils'
+import {
+  findDir,
+  findProp,
+  propToExpression,
+  resolveExpression,
+} from '../utils'
 import { markNonTemplate } from './transformText'
 import { ignoreComment } from './transformComment'
 
@@ -197,11 +202,13 @@ function transformTemplateSlot(
     }
   } else if (vFor) {
     if (vFor.forParseResult) {
+      const keyProp = findProp(node, 'key')
       registerDynamicSlot(slots, {
         slotType: IRSlotType.LOOP,
         name: arg!,
         fn: block,
         loop: vFor.forParseResult as IRFor,
+        keyProp: keyProp && propToExpression(keyProp),
       })
     } else {
       context.options.onError(

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -2699,11 +2699,11 @@ describe('component: slots', () => {
           default: () =>
             createComponent(Leaf, null, {
               $: [
-                () =>
-                  createForSlots(slots, (_slot, name) => ({
-                    name,
-                    fn: () => createSlot(name),
-                  })),
+                createForSlots(
+                  () => slots,
+                  (_slot, name) => () => createSlot(() => name!.value),
+                  (_slot, name) => name,
+                ),
               ],
             }),
         })
@@ -6141,16 +6141,17 @@ describe('component: slots', () => {
               null,
               {
                 $: [
-                  () =>
-                    createForSlots(values.value, value => ({
-                      name: 'default',
-                      fn: () => {
-                        if (value === 1) {
-                          throw new Error('slot boom')
-                        }
-                        return template('<span>ok</span>')()
-                      },
-                    })),
+                  createForSlots(
+                    () => values.value,
+                    value => () => {
+                      if (value.value === 1) {
+                        throw new Error('slot boom')
+                      }
+                      return template('<span>ok</span>')()
+                    },
+                    () => 'default',
+                    value => value,
+                  ),
                 ],
               },
               true,
@@ -6827,11 +6828,11 @@ describe('component: slots', () => {
         setup() {
           return createComponent(Child, null, {
             $: [
-              () =>
-                createForSlots(loop.value, (item, i) => ({
-                  name: item,
-                  fn: () => template(item + i)(),
-                })),
+              createForSlots(
+                () => loop.value,
+                (item, i) => () => template(item.value + i!.value)(),
+                item => item,
+              ),
             ],
           })
         },
@@ -6847,6 +6848,43 @@ describe('component: slots', () => {
       loop.value.shift()
       await nextTick()
       expect(instance.slots).not.toHaveProperty('1')
+    })
+
+    test('should preserve result identity when slot resolution is unchanged', () => {
+      const items = ref([
+        { id: 1, name: 'a', label: 'A0' },
+        { id: 2, name: 'b', label: 'B0' },
+      ])
+      let renderedItem: any
+      const source = createForSlots(
+        () => items.value,
+        item => () => {
+          renderedItem = item.value
+          return template('content')()
+        },
+        item => item.name,
+        item => item.id,
+      )
+
+      const first = source()
+      const firstSlot = first[0]
+      items.value = [
+        { id: 1, name: 'a', label: 'A1' },
+        { id: 2, name: 'b', label: 'B1' },
+      ]
+      const second = source()
+
+      expect(second).toBe(first)
+      expect(second[0]).toBe(firstSlot)
+      second[0].fn()
+      expect(renderedItem).toBe(items.value[0])
+
+      items.value.reverse()
+      const reordered = source()
+      expect(reordered).not.toBe(second)
+
+      items.value[0].name = 'c'
+      expect(source()).not.toBe(reordered)
     })
 
     test('should cache dynamic slot source result', async () => {
@@ -6875,11 +6913,11 @@ describe('component: slots', () => {
         setup() {
           return createComponent(Child, null, {
             $: [
-              () =>
-                createForSlots(getItems(), (item, i) => ({
-                  name: 'slot' + item,
-                  fn: () => template(String(item))(),
-                })),
+              createForSlots(
+                getItems,
+                item => () => template(String(item.value))(),
+                item => 'slot' + item,
+              ),
             ],
           })
         },
@@ -6918,11 +6956,11 @@ describe('component: slots', () => {
         setup() {
           return createComponent(Child, null, {
             $: [
-              () =>
-                createForSlots(getItems(), (item, i) => ({
-                  name: 'slot' + item,
-                  fn: () => template(String(item))(),
-                })),
+              createForSlots(
+                getItems,
+                item => () => template(String(item.value))(),
+                item => 'slot' + item,
+              ),
             ],
           })
         },
@@ -6961,11 +6999,11 @@ describe('component: slots', () => {
         setup() {
           return createComponent(Child, null, {
             $: [
-              () =>
-                createForSlots(items.value, item => ({
-                  name: 'slot' + item,
-                  fn: () => template('content' + item)(),
-                })),
+              createForSlots(
+                () => items.value,
+                item => () => template('content' + item.value)(),
+                item => 'slot' + item,
+              ),
             ],
           })
         },
@@ -7006,11 +7044,15 @@ describe('component: slots', () => {
         setup() {
           return createComponent(Child, null, {
             $: [
-              () =>
-                createForSlots(list.value, item => ({
-                  name: 'default',
-                  fn: () => template(String(item))(),
-                })),
+              createForSlots(
+                () => list.value,
+                item => () => {
+                  const n = template(' ')() as Text
+                  renderEffect(() => setText(n, String(item.value)))
+                  return n
+                },
+                () => 'default',
+              ),
             ],
           })
         },
@@ -7048,11 +7090,11 @@ describe('component: slots', () => {
         setup() {
           return createComponent(Child, null, {
             $: [
-              () =>
-                createForSlots(loop.value as any, (item, i) => ({
-                  name: item,
-                  fn: () => template(item + i)(),
-                })),
+              createForSlots(
+                () => loop.value as any,
+                (item, i) => () => template(item.value + i!.value)(),
+                item => item,
+              ),
             ],
           })
         },
@@ -7066,6 +7108,153 @@ describe('component: slots', () => {
       loop.value = null
       await nextTick()
       expect(instance.slots).toEqual({})
+    })
+
+    // #15276
+    test('should preserve keyed slot records across source updates', async () => {
+      const state = ref({
+        showA: false,
+        items: [
+          { id: 'a1', name: 'a', label: 'A0' },
+          { id: 'b1', name: 'b', label: 'B0' },
+        ],
+      })
+      const unmounted = vi.fn()
+      const Content = compile(
+        `<script setup vapor>
+        import { onUnmounted, ref } from 'vue'
+        const props = defineProps(['label'])
+        const count = ref(0)
+        onUnmounted(_components.unmounted)
+        </script>
+        <template>
+          <button @click="count++">{{ props.label }}:{{ count }}</button>
+        </template>`,
+        state,
+        { unmounted },
+      )
+      const Child = compile(
+        `<template>
+          <div id="b"><slot name="b" /></div>
+          <div v-if="data.showA" id="a"><slot name="a" /></div>
+        </template>`,
+        state,
+      )
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template
+              v-for="item in data.items"
+              :key="item.id"
+              #[item.name]
+            >
+              <components.Content :label="item.label" />
+            </template>
+          </components.Child>
+        </template>`,
+        state,
+        { Child, Content },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+
+      try {
+        app.mount(root)
+        state.value.items = [
+          { id: 'a1', name: 'a', label: 'A1' },
+          { id: 'b1', name: 'b', label: 'B1' },
+        ]
+        await nextTick()
+
+        state.value.showA = true
+        await nextTick()
+        const firstButton = root.querySelector<HTMLButtonElement>('#a button')!
+        expect(firstButton.textContent).toBe('A1:0')
+        firstButton.click()
+        firstButton.click()
+        await nextTick()
+
+        state.value.items = [
+          { id: 'a1', name: 'a', label: 'A2' },
+          { id: 'b1', name: 'b', label: 'B2' },
+        ]
+        await nextTick()
+
+        expect(root.querySelector('#a button')).toBe(firstButton)
+        expect(firstButton.textContent).toBe('A2:2')
+        expect(root.querySelector('#b')!.textContent).toBe('B2:0')
+        expect(unmounted).not.toHaveBeenCalled()
+
+        state.value.items = [
+          { id: 'a2', name: 'a', label: 'A3' },
+          { id: 'b1', name: 'b', label: 'B3' },
+        ]
+        await nextTick()
+
+        expect(root.querySelector('#a button')).not.toBe(firstButton)
+        expect(root.querySelector('#a')!.textContent).toBe('A3:0')
+        expect(unmounted).toHaveBeenCalledOnce()
+      } finally {
+        app.unmount()
+      }
+    })
+
+    test('should preserve unkeyed slot content by name when reordered', async () => {
+      const items = ref([
+        { name: 'a', label: 'A0' },
+        { name: 'b', label: 'B0' },
+      ])
+      const Content = compile(
+        `<script setup vapor>
+        import { ref } from 'vue'
+        const props = defineProps(['label'])
+        const count = ref(0)
+        </script>
+        <template>
+          <button @click="count++">{{ props.label }}:{{ count }}</button>
+        </template>`,
+        items,
+      )
+      const Child = compile(
+        `<template><slot name="a" /><slot name="b" /></template>`,
+        items,
+      )
+      const App = compile(
+        `<template>
+          <components.Child>
+            <template v-for="item in data" #[item.name]>
+              <components.Content :label="item.label" />
+            </template>
+          </components.Child>
+        </template>`,
+        items,
+        { Child, Content },
+      )
+      const root = document.createElement('div')
+      const app = createVaporApp(App)
+
+      try {
+        app.mount(root)
+        const [buttonA, buttonB] = root.querySelectorAll('button')
+        buttonA.click()
+        buttonB.click()
+        buttonB.click()
+        await nextTick()
+
+        items.value = [
+          { name: 'b', label: 'B1' },
+          { name: 'a', label: 'A1' },
+        ]
+        await nextTick()
+
+        const buttons = root.querySelectorAll('button')
+        expect(buttons[0]).toBe(buttonA)
+        expect(buttons[0].textContent).toBe('A1:1')
+        expect(buttons[1]).toBe(buttonB)
+        expect(buttons[1].textContent).toBe('B1:2')
+      } finally {
+        app.unmount()
+      }
     })
 
     test('should remove teleported content when a dynamic v-for slot is removed', async () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -1698,11 +1698,11 @@ describe('vdomInterop', () => {
         const slots = useSlots()
         return createComponent(Inner, null, {
           $: [
-            () =>
-              createForSlots(slots, (_slot, name) => ({
-                name,
-                fn: () => createSlot(name),
-              })) as any,
+            createForSlots(
+              () => slots,
+              (_slot, name) => () => createSlot(() => name!.value),
+              (_slot, name) => name,
+            ) as any,
           ],
         })
       })
@@ -2106,16 +2106,16 @@ describe('vdomInterop', () => {
         setup() {
           return createComponent(VDomChild as any, null, {
             $: [
-              () =>
-                createForSlots(list.value, value => ({
-                  name: 'default',
-                  fn: () => {
-                    const n = template('<span> </span>')() as Element
-                    const t = txt(n) as Text
-                    renderEffect(() => setText(t, toDisplayString(value)))
-                    return n
-                  },
-                })),
+              createForSlots(
+                () => list.value,
+                value => () => {
+                  const n = template('<span> </span>')() as Element
+                  const t = txt(n) as Text
+                  renderEffect(() => setText(t, toDisplayString(value.value)))
+                  return n
+                },
+                () => 'default',
+              ),
             ],
           })
         },
@@ -2140,7 +2140,7 @@ describe('vdomInterop', () => {
       expect(html()).toBe('<div><span>1</span></div>')
     })
 
-    test('dynamic slots via createForSlots should re-mount fragment slot in vdom child', async () => {
+    test('dynamic slots via createForSlots should update fragment slot in vdom child', async () => {
       const list = ref([0, 1, 2])
 
       const VDomChild = defineComponent({
@@ -2153,20 +2153,22 @@ describe('vdomInterop', () => {
         setup() {
           return createComponent(VDomChild as any, null, {
             $: [
-              () =>
-                createForSlots(list.value, value => ({
-                  name: 'default',
-                  fn: () =>
-                    createIf(
-                      () => true,
-                      () => {
-                        const n = template('<span> </span>')() as Element
-                        const t = txt(n) as Text
-                        renderEffect(() => setText(t, toDisplayString(value)))
-                        return n
-                      },
-                    ),
-                })),
+              createForSlots(
+                () => list.value,
+                value => () =>
+                  createIf(
+                    () => true,
+                    () => {
+                      const n = template('<span> </span>')() as Element
+                      const t = txt(n) as Text
+                      renderEffect(() =>
+                        setText(t, toDisplayString(value.value)),
+                      )
+                      return n
+                    },
+                  ),
+                () => 'default',
+              ),
             ],
           })
         },
@@ -2208,20 +2210,21 @@ describe('vdomInterop', () => {
         setup() {
           return createComponent(VDomChild as any, null, {
             $: [
-              () =>
-                createForSlots(list.value, value => ({
-                  name: 'default',
-                  fn: () => {
-                    const state = slotStates.get(value)!
-                    const n = template('<span> </span>')() as Element
-                    const t = txt(n) as Text
-                    renderEffect(() => {
-                      state.runs()
-                      setText(t, state.text.value)
-                    })
-                    return n
-                  },
-                })),
+              createForSlots(
+                () => list.value,
+                value => () => {
+                  const state = slotStates.get(value.value)!
+                  const n = template('<span> </span>')() as Element
+                  const t = txt(n) as Text
+                  renderEffect(() => {
+                    state.runs()
+                    setText(t, state.text.value)
+                  })
+                  return n
+                },
+                () => 'default',
+                value => value,
+              ),
             ],
           })
         },

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -29,6 +29,7 @@ import { queuePostFlushCb, warn } from '@vue/runtime-dom'
 import { currentInstance } from './component'
 import {
   type DynamicSlot,
+  type VaporSlot,
   currentSlotOwner,
   setCurrentSlotOwner,
 } from './componentSlots'
@@ -789,16 +790,90 @@ function stopBlockScopes(blocks: ForBlock[]): void {
 }
 
 export function createForSlots(
-  rawSource: Source,
-  getSlot: (item: any, key: any, index?: number) => DynamicSlot,
-): DynamicSlot[] {
-  const source = normalizeSource(rawSource)
-  const sourceLength = source.values.length
-  const slots = new Array<DynamicSlot>(sourceLength)
-  for (let i = 0; i < sourceLength; i++) {
-    slots[i] = getSlot(...getItem(source, i))
+  rawSource: () => Source,
+  renderSlot: (
+    item: ShallowRef,
+    key?: ShallowRef,
+    index?: ShallowRef,
+  ) => VaporSlot,
+  getName: (item: any, key: any, index?: number) => unknown,
+  getKey?: (item: any, key: any, index?: number) => unknown,
+): () => DynamicSlot[] {
+  type SlotRecord = DynamicSlot & {
+    rawIdentity: unknown
+    itemRef: ShallowRef
+    keyRef?: ShallowRef
+    indexRef?: ShallowRef
   }
-  return slots
+
+  let oldRecords: SlotRecord[] = []
+  const needKey = renderSlot.length > 1
+  const needIndex = renderSlot.length > 2
+
+  return () => {
+    const source = normalizeSource(rawSource())
+    const sourceLength = source.values.length
+    const names = new Array<string>(sourceLength)
+    const identities = new Array<unknown>(sourceLength)
+
+    for (let i = 0; i < sourceLength; i++) {
+      const item = getItem(source, i)
+      names[i] = String(getName(...item))
+      identities[i] = getKey ? getKey(...item) : names[i]
+    }
+
+    const oldByIdentity = new Map<unknown, SlotRecord>()
+    for (let i = 0; i < oldRecords.length; i++) {
+      oldByIdentity.set(oldRecords[i].rawIdentity, oldRecords[i])
+    }
+
+    const records = new Array<SlotRecord>(sourceLength)
+    // Ref value updates don't affect slot resolution. Only replace the result
+    // when its records, order, or names change.
+    let changed = sourceLength !== oldRecords.length
+    const prevSub = setActiveSub()
+    for (let i = sourceLength - 1; i >= 0; i--) {
+      const [item, key, index] = getItem(source, i)
+      const rawIdentity = identities[i]
+      let record = oldByIdentity.get(rawIdentity)
+      if (record) {
+        oldByIdentity.delete(rawIdentity)
+        if (record !== oldRecords[i] || record.name !== names[i]) {
+          changed = true
+        }
+        if (!Object.is(record.itemRef.value, item)) {
+          record.itemRef.value = item
+        }
+        if (record.keyRef && !Object.is(record.keyRef.value, key)) {
+          record.keyRef.value = key
+        }
+        if (record.indexRef && !Object.is(record.indexRef.value, index)) {
+          record.indexRef.value = index
+        }
+        record.name = names[i]
+      } else {
+        changed = true
+        const itemRef = shallowRef(item)
+        const keyRef = needKey ? shallowRef(key) : undefined
+        const indexRef = needIndex ? shallowRef(index) : undefined
+        record = {
+          rawIdentity,
+          itemRef,
+          keyRef,
+          indexRef,
+          name: names[i],
+          fn: renderSlot(itemRef, keyRef, indexRef),
+          // The item ref is stable for the lifetime of this slot record.
+          key: itemRef,
+        }
+      }
+      records[i] = record
+    }
+    setActiveSub(prevSub)
+    if (!changed) return oldRecords
+    oldRecords = records
+    return records
+  }
 }
 
 function normalizeSource(source: any): ResolvedSource {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -789,6 +789,10 @@ function stopBlockScopes(blocks: ForBlock[]): void {
   }
 }
 
+function isSameMapKey(a: unknown, b: unknown): boolean {
+  return Object.is(a, b) || (a === 0 && b === 0)
+}
+
 export function createForSlots(
   rawSource: () => Source,
   renderSlot: (
@@ -810,17 +814,51 @@ export function createForSlots(
   const needKey = renderSlot.length > 1
   const needIndex = renderSlot.length > 2
 
+  const update = (
+    record: SlotRecord,
+    [item, key, index]: ReturnType<typeof getItem>,
+  ) => {
+    if (!Object.is(record.itemRef.value, item)) {
+      record.itemRef.value = item
+    }
+    if (record.keyRef && !Object.is(record.keyRef.value, key)) {
+      record.keyRef.value = key
+    }
+    if (record.indexRef && !Object.is(record.indexRef.value, index)) {
+      record.indexRef.value = index
+    }
+  }
+
   return () => {
     const source = normalizeSource(rawSource())
     const sourceLength = source.values.length
     const names = new Array<string>(sourceLength)
-    const identities = new Array<unknown>(sourceLength)
+    const identities: unknown[] = getKey
+      ? new Array<unknown>(sourceLength)
+      : names
     const items = new Array<ReturnType<typeof getItem>>(sourceLength)
+    let sameResolution = sourceLength === oldRecords.length
 
     for (let i = 0; i < sourceLength; i++) {
       const item = (items[i] = getItem(source, i))
-      names[i] = String(getName(...item))
-      identities[i] = getKey ? getKey(...item) : names[i]
+      const name = (names[i] = String(getName(...item)))
+      const identity = (identities[i] = getKey ? getKey(...item) : name)
+      if (
+        sameResolution &&
+        (!isSameMapKey(oldRecords[i].rawIdentity, identity) ||
+          oldRecords[i].name !== name)
+      ) {
+        sameResolution = false
+      }
+    }
+
+    if (sameResolution) {
+      const prevSub = setActiveSub()
+      for (let i = sourceLength - 1; i >= 0; i--) {
+        update(oldRecords[i], items[i])
+      }
+      setActiveSub(prevSub)
+      return oldRecords
     }
 
     const oldByIdentity = new Map<unknown, SlotRecord>()
@@ -829,31 +867,17 @@ export function createForSlots(
     }
 
     const records = new Array<SlotRecord>(sourceLength)
-    // Ref value updates don't affect slot resolution. Only replace the result
-    // when its records, order, or names change.
-    let changed = sourceLength !== oldRecords.length
     const prevSub = setActiveSub()
     for (let i = sourceLength - 1; i >= 0; i--) {
-      const [item, key, index] = items[i]
+      const slotItem = items[i]
       const rawIdentity = identities[i]
       let record = oldByIdentity.get(rawIdentity)
       if (record) {
         oldByIdentity.delete(rawIdentity)
-        if (record !== oldRecords[i] || record.name !== names[i]) {
-          changed = true
-        }
-        if (!Object.is(record.itemRef.value, item)) {
-          record.itemRef.value = item
-        }
-        if (record.keyRef && !Object.is(record.keyRef.value, key)) {
-          record.keyRef.value = key
-        }
-        if (record.indexRef && !Object.is(record.indexRef.value, index)) {
-          record.indexRef.value = index
-        }
+        update(record, slotItem)
         record.name = names[i]
       } else {
-        changed = true
+        const [item, key, index] = slotItem
         const itemRef = shallowRef(item)
         const keyRef = needKey ? shallowRef(key) : undefined
         const indexRef = needIndex ? shallowRef(index) : undefined
@@ -871,7 +895,6 @@ export function createForSlots(
       records[i] = record
     }
     setActiveSub(prevSub)
-    if (!changed) return oldRecords
     oldRecords = records
     return records
   }

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -815,9 +815,10 @@ export function createForSlots(
     const sourceLength = source.values.length
     const names = new Array<string>(sourceLength)
     const identities = new Array<unknown>(sourceLength)
+    const items = new Array<ReturnType<typeof getItem>>(sourceLength)
 
     for (let i = 0; i < sourceLength; i++) {
-      const item = getItem(source, i)
+      const item = (items[i] = getItem(source, i))
       names[i] = String(getName(...item))
       identities[i] = getKey ? getKey(...item) : names[i]
     }
@@ -833,7 +834,7 @@ export function createForSlots(
     let changed = sourceLength !== oldRecords.length
     const prevSub = setActiveSub()
     for (let i = sourceLength - 1; i >= 0; i--) {
-      const [item, key, index] = getItem(source, i)
+      const [item, key, index] = items[i]
       const rawIdentity = identities[i]
       let record = oldByIdentity.get(rawIdentity)
       if (record) {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -92,7 +92,7 @@ export type StaticSlots = Record<string, VaporSlot>
 export type VaporSlot = BlockFn & {
   _?: VaporSlotFlags.NON_STABLE
 }
-export type DynamicSlot = { name: string; fn: VaporSlot }
+export type DynamicSlot = { name: string; fn: VaporSlot; key?: unknown }
 export type DynamicSlotFn = () => DynamicSlot | DynamicSlot[]
 export type DynamicSlotSource = StaticSlots | DynamicSlotFn
 
@@ -197,6 +197,16 @@ export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
 }
 
 export function getSlot(target: RawSlots, key: string): VaporSlot | undefined {
+  const slot = resolveSlot(target, key)
+  if (slot) {
+    return getOwnedSlot(target, key, isFunction(slot) ? slot : slot.fn)
+  }
+}
+
+function resolveSlot(
+  target: RawSlots,
+  key: string,
+): VaporSlot | DynamicSlot | undefined {
   if (key === '$') return
   const dynamicSources = target.$
   if (dynamicSources) {
@@ -212,20 +222,20 @@ export function getSlot(target: RawSlots, key: string): VaporSlot | undefined {
           if (isArray(slot)) {
             for (let j = slot.length - 1; j >= 0; j--) {
               if (String(slot[j].name) === key) {
-                return getOwnedSlot(target, key, slot[j].fn)
+                return slot[j]
               }
             }
           } else if (String(slot.name) === key) {
-            return getOwnedSlot(target, key, slot.fn)
+            return slot
           }
         }
       } else if (hasOwn(source, key)) {
-        return getOwnedSlot(target, key, source[key])
+        return source[key]
       }
     }
   }
   if (hasOwn(target, key)) {
-    return getOwnedSlot(target, key, target[key])
+    return target[key]
   }
 }
 
@@ -374,20 +384,31 @@ export function createSlot(
         return
       }
 
-      const slot = getSlot(rawSlots, slotName)
+      const resolvedSlot = resolveSlot(rawSlots, slotName)
+      const slot = resolvedSlot
+        ? getOwnedSlot(
+            rawSlots,
+            slotName,
+            isFunction(resolvedSlot) ? resolvedSlot : resolvedSlot.fn,
+          )
+        : undefined
       const render = slot ? getBoundSlot(slot) : undefined
+      const key =
+        resolvedSlot && !isFunction(resolvedSlot) && hasOwn(resolvedSlot, 'key')
+          ? resolvedSlot.key
+          : render || fallback
       if (slotFragment) {
-        slotFragment.updateSlot(render, fallback)
+        slotFragment.updateSlot(render, fallback, key)
       } else {
         // When no slot render exists, the fast path hands fallback to the
         // DynamicFragment; during hydration it owns the slot SSR range, so
         // empty dynamic roots get its close marker.
         if (isHydrating) {
           withHydratingSlotBoundary(() =>
-            dynamicFragment!.update(render || fallback),
+            dynamicFragment!.update(render || fallback, key),
           )
         } else {
-          dynamicFragment!.update(render || fallback)
+          dynamicFragment!.update(render || fallback, key)
         }
       }
     }


### PR DESCRIPTION
close #15276

Make createForSlots retain slot records across source updates. Reconcile keyed slots by their template key and unkeyed slots by their resolved slot name, updating loop alias refs without recreating slot functions.

Pass a stable record identity to slot fragments so unchanged slots retain their mounted content and local state. Reuse the resolved records array when slot resolution is unchanged to avoid unnecessary outlet updates.

Update compiler-vapor to emit separate source, slot factory, name, and key callbacks, and add regression coverage for keyed and unkeyed dynamic slots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved dynamic slot handling in keyed and unkeyed loops.
  - Slot content now responds more reliably to reactive changes in items, names, and keys.
  - Added support for preserving slot identity during reordering and updates.

- **Bug Fixes**
  - Prevented unnecessary slot recreation when loop results remain unchanged.
  - Improved updates for forwarded and fragment slots, duplicate names, and stale content cleanup.
  - Fixed dynamic slot rendering when loop items or keys change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->