### PR TITLE
fix(v-model): re-sync select when model is overridden in change handler

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1358,7 +1358,53 @@ describe('vModel', () => {
 
     // the DOM should reflect the overridden model value, not the value the
     // user just selected
-    expect(data.value).toMatchObject(new Set(['foo']))
+    expect(Array.from(data.value)).toEqual(['foo'])
+    expect(foo.selected).toEqual(true)
+    expect(bar.selected).toEqual(false)
+  })
+
+  // #10505
+  it('single select should sync DOM when the model is overridden in the change handler', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: null as string | null }
+      },
+      render() {
+        return [
+          withVModel(
+            h(
+              'select',
+              {
+                value: null,
+                // a select that always forces its value back to 'foo'
+                'onUpdate:modelValue': () => {
+                  this.value = 'foo'
+                },
+              },
+              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
+            ),
+            this.value,
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const input = root.querySelector('select')
+    const foo = root.querySelector('option[value=foo]')
+    const bar = root.querySelector('option[value=bar]')
+    const data = root._vnode.component.data
+
+    // user picks 'bar', but the handler overrides the model back to 'foo'
+    foo.selected = false
+    bar.selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    // the DOM should reflect the overridden model value ('foo'), not the
+    // value the user just selected ('bar')
+    expect(data.value).toEqual('foo')
+    expect(input.selectedIndex).toEqual(0)
     expect(foo.selected).toEqual(true)
     expect(bar.selected).toEqual(false)
   })

--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1317,179 +1317,288 @@ describe('vModel', () => {
     expect(bar.selected).toEqual(true)
   })
 
-  // #10505
-  it('multiple select should sync DOM when the Set model is overridden in the change handler', async () => {
+  function mountSelectModel(
+    initialValue: any,
+    update: (value: any) => any,
+    multiple = false,
+    optionValues: any[] = ['foo', 'bar'],
+  ) {
     const component = defineComponent({
-      data() {
-        return { value: new Set() as Set<string> }
-      },
+      data: () => ({ value: initialValue }),
       render() {
-        return [
-          withVModel(
-            h(
-              'select',
-              {
-                value: null,
-                multiple: true,
-                // a select that always forces its value back to {'foo'}
-                'onUpdate:modelValue': () => {
-                  this.value = new Set(['foo'])
-                },
+        return withVModel(
+          h(
+            'select',
+            {
+              multiple,
+              'onUpdate:modelValue': (value: any) => {
+                this.value = update(value)
               },
-              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
-            ),
-            this.value,
+            },
+            optionValues.map(value => h('option', { value })),
           ),
-        ]
+          this.value,
+        )
       },
     })
     render(h(component), root)
+    const input = root.querySelector('select') as HTMLSelectElement
+    return { input, options: input.options, data: root._vnode.component.data }
+  }
 
-    const input = root.querySelector('select')
-    const foo = root.querySelector('option[value=foo]')
-    const bar = root.querySelector('option[value=bar]')
-    const data = root._vnode.component.data
+  function trackSelectedWrites(input: HTMLSelectElement) {
+    const selected = Object.getOwnPropertyDescriptor(
+      HTMLOptionElement.prototype,
+      'selected',
+    )!
+    let writes = 0
+    for (const option of input.options) {
+      Object.defineProperty(option, 'selected', {
+        configurable: true,
+        get: selected.get,
+        set(value) {
+          writes++
+          selected.set!.call(this, value)
+        },
+      })
+    }
+    return () => writes
+  }
 
-    // user picks 'bar', but the handler overrides the model to {'foo'}
-    foo.selected = false
+  it('should sync a multiple select when the Set model is overridden', async () => {
+    const { input, options, data } = mountSelectModel(
+      new Set<string>(),
+      () => new Set(['foo']),
+      true,
+    )
+    const foo = options[0]
+    const bar = options[1]
+
     bar.selected = true
     triggerEvent('change', input)
     await nextTick()
 
-    // the DOM should reflect the overridden model value, not the value the
-    // user just selected
     expect(Array.from(data.value)).toEqual(['foo'])
-    expect(foo.selected).toEqual(true)
-    expect(bar.selected).toEqual(false)
+    expect(foo.selected).toBe(true)
+    expect(bar.selected).toBe(false)
   })
 
-  // #10505
-  it('multiple select should sync DOM when the Set model is mutated in the change handler', async () => {
+  it('should clear a single select when a native change handler clears the model', async () => {
     const component = defineComponent({
       data() {
-        return { value: new Set(['foo']) as Set<string> }
+        return { value: null as string | null }
       },
       render() {
-        return [
-          withVModel(
-            h(
-              'select',
-              {
-                multiple: true,
-                // handler enforces "bar is never allowed" by mutating the
-                // Set it received, then assigning it
-                'onUpdate:modelValue': (v: Set<string>) => {
-                  v.delete('bar')
-                  this.value = v
-                },
+        return withVModel(
+          h(
+            'select',
+            {
+              'onUpdate:modelValue': setValue.bind(this),
+              onChange: () => {
+                this.value = null
               },
-              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
-            ),
-            this.value,
+            },
+            [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
           ),
-        ]
+          this.value,
+        )
       },
     })
     render(h(component), root)
-
-    const input = root.querySelector('select')
-    const foo = root.querySelector('option[value=foo]')
-    const bar = root.querySelector('option[value=bar]')
+    const input = root.querySelector('select') as HTMLSelectElement
     const data = root._vnode.component.data
 
-    // user picks both, handler strips 'bar' from the same Set object
+    input.options[1].selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    expect(data.value).toBe(null)
+    expect(input.selectedIndex).toBe(-1)
+  })
+
+  it('should preserve the selected option when duplicate values exist', async () => {
+    const { input, options, data } = mountSelectModel(
+      null,
+      value => value,
+      false,
+      ['foo', 'foo'],
+    )
+
+    options[1].selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    expect(data.value).toBe('foo')
+    expect(input.selectedIndex).toBe(1)
+  })
+
+  it('should resync when a multiple select becomes single during the pending update', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: [] as string[], multiple: true }
+      },
+      render() {
+        return withVModel(
+          h(
+            'select',
+            {
+              multiple: this.multiple,
+              'onUpdate:modelValue': (value: string[]) => {
+                this.value = value
+                this.multiple = false
+              },
+            },
+            [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
+          ),
+          this.value,
+        )
+      },
+    })
+    render(h(component), root)
+    const input = root.querySelector('select') as HTMLSelectElement
+    const data = root._vnode.component.data
+
+    input.options[1].selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    expect(data.value).toEqual(['bar'])
+    expect(input.multiple).toBe(false)
+    expect(input.selectedIndex).toBe(-1)
+  })
+
+  it('should snapshot an emitted Array before the change handler mutates it', async () => {
+    const { input, options, data } = mountSelectModel(
+      ['foo'],
+      (value: string[]) => {
+        value.pop()
+        return value
+      },
+      true,
+    )
+    const foo = options[0]
+    const bar = options[1]
+
+    foo.selected = true
+    bar.selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    expect(data.value).toEqual(['foo'])
+    expect(foo.selected).toBe(true)
+    expect(bar.selected).toBe(false)
+  })
+
+  it('should resync after the emitted Set is mutated in the change handler', async () => {
+    const { input, options, data } = mountSelectModel(
+      new Set(['foo']),
+      (value: Set<string>) => {
+        value.delete('bar')
+        return value
+      },
+      true,
+    )
+    const foo = options[0]
+    const bar = options[1]
+
     foo.selected = true
     bar.selected = true
     triggerEvent('change', input)
     await nextTick()
 
     expect(Array.from(data.value)).toEqual(['foo'])
-    expect(foo.selected).toEqual(true)
-    expect(bar.selected).toEqual(false)
+    expect(foo.selected).toBe(true)
+    expect(bar.selected).toBe(false)
   })
 
-  // #10505
-  it('single select should sync DOM when the model is cleared in the change handler', async () => {
-    const component = defineComponent({
-      data() {
-        return { value: 'foo' as string | null }
-      },
-      render() {
-        return [
-          withVModel(
-            h(
-              'select',
-              {
-                value: null,
-                'onUpdate:modelValue': () => {
-                  this.value = null
-                },
-              },
-              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
-            ),
-            this.value,
-          ),
-        ]
-      },
-    })
-    render(h(component), root)
+  it('should not rewrite options after assigning a Set of objects', async () => {
+    const fooValue = { id: 'foo' }
+    const barValue = { id: 'bar' }
+    const { input, options } = mountSelectModel(
+      new Set([fooValue]),
+      value => value,
+      true,
+      [fooValue, barValue],
+    )
 
-    const input = root.querySelector('select')
-    const bar = root.querySelector('option[value=bar]')
-    const data = root._vnode.component.data
-
-    bar.selected = true
+    options[0].selected = false
+    options[1].selected = true
+    const getWrites = trackSelectedWrites(input)
     triggerEvent('change', input)
     await nextTick()
 
-    expect(data.value).toEqual(null)
-    expect(input.selectedIndex).toEqual(-1)
+    expect(getWrites()).toBe(0)
   })
 
-  // #10505
-  it('single select should sync DOM when the model is overridden in the change handler', async () => {
-    const component = defineComponent({
-      data() {
-        return { value: null as string | null }
-      },
-      render() {
-        return [
-          withVModel(
-            h(
-              'select',
-              {
-                value: null,
-                // a select that always forces its value back to 'foo'
-                'onUpdate:modelValue': () => {
-                  this.value = 'foo'
-                },
-              },
-              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
-            ),
-            this.value,
-          ),
-        ]
-      },
-    })
-    render(h(component), root)
+  it('should not rewrite options after assigning an Array of objects', async () => {
+    const fooValue = { id: 'foo' }
+    const barValue = { id: 'bar' }
+    const { input, options } = mountSelectModel([], value => value, true, [
+      fooValue,
+      barValue,
+    ])
 
-    const input = root.querySelector('select')
-    const foo = root.querySelector('option[value=foo]')
-    const bar = root.querySelector('option[value=bar]')
-    const data = root._vnode.component.data
-
-    // user picks 'bar', but the handler overrides the model back to 'foo'
-    foo.selected = false
-    bar.selected = true
+    options[1].selected = true
+    const getWrites = trackSelectedWrites(input)
     triggerEvent('change', input)
     await nextTick()
 
-    // the DOM should reflect the overridden model value ('foo'), not the
-    // value the user just selected ('bar')
-    expect(data.value).toEqual('foo')
-    expect(input.selectedIndex).toEqual(0)
-    expect(foo.selected).toEqual(true)
-    expect(bar.selected).toEqual(false)
+    expect(getWrites()).toBe(0)
+  })
+
+  it('should not rewrite options for a primitive Array model', async () => {
+    const optionValues = Array.from({ length: 10 }, (_, i) => i)
+    const { input, options, data } = mountSelectModel(
+      [],
+      value => value,
+      true,
+      optionValues,
+    )
+
+    for (let i = 0; i < 5; i++) options[i].selected = true
+    const getWrites = trackSelectedWrites(input)
+    triggerEvent('change', input)
+    await nextTick()
+
+    expect(data.value).toHaveLength(5)
+    expect(getWrites()).toBe(0)
+  })
+
+  it('should clear the pending assignment when the assigner throws', async () => {
+    const error = new Error('assign failed')
+    const component = defineComponent({
+      data: () => ({ value: [] }),
+      render() {
+        return withVModel(
+          h(
+            'select',
+            {
+              multiple: true,
+              'onUpdate:modelValue': () => {
+                throw error
+              },
+            },
+            [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
+          ),
+          this.value,
+        )
+      },
+    })
+    render(h(component), root)
+    const input = root.querySelector('select') as HTMLSelectElement
+    const onError = vi.fn((event: ErrorEvent) => event.preventDefault())
+    window.addEventListener('error', onError)
+
+    try {
+      input.options[1].selected = true
+      triggerEvent('change', input)
+      await nextTick()
+
+      expect(onError).toHaveBeenCalled()
+      expect((input as any)._pendingValue).toBeUndefined()
+    } finally {
+      window.removeEventListener('error', onError)
+    }
   })
 
   it('multiple select uses current Array/Set model type', async () => {

--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1364,6 +1364,89 @@ describe('vModel', () => {
   })
 
   // #10505
+  it('multiple select should sync DOM when the Set model is mutated in the change handler', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: new Set(['foo']) as Set<string> }
+      },
+      render() {
+        return [
+          withVModel(
+            h(
+              'select',
+              {
+                multiple: true,
+                // handler enforces "bar is never allowed" by mutating the
+                // Set it received, then assigning it
+                'onUpdate:modelValue': (v: Set<string>) => {
+                  v.delete('bar')
+                  this.value = v
+                },
+              },
+              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
+            ),
+            this.value,
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const input = root.querySelector('select')
+    const foo = root.querySelector('option[value=foo]')
+    const bar = root.querySelector('option[value=bar]')
+    const data = root._vnode.component.data
+
+    // user picks both, handler strips 'bar' from the same Set object
+    foo.selected = true
+    bar.selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    expect(Array.from(data.value)).toEqual(['foo'])
+    expect(foo.selected).toEqual(true)
+    expect(bar.selected).toEqual(false)
+  })
+
+  // #10505
+  it('single select should sync DOM when the model is cleared in the change handler', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: 'foo' as string | null }
+      },
+      render() {
+        return [
+          withVModel(
+            h(
+              'select',
+              {
+                value: null,
+                'onUpdate:modelValue': () => {
+                  this.value = null
+                },
+              },
+              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
+            ),
+            this.value,
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const input = root.querySelector('select')
+    const bar = root.querySelector('option[value=bar]')
+    const data = root._vnode.component.data
+
+    bar.selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    expect(data.value).toEqual(null)
+    expect(input.selectedIndex).toEqual(-1)
+  })
+
+  // #10505
   it('single select should sync DOM when the model is overridden in the change handler', async () => {
     const component = defineComponent({
       data() {

--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1317,6 +1317,52 @@ describe('vModel', () => {
     expect(bar.selected).toEqual(true)
   })
 
+  // #10505
+  it('multiple select should sync DOM when the Set model is overridden in the change handler', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: new Set() as Set<string> }
+      },
+      render() {
+        return [
+          withVModel(
+            h(
+              'select',
+              {
+                value: null,
+                multiple: true,
+                // a select that always forces its value back to {'foo'}
+                'onUpdate:modelValue': () => {
+                  this.value = new Set(['foo'])
+                },
+              },
+              [h('option', { value: 'foo' }), h('option', { value: 'bar' })],
+            ),
+            this.value,
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const input = root.querySelector('select')
+    const foo = root.querySelector('option[value=foo]')
+    const bar = root.querySelector('option[value=bar]')
+    const data = root._vnode.component.data
+
+    // user picks 'bar', but the handler overrides the model to {'foo'}
+    foo.selected = false
+    bar.selected = true
+    triggerEvent('change', input)
+    await nextTick()
+
+    // the DOM should reflect the overridden model value, not the value the
+    // user just selected
+    expect(data.value).toMatchObject(new Set(['foo']))
+    expect(foo.selected).toEqual(true)
+    expect(bar.selected).toEqual(false)
+  })
+
   it('multiple select uses current Array/Set model type', async () => {
     const component = defineComponent({
       data() {

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -45,6 +45,7 @@ type ModelDirective<T, Modifiers extends string = string> = ObjectDirective<
     [assignKey]: AssignerFn
     [initialValueKey]?: string
     _assigning?: boolean
+    _assignedValue?: any
   },
   any,
   Modifiers
@@ -240,13 +241,16 @@ export const vModelSelect: ModelDirective<HTMLSelectElement, 'number'> = {
         .map((o: HTMLOptionElement) =>
           number ? looseToNumber(getValue(o)) : getValue(o),
         )
-      el[assignKey](
-        el.multiple
-          ? isSet((el as any)._modelValue)
-            ? new Set(selectedVal)
-            : selectedVal
-          : selectedVal[0],
-      )
+      const assignedValue = el.multiple
+        ? isSet((el as any)._modelValue)
+          ? new Set(selectedVal)
+          : selectedVal
+        : selectedVal[0]
+      el[assignKey](assignedValue)
+      // remember the value just assigned by the user interaction so that the
+      // `updated` hook can detect when the model is later overridden (e.g.
+      // reset) inside the update handler. #10505
+      ;(el as any)._assignedValue = assignedValue
       el._assigning = true
       nextTick(() => {
         el._assigning = false
@@ -264,10 +268,28 @@ export const vModelSelect: ModelDirective<HTMLSelectElement, 'number'> = {
     el[assignKey] = getModelAssigner(vnode)
   },
   updated(el, { value }) {
-    if (!el._assigning) {
+    // Skip the redundant DOM sync only when the model still holds the value
+    // produced by the user's selection. If it was overridden during the
+    // update, the DOM must be re-synced. #10505
+    if (!el._assigning || !assignedValueEquals(value, el._assignedValue)) {
       setSelected(el, value)
     }
   },
+}
+
+// Compares the current model value against the value assigned by the user's
+// selection. `looseEqual` alone would treat any two `Set` values as equal,
+// because their `Object.keys` are always empty, so Set contents are compared
+// explicitly using the same `has` semantics as `setSelected`.
+function assignedValueEquals(a: any, b: any): boolean {
+  if (isSet(a) && isSet(b)) {
+    if (a.size !== b.size) return false
+    for (const item of a) {
+      if (!b.has(item)) return false
+    }
+    return true
+  }
+  return looseEqual(a, b)
 }
 
 function setSelected(el: HTMLSelectElement, value: any) {

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -44,8 +44,7 @@ type ModelDirective<T, Modifiers extends string = string> = ObjectDirective<
   T & {
     [assignKey]: AssignerFn
     [initialValueKey]?: string
-    _assigning?: boolean
-    _assignedValue?: any
+    _pendingValue?: [multiple: boolean, value: any]
   },
   any,
   Modifiers
@@ -241,25 +240,31 @@ export const vModelSelect: ModelDirective<HTMLSelectElement, 'number'> = {
         .map((o: HTMLOptionElement) =>
           number ? looseToNumber(getValue(o)) : getValue(o),
         )
-      const assignedValue = el.multiple
+      const multiple = el.multiple
+      const assignedValue = multiple
         ? isSet((el as any)._modelValue)
           ? new Set(selectedVal)
           : selectedVal
         : selectedVal[0]
-      // remember the value assigned by the user interaction so that the
-      // `updated` hook can detect when the model is later overridden (e.g.
-      // reset) inside the update handler. Snapshot it BEFORE invoking the
-      // assigner, which may mutate the received value in place. #10505
-      ;(el as any)._assignedValue = isSet(assignedValue)
-        ? new Set(assignedValue)
-        : isArray(assignedValue)
-          ? assignedValue.slice()
-          : assignedValue
-      el[assignKey](assignedValue)
-      el._assigning = true
-      nextTick(() => {
-        el._assigning = false
-      })
+      // Array models receive selectedVal directly, so snapshot it before user
+      // code can mutate it. Set models already receive a fresh Set.
+      const pending = (el._pendingValue = [
+        multiple,
+        multiple
+          ? isArray(assignedValue)
+            ? selectedVal.slice()
+            : selectedVal
+          : assignedValue,
+      ])
+      try {
+        el[assignKey](assignedValue)
+      } finally {
+        nextTick(() => {
+          if (el._pendingValue === pending) {
+            el._pendingValue = undefined
+          }
+        })
+      }
     })
     el[assignKey] = getModelAssigner(vnode)
   },
@@ -273,28 +278,33 @@ export const vModelSelect: ModelDirective<HTMLSelectElement, 'number'> = {
     el[assignKey] = getModelAssigner(vnode)
   },
   updated(el, { value }) {
-    // Skip the redundant DOM sync only when the model still holds the value
-    // produced by the user's selection. If it was overridden during the
-    // update, the DOM must be re-synced. #10505
-    if (!el._assigning || !assignedValueEquals(value, el._assignedValue)) {
+    const pending = el._pendingValue
+    el._pendingValue = undefined
+    if (
+      !pending ||
+      pending[0] !== el.multiple ||
+      !isSameSelectValue(value, pending[1], pending[0])
+    ) {
       setSelected(el, value)
     }
   },
 }
 
-// Compares the current model value against the value assigned by the user's
-// selection. `looseEqual` alone would treat any two `Set` values as equal,
-// because their `Object.keys` are always empty, so Set contents are compared
-// explicitly using the same `has` semantics as `setSelected`.
-function assignedValueEquals(a: any, b: any): boolean {
-  if (isSet(a) && isSet(b)) {
-    if (a.size !== b.size) return false
-    for (const item of a) {
-      if (!b.has(item)) return false
+function isSameSelectValue(
+  value: any,
+  assignedValue: any,
+  multiple: boolean,
+): boolean {
+  if (!multiple) return looseEqual(value, assignedValue)
+  if (isArray(value)) return looseEqual(value, assignedValue)
+  if (isSet(value)) {
+    if (value.size !== assignedValue.length) return false
+    for (const item of assignedValue) {
+      if (!value.has(item)) return false
     }
     return true
   }
-  return looseEqual(a, b)
+  return false
 }
 
 function setSelected(el: HTMLSelectElement, value: any) {

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -246,11 +246,16 @@ export const vModelSelect: ModelDirective<HTMLSelectElement, 'number'> = {
           ? new Set(selectedVal)
           : selectedVal
         : selectedVal[0]
-      el[assignKey](assignedValue)
-      // remember the value just assigned by the user interaction so that the
+      // remember the value assigned by the user interaction so that the
       // `updated` hook can detect when the model is later overridden (e.g.
-      // reset) inside the update handler. #10505
-      ;(el as any)._assignedValue = assignedValue
+      // reset) inside the update handler. Snapshot it BEFORE invoking the
+      // assigner, which may mutate the received value in place. #10505
+      ;(el as any)._assignedValue = isSet(assignedValue)
+        ? new Set(assignedValue)
+        : isArray(assignedValue)
+          ? assignedValue.slice()
+          : assignedValue
+      el[assignKey](assignedValue)
       el._assigning = true
       nextTick(() => {
         el._assigning = false


### PR DESCRIPTION
## Problem

Closes #10505

When a `<select v-model>` has a change handler (or watcher) that reassigns the model to a value different from the option the user just selected, the select's DOM state is left out of sync with the model.

This picks up the stalled #14960 (author inactive since June) and addresses @edison1105's review feedback: `looseEqual` does not compare `Set` contents, so for a `multiple <select v-model>` with a `Set` model, two different Sets fall through the generic object path (both have empty `Object.keys`) and are treated as equal. `setSelected` was skipped, leaving the model as `Set(['foo'])` while the DOM still reflected the user-selected `bar`.

## Solution

1. Remember the value assigned by the user interaction in `el._assignedValue` (the change handler already computed it).
2. In the `updated` hook, skip the redundant DOM sync only when the model still matches the assigned value, using a comparison that handles `Set` explicitly:

```ts
function assignedValueEquals(a: any, b: any): boolean {
  if (isSet(a) && isSet(b)) {
    if (a.size !== b.size) return false
    for (const item of a) {
      if (!b.has(item)) return false
    }
    return true
  }
  return looseEqual(a, b)
}
```

The `Set` comparison uses the same `has` semantics as `setSelected`'s option matching.

## Tests

Added `multiple select should sync DOM when the Set model is overridden in the change handler` to `vModel.spec.ts`:

- multiple select with a `Set` model, handler forces the model back to `{foo}` when the user picks `bar`
- asserts the DOM re-syncs to `foo` after `nextTick`

Verified the test fails against the old `_assigning`-only guard and passes with the fix. Full `runtime-dom` suite passes (242 tests), lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed single- and multiple-select `v-model` behavior when change handlers override or mutate selected values.
  * Improved synchronization when clearing selections, changing selection modes, or updating options.
  * Preserved correct behavior for mutable option values and array or `Set` models.
  * Prevented unnecessary option updates when the displayed selection already matches the model.
  * Ensured selection state recovers correctly when model updates encounter errors.

* **Tests**
  * Added regression coverage for selection overrides, mutations, option changes, and model synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->