### PR TITLE
fix(runtime-vapor): preserve nested vdom slot content (fix #15303)

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -1311,6 +1311,47 @@ describe('Transition', () => {
     expect(onLeave).not.toHaveBeenCalled()
   })
 
+  test('preserves multi-element vdom slot content nested under transition root', () => {
+    const data = ref({})
+    const Child = compile(
+      `<script setup vapor>
+        defineProps({ show: Boolean })
+      </script>
+      <template>
+        <Transition>
+          <div v-if="show" class="with-transition">
+            <slot />
+          </div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<script setup>
+        const Child = _components.Child
+      </script>
+      <template>
+        <Child :show="true">
+          <button class="first">First</button>
+          <button class="last">Last</button>
+        </Child>
+      </template>`,
+      data,
+      { Child },
+      { vapor: false },
+    )
+    const { host } = defineInterop(App as any).render()
+
+    expect(
+      '<transition> can only be used on a single element or component',
+    ).not.toHaveBeenWarned()
+    expect(
+      Array.from(host.querySelectorAll('.with-transition > button')).map(
+        el => el.textContent,
+      ),
+    ).toEqual(['First', 'Last'])
+  })
+
   test('vdom slot content should participate in transitions', async () => {
     let enterDone: (() => void) | undefined
     let leaveDone: (() => void) | undefined

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -13348,6 +13348,38 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate direct v-once VDOM slot content inside Vapor Transition', async () => {
+    const { container } = await testWithVDOMApp(
+      `<script setup>
+        const components = _components
+      </script>
+      <template>
+        <components.VaporChild>
+          <button>content</button>
+        </components.VaporChild>
+      </template>`,
+      {
+        VaporChild: {
+          code: `<template>
+            <Transition>
+              <slot v-once />
+            </Transition>
+            <span id="after">after</span>
+          </template>`,
+          vapor: true,
+        },
+      },
+    )
+
+    expect(
+      '<transition> can only be used on a single element or component',
+    ).not.toHaveBeenWarned()
+    expect(container.querySelector('button')?.textContent).toBe('content')
+    expect(container.querySelector('#after')?.previousElementSibling).toBe(
+      container.querySelector('button'),
+    )
+  })
+
   test('hydrate Vapor Transition fallback in out-in mode', async () => {
     let leaveDone: (() => void) | undefined
     const onLeave = vi.fn((_el: Element, done: () => void) => {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -208,6 +208,7 @@ function isVaporTransitionHooks(
 function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
+  isDirectSlotRoot: boolean,
   previous: VNode | undefined,
   resumeAfterLeave: () => void,
   delayedLeaveSource?: TransitionHooks,
@@ -225,10 +226,15 @@ function prepareInteropSlotTransition(
   if (transition && transition.applyGroup) return
 
   // The slot can render before VaporTransition propagates its hooks, notably
-  // during hydration, but it must already use BaseTransition's branch shape.
+  // during hydration, but a direct slot root must already use
+  // BaseTransition's branch shape.
   if (
     !transition &&
-    !(instance && isVaporTransition(instance.type as VaporComponent))
+    !(
+      isDirectSlotRoot &&
+      instance &&
+      isVaporTransition(instance.type as VaporComponent)
+    )
   ) {
     return
   }
@@ -1562,6 +1568,7 @@ function renderVDOMSlot(
 ): VaporFragment {
   let suspense = currentParentSuspense || parentComponent.suspense
   const frag = createInteropFragment()
+  const isDirectSlotRoot = !!(slotRoot || sharedFallback || inheritFallback)
   // `isBlockValid` below reports VDOM-side validity (`contentState.valid`), not
   // `isValidBlock(frag.nodes)`: `frag.nodes` tracks the active fallback when one
   // is shown. (Optimism rationale: see createVNodeFragment.)
@@ -1814,8 +1821,13 @@ function renderVDOMSlot(
       const content = pending.content
       if (isVNode(content)) {
         const nextVNode =
-          prepareInteropSlotTransition(frag, content, undefined, NOOP) ||
-          content
+          prepareInteropSlotTransition(
+            frag,
+            content,
+            isDirectSlotRoot,
+            undefined,
+            NOOP,
+          ) || content
         patchSlotVNode(
           pending.placeholder,
           nextVNode,
@@ -1987,6 +1999,7 @@ function renderVDOMSlot(
                 const transitionChild = prepareInteropSlotTransition(
                   frag,
                   hydratedContent,
+                  isDirectSlotRoot,
                   undefined,
                   NOOP,
                 )
@@ -2201,6 +2214,7 @@ function renderVDOMSlot(
                     prepareInteropSlotTransition(
                       frag,
                       slotContent,
+                      isDirectSlotRoot,
                       undefined,
                       NOOP,
                     ) || createCommentVNode()
@@ -2249,6 +2263,7 @@ function renderVDOMSlot(
               const transitionChild = prepareInteropSlotTransition(
                 frag,
                 slotContent,
+                isDirectSlotRoot,
                 prevVNode || undefined,
                 resumeOutIn,
                 delayedLeaveSource,


### PR DESCRIPTION
## Summary

- avoid treating VDOM slot outlets nested below a Vapor `<Transition>` root as direct transition children before hooks are propagated
- use existing compiler root-exposure metadata, including the fallback ownership flags retained by `v-once`, so direct slot children keep transition branch selection during hydration
- add regression coverage with a compiled Vapor child consumed by a compiled VDOM parent

This is limited to the Vapor/VDOM interop path.

## Test plan

- `pnpm exec vp test packages/runtime-vapor/__tests__/components/Transition.spec.ts packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts packages/runtime-vapor/__tests__/vdomInterop.spec.ts --run`
- `pnpm exec vp test packages/runtime-vapor/__tests__/hydration.spec.ts -t 'slot content inside Vapor Transition' --run`
- `pnpm run check`
- `pnpm exec vp lint packages/runtime-vapor/src/vdomInterop.ts packages/runtime-vapor/__tests__/components/Transition.spec.ts packages/runtime-vapor/__tests__/hydration.spec.ts`
- `pnpm exec vp fmt --check packages/runtime-vapor/src/vdomInterop.ts packages/runtime-vapor/__tests__/components/Transition.spec.ts packages/runtime-vapor/__tests__/hydration.spec.ts`

Fixes #15303