### PR TITLE
fix(runtime-vapor): clean up removed v-for components

### DIFF
--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -1,4 +1,5 @@
 import {
+  type VaporComponentInstance,
   child,
   createComponent,
   createDynamicComponent,
@@ -28,7 +29,7 @@ import {
   toDisplayString,
   triggerRef,
 } from '@vue/runtime-dom'
-import { makeRender, shuffle } from './_utils'
+import { compile, makeRender, shuffle } from './_utils'
 import { VaporVForFlags } from '@vue/shared'
 
 const define = makeRender()
@@ -1883,6 +1884,98 @@ describe('createFor', () => {
 
       expect(html()).toBe('<!--for-->')
       expect(unmounted).toHaveBeenCalledTimes(2)
+    })
+
+    test('component item cleanups do not accumulate in the owner scope', async () => {
+      const state = ref({
+        items: [] as number[],
+      })
+      const unmounted = vi.fn()
+      const Child = compile(
+        `<script setup vapor>
+        import { onUnmounted } from 'vue'
+        const props = defineProps(['index'])
+        onUnmounted(_components.unmounted)
+        </script>
+        <template><span>{{ props.index }}</span></template>`,
+        state,
+        { unmounted },
+      )
+      const App = compile(
+        `<template>
+          <components.Child
+            v-for="item in data.items"
+            :key="item"
+            :index="item"
+            ref="children"
+          />
+        </template>`,
+        state,
+        { Child },
+      )
+      const { app, instance } = define(App).render()
+      const cleanupBaseline = instance!.scope.cleanupsLength
+      const effectBaseline = getEffectsCount(instance!.scope)
+      const expectStableResources = () => {
+        expect(instance!.scope.cleanups).toHaveLength(cleanupBaseline)
+        expect(getEffectsCount(instance!.scope)).toBe(effectBaseline)
+        expect(instance!.refs.children).toHaveLength(state.value.items.length)
+      }
+
+      state.value.items = [0, 1, 2]
+      await nextTick()
+      expectStableResources()
+
+      state.value.items.splice(1, 1)
+      await nextTick()
+      expect(unmounted).toHaveBeenCalledOnce()
+      expectStableResources()
+
+      for (let id = 3; id < 6; id++) {
+        state.value.items = [state.value.items[1], id]
+        await nextTick()
+        expectStableResources()
+      }
+
+      expect(unmounted).toHaveBeenCalledTimes(4)
+
+      app.unmount()
+      await nextTick()
+
+      expect(unmounted).toHaveBeenCalledTimes(6)
+      expect(instance!.refs.children).toHaveLength(0)
+    })
+
+    test('removes component items before running captured cleanups', async () => {
+      const state = ref({ items: [0] })
+      let child!: VaporComponentInstance
+      const cleanup = vi.fn(() => {
+        expect((child.block as Node).isConnected).toBe(false)
+      })
+      const refFn = (value: VaporComponentInstance | null) => {
+        if (value) child = value
+        else cleanup()
+      }
+      const Child = compile(`<template><span /></template>`, state)
+      const App = compile(
+        `<template>
+          <components.Child
+            v-for="item in data.items"
+            :key="item"
+            :ref="components.refFn"
+          />
+        </template>`,
+        state,
+        { Child, refFn },
+      )
+      const { app } = define(App).render()
+      await nextTick()
+
+      state.value.items = []
+      await nextTick()
+
+      expect(cleanup).toHaveBeenCalledOnce()
+      app.unmount()
     })
 
     test('slot fallback fragments can be reordered and removed', async () => {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -1,6 +1,7 @@
 import {
   EffectScope,
   type ShallowRef,
+  getCurrentScope,
   isReactive,
   isReadonly,
   isShallow,
@@ -143,6 +144,7 @@ export const createFor = (
   )
   const instance = currentInstance!
   const isComponent = !!(flags & VaporVForFlags.IS_COMPONENT)
+  const ownerScope = isComponent ? getCurrentScope()! : undefined
   const canUseFastRemove =
     !!(flags & VaporVForFlags.FAST_REMOVE) && !isComponent
   const isSingleNode = !!(flags & VaporVForFlags.IS_SINGLE_NODE)
@@ -155,16 +157,14 @@ export const createFor = (
     warn('createFor() can only be used inside setup()')
   }
 
-  if (!isComponent) {
-    onScopeDispose(() => {
-      stopBlockScopes(oldBlocks)
-      if (newBlocks && newBlocks !== oldBlocks) {
-        stopBlockScopes(newBlocks)
-      }
-      oldBlocks = []
-      newBlocks = []
-    }, true)
-  }
+  onScopeDispose(() => {
+    cleanupBlocks(oldBlocks, isComponent)
+    if (newBlocks && newBlocks !== oldBlocks) {
+      cleanupBlocks(newBlocks, isComponent)
+    }
+    oldBlocks = []
+    newBlocks = []
+  }, true)
 
   const renderList = () => {
     const source = normalizeSource(src())
@@ -209,7 +209,7 @@ export const createFor = (
       } else if (!newLength) {
         // fast path for clearing all.
         // Fire reset listeners BEFORE per-item unmount so attached selectors
-        // bump their generation counter; the subsequent block.scope.stop()
+        // bump their generation counter; the subsequent item scope cleanup
         // calls then short-circuit their onScopeDispose deregisters instead
         // of doing N individual Map.delete() ops.
         if (frag.resetListeners) {
@@ -432,9 +432,9 @@ export const createFor = (
   const needIndex = renderItem.length > 2
 
   type InsertForBlock = (block: ForBlock, anchor: Node | undefined) => void
-  // IS_COMPONENT means the item owns its own scope, not that block.nodes is
-  // guaranteed to be a VaporComponentInstance. Component fallback may produce a
-  // plain DOM node, so component-shaped blocks still use the generic block path.
+  // IS_COMPONENT does not guarantee that block.nodes is a
+  // VaporComponentInstance. Component fallback may produce a plain DOM node, so
+  // component-shaped blocks still use the generic block path.
   const insertForBlock: InsertForBlock = isSingleNode
     ? (block, anchor) => insertNode(block.nodes as Node, parent!, anchor)
     : isFragment
@@ -462,12 +462,22 @@ export const createFor = (
     const indexRef = needIndex ? shallowRef(index) : undefined
 
     let nodes: Block
-    let scope: EffectScope | undefined
+    let cleanup: ForBlock['cleanup']
     if (isComponent) {
-      // component already has its own scope so no outer scope needed
+      // Component items skip per-item scopes. Transfer cleanups registered while
+      // rendering this item from the owner scope to its ForBlock instead.
+      const scope = ownerScope!
+      const cleanupStart = scope.cleanupsLength
       nodes = renderItem(itemRef, keyRef as any, indexRef as any)
+      const cleanupCount = scope.cleanupsLength - cleanupStart
+      if (cleanupCount) {
+        const cleanups = scope.cleanups
+        cleanup =
+          cleanupCount === 1 ? cleanups.pop()! : cleanups.splice(cleanupStart)
+        scope.cleanupsLength = cleanupStart
+      }
     } else {
-      scope = new EffectScope(true)
+      const scope = new EffectScope(true)
       try {
         nodes = scope.run(() =>
           renderItem(itemRef, keyRef as any, indexRef as any),
@@ -476,11 +486,12 @@ export const createFor = (
         scope.stop()
         throw err
       }
+      cleanup = scope
     }
 
     const block = (newBlocks[idx] = new ForBlock(
       nodes,
-      scope,
+      cleanup,
       itemRef,
       keyRef,
       indexRef,
@@ -631,10 +642,13 @@ export const createFor = (
 
   const unmount = (block: ForBlock, doRemove = true) => {
     if (!isComponent) {
-      block.scope!.stop()
+      ;(block.cleanup as EffectScope).stop()
     }
     if (doRemove) {
       removeForBlock(block)
+    }
+    if (isComponent) {
+      cleanupComponentBlock(block)
     }
   }
 
@@ -779,12 +793,30 @@ function moveLink(block: ForBlock, newPrev?: ForBlock, newNext?: ForBlock) {
   block.prevAnchor = block
 }
 
-function stopBlockScopes(blocks: ForBlock[]): void {
+function cleanupBlocks(blocks: ForBlock[], isComponent: boolean): void {
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]
     if (block) {
-      const scope = block.scope
-      if (scope) scope.stop()
+      if (isComponent) cleanupComponentBlock(block)
+      else {
+        const cleanup = block.cleanup as EffectScope | undefined
+        if (cleanup) {
+          block.cleanup = undefined
+          cleanup.stop()
+        }
+      }
+    }
+  }
+}
+
+function cleanupComponentBlock(block: ForBlock): void {
+  const cleanup = block.cleanup
+  if (cleanup) {
+    block.cleanup = undefined
+    if (isArray(cleanup)) {
+      for (let i = 0; i < cleanup.length; i++) cleanup[i]()
+    } else {
+      ;(cleanup as () => void)()
     }
   }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -214,7 +214,7 @@ export class ForFragment extends VaporFragment<Block[]> {
 }
 
 export class ForBlock extends VaporFragment {
-  scope: EffectScope | undefined
+  cleanup: EffectScope | (() => void) | (() => void)[] | undefined
   key: any
   prev?: ForBlock
   next?: ForBlock
@@ -226,14 +226,14 @@ export class ForBlock extends VaporFragment {
 
   constructor(
     nodes: Block,
-    scope: EffectScope | undefined,
+    cleanup: ForBlock['cleanup'],
     item: ShallowRef<any>,
     key: ShallowRef<any> | undefined,
     index: ShallowRef<number | undefined> | undefined,
     renderKey: any,
   ) {
     super(nodes, FOR_ITEM)
-    this.scope = scope
+    this.cleanup = cleanup
     this.itemRef = item
     this.keyRef = key
     this.indexRef = index


### PR DESCRIPTION
Closes #15282

Capture cleanup callbacks registered while rendering component v-for items and transfer them from the owner scope to the corresponding ForBlock.

Run the captured callbacks after structural removal so removed component instances and their DOM can be released immediately. This preserves the component v-for optimization by avoiding an additional EffectScope for every item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup handling for dynamically rendered list items and component instances.
  * Prevented cleanup callbacks from accumulating in parent scopes.
  * Ensured component items are removed before associated reference cleanup callbacks run.
  * Improved unmount behavior so all relevant effects and callbacks are reliably disposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->