### PR TITLE
fix(runtime-core): avoid caching unmounted suspense children

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -2111,6 +2111,77 @@ describe('Suspense', () => {
     expect(serializeInner(root)).toBe(`<div>async2</div>`)
   })
 
+  // #15288
+  test('KeepAlive + Suspense switch while ancestor is pending', async () => {
+    let resolveRootDep!: (comp: ComponentOptions) => void
+    const rootDep = new Promise<ComponentOptions>(resolve => {
+      resolveRootDep = resolve
+    })
+    const RootDep = defineAsyncComp(() => rootDep)
+    const makePage = (name: string) =>
+      defineAsyncComponent({
+        render: () => h('div', `page ${name}`),
+      })
+    const PageA = makePage('A')
+    const PageB = makePage('B')
+    const page = shallowRef(PageA)
+    const key = ref('a')
+    const root = nodeOps.createElement('div')
+    const App = {
+      render() {
+        return h(Suspense, null, {
+          default: h('div', [
+            h(RootDep),
+            h(KeepAlive, null, {
+              default: () =>
+                h(Suspense, null, {
+                  default: h(page.value, { key: key.value }),
+                }),
+            }),
+          ]),
+          fallback: h('div', 'loading'),
+        })
+      },
+    }
+
+    render(h(App), root)
+    expect(serializeInner(root)).toBe('<div>loading</div>')
+
+    await Promise.all(deps)
+    await nextTick()
+
+    page.value = PageB
+    key.value = 'b'
+    await nextTick()
+    expect(serializeInner(root)).toBe('<div>loading</div>')
+
+    resolveRootDep({
+      render: () => h('div', 'root'),
+    })
+    await rootDep
+    await new Promise(r => setTimeout(r))
+    await nextTick()
+    expect(serializeInner(root)).toBe(
+      '<div><div>root</div><div>page A</div></div>',
+    )
+
+    page.value = PageA
+    key.value = 'a'
+    await nextTick()
+    expect(serializeInner(root)).toBe(
+      '<div><div>root</div><div>page A</div></div>',
+    )
+
+    page.value = PageB
+    key.value = 'b'
+    await nextTick()
+    await Promise.all(deps)
+    await nextTick()
+    expect(serializeInner(root)).toBe(
+      '<div><div>root</div><div>page B</div></div>',
+    )
+  })
+
   test('KeepAlive + Suspense + comment slot', async () => {
     const toggle = ref(false)
     const Async = defineAsyncComponent({

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -248,7 +248,10 @@ const KeepAliveImpl: ComponentOptions = {
         // avoid caching vnode that not been mounted
         if (isSuspense(instance.subTree.type)) {
           queuePostRenderEffect(() => {
-            cache.set(pendingCacheKey!, getInnerChild(instance.subTree))
+            const vnode = getInnerChild(instance.subTree)
+            if (vnode.component) {
+              cache.set(pendingCacheKey!, vnode)
+            }
           }, instance.subTree.suspense)
         } else {
           cache.set(pendingCacheKey, getInnerChild(instance.subTree))


### PR DESCRIPTION
## Problem

When a nested `Suspense` is updated while an ancestor boundary is pending, the update is intentionally skipped to avoid processing the pending subtree twice. Its incoming child vnode therefore has no component instance.

`KeepAlive` still cached that vnode from its post-render hook. Reusing the poisoned entry later marked it as kept alive with `component === null`, causing `patchSuspense` to throw while reading `component.suspenseId`.

## Fix

Only cache a Suspense inner child after the renderer has created its component instance. This keeps the existing ancestor-Suspense early return intact and prevents unmounted children from entering the KeepAlive cache.

Add a regression test covering the full pending-ancestor navigation sequence.

Closes #15288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `KeepAlive` and `Suspense` behavior when switching between cached pages during asynchronous loading.
  * Prevented invalid caching of content without an associated component, improving rendering stability.
  * Ensured fallback content remains visible until the parent loading state resolves, after which the correct cached and switched pages render properly.

* **Tests**
  * Added regression coverage for nested `KeepAlive` and `Suspense` page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->