### PR TITLE
fix(compiler-core): avoid codegen crash on template with invalid structural directive

### DIFF
--- a/packages/compiler-core/__tests__/compile.spec.ts
+++ b/packages/compiler-core/__tests__/compile.spec.ts
@@ -1,4 +1,4 @@
-import { baseCompile as compile } from '../src'
+import { ErrorCodes, baseCompile as compile } from '../src'
 import { type RawSourceMap, SourceMapConsumer } from 'source-map-js'
 
 describe('compiler: integration tests', () => {
@@ -261,5 +261,36 @@ describe('compiler: integration tests', () => {
     expect(
       consumer.originalPositionFor(getPositionInCode(code, `value + index`)),
     ).toMatchObject(getPositionInCode(source, `value + index`))
+  })
+
+  // When a <template> carries a structural directive that is invalid in its
+  // position, the directive transform reports a compiler error but leaves the
+  // node in the tree without a codegenNode. With a non-throwing `onError` the
+  // node still reaches codegen, which used to crash with an internal
+  // "Codegen node is missing" error. It should degrade to a placeholder instead.
+  describe('codegen does not crash on invalid structural directive', () => {
+    test.each([
+      `<template v-else>x</template>`,
+      `<template v-else-if="a">x</template>`,
+      `<template #slot>x</template>`,
+      `<div><template #slot>x</template></div>`,
+    ])('%s', source => {
+      const onError = vi.fn()
+      let code!: string
+      expect(() => {
+        code = compile(source, { onError }).code
+      }).not.toThrow()
+      expect(code).toContain(`return`)
+    })
+
+    test('still reports the underlying error', () => {
+      const onError = vi.fn()
+      expect(() =>
+        compile(`<template v-else>x</template>`, { onError }),
+      ).not.toThrow()
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: ErrorCodes.X_V_ELSE_NO_ADJACENT_IF }),
+      )
+    })
   })
 })

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -660,13 +660,17 @@ function genNode(node: CodegenNode | symbol | string, context: CodegenContext) {
     case NodeTypes.ELEMENT:
     case NodeTypes.IF:
     case NodeTypes.FOR:
-      __DEV__ &&
-        assert(
-          node.codegenNode != null,
-          `Codegen node is missing for element/if/for node. ` +
-            `Apply appropriate transforms first.`,
-        )
-      genNode(node.codegenNode!, context)
+      // A codegenNode is normally produced by the structural transforms. It
+      // can legitimately be absent when the node carried an invalid
+      // structural directive (e.g. a misplaced v-slot, or a v-else/v-else-if
+      // with no adjacent v-if) whose transform reported a compiler error but
+      // left the node in the tree. With a non-throwing `onError`, that node
+      // still reaches codegen, so emit a placeholder instead of crashing.
+      if (node.codegenNode == null) {
+        context.push(`null`, NewlineType.None, node)
+        break
+      }
+      genNode(node.codegenNode, context)
       break
     case NodeTypes.TEXT:
       genText(node, context)


### PR DESCRIPTION
## Problem

Closes #14955

When fuzzing `baseCompile` with a non-throwing `onError`, compiling a `<template>` that carries a structural directive invalid in its position crashes with an internal assert:

- `<template v-else>x</template>` (no adjacent v-if)
- `<template v-else-if="a">x</template>`
- `<template #slot>x</template>` (misplaced v-slot)

The structural transform reports a proper compiler error and bails, but leaves the element node in the tree without a `codegenNode`. With a non-throwing `onError`, that node still reaches codegen and hits:

```
Error: Codegen node is missing for element/if/for node. Apply appropriate transforms first.
```

## Solution

In `genNode`, when an element/if/for node has no `codegenNode`, emit a `null` placeholder instead of asserting. The placeholder is a valid vnode expression (the runtime skips null children), so the render function still compiles and the original compiler error is still reported via `onError`.

```ts
if (node.codegenNode == null) {
  context.push(`null`, NewlineType.None, node)
  break
}
genNode(node.codegenNode, context)
```

## Tests

Added `codegen does not crash on invalid structural directive` to `compile.spec.ts` covering all four crashing templates plus an assertion that the underlying `X_V_ELSE_NO_ADJACENT_IF` error is still reported. The full `compiler-core` suite passes (676 tests).

## Note

This re-implements the fix from the stalled #14955 (author inactive since June, CI was failing on e2e) on top of current `main`. The codegen change is equivalent; the regression tests are the same four cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented code generation from crashing when structural directives are invalid and compiler errors are handled without throwing.
  * The compiler now safely generates `null` for incomplete element, conditional, and loop nodes while still reporting the underlying errors.
* **Tests**
  * Added regression coverage for invalid structural directive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->