### PR TITLE
fix(runtime-vapor): preserve cached input effects across nested branch teardown

### DIFF
--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1025,6 +1025,53 @@ describe('VaporKeepAlive', () => {
     expect(compHooks.mounted).toHaveBeenCalledTimes(1)
   })
 
+  test('should update props after reactivating a nested unkeyed v-if branch', async () => {
+    const mounted = vi.fn()
+    const Child = defineVaporComponent({
+      props: ['msg'],
+      setup(props) {
+        onMounted(mounted)
+        const n0 = template(`<div> </div>`)() as any
+        const x0 = child(n0) as any
+        renderEffect(() => setText(x0, props.msg))
+        return n0
+      },
+    })
+    const state = reactive({ outer: true, inner: true, msg: 'a' })
+    const App = compile(
+      `<script setup vapor>
+        const state = _data
+        const Child = _components.Child
+      </script>
+      <template>
+        <KeepAlive>
+          <template v-if="state.outer">
+            <Child v-if="state.inner" :msg="state.msg" />
+          </template>
+        </KeepAlive>
+      </template>`,
+      state as any,
+      { Child },
+    )
+    const { host } = define(App).render()
+
+    expect(host.textContent).toBe('a')
+    expect(mounted).toHaveBeenCalledTimes(1)
+
+    state.inner = false
+    await nextTick()
+    expect(host.textContent).toBe('')
+
+    state.inner = true
+    await nextTick()
+    expect(host.textContent).toBe('a')
+    expect(mounted).toHaveBeenCalledTimes(1)
+
+    state.msg = 'b'
+    await nextTick()
+    expect(host.textContent).toBe('b')
+  })
+
   async function assertNameMatch(props: LooseRawProps) {
     const outerRef = ref(true)
     const viewRef = ref('one')

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -390,21 +390,36 @@ export function createComponent(
       return frag as any
     }
 
-    if (keepAliveCtx) {
+    let inputScope: EffectScope | undefined
+    if (
+      keepAliveCtx &&
+      ((rawProps && !once) || (rawSlots && (rawSlots as RawSlots).$))
+    ) {
       // The cached component keeps its detached scope active, so commit only
-      // its direct inputs through the KeepAlive branch scope. Descendants read
-      // from the same committed inputs and need no additional isolation.
+      // its direct inputs through a cache-owned scope. Descendants read from
+      // the same committed inputs and need no additional isolation.
       // v-once snapshots raw props in the instance constructor, so it does not
       // need a live commit effect after creation.
-      if (rawProps && !once) {
-        rawProps = keepAliveCtx.isolatePropSources(rawProps as RawProps)
-      }
+      const scope = new EffectScope(true)
+      let isolated = false
+      scope.run(() => {
+        if (rawProps && !once) {
+          const next = keepAliveCtx!.isolatePropSources(rawProps as RawProps)
+          isolated = next !== rawProps
+          rawProps = next
+        }
 
-      // Static slots are fixed function entries. Only `$` contains live slot
-      // descriptor sources that useSlots() can re-resolve while cached; slot
-      // function execution retains its existing closure semantics.
-      if (rawSlots && (rawSlots as RawSlots).$) {
-        rawSlots = keepAliveCtx.isolateSlotSources(rawSlots as RawSlots)
+        // Static slots are fixed function entries. Only `$` contains live slot
+        // descriptor sources that useSlots() can re-resolve while cached; slot
+        // function execution retains its existing closure semantics.
+        if (rawSlots && (rawSlots as RawSlots).$) {
+          const next = keepAliveCtx!.isolateSlotSources(rawSlots as RawSlots)
+          isolated = isolated || next !== rawSlots
+          rawSlots = next
+        }
+      })
+      if (isolated) {
+        inputScope = scope
       }
     }
 
@@ -416,6 +431,9 @@ export function createComponent(
       once,
       ce,
     )
+    if (inputScope) {
+      instance.inputScope = inputScope
+    }
 
     // Async wrappers are skipped here: their DynamicFragment resolves the outer
     // KeepAlive context from the wrapper's parent chain during setup.
@@ -1372,6 +1390,10 @@ export function unmountComponent(
       invokeArrayFns(instance.bum)
     }
 
+    if (isKeepAliveEnabled) {
+      const inputScope = instance.inputScope
+      if (inputScope) inputScope.stop()
+    }
     instance.scope.stop()
 
     if (instance.um) {

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -138,11 +138,12 @@ export function isolatePropSources(rawProps: RawProps): RawProps {
   }
 
   // Each source keeps its original position and key spelling so prop/attr
-  // precedence is unchanged. The writer belongs to the KeepAlive branch scope,
-  // so deactivation pauses parent updates without pausing the component.
+  // precedence is unchanged. The writer belongs to the cached component's
+  // KeepAlive input scope, so deactivation pauses parent updates without
+  // pausing the component.
   // Source invalidations while this effect is paused still leave it dirty.
-  // Resuming the branch scope therefore schedules one commit with the latest
-  // raw props, while an unchanged cache entry needs no work on activation.
+  // Resuming the input scope therefore schedules one commit with the
+  // latest raw props, while an unchanged cache entry needs no work on activation.
   renderEffect(() => {
     if (committed) {
       for (const key in rawProps) {

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -410,10 +410,8 @@ const VaporKeepAliveImpl = defineVaporComponent({
           scope.stop()
           return false
         }
-        // Component scopes are detached from this DynamicFragment scope.
-        // Pausing it freezes branch-owned input commits without pausing the
-        // cached component's own effects; those effects keep reading the last
-        // committed inputs, like a cached VNode whose props are not patched.
+        // Component and KeepAlive input scopes are detached from this
+        // DynamicFragment scope, so this only pauses branch-owned effects.
         scope.pause()
         cacheScope(cacheKey, frag.current, scope)
         return true
@@ -621,6 +619,8 @@ export function activate(
   anchor?: Node | null,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
+  const inputScope = instance.inputScope
+  if (inputScope) inputScope.resume()
   move(instance, parentNode, anchor, MoveType.ENTER, instance, parentSuspense)
 
   queuePostRenderEffect(
@@ -642,6 +642,8 @@ export function deactivate(
   container: ParentNode,
   parentSuspense: SuspenseBoundary | null = instance.suspense,
 ): void {
+  const inputScope = instance.inputScope
+  if (inputScope) inputScope.pause()
   // Clear refs before deactivation, matching VDOM core's unmount path
   // which calls setRef(null) before the deactivation check.
   unsetRef(instance)
@@ -684,9 +686,9 @@ function isolateSlotSources(rawSlots: RawSlots): RawSlots {
 
   const isolated = { ...rawSlots, $: isolatedSources } as RawSlots
   // VDOM materializes dynamic slots before caching a child. Commit Vapor's
-  // live slot descriptors through the branch scope so useSlots() observes the
-  // same last-patched slot table while deactivated. Slot functions themselves
-  // remain unchanged and retain their existing closure semantics.
+  // live slot descriptors through the input scope so useSlots() observes
+  // the same last-patched slot table while deactivated. Slot functions
+  // themselves remain unchanged and retain their existing closure semantics.
   renderEffect(() => {
     for (let i = 0; i < dynamicSources.length; i++) {
       const source = dynamicSources[i]


### PR DESCRIPTION
Move isolated prop and slot source effects into a cache-owned scope so nested branch teardown does not stop them. Pause the scope while deactivated, resume it on activation, and stop it when the cached component is unmounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `KeepAlive` behavior when cached components are deactivated and reactivated.
  * Cached components now correctly reflect updated props and dynamic slot content after reactivation.
  * Prevented unnecessary remounting when nested conditional content is restored from the cache.
  * Improved state handling across repeated deactivation and reactivation cycles.
* **Tests**
  * Added coverage for prop updates on reactivated, nested conditional components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->