### PR TITLE
fix(compiler-core): report ambiguous setup template references

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -127,6 +127,131 @@ describe('compiler: element transform', () => {
     expect(node.tag).toBe(`Example`)
   })
 
+  test('error on ambiguous setup binding component reference during hmr', () => {
+    const onError = vi.fn()
+    const onWarn = vi.fn()
+    const { root, node } = parseWithElementTransform(`<popup-status/>`, {
+      bindingMetadata: {
+        popupStatus: BindingTypes.SETUP_CONST,
+        PopupStatus: BindingTypes.SETUP_MAYBE_REF,
+      },
+      isNativeTag: tag => tag === 'div',
+      hmr: true,
+      onError,
+      onWarn,
+    })
+
+    expect(root.helpers).not.toContain(RESOLVE_COMPONENT)
+    expect(node.tag).toBe(`$setup["popupStatus"]`)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      code: ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT,
+    })
+    expect(onError.mock.calls[0][0].message).toContain(
+      `Component tag <popup-status> matches multiple script setup bindings: "popupStatus", "PopupStatus".`,
+    )
+    expect(onWarn).not.toHaveBeenCalled()
+  })
+
+  test('warn on ambiguous setup binding component reference during build', () => {
+    const onError = vi.fn()
+    const onWarn = vi.fn()
+    const { root, node } = parseWithElementTransform(`<popup-status/>`, {
+      bindingMetadata: {
+        popupStatus: BindingTypes.SETUP_CONST,
+        PopupStatus: BindingTypes.SETUP_MAYBE_REF,
+      },
+      isNativeTag: tag => tag === 'div',
+      onError,
+      onWarn,
+    })
+
+    expect(root.helpers).not.toContain(RESOLVE_COMPONENT)
+    expect(node.tag).toBe(`$setup["popupStatus"]`)
+    expect(onError).not.toHaveBeenCalled()
+    expect(onWarn).toHaveBeenCalledTimes(1)
+    expect(onWarn.mock.calls[0][0]).toMatchObject({
+      code: ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT,
+    })
+    expect(onWarn.mock.calls[0][0].message).toContain(
+      `Component tag <popup-status> matches multiple script setup bindings: "popupStatus", "PopupStatus".`,
+    )
+  })
+
+  test('includes kebab-case setup binding names in component ambiguity check', () => {
+    const onError = vi.fn()
+    const onWarn = vi.fn()
+    const { root, node } = parseWithElementTransform(`<popup-status/>`, {
+      bindingMetadata: {
+        'popup-status': BindingTypes.PROPS,
+        popupStatus: BindingTypes.SETUP_CONST,
+        PopupStatus: BindingTypes.SETUP_MAYBE_REF,
+      },
+      isNativeTag: tag => tag === 'div',
+      onError,
+      onWarn,
+    })
+
+    expect(root.helpers).not.toContain(RESOLVE_COMPONENT)
+    expect(node.tag).toBe(`$setup["popupStatus"]`)
+    expect(onError).not.toHaveBeenCalled()
+    expect(onWarn).toHaveBeenCalledTimes(1)
+    expect(onWarn.mock.calls[0][0]).toMatchObject({
+      code: ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT,
+    })
+    expect(onWarn.mock.calls[0][0].message).toContain(
+      `Component tag <popup-status> matches multiple script setup bindings: "popup-status", "popupStatus", "PopupStatus".`,
+    )
+  })
+
+  test('do not warn on PascalCase setup binding component reference', () => {
+    const onError = vi.fn()
+    const onWarn = vi.fn()
+    const { root, node } = parseWithElementTransform(`<PopupStatus/>`, {
+      bindingMetadata: {
+        popupStatus: BindingTypes.SETUP_CONST,
+        PopupStatus: BindingTypes.SETUP_MAYBE_REF,
+      },
+      isNativeTag: tag => tag === 'div',
+      hmr: true,
+      onError,
+      onWarn,
+    })
+
+    expect(root.helpers).not.toContain(RESOLVE_COMPONENT)
+    expect(node.tag).toBe(`$setup["PopupStatus"]`)
+    expect(onError).not.toHaveBeenCalled()
+    expect(onWarn).not.toHaveBeenCalled()
+  })
+
+  test('error on ambiguous setup binding directive reference during hmr', () => {
+    const onError = vi.fn()
+    const onWarn = vi.fn()
+    const { root, node } = parseWithElementTransform(`<div v-popup-status/>`, {
+      bindingMetadata: {
+        vPopupStatus: BindingTypes.SETUP_CONST,
+        VPopupStatus: BindingTypes.SETUP_MAYBE_REF,
+      },
+      hmr: true,
+      onError,
+      onWarn,
+    })
+
+    expect(root.helpers).not.toContain(RESOLVE_DIRECTIVE)
+    expect(root.directives.length).toBe(0)
+    expect(node.directives!.elements[0].elements[0]).toBe(
+      `$setup["vPopupStatus"]`,
+    )
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      code: ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT,
+    })
+    expect(onError.mock.calls[0][0].message).toContain(
+      `Custom directive v-popup-status matches multiple script setup bindings: "vPopupStatus", "VPopupStatus".`,
+    )
+    expect(onWarn).not.toHaveBeenCalled()
+  })
+
   test('resolve namespaced component from setup bindings', () => {
     const { root, node } = parseWithElementTransform(`<Foo.Example/>`, {
       bindingMetadata: {

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -102,6 +102,7 @@ export enum ErrorCodes {
   // placed here to preserve order for the current minor
   // TODO adjust order in 3.5
   X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
+  X_SETUP_TEMPLATE_REFERENCE_CONFLICT,
 
   // Special value for higher-order compilers to pick up the last code
   // to avoid collision of error codes. This should always be kept as the last
@@ -181,6 +182,7 @@ export const errorMessages: Record<ErrorCodes, string> = {
   [ErrorCodes.X_INVALID_EXPRESSION]: `Error parsing JavaScript expression: `,
   [ErrorCodes.X_KEEP_ALIVE_INVALID_CHILDREN]: `<KeepAlive> expects exactly one child component.`,
   [ErrorCodes.X_VNODE_HOOKS]: `@vnode-* hooks in templates are no longer supported. Use the vue: prefix instead. For example, @vnode-mounted should be changed to @vue:mounted. @vnode-* hooks support has been removed in 3.4.`,
+  [ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT]: `Ambiguous template reference in <script setup>.`,
 
   // generic errors
   [ErrorCodes.X_PREFIX_ID_NOT_SUPPORTED]: `"prefixIdentifiers" option is not supported in this build of compiler.`,

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -13,6 +13,7 @@ import {
   NodeTypes,
   type ObjectExpression,
   type Property,
+  type SourceLocation,
   type TemplateTextChildNode,
   type VNodeCall,
   createArrayExpression,
@@ -296,13 +297,21 @@ export function resolveComponentType(
   // this is skipped in browser build since browser builds do not perform
   // binding analysis.
   if (!__BROWSER__) {
-    const fromSetup = resolveSetupReference(tag, context)
+    const fromSetup = resolveSetupReference(tag, context, {
+      type: 'component',
+      name: tag,
+      loc: node.loc,
+    })
     if (fromSetup) {
       return fromSetup
     }
     const dotIndex = tag.indexOf('.')
     if (dotIndex > 0) {
-      const ns = resolveSetupReference(tag.slice(0, dotIndex), context)
+      const ns = resolveSetupReference(tag.slice(0, dotIndex), context, {
+        type: 'component',
+        name: tag,
+        loc: node.loc,
+      })
       if (ns) {
         return ns + tag.slice(dotIndex)
       }
@@ -329,7 +338,33 @@ export function resolveComponentType(
   return toValidAssetId(tag, `component`)
 }
 
-function resolveSetupReference(name: string, context: TransformContext) {
+type SetupTemplateReference = {
+  type: 'component' | 'directive'
+  name: string
+  loc: SourceLocation
+}
+
+function describeSetupTemplateReference(reference: SetupTemplateReference) {
+  if (reference.type === 'component') {
+    return `Component tag <${reference.name}>`
+  }
+  return `Custom directive ${reference.name}`
+}
+
+function getSetupTemplateReferenceSuggestion(
+  reference: SetupTemplateReference,
+) {
+  if (reference.type === 'component') {
+    return `Rename one of the bindings or use an unambiguous component tag.`
+  }
+  return `Rename one of the bindings or use an unambiguous directive name.`
+}
+
+function resolveSetupReference(
+  name: string,
+  context: TransformContext,
+  reference: SetupTemplateReference,
+) {
   const bindings = context.bindingMetadata
   if (!bindings || bindings.__isScriptSetup === false) {
     return
@@ -337,6 +372,31 @@ function resolveSetupReference(name: string, context: TransformContext) {
 
   const camelName = camelize(name)
   const PascalName = capitalize(camelName)
+  const candidateNames = [...new Set([name, camelName, PascalName])]
+  const matchingNames = candidateNames.filter(candidate =>
+    canResolveSetupReference(bindings[candidate]),
+  )
+  const emitIfAmbiguous = (resolved: string) => {
+    if (matchingNames.length <= 1) {
+      return
+    }
+    const error = createCompilerError(
+      ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT,
+      reference.loc,
+      undefined,
+      ` ${describeSetupTemplateReference(
+        reference,
+      )} matches multiple script setup bindings: ` +
+        `${matchingNames.map(name => JSON.stringify(name)).join(', ')}. ` +
+        `It currently resolves to ${JSON.stringify(resolved)}. ` +
+        getSetupTemplateReferenceSuggestion(reference),
+    )
+    if (context.hmr) {
+      context.onError(error)
+    } else {
+      context.onWarn(error)
+    }
+  }
   const checkType = (type: BindingTypes) => {
     if (bindings[name] === type) {
       return name
@@ -354,6 +414,7 @@ function resolveSetupReference(name: string, context: TransformContext) {
     checkType(BindingTypes.SETUP_REACTIVE_CONST) ||
     checkType(BindingTypes.LITERAL_CONST)
   if (fromConst) {
+    emitIfAmbiguous(fromConst)
     return context.inline
       ? // in inline mode, const setup bindings (e.g. imports) can be used as-is
         fromConst
@@ -365,6 +426,7 @@ function resolveSetupReference(name: string, context: TransformContext) {
     checkType(BindingTypes.SETUP_REF) ||
     checkType(BindingTypes.SETUP_MAYBE_REF)
   if (fromMaybeRef) {
+    emitIfAmbiguous(fromMaybeRef)
     return context.inline
       ? // setup scope bindings that may be refs need to be unrefed
         `${context.helperString(UNREF)}(${fromMaybeRef})`
@@ -373,10 +435,23 @@ function resolveSetupReference(name: string, context: TransformContext) {
 
   const fromProps = checkType(BindingTypes.PROPS)
   if (fromProps) {
+    emitIfAmbiguous(fromProps)
     return `${context.helperString(UNREF)}(${
       context.inline ? '__props' : '$props'
     }[${JSON.stringify(fromProps)}])`
   }
+}
+
+function canResolveSetupReference(type: BindingTypes | undefined): boolean {
+  return (
+    type === BindingTypes.SETUP_CONST ||
+    type === BindingTypes.SETUP_REACTIVE_CONST ||
+    type === BindingTypes.LITERAL_CONST ||
+    type === BindingTypes.SETUP_LET ||
+    type === BindingTypes.SETUP_REF ||
+    type === BindingTypes.SETUP_MAYBE_REF ||
+    type === BindingTypes.PROPS
+  )
 }
 
 export type PropsExpression = ObjectExpression | CallExpression | ExpressionNode
@@ -912,8 +987,14 @@ export function buildDirectiveArgs(
   } else {
     // user directive.
     // see if we have directives exposed via <script setup>
+    const directiveName = 'v-' + dir.name
     const fromSetup =
-      !__BROWSER__ && resolveSetupReference('v-' + dir.name, context)
+      !__BROWSER__ &&
+      resolveSetupReference(directiveName, context, {
+        type: 'directive',
+        name: directiveName,
+        loc: dir.loc,
+      })
     if (fromSetup) {
       dirArgs.push(fromSetup)
     } else {

--- a/packages/compiler-dom/src/errors.ts
+++ b/packages/compiler-dom/src/errors.ts
@@ -21,7 +21,7 @@ export function createDOMCompilerError(
 }
 
 export enum DOMErrorCodes {
-  X_V_HTML_NO_EXPRESSION = 54 /* ErrorCodes.__EXTEND_POINT__ */,
+  X_V_HTML_NO_EXPRESSION = 55 /* ErrorCodes.__EXTEND_POINT__ */,
   X_V_HTML_WITH_CHILDREN,
   X_V_TEXT_NO_EXPRESSION,
   X_V_TEXT_WITH_CHILDREN,

--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -4,6 +4,7 @@ import {
   type SFCTemplateCompileOptions,
   compileTemplate,
 } from '../src/compileTemplate'
+import { BindingTypes, ErrorCodes } from '@vue/compiler-core'
 import { type SFCTemplateBlock, parse } from '../src/parse'
 import { compileScript } from '../src'
 import { getPositionInCode } from './utils'
@@ -24,6 +25,51 @@ test('should work', () => {
   expect(result.source).toBe(source)
   // should expose render fn
   expect(result.code).toMatch(`export function render(`)
+})
+
+test('error ambiguous script setup component reference in dev', () => {
+  const result = compile({
+    filename: 'example.vue',
+    source: `<popup-status/>`,
+    compilerOptions: {
+      bindingMetadata: {
+        popupStatus: BindingTypes.SETUP_CONST,
+        PopupStatus: BindingTypes.SETUP_MAYBE_REF,
+      },
+    },
+  })
+
+  expect(result.errors.length).toBe(1)
+  expect(result.errors[0]).toMatchObject({
+    code: ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT,
+  })
+  expect((result.errors[0] as SyntaxError).message).toContain(
+    `Component tag <popup-status> matches multiple script setup bindings: "popupStatus", "PopupStatus".`,
+  )
+  expect(result.tips.length).toBe(0)
+  expect(result.code).toContain(`_createBlock($setup["popupStatus"])`)
+})
+
+test('warn ambiguous script setup directive reference in production', () => {
+  const result = compile({
+    filename: 'example.vue',
+    source: `<div v-popup-status/>`,
+    isProd: true,
+    compilerOptions: {
+      bindingMetadata: {
+        vPopupStatus: BindingTypes.SETUP_CONST,
+        VPopupStatus: BindingTypes.SETUP_MAYBE_REF,
+      },
+    },
+  })
+
+  expect(result.errors.length).toBe(0)
+  expect(result.tips.length).toBe(1)
+  expect(result.tips[0]).toContain(
+    `Custom directive v-popup-status matches multiple script setup bindings: "vPopupStatus", "VPopupStatus".`,
+  )
+  expect(result.code).toContain(`_withDirectives`)
+  expect(result.code).toContain(`$setup["vPopupStatus"]`)
 })
 
 // #6807

--- a/packages/compiler-ssr/src/errors.ts
+++ b/packages/compiler-ssr/src/errors.ts
@@ -17,7 +17,7 @@ export function createSSRCompilerError(
 }
 
 export enum SSRErrorCodes {
-  X_SSR_UNSAFE_ATTR_NAME = 65 /* DOMErrorCodes.__EXTEND_POINT__ */,
+  X_SSR_UNSAFE_ATTR_NAME = 66 /* DOMErrorCodes.__EXTEND_POINT__ */,
   X_SSR_NO_TELEPORT_TARGET,
   X_SSR_INVALID_AST_NODE,
 }


### PR DESCRIPTION
## Summary

This PR reports ambiguous `<script setup>` template references when a template name resolves to more than one setup binding after Vue's existing name normalization.

It does **not** change the existing resolution order or generated render code. Instead, it keeps the current result and adds a diagnostic so users can see that the template reference is ambiguous.

Refs #9303 and #11437.

## Problem

`<script setup>` exposes top-level bindings to the template. Component imports, local variables, functions, props bindings, and local directives can all participate in template reference resolution.

For component tags, `resolveSetupReference()` currently checks these normalized candidates:

```vue
<template>
  <popup-status :message="popupStatus.message" />
</template>

<script setup>
import { PopupStatus } from './components'

const popupStatus = {
  message: 'Saved',
}
</script>
```

For `<popup-status>`, the setup binding candidates are:

```text
popup-status -> popupStatus -> PopupStatus
```

With current behavior, the tag resolves to `popupStatus`, so the generated code uses the local state object as the component type:

```js
_createBlock($setup["popupStatus"], {
  message: $setup.popupStatus.message
})
```

This is technically consistent with the existing compiler resolution rules, but it is very likely not what the user intended. In dev, the user usually only sees a runtime warning such as `Component is missing template or render function`; in production, this can look like a component silently disappearing.

The same ambiguity exists for local custom directives because `buildDirectiveArgs()` also resolves `v-` + directive name through `resolveSetupReference()`:

```vue
<template>
  <input v-popup-status />
</template>

<script setup>
import { VPopupStatus } from './directives'

const vPopupStatus = {
  mounted() {},
}
</script>
```

For `v-popup-status`, the candidates are:

```text
v-popup-status -> vPopupStatus -> VPopupStatus
```

## Changes

This PR adds a compiler diagnostic for this ambiguous setup-template-reference case:

- Adds `ErrorCodes.X_SETUP_TEMPLATE_REFERENCE_CONFLICT`.
- Extends `resolveSetupReference()` with reference context for better diagnostics:
  - `component` references report `Component tag <...>`.
  - `directive` references report `Custom directive ...`.
  - `loc` points to the template tag/directive location.
- Detects ambiguity by collecting all matching `raw / camelCase / PascalCase` candidates that can be resolved by `resolveSetupReference()`.
- Keeps the current codegen selection exactly as before.
- Reports as a compiler error when `context.hmr` is true.
- Reports as a compiler warning when `context.hmr` is false.
- Updates DOM and SSR compiler error-code offsets after adding a core compiler error code.

Example dev diagnostic:

```text
Ambiguous template reference in <script setup>. Component tag <popup-status> matches multiple script setup bindings: "popupStatus", "PopupStatus". It currently resolves to "popupStatus". Rename one of the bindings or use an unambiguous component tag.
```

Example directive diagnostic:

```text
Ambiguous template reference in <script setup>. Custom directive v-popup-status matches multiple script setup bindings: "vPopupStatus", "VPopupStatus". It currently resolves to "vPopupStatus". Rename one of the bindings or use an unambiguous directive name.
```

## Why this does not change resolution

There have already been two related implementation directions:

- #11438 changes the candidate order from `raw -> camelCase -> PascalCase` to `raw -> PascalCase -> camelCase`.
- #13624 adds `knownComponents` metadata and prioritizes candidates that look like component imports.

Both approaches can change the generated render code.

Changing the casing order fixes one direction of the conflict, but it creates the reverse problem. For example, if the component import is lower camel case and the local function is PascalCase, prioritizing PascalCase would choose the wrong binding.

The `knownComponents` direction is closer to the real question, but it still relies on import-shape heuristics. In #13624, `compileScript()` marks these imports as known components:

```ts
imported === '*' ||
(imported === 'default' && source.endsWith('.vue')) ||
source === 'vue'
```

That helps for a direct default `.vue` import:

```ts
import PopupStatus from './PopupStatus.vue'
```

It does not cover common barrel imports:

```ts
import { PopupStatus } from './components'
```

It also requires the extra metadata to be propagated through template compilation paths. For example, non-inline `compileTemplate()` callers that only pass `bindingMetadata` would not benefit unless they also pass the new option. This can make inline and non-inline compilation behave differently.

This PR avoids those compatibility and propagation problems by making the ambiguity visible without guessing which binding is the "real" component and without changing the generated code.

## Dev error, production warning

A warning is easy to miss in dev console or build output, especially because the runtime symptom can be misleading. The compiler has enough context to produce a much more precise message: the original template reference, all matching setup bindings, and the binding currently selected by the existing rules.

This PR reports the ambiguity through `onError()` when `context.hmr` is true. In `@vue/compiler-sfc`, `compileTemplate()` already sets:

```ts
hmr: !isProd
```

That means dev template compilation receives an error, which existing integrations such as Vite, Nuxt, and vue-loader can surface through their normal compiler-error path / browser overlay.

When `context.hmr` is false, the diagnostic goes through `onWarn()` and keeps the current render output. This avoids turning existing production builds into hard failures.

If `hmr` is considered too broad as a severity signal, I am happy to adjust this to a more explicit compiler option.

## Scope

Covered:

- Component tags resolved from `<script setup>` bindings.
- Namespaced component roots, because they also go through `resolveSetupReference()`.
- Local custom directives resolved from `<script setup>` bindings.
- Raw, camelCase, and PascalCase candidates, matching existing Vue normalization.
- `SETUP_CONST`, `SETUP_REACTIVE_CONST`, `LITERAL_CONST`, `SETUP_LET`, `SETUP_REF`, `SETUP_MAYBE_REF`, and `PROPS`, matching the binding types that `resolveSetupReference()` can return.

Not covered:

- Static event names such as `@save-user`.
- Props / attrs / `v-model` arguments.
- Slot names.
- Template ref string keys.
- Dynamic component expressions.
- Runtime warning changes.

Those cases follow different compiler paths and do not share the same `resolveSetupReference()` candidate lookup.

## Tests

Added compiler-core coverage for:

- Dev/HMR component ambiguity reports `X_SETUP_TEMPLATE_REFERENCE_CONFLICT` through `onError()`.
- Build/non-HMR component ambiguity reports the same diagnostic through `onWarn()`.
- Raw kebab-case candidates are included in ambiguity detection.
- PascalCase component tags remain unambiguous when only the PascalCase binding matches.
- Local custom directive ambiguity reports through `onError()` in HMR.

Added compiler-sfc coverage for:

- Dev `compileTemplate()` returns the ambiguity in `errors`.
- Production `compileTemplate({ isProd: true })` returns the ambiguity in `tips`.

Validated locally with:

```sh
pnpm exec vitest run --project unit packages/compiler-core/__tests__/transforms/transformElement.spec.ts packages/compiler-sfc/__tests__/compileTemplate.spec.ts
pnpm exec prettier --check packages/compiler-core/src/errors.ts packages/compiler-core/src/transforms/transformElement.ts packages/compiler-core/__tests__/transforms/transformElement.spec.ts packages/compiler-sfc/__tests__/compileTemplate.spec.ts packages/compiler-dom/src/errors.ts packages/compiler-ssr/src/errors.ts
pnpm exec eslint packages/compiler-core/src/errors.ts packages/compiler-core/src/transforms/transformElement.ts packages/compiler-core/__tests__/transforms/transformElement.spec.ts packages/compiler-sfc/__tests__/compileTemplate.spec.ts packages/compiler-dom/src/errors.ts packages/compiler-ssr/src/errors.ts
git diff --check
```

## Additional context

I wrote a detailed investigation with the original real-world failure, generated render output, related eslint-plugin-vue rule boundaries, and the comparison with #11438 / #13624:

- [Chinese blog post] Vue `<script setup>` 中组件静默消失的原因：一次命名冲突排查: https://shengsheng.fun/2026/05/26/vue-script-setup-component-name-conflict/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of ambiguous component and custom-directive references in `<script setup>`, including references that differ only by casing.
  - HMR now reports clear compiler errors for ambiguous references.
  - Production builds provide warnings or tips while preserving the selected binding.
  - Kebab-case and PascalCase references now resolve more consistently.
- **Tests**
  - Added coverage for ambiguity detection, diagnostics, and generated component/directive resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->