### PR TITLE
fix(runtime-vapor): normalize declared style props (fix #15285)

### DIFF
--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -681,6 +681,62 @@ describe('component: props', () => {
     expect('Invalid prop').not.toHaveBeenWarned()
   })
 
+  // #15285
+  test('declared style prop should be normalized', () => {
+    const data = ref({ style: { color: 'red' } })
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps({ style: { type: Object } })
+      </script>
+      <template><div>{{ JSON.stringify(props.style) }}</div></template>`,
+      data,
+    )
+    const Parent = compile(
+      `<script setup vapor>
+        const data = _data
+        const Child = _components.Child
+      </script>
+      <template><Child style="font-weight:bold" :style="data.style" /></template>`,
+      data,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe(
+      '<div>{"font-weight":"bold","color":"red"}</div>',
+    )
+    expect('Invalid prop').not.toHaveBeenWarned()
+  })
+
+  test('style prop should only normalize the value that was passed', () => {
+    let props: any
+    const fallback = ['color:red']
+    const { render } = define({
+      props: { style: { default: () => fallback } },
+      setup(_props: any) {
+        props = _props
+        return []
+      },
+    })
+
+    render({ style: () => 'color: red' })
+    expect(props.style).toBe('color: red')
+
+    // style is absent or empty here, so the default is used as-is
+    render()
+    expect(props.style).toBe(fallback)
+
+    render({ style: () => undefined })
+    expect(props.style).toBe(fallback)
+
+    render({ style: () => 42 })
+    expect(props.style).toBe(42)
+
+    const styleFn = () => {}
+    render({ style: () => styleFn })
+    expect(props.style).toBe(styleFn)
+  })
+
   describe('dynamic props source caching', () => {
     test('v-bind object should be cached when child accesses multiple props', () => {
       let sourceCallCount = 0

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -6,9 +6,11 @@ import {
   hasOwn,
   isArray,
   isFunction,
+  isObject,
   isPlainObject,
   isString,
   normalizeClass,
+  normalizeStyle,
 } from '@vue/shared'
 import type { VaporComponent, VaporComponentInstance } from './component'
 import {
@@ -319,10 +321,14 @@ export function getPropsProxyHandlers(
           !isEmitListener(emitsOptions, key)
       : (key: string | symbol) => isString(key)
 
-  // vdom normalizes class on the vnode, so prop resolution already receives a
-  // normalized value. Match that order here.
-  const normalizeRawProp = (key: string, value: unknown) =>
-    key === 'class' && value && !isString(value) ? normalizeClass(value) : value
+  // vdom normalizes class and style on the vnode, so prop resolution already
+  // receives normalized values. Match that order here.
+  const normalizeRawProp = (key: string, value: unknown) => {
+    if (!value) return value
+    if (key === 'class' && !isString(value)) return normalizeClass(value)
+    if (key === 'style' && isObject(value)) return normalizeStyle(value)
+    return value
+  }
 
   const getProp = (instance: VaporComponentInstance, key: string | symbol) => {
     // this enables direct watching of props and prevents `Invalid watch source` DEV warnings.


### PR DESCRIPTION
When a Vapor component receives both static and dynamic `style` bindings, the compiler produces an array. VDOM normalizes that value before component prop resolution, but Vapor passed the array directly to a declared `style` prop. This made an `Object` prop receive an `Array` and emit a validation warning.

This extends the existing raw-prop normalization used for `class`: object-valued `style` inputs now go through `normalizeStyle` before default and casting logic. Strings, primitive values, functions, and defaults remain unchanged.

The regression test uses compiled parent and child templates, and the boundary coverage checks string, default, primitive, and function values.

Closes #15285

Validation:
- `pnpm vp test run packages/runtime-vapor/__tests__/componentProps.spec.ts` (35 passed)
- `pnpm vp test run runtime-vapor` (47 files, 1740 passed, 2 expected failures, 15 todo)
- `pnpm vp run check`
- `pnpm vp run lint`
- `pnpm vp run format-check`
- `pnpm vp run build runtime-vapor`

Against the exact `minor` base, the runtime-vapor ESM bundle changes by 117 bytes raw and 14 bytes gzip.
