### PR TITLE
fix(runtime-vapor): dispose component v-for item resources on removal

### DIFF
--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -1,4 +1,5 @@
 import {
+  type VaporComponentInstance,
   child,
   createComponent,
   createDynamicComponent,
@@ -28,7 +29,7 @@ import {
   toDisplayString,
   triggerRef,
 } from '@vue/runtime-dom'
-import { makeRender, shuffle } from './_utils'
+import { compile, makeRender, shuffle } from './_utils'
 import { VaporVForFlags } from '@vue/shared'
 
 const define = makeRender()
@@ -86,6 +87,40 @@ describe('createFor', () => {
     }
 
     expect(instance!.scope.cleanupsLength).toBe(emptyCount)
+  })
+
+  test('removes component items before stopping their scope', async () => {
+    const state = ref({ items: [0] })
+    let child!: VaporComponentInstance
+    const cleanup = vi.fn(() => {
+      expect((child.block as Node).isConnected).toBe(false)
+    })
+    const refFn = (value: VaporComponentInstance | null) => {
+      if (value) {
+        child = value
+      } else {
+        cleanup()
+      }
+    }
+    const Child = compile(`<template><span /></template>`, state)
+    const App = compile(
+      `<template>
+        <components.Child
+          v-for="item in data.items"
+          :key="item"
+          :ref="components.refFn"
+        />
+      </template>`,
+      state,
+      { Child, refFn },
+    )
+    const { app } = define(App).render()
+
+    state.value.items = []
+    await nextTick()
+
+    expect(cleanup).toHaveBeenCalledOnce()
+    app.unmount()
   })
 
   test('should stop DOM item scopes when parent scope is disposed', async () => {

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -20,6 +20,7 @@ import {
 import {
   type Ref,
   nextTick,
+  onMounted,
   onScopeDispose,
   onUnmounted,
   reactive,
@@ -118,8 +119,95 @@ describe('createFor', () => {
     expect(instance!.refs.children).toHaveLength(0)
   })
 
+  test('stops dynamic component effects when an item is removed', async () => {
+    const mountedA = vi.fn()
+    const mountedB = vi.fn()
+    const A = defineVaporComponent({
+      setup() {
+        onMounted(mountedA)
+        return template('<span>A</span>')()
+      },
+    })
+    const B = defineVaporComponent({
+      setup() {
+        onMounted(mountedB)
+        return template('<span>B</span>')()
+      },
+    })
+    const state = shallowRef({ items: [] as number[], type: A })
+    const App = compile(
+      `<template>
+        <component
+          :is="data.type"
+          v-for="item in data.items"
+          :key="item"
+        />
+      </template>`,
+      state,
+    )
+    const { app, html, instance } = define(App).render()
+    const effectBaseline = getEffectsCount(instance!.scope)
+
+    state.value = { items: [0, 1, 2], type: A }
+    await nextTick()
+
+    expect(mountedA).toHaveBeenCalledTimes(3)
+    expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
+
+    state.value = { items: [0, 1, 2], type: B }
+    await nextTick()
+
+    expect(mountedB).toHaveBeenCalledTimes(3)
+
+    state.value = { items: [], type: B }
+    await nextTick()
+    state.value = { items: [], type: A }
+    await nextTick()
+
+    expect(html()).toBe('<!--for-->')
+    expect(mountedA).toHaveBeenCalledTimes(3)
+    expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
+    app.unmount()
+  })
+
+  test('stops component v-show effects when an item is removed', async () => {
+    const state = ref({ items: [] as number[], visible: true })
+    const Child = compile(`<template><span>child</span></template>`, state)
+    const App = compile(
+      `<template>
+        <components.Child
+          v-for="item in data.items"
+          :key="item"
+          v-show="data.visible"
+        />
+      </template>`,
+      state,
+      { Child },
+    )
+    const { app, host, instance } = define(App).render()
+    const effectBaseline = getEffectsCount(instance!.scope)
+
+    state.value.items = [0, 1, 2]
+    await nextTick()
+    const removedNodes = [...host.querySelectorAll('span')]
+
+    expect(removedNodes).toHaveLength(3)
+    expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
+
+    state.value.items = []
+    await nextTick()
+    expect(removedNodes.every(node => !node.isConnected)).toBe(true)
+
+    state.value.visible = false
+    await nextTick()
+
+    expect(removedNodes.every(node => node.style.display === '')).toBe(true)
+    expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
+    app.unmount()
+  })
+
   test('removes component items before stopping their scope', async () => {
-    const state = ref({ items: [0] })
+    const state = ref({ items: [] as number[] })
     let child!: VaporComponentInstance
     const cleanup = vi.fn(() => {
       expect((child.block as Node).isConnected).toBe(false)
@@ -143,12 +231,19 @@ describe('createFor', () => {
       state,
       { Child, refFn },
     )
-    const { app } = define(App).render()
+    const { app, instance } = define(App).render()
+    const effectBaseline = getEffectsCount(instance!.scope)
+
+    state.value.items = [0]
+    await nextTick()
+
+    expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
 
     state.value.items = []
     await nextTick()
 
     expect(cleanup).toHaveBeenCalledOnce()
+    expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
     app.unmount()
   })
 

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -170,6 +170,55 @@ describe('createFor', () => {
     app.unmount()
   })
 
+  test('does not retain prop source caches for native component fallbacks', async () => {
+    const state = ref({
+      items: [] as { id: number; value: string }[],
+    })
+    const Wrapper = compile(
+      `<template>
+        <section>
+          <component
+            :is="'div'"
+            v-for="item in data.items"
+            :key="item.id"
+            :data-id="item.value"
+          />
+        </section>
+      </template>`,
+      state,
+    )
+    const App = compile(
+      `<template><components.Wrapper ref="wrapper" /></template>`,
+      state,
+      { Wrapper },
+    )
+    const { app, host, instance } = define(App).render()
+    const wrapper = instance!.refs.wrapper as VaporComponentInstance
+    const cleanupBaseline = wrapper.scope.cleanupsLength
+    const effectBaseline = getEffectsCount(wrapper.scope)
+    const expectStableResources = () => {
+      expect(wrapper.scope.cleanups).toHaveLength(cleanupBaseline)
+      expect(getEffectsCount(wrapper.scope)).toBe(effectBaseline)
+    }
+
+    state.value.items = [{ id: 0, value: 'a' }]
+    await nextTick()
+
+    expect(host.querySelector('div')!.dataset.id).toBe('a')
+    expectStableResources()
+
+    state.value.items = [{ id: 0, value: 'b' }]
+    await nextTick()
+
+    expect(host.querySelector('div')!.dataset.id).toBe('b')
+
+    state.value.items = []
+    await nextTick()
+
+    expectStableResources()
+    app.unmount()
+  })
+
   test('stops component v-show effects when an item is removed', async () => {
     const state = ref({ items: [] as number[], visible: true })
     const Child = compile(`<template><span>child</span></template>`, state)

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -60,33 +60,62 @@ describe('createFor', () => {
     expect(getEffectsCount(filled.instance!.scope)).toBe(emptyCount)
   })
 
-  test('should not retain unmounted component items on parent scope', async () => {
-    const list = ref<number[]>([])
-    const Child = defineVaporComponent({
-      setup() {
-        return template('<span>child</span>')()
-      },
-    })
-
-    const { instance } = define(() => {
-      return createFor(
-        () => list.value,
-        () => createComponent(Child),
-        item => item,
-        VaporVForFlags.IS_COMPONENT,
-      )
-    }).render()
-
-    const emptyCount = instance!.scope.cleanupsLength
-
-    for (let i = 0; i < 3; i++) {
-      list.value = [1, 2, 3]
-      await nextTick()
-      list.value = []
-      await nextTick()
+  test('component item resources do not accumulate in the owner scope', async () => {
+    const state = ref({ items: [] as number[] })
+    const unmounted = vi.fn()
+    const Child = compile(
+      `<script setup vapor>
+      import { onUnmounted } from 'vue'
+      const props = defineProps(['index'])
+      onUnmounted(_components.unmounted)
+      </script>
+      <template><span>{{ props.index }}</span></template>`,
+      state,
+      { unmounted },
+    )
+    const App = compile(
+      `<template>
+        <components.Child
+          v-for="item in data.items"
+          :key="item"
+          :index="item"
+          ref="children"
+        />
+      </template>`,
+      state,
+      { Child },
+    )
+    const { app, instance } = define(App).render()
+    const cleanupBaseline = instance!.scope.cleanupsLength
+    const effectBaseline = getEffectsCount(instance!.scope)
+    const expectStableResources = () => {
+      expect(instance!.scope.cleanups).toHaveLength(cleanupBaseline)
+      expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
+      expect(instance!.refs.children).toHaveLength(state.value.items.length)
     }
 
-    expect(instance!.scope.cleanupsLength).toBe(emptyCount)
+    state.value.items = [0, 1, 2]
+    await nextTick()
+    expectStableResources()
+
+    state.value.items.splice(1, 1)
+    await nextTick()
+    expect(unmounted).toHaveBeenCalledOnce()
+    expectStableResources()
+
+    for (let id = 3; id < 6; id++) {
+      state.value.items = [state.value.items[1], id]
+      await nextTick()
+      expectStableResources()
+    }
+
+    expect(unmounted).toHaveBeenCalledTimes(4)
+
+    app.unmount()
+    await nextTick()
+
+    expect(unmounted).toHaveBeenCalledTimes(6)
+    expect(instance!.refs.children).toHaveLength(0)
   })
 
   test('removes component items before stopping their scope', async () => {

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -59,6 +59,35 @@ describe('createFor', () => {
     expect(getEffectsCount(filled.instance!.scope)).toBe(emptyCount)
   })
 
+  test('should not retain unmounted component items on parent scope', async () => {
+    const list = ref<number[]>([])
+    const Child = defineVaporComponent({
+      setup() {
+        return template('<span>child</span>')()
+      },
+    })
+
+    const { instance } = define(() => {
+      return createFor(
+        () => list.value,
+        () => createComponent(Child),
+        item => item,
+        VaporVForFlags.IS_COMPONENT,
+      )
+    }).render()
+
+    const emptyCount = instance!.scope.cleanupsLength
+
+    for (let i = 0; i < 3; i++) {
+      list.value = [1, 2, 3]
+      await nextTick()
+      list.value = []
+      await nextTick()
+    }
+
+    expect(instance!.scope.cleanupsLength).toBe(emptyCount)
+  })
+
   test('should stop DOM item scopes when parent scope is disposed', async () => {
     const show = ref(true)
     const list = ref([1, 2, 3])

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -155,16 +155,14 @@ export const createFor = (
     warn('createFor() can only be used inside setup()')
   }
 
-  if (!isComponent) {
-    onScopeDispose(() => {
-      stopBlockScopes(oldBlocks)
-      if (newBlocks && newBlocks !== oldBlocks) {
-        stopBlockScopes(newBlocks)
-      }
-      oldBlocks = []
-      newBlocks = []
-    }, true)
-  }
+  onScopeDispose(() => {
+    stopBlockScopes(oldBlocks)
+    if (newBlocks && newBlocks !== oldBlocks) {
+      stopBlockScopes(newBlocks)
+    }
+    oldBlocks = []
+    newBlocks = []
+  }, true)
 
   const renderList = () => {
     const source = normalizeSource(src())
@@ -462,20 +460,14 @@ export const createFor = (
     const indexRef = needIndex ? shallowRef(index) : undefined
 
     let nodes: Block
-    let scope: EffectScope | undefined
-    if (isComponent) {
-      // component already has its own scope so no outer scope needed
-      nodes = renderItem(itemRef, keyRef as any, indexRef as any)
-    } else {
-      scope = new EffectScope(true)
-      try {
-        nodes = scope.run(() =>
-          renderItem(itemRef, keyRef as any, indexRef as any),
-        )!
-      } catch (err) {
-        scope.stop()
-        throw err
-      }
+    const scope = new EffectScope(true)
+    try {
+      nodes = scope.run(() =>
+        renderItem(itemRef, keyRef as any, indexRef as any),
+      )!
+    } catch (err) {
+      scope.stop()
+      throw err
     }
 
     const block = (newBlocks[idx] = new ForBlock(
@@ -630,9 +622,7 @@ export const createFor = (
   }
 
   const unmount = (block: ForBlock, doRemove = true) => {
-    if (!isComponent) {
-      block.scope!.stop()
-    }
+    block.scope!.stop()
     if (doRemove) {
       removeForBlock(block)
     }

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -430,9 +430,9 @@ export const createFor = (
   const needIndex = renderItem.length > 2
 
   type InsertForBlock = (block: ForBlock, anchor: Node | undefined) => void
-  // IS_COMPONENT means the item owns its own scope, not that block.nodes is
-  // guaranteed to be a VaporComponentInstance. Component fallback may produce a
-  // plain DOM node, so component-shaped blocks still use the generic block path.
+  // IS_COMPONENT requires component teardown ordering but does not guarantee
+  // that block.nodes is a VaporComponentInstance. Component fallback may
+  // produce a plain DOM node, so these blocks still use the generic block path.
   const insertForBlock: InsertForBlock = isSingleNode
     ? (block, anchor) => insertNode(block.nodes as Node, parent!, anchor)
     : isFragment

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -622,9 +622,16 @@ export const createFor = (
   }
 
   const unmount = (block: ForBlock, doRemove = true) => {
-    block.scope!.stop()
+    if (!isComponent) {
+      block.scope!.stop()
+    }
     if (doRemove) {
       removeForBlock(block)
+    }
+    if (isComponent) {
+      // Component item cleanups such as template refs must observe the
+      // component after structural removal.
+      block.scope!.stop()
     }
   }
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -196,9 +196,9 @@ export function resolveFunctionSource<T>(
   // where source was defined.
   const parent = currentInstance && currentInstance.parent
   if (parent) {
-    // create the computed in the parent's context so it is collected by the
-    // parent's scope rather than whatever scope happens to be active here
-    const prev = setCurrentInstance(parent)
+    // execute the source in the parent's context, but collect its cache in the
+    // reading component's scope
+    const prev = setCurrentInstance(parent, currentInstance!.scope)
     try {
       source._cache = computed(oldValue => {
         const prevInner = setCurrentInstance(parent)

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -30,6 +30,7 @@ import {
   type ComputedRef,
   ReactiveFlags,
   computed,
+  getCurrentScope,
   onScopeDispose,
   shallowReactive,
 } from '@vue/reactivity'
@@ -197,8 +198,8 @@ export function resolveFunctionSource<T>(
   const parent = currentInstance && currentInstance.parent
   if (parent) {
     // execute the source in the parent's context, but collect its cache in the
-    // reading component's scope
-    const prev = setCurrentInstance(parent, currentInstance!.scope)
+    // active consumer scope
+    const prev = setCurrentInstance(parent, getCurrentScope())
     try {
       source._cache = computed(oldValue => {
         const prevInner = setCurrentInstance(parent)

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -9,10 +9,10 @@ export enum VaporVForFlags {
    */
   FAST_REMOVE = 1,
   /**
-   * v-for used on component - we can skip creating child scopes for each block
-   * because the component itself already has a scope. This does not guarantee
-   * the item block is a VaporComponentInstance: component fallback paths may
-   * still return a DOM Node.
+   * v-for used on a component-shaped item. Component items require structural
+   * removal before item scope cleanup and cannot use the fast-clear path. This
+   * does not guarantee the item block is a VaporComponentInstance: component
+   * fallback paths may still return a DOM Node.
    */
   IS_COMPONENT = 1 << 1,
   /**


### PR DESCRIPTION
close #15282

When a v-for item is a component, `createFor` skipped the per-item effect scope on the assumption that the component instance already owns one. The unmount callback that `createComponent` registers through `onScopeDispose` then landed on the enclosing parent scope, and nothing removed it when the item was unmounted. Every add/remove cycle appended another closure holding a dead instance and its DOM, so retained nodes kept climbing until the parent scope stopped.

Component items now get the same item scope as every other block, and unmounting a block stops it. Teardown of the whole list on parent disposal still works because the fragment stops any remaining item scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup handling when repeatedly mounting and unmounting component items in lists.
  * Prevented cleanup scopes from accumulating during list updates.
  * Improved recovery when rendering a list item fails.
  * Ensured effects and unmount callbacks are disposed of in the correct order.
  * Fixed cleanup behavior for dynamically rendered components and visibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->