### PR TITLE
fix(runtime-vapor): preserve child keys in nested fragments

### DIFF
--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -20,7 +20,12 @@ import {
   VaporVForFlags,
   extend,
 } from '@vue/shared'
-import type { LooseRawProps, VaporComponent } from '../../src/component'
+import {
+  type LooseRawProps,
+  type VaporComponent,
+  type VaporComponentInstance,
+  currentInstance,
+} from '../../src/component'
 import { compile, ifFlags, makeRender } from '../_utils'
 import { VaporKeepAlive } from '../../src/components/KeepAlive'
 import {
@@ -1023,6 +1028,50 @@ describe('VaporKeepAlive', () => {
     expect(html()).toBe('<div>comp</div><!--if--><!--if-->')
     expect(compHooks.activated).toHaveBeenCalledTimes(3)
     expect(compHooks.mounted).toHaveBeenCalledTimes(1)
+  })
+
+  test('should preserve component identity in nested keyed v-if branches', async () => {
+    const mounted = vi.fn()
+    let childInstance!: VaporComponentInstance
+    const Child = defineVaporComponent({
+      setup() {
+        childInstance = currentInstance! as VaporComponentInstance
+        onMounted(mounted)
+        return template(`<div>child</div>`)()
+      },
+    })
+    const state = reactive({ outer: true, inner: true })
+    const App = compile(
+      `<script setup vapor>
+        const state = _data
+        const Child = _components.Child
+      </script>
+      <template>
+        <KeepAlive>
+          <template v-if="state.outer">
+            <Child v-if="state.inner" />
+            <span v-else>inner-off</span>
+          </template>
+          <span v-else>outer-off</span>
+        </KeepAlive>
+      </template>`,
+      state as any,
+      { Child },
+    )
+    const { host } = define(App).render()
+
+    expect(host.textContent).toBe('child')
+    expect(mounted).toHaveBeenCalledTimes(1)
+    expect(childInstance.$key).toBe(0)
+
+    state.inner = false
+    await nextTick()
+    expect(host.textContent).toBe('inner-off')
+
+    state.inner = true
+    await nextTick()
+    expect(host.textContent).toBe('child')
+    expect(mounted).toHaveBeenCalledTimes(1)
   })
 
   async function assertNameMatch(props: LooseRawProps) {

--- a/packages/runtime-vapor/__tests__/helpers/setKey.spec.ts
+++ b/packages/runtime-vapor/__tests__/helpers/setKey.spec.ts
@@ -16,6 +16,16 @@ describe('helpers: setBlockKey', () => {
     const el = template(`<div></div>`)() as any
     setBlockKey(el, 'foo')
     expect(el.$key).toBe('foo')
+
+    setBlockKey(el, 'bar')
+    expect(el.$key).toBe('bar')
+  })
+
+  test('does not override an existing key when overwrite is false', () => {
+    const el = template(`<div></div>`)() as any
+    setBlockKey(el, 'inner')
+    setBlockKey(el, 'outer', false)
+    expect(el.$key).toBe('inner')
   })
 
   test('sets key on component and rendered block', () => {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -418,14 +418,14 @@ export class DynamicFragment extends RenderContextFragment {
             this.scope,
           )
         } finally {
-          // propagate the fragment key onto freshly rendered nodes.
+          // Inherit the fragment key without overriding a child's own key.
           const key = this.keyed ? this.current : this.$key
           // Only propagate branch keys when Transition or KeepAlive consumes them.
           if (
             key !== undefined &&
             (transition || this.inTransition || keepAliveCtx)
           ) {
-            setBlockKey(this.nodes, key)
+            setBlockKey(this.nodes, key, false)
           }
 
           if (isTransitionEnabled && transition) {

--- a/packages/runtime-vapor/src/helpers/setKey.ts
+++ b/packages/runtime-vapor/src/helpers/setKey.ts
@@ -8,26 +8,30 @@ import { isInteropEnabled } from '../vdomInteropState'
 export function setBlockKey(
   block: (Block & { $key?: any }) | null | undefined,
   key: any,
+  overwrite: boolean = true,
 ): void {
   if (!block) return
 
   if (block instanceof Node) {
+    if (!overwrite && block.$key != null) return
     block.$key = key
   } else if (isVaporComponent(block)) {
+    if (!overwrite && block.$key != null) return
     block.$key = key
     // KeepAlive resolves cache keys from its child block. An outer wrapper key
     // (for example from v-if) must not override the child's own component type
     // or explicit key, otherwise cached branches will not be found again.
     if ((!isKeepAliveEnabled || !isKeepAlive(block)) && block.block) {
-      setBlockKey(block.block, key)
+      setBlockKey(block.block, key, overwrite)
     }
   } else if (isArray(block)) {
     if (block.length === 1) {
-      setBlockKey(block[0], key)
+      setBlockKey(block[0], key, overwrite)
     }
   } else {
+    if (!overwrite && block.$key != null) return
     block.$key = key
     if (isInteropEnabled && block.vnode) block.vnode.key = key
-    setBlockKey(block.nodes, key)
+    setBlockKey(block.nodes, key, overwrite)
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `KeepAlive` behavior so cached component instances remain stable when toggling nested keyed conditional branches.
  - Preserved existing child keys during dynamic fragment updates, improving transition and cached-component handling.

- **Tests**
  - Added regression coverage for nested keyed conditional branches.
  - Expanded key-handling tests to verify both overwriting and preserving existing keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->