### PR TITLE
fix(runtime-core): trigger nested transition appear hooks in Suspense (fix #12435)

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -3376,4 +3376,41 @@ describe('Suspense', () => {
       expect(onEnter).not.toHaveBeenCalled()
     },
   )
+
+  test('does not duplicate appear hooks under a Fragment root', async () => {
+    const Async = defineAsyncComponent({
+      render: () => h('div', 'async'),
+    })
+    const onBeforeAppear = vi.fn()
+    const onAppear = vi.fn((_: unknown, done: () => void) => done())
+    const onEnter = vi.fn((_: unknown, done: () => void) => done())
+
+    const Comp = {
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () =>
+            h(Fragment, [
+              h(
+                BaseTransition,
+                { appear: true, onBeforeAppear, onAppear, onEnter },
+                () => h('div', 'sync'),
+              ),
+              h(Async),
+            ]),
+          fallback: () => h('div', 'fallback'),
+        }),
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+
+    await Promise.all(deps)
+    await nextTick()
+    await nextTick()
+
+    expect(onBeforeAppear).toHaveBeenCalledOnce()
+    expect(onAppear).toHaveBeenCalledOnce()
+    expect(onEnter).not.toHaveBeenCalled()
+  })
 })

--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  BaseTransition,
   type ComponentOptions,
   Fragment,
   KeepAlive,
@@ -3273,4 +3274,106 @@ describe('Suspense', () => {
       expect(updateSpy).not.toHaveBeenCalled()
     })
   })
+
+  // #12435
+  test('appear hooks are called for a Transition nested under an element', async () => {
+    const Async = defineAsyncComponent({
+      render: () => h('div', 'async'),
+    })
+    const onBeforeAppear = vi.fn()
+    const onAppear = vi.fn((_: unknown, done: () => void) => done())
+    const onEnter = vi.fn((_: unknown, done: () => void) => done())
+
+    const Comp = {
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () =>
+            h('div', [
+              h(
+                BaseTransition,
+                { appear: true, onBeforeAppear, onAppear, onEnter },
+                () => h(Async),
+              ),
+            ]),
+          fallback: () => h('div', 'fallback'),
+        }),
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+
+    await Promise.all(deps)
+    await nextTick()
+    await nextTick()
+
+    expect(serializeInner(root)).toBe(`<div><div>async</div></div>`)
+    expect(onBeforeAppear).toHaveBeenCalledOnce()
+    expect(onAppear).toHaveBeenCalledOnce()
+    expect(onEnter).not.toHaveBeenCalled()
+  })
+
+  test.each([false, true])(
+    'uses the latest nested Transition hooks after a pending update (persisted: %s)',
+    async persistedAfterUpdate => {
+      let resolveAsync!: () => void
+      const Async = {
+        setup: () => {
+          const dependency = new Promise<() => ReturnType<typeof h>>(
+            resolve => {
+              resolveAsync = () => resolve(() => h('div', 'async'))
+            },
+          )
+          deps.push(dependency.then(() => Promise.resolve()))
+          return dependency
+        },
+      }
+      const text = ref('one')
+      const persisted = ref(false)
+      const onBeforeAppear = vi.fn()
+      const onAppear = vi.fn((_: unknown, done: () => void) => done())
+      const onEnter = vi.fn((_: unknown, done: () => void) => done())
+
+      const Comp = {
+        setup: () => () =>
+          h(Suspense, null, {
+            default: () =>
+              h('div', [
+                h(
+                  BaseTransition,
+                  {
+                    appear: true,
+                    persisted: persisted.value,
+                    onBeforeAppear,
+                    onAppear,
+                    onEnter,
+                  },
+                  () => h('div', text.value),
+                ),
+                h(Async),
+              ]),
+            fallback: () => h('div', 'fallback'),
+          }),
+      }
+
+      const root = nodeOps.createElement('div')
+      render(h(Comp), root)
+      expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+
+      text.value = 'two'
+      persisted.value = persistedAfterUpdate
+      await nextTick()
+      resolveAsync()
+      await Promise.all(deps)
+      await nextTick()
+      await nextTick()
+
+      expect(serializeInner(root)).toBe(
+        `<div><div>two</div><div>async</div></div>`,
+      )
+      expect(onBeforeAppear).toHaveBeenCalledTimes(persistedAfterUpdate ? 0 : 1)
+      expect(onAppear).toHaveBeenCalledTimes(persistedAfterUpdate ? 0 : 1)
+      expect(onEnter).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -1,5 +1,6 @@
 import {
   Comment,
+  Fragment,
   type VNode,
   type VNodeProps,
   closeBlock,
@@ -63,6 +64,10 @@ let suspenseId = 0
  * For testing only
  */
 export const resetSuspenseId = (): number => (suspenseId = 0)
+
+// suspense branch id for transitions deferred during hidden mount
+export const suspenseDeferredTransitions: WeakMap<RendererElement, number> =
+  new WeakMap()
 
 // Suspense exposes a component-like API, and is treated like a component
 // in the compiler, but internally it's a special built-in type that hooks
@@ -156,6 +161,44 @@ function triggerEvent(
   const eventListener = vnode.props && vnode.props[name]
   if (isFunction(eventListener)) {
     eventListener()
+  }
+}
+
+function triggerDeferredTransitions(
+  vnode: VNode,
+  pendingId: number,
+  isMoveRoot = true,
+) {
+  const { shapeFlag, transition, children, el } = vnode
+  if (shapeFlag & ShapeFlags.COMPONENT) {
+    triggerDeferredTransitions(vnode.component!.subTree, pendingId, isMoveRoot)
+    return
+  }
+  if (shapeFlag & (ShapeFlags.TELEPORT | ShapeFlags.SUSPENSE)) {
+    return
+  }
+  if (isMoveRoot && vnode.type === Fragment) {
+    for (const child of children as VNode[]) {
+      triggerDeferredTransitions(child, pendingId)
+    }
+    return
+  }
+  if (
+    !isMoveRoot &&
+    shapeFlag & ShapeFlags.ELEMENT &&
+    transition &&
+    suspenseDeferredTransitions.get(el!) === pendingId
+  ) {
+    suspenseDeferredTransitions.delete(el!)
+    if (!transition.persisted) {
+      transition.beforeEnter(el!)
+      queuePostRenderEffect(() => transition.enter(el!), null)
+    }
+  }
+  if (shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
+    for (const child of children as VNode[]) {
+      triggerDeferredTransitions(child, pendingId, false)
+    }
   }
 }
 
@@ -557,6 +600,7 @@ function createSuspenseBoundary(
         if (delayEnter) {
           activeBranch!.transition!.afterLeave = () => {
             if (pendingId === suspense.pendingId) {
+              triggerDeferredTransitions(pendingBranch!, pendingId)
               move(
                 pendingBranch!,
                 container,
@@ -600,6 +644,7 @@ function createSuspenseBoundary(
         }
         if (!delayEnter) {
           // move content from off-dom container to actual container
+          triggerDeferredTransitions(pendingBranch!, pendingId)
           move(pendingBranch!, container, anchor, MoveType.ENTER)
         }
       }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -64,6 +64,7 @@ import {
   type SuspenseImpl,
   isSuspense,
   queueEffectWithSuspense,
+  suspenseDeferredTransitions,
 } from './components/Suspense'
 import {
   TeleportEndKey,
@@ -731,6 +732,13 @@ function baseCreateRenderer(
     const needCallTransitionHooks = needTransition(parentSuspense, transition)
     if (needCallTransitionHooks) {
       transition!.beforeEnter(el)
+    } else if (
+      transition &&
+      !transition.persisted &&
+      parentSuspense &&
+      parentSuspense.pendingBranch
+    ) {
+      suspenseDeferredTransitions.set(el, parentSuspense.pendingId)
     }
     hostInsert(el, container, anchor)
     if (
@@ -2089,6 +2097,7 @@ function baseCreateRenderer(
       transition
     if (needTransition) {
       if (moveType === MoveType.ENTER) {
+        suspenseDeferredTransitions.delete(el!)
         // #14031 if there is no pending v-show leave, the persisted
         // transition lifecycle is directive-owned, so activating a kept-alive
         // node only relocates it.


### PR DESCRIPTION
## Problem

When a Suspense pending branch is mounted in its hidden container, a Transition nested under a regular element does not receive its appear hooks when the branch resolves. The hooks can also be replaced by an update while the boundary is still pending.

## Solution

Track deferred transitions by host element and pending branch id, then invoke the current non-persisted transition hooks before moving the resolved branch. Teleports, nested Suspense boundaries, and transition roots handled by the normal move path are excluded.

## Tests

- Added coverage for a Transition nested under a regular element.
- Added coverage for transition updates while Suspense remains pending.
- Added coverage for transitions that become persisted while pending.

## Validation

- `pnpm test runtime-core --run`
- `pnpm test-unit --run`
- `pnpm check`
- ESLint and Prettier checks
- `pnpm build runtime-core -f esm-bundler`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transition behavior for elements rendered inside pending Suspense boundaries.
  * Enter transitions now start at the correct time when Suspense content becomes visible.
  * Ensured the latest nested transition hooks are used after pending updates.
  * Improved handling for persisted and non-persisted transitions.
  * Prevented duplicate appear hooks and suppressed inappropriate enter hooks during deferred rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->