### PR TITLE
fix(compiler-core): error on unexpected first character of an attribute name

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
@@ -2473,6 +2473,375 @@ exports[`compiler: parse > Errors > MISSING_END_TAG_NAME > <template></></templa
 }
 `;
 
+exports[`compiler: parse > Errors > UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME > <template><div "bc=''></div></template> 1`] = `
+{
+  "cached": [],
+  "children": [
+    {
+      "children": [
+        {
+          "children": [],
+          "codegenNode": undefined,
+          "loc": {
+            "end": {
+              "column": 29,
+              "line": 1,
+              "offset": 28,
+            },
+            "source": "<div "bc=''></div>",
+            "start": {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "ns": 0,
+          "props": [
+            {
+              "loc": {
+                "end": {
+                  "column": 22,
+                  "line": 1,
+                  "offset": 21,
+                },
+                "source": ""bc=''",
+                "start": {
+                  "column": 16,
+                  "line": 1,
+                  "offset": 15,
+                },
+              },
+              "name": ""bc",
+              "nameLoc": {
+                "end": {
+                  "column": 19,
+                  "line": 1,
+                  "offset": 18,
+                },
+                "source": ""bc",
+                "start": {
+                  "column": 16,
+                  "line": 1,
+                  "offset": 15,
+                },
+              },
+              "type": 6,
+              "value": {
+                "content": "",
+                "loc": {
+                  "end": {
+                    "column": 22,
+                    "line": 1,
+                    "offset": 21,
+                  },
+                  "source": "''",
+                  "start": {
+                    "column": 20,
+                    "line": 1,
+                    "offset": 19,
+                  },
+                },
+                "type": 2,
+              },
+            },
+          ],
+          "tag": "div",
+          "tagType": 0,
+          "type": 1,
+        },
+      ],
+      "codegenNode": undefined,
+      "loc": {
+        "end": {
+          "column": 40,
+          "line": 1,
+          "offset": 39,
+        },
+        "source": "<template><div "bc=''></div></template>",
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "ns": 0,
+      "props": [],
+      "tag": "template",
+      "tagType": 0,
+      "type": 1,
+    },
+  ],
+  "codegenNode": undefined,
+  "components": [],
+  "directives": [],
+  "helpers": Set {},
+  "hoists": [],
+  "imports": [],
+  "loc": {
+    "end": {
+      "column": 40,
+      "line": 1,
+      "offset": 39,
+    },
+    "source": "<template><div "bc=''></div></template>",
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "source": "<template><div "bc=''></div></template>",
+  "temps": 0,
+  "type": 0,
+}
+`;
+
+exports[`compiler: parse > Errors > UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME > <template><div 'bc=''></div></template> 1`] = `
+{
+  "cached": [],
+  "children": [
+    {
+      "children": [
+        {
+          "children": [],
+          "codegenNode": undefined,
+          "loc": {
+            "end": {
+              "column": 29,
+              "line": 1,
+              "offset": 28,
+            },
+            "source": "<div 'bc=''></div>",
+            "start": {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "ns": 0,
+          "props": [
+            {
+              "loc": {
+                "end": {
+                  "column": 22,
+                  "line": 1,
+                  "offset": 21,
+                },
+                "source": "'bc=''",
+                "start": {
+                  "column": 16,
+                  "line": 1,
+                  "offset": 15,
+                },
+              },
+              "name": "'bc",
+              "nameLoc": {
+                "end": {
+                  "column": 19,
+                  "line": 1,
+                  "offset": 18,
+                },
+                "source": "'bc",
+                "start": {
+                  "column": 16,
+                  "line": 1,
+                  "offset": 15,
+                },
+              },
+              "type": 6,
+              "value": {
+                "content": "",
+                "loc": {
+                  "end": {
+                    "column": 22,
+                    "line": 1,
+                    "offset": 21,
+                  },
+                  "source": "''",
+                  "start": {
+                    "column": 20,
+                    "line": 1,
+                    "offset": 19,
+                  },
+                },
+                "type": 2,
+              },
+            },
+          ],
+          "tag": "div",
+          "tagType": 0,
+          "type": 1,
+        },
+      ],
+      "codegenNode": undefined,
+      "loc": {
+        "end": {
+          "column": 40,
+          "line": 1,
+          "offset": 39,
+        },
+        "source": "<template><div 'bc=''></div></template>",
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "ns": 0,
+      "props": [],
+      "tag": "template",
+      "tagType": 0,
+      "type": 1,
+    },
+  ],
+  "codegenNode": undefined,
+  "components": [],
+  "directives": [],
+  "helpers": Set {},
+  "hoists": [],
+  "imports": [],
+  "loc": {
+    "end": {
+      "column": 40,
+      "line": 1,
+      "offset": 39,
+    },
+    "source": "<template><div 'bc=''></div></template>",
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "source": "<template><div 'bc=''></div></template>",
+  "temps": 0,
+  "type": 0,
+}
+`;
+
+exports[`compiler: parse > Errors > UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME > <template><div <bc=''></div></template> 1`] = `
+{
+  "cached": [],
+  "children": [
+    {
+      "children": [
+        {
+          "children": [],
+          "codegenNode": undefined,
+          "loc": {
+            "end": {
+              "column": 29,
+              "line": 1,
+              "offset": 28,
+            },
+            "source": "<div <bc=''></div>",
+            "start": {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "ns": 0,
+          "props": [
+            {
+              "loc": {
+                "end": {
+                  "column": 22,
+                  "line": 1,
+                  "offset": 21,
+                },
+                "source": "<bc=''",
+                "start": {
+                  "column": 16,
+                  "line": 1,
+                  "offset": 15,
+                },
+              },
+              "name": "<bc",
+              "nameLoc": {
+                "end": {
+                  "column": 19,
+                  "line": 1,
+                  "offset": 18,
+                },
+                "source": "<bc",
+                "start": {
+                  "column": 16,
+                  "line": 1,
+                  "offset": 15,
+                },
+              },
+              "type": 6,
+              "value": {
+                "content": "",
+                "loc": {
+                  "end": {
+                    "column": 22,
+                    "line": 1,
+                    "offset": 21,
+                  },
+                  "source": "''",
+                  "start": {
+                    "column": 20,
+                    "line": 1,
+                    "offset": 19,
+                  },
+                },
+                "type": 2,
+              },
+            },
+          ],
+          "tag": "div",
+          "tagType": 0,
+          "type": 1,
+        },
+      ],
+      "codegenNode": undefined,
+      "loc": {
+        "end": {
+          "column": 40,
+          "line": 1,
+          "offset": 39,
+        },
+        "source": "<template><div <bc=''></div></template>",
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "ns": 0,
+      "props": [],
+      "tag": "template",
+      "tagType": 0,
+      "type": 1,
+    },
+  ],
+  "codegenNode": undefined,
+  "components": [],
+  "directives": [],
+  "helpers": Set {},
+  "hoists": [],
+  "imports": [],
+  "loc": {
+    "end": {
+      "column": 40,
+      "line": 1,
+      "offset": 39,
+    },
+    "source": "<template><div <bc=''></div></template>",
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "source": "<template><div <bc=''></div></template>",
+  "temps": 0,
+  "type": 0,
+}
+`;
+
 exports[`compiler: parse > Errors > UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME > <template><div a"bc=''></div></template> 1`] = `
 {
   "cached": [],
@@ -2837,6 +3206,140 @@ exports[`compiler: parse > Errors > UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME > <te
     },
   },
   "source": "<template><div a<bc=''></div></template>",
+  "temps": 0,
+  "type": 0,
+}
+`;
+
+exports[`compiler: parse > Errors > UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME > <template><div\\x0a;  <span>hi</span>\\x0a;</div></template> 1`] = `
+{
+  "cached": [],
+  "children": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "content": "hi ",
+              "loc": {
+                "end": {
+                  "column": 1,
+                  "line": 3,
+                  "offset": 33,
+                },
+                "source": "hi</span>
+",
+                "start": {
+                  "column": 9,
+                  "line": 2,
+                  "offset": 23,
+                },
+              },
+              "type": 2,
+            },
+          ],
+          "codegenNode": undefined,
+          "loc": {
+            "end": {
+              "column": 7,
+              "line": 3,
+              "offset": 39,
+            },
+            "source": "<div
+  <span>hi</span>
+</div>",
+            "start": {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "ns": 0,
+          "props": [
+            {
+              "loc": {
+                "end": {
+                  "column": 8,
+                  "line": 2,
+                  "offset": 22,
+                },
+                "source": "<span",
+                "start": {
+                  "column": 3,
+                  "line": 2,
+                  "offset": 17,
+                },
+              },
+              "name": "<span",
+              "nameLoc": {
+                "end": {
+                  "column": 8,
+                  "line": 2,
+                  "offset": 22,
+                },
+                "source": "<span",
+                "start": {
+                  "column": 3,
+                  "line": 2,
+                  "offset": 17,
+                },
+              },
+              "type": 6,
+              "value": undefined,
+            },
+          ],
+          "tag": "div",
+          "tagType": 0,
+          "type": 1,
+        },
+      ],
+      "codegenNode": undefined,
+      "loc": {
+        "end": {
+          "column": 18,
+          "line": 3,
+          "offset": 50,
+        },
+        "source": "<template><div
+  <span>hi</span>
+</div></template>",
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "ns": 0,
+      "props": [],
+      "tag": "template",
+      "tagType": 0,
+      "type": 1,
+    },
+  ],
+  "codegenNode": undefined,
+  "components": [],
+  "directives": [],
+  "helpers": Set {},
+  "hoists": [],
+  "imports": [],
+  "loc": {
+    "end": {
+      "column": 18,
+      "line": 3,
+      "offset": 50,
+    },
+    "source": "<template><div
+  <span>hi</span>
+</div></template>",
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "source": "<template><div
+  <span>hi</span>
+</div></template>",
   "temps": 0,
   "type": 0,
 }

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -3220,6 +3220,49 @@ describe('compiler: parse', () => {
             },
           ],
         },
+        {
+          code: "<template><div \"bc=''></div></template>",
+          errors: [
+            {
+              type: ErrorCodes.UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME,
+              loc: { offset: 15, line: 1, column: 16 },
+            },
+          ],
+        },
+        {
+          code: "<template><div 'bc=''></div></template>",
+          errors: [
+            {
+              type: ErrorCodes.UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME,
+              loc: { offset: 15, line: 1, column: 16 },
+            },
+          ],
+        },
+        {
+          code: "<template><div <bc=''></div></template>",
+          errors: [
+            {
+              type: ErrorCodes.UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME,
+              loc: { offset: 15, line: 1, column: 16 },
+            },
+          ],
+        },
+        {
+          // #13319 a new tag opened before the current one is closed used to
+          // be silently swallowed as an attribute, leaving only a misleading
+          // "Invalid end tag." pointing at the closing tag
+          code: '<template><div\n  <span>hi</span>\n</div></template>',
+          errors: [
+            {
+              type: ErrorCodes.UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME,
+              loc: { offset: 17, line: 2, column: 3 },
+            },
+            {
+              type: ErrorCodes.X_INVALID_END_TAG,
+              loc: { offset: 25, line: 2, column: 11 },
+            },
+          ],
+        },
       ],
       UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE: [
         {

--- a/packages/compiler-core/src/tokenizer.ts
+++ b/packages/compiler-core/src/tokenizer.ts
@@ -690,6 +690,17 @@ export default class Tokenizer {
       this.state = State.InDirArg
       this.sectionStart = this.index + 1
     } else {
+      if (
+        (__DEV__ || !__BROWSER__) &&
+        (c === CharCodes.DoubleQuote ||
+          c === CharCodes.SingleQuote ||
+          c === CharCodes.Lt)
+      ) {
+        this.cbs.onerr(
+          ErrorCodes.UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME,
+          this.index,
+        )
+      }
       this.state = State.InAttrName
       this.sectionStart = this.index
     }


### PR DESCRIPTION
close #13319

## The problem

When a new tag is opened while the previous one is still unclosed, the opening `<` is silently swallowed as the first character of an attribute name, and the only diagnostic is a misleading `Invalid end tag.` pointing at the closing tag:

```html
<div
  <span>hi</span>
</div>
```

```
Invalid end tag.  (2:11)
```

`<span` becomes an attribute of `div`, so to the parser `</span>` is indeed unmatched — but the reported location is the symptom, not the mistake, and the closing tag it points at visibly *does* have a matching open tag right before it.

## Root cause

The tokenizer implements the [attribute name state](https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state) parse error for `"`, `'` and `<` — but only for characters consumed while already in `State.InAttrName`. Per the spec, `unexpected-character-in-attribute-name` also fires when one of these characters is *reconsumed as the first character* of the name from the [before attribute name state](https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-name-state). That reconsume path goes through `handleAttrStart`, which entered `State.InAttrName` without the check:

```html
<div a<b=''>   <!-- errors today -->
<div <b=''>    <!-- silently parsed as an attribute named `<b` -->
```

## The fix

`handleAttrStart` now reports `UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME` for a leading `"`, `'` or `<`, under the same `__DEV__ || !__BROWSER__` guard as the existing in-name check. Error recovery is untouched: the character still becomes part of the attribute name and the resulting AST is unchanged, exactly as in the non-leading case. The snippet above now reports

```
Attribute name cannot contain U+0022 ("), U+0027 ('), and U+003C (<).  (2:3)
Invalid end tag.  (2:11)
```

with the first error sitting exactly on the `<` of `<span>`.

Regarding [the concern about compile-time failures on browser-tolerated input](https://github.com/vuejs/core/issues/13319#issuecomment-2885434401): this doesn't introduce a new failure mode. This input already failed to compile (`Invalid end tag.`), the HTML spec itself classifies the leading character as a (recoverable) parse error, and the compiler already reports the identical error for the identical characters one position later. The change only removes the first-character blind spot so the error carries a useful location.

## Tests

Four new cases in the parse error table: the three leading characters mirroring the existing `a"bc=''` / `a'bc=''` / `a<bc=''` cases, plus the scenario from the issue asserting both errors with exact locations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template parsing to report clearer errors when unsupported characters appear in attribute names.
  * Corrected error detection for newly opened tags inside unclosed tags.
  * Error messages now include more accurate codes and source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->