### PR TITLE
fix(runtime-vapor): reconcile root bindings with fallthrough attrs

### DIFF
--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1733,32 +1733,18 @@ describe('attribute fallthrough', () => {
     expect(host.innerHTML).toBe('<div>class prop = DROPPED</div>')
   })
 
-  it('should apply attrs added after an initially empty v-bind', async () => {
-    const attrs = ref<Record<string, string>>({})
-    const Child = compile(`<template><div id="child" /></template>`, ref(null))
-    const App = compile(
-      `<template><components.Child v-bind="data" /></template>`,
-      attrs,
-      { Child },
-    )
-
-    const { host } = define(App).render()
-    expect(host.innerHTML).toBe('<div id="child"></div>')
-
-    attrs.value = { id: 'parent' }
-    await nextTick()
-    expect(host.innerHTML).toBe('<div id="parent"></div>')
-  })
-
-  it('should restore the latest local value after an attr is removed', async () => {
+  it('should reconcile dynamic local and fallthrough attrs', async () => {
     const title = ref('child')
-    const attrs = ref<Record<string, string>>({
-      id: 'parent',
-      title: 'parent',
-      dir: 'rtl',
-    })
+    const attrs = ref<Record<string, any>>({})
     const Child = compile(
-      `<template><div id="child" :title="data" /></template>`,
+      `<template>
+        <div
+          id="child"
+          class="child"
+          style="color: red"
+          :title="data"
+        />
+      </template>`,
       title,
     )
     const App = compile(
@@ -1768,89 +1754,81 @@ describe('attribute fallthrough', () => {
     )
 
     const { host } = define(App).render()
-    expect(host.innerHTML).toBe(
-      '<div id="parent" title="parent" dir="rtl"></div>',
-    )
+    const el = host.firstElementChild as HTMLElement
+    expect(el.id).toBe('child')
+    expect(el.title).toBe('child')
+    expect(el.className).toBe('child')
+    expect(el.style.color).toBe('red')
+
+    attrs.value = {
+      id: 'parent',
+      title: 'parent',
+      class: 'child parent',
+      style: { color: 'blue' },
+    }
+    await nextTick()
+    expect(el.id).toBe('parent')
+    expect(el.title).toBe('parent')
 
     title.value = 'child-next'
     await nextTick()
-    expect(host.innerHTML).toBe(
-      '<div id="parent" title="parent" dir="rtl"></div>',
-    )
+    expect(el.title).toBe('parent')
 
     attrs.value = {}
     await nextTick()
-    expect(host.innerHTML).toBe('<div id="child" title="child-next"></div>')
+    expect(el.hasAttribute('id')).toBe(false)
+    expect(el.title).toBe('child-next')
+    expect(el.className).toBe('')
+    expect(el.style.color).toBe('')
   })
 
-  it('should apply local and fallthrough dynamic listeners', async () => {
-    const child = vi.fn()
-    const parent = vi.fn()
-    const parentListener = ref<any>(parent)
-    const Child = compile(
-      `<template><button v-bind="data" /></template>`,
-      ref({ onClick: child }),
-    )
+  it('should discard a local v-bind source removed while shadowed', async () => {
+    const local = ref<Record<string, string>>({ title: 'child' })
+    const attrs = ref<Record<string, string>>({ title: 'parent' })
+    const Child = compile(`<template><div v-bind="data" /></template>`, local)
     const App = compile(
-      `<template><components.Child :onClick="data" /></template>`,
-      parentListener,
+      `<template><components.Child v-bind="data" /></template>`,
+      attrs,
       { Child },
     )
 
     const { host } = define(App).render()
-    ;(host.firstElementChild as HTMLButtonElement).click()
-    expect(child).toHaveBeenCalledTimes(1)
-    expect(parent).toHaveBeenCalledTimes(1)
+    const el = host.firstElementChild as HTMLElement
+    expect(el.title).toBe('parent')
 
-    parentListener.value = undefined
+    local.value = {}
     await nextTick()
-    ;(host.firstElementChild as HTMLButtonElement).click()
-    expect(child).toHaveBeenCalledTimes(2)
-    expect(parent).toHaveBeenCalledTimes(1)
+    expect(el.title).toBe('parent')
+
+    attrs.value = {}
+    await nextTick()
+    expect(el.hasAttribute('title')).toBe(false)
   })
 
-  it('should preserve local listeners when $attrs is merged during render', () => {
-    const child = vi.fn()
-    const parent = vi.fn()
-    const Child = defineVaporComponent({
-      setup(_, { attrs }) {
-        const el = template('<button></button>', 1)() as Element
-        renderEffect(() => setDynamicProps(el, [{ onClick: child }, attrs]))
-        return el
-      },
-    })
-    const App = defineVaporComponent({
-      setup() {
-        return createComponent(Child, { onClick: () => parent })
-      },
-    })
-
-    const { host } = define(App).render()
-    ;(host.firstElementChild as HTMLButtonElement).click()
-
-    expect(child).toHaveBeenCalledTimes(1)
-    expect(parent).toHaveBeenCalledTimes(1)
-  })
-
-  it('should preserve listener order after a local listener update', async () => {
+  it('should merge and update local and fallthrough listeners', async () => {
     const calls: string[] = []
     const local = ref<{ onClick: (event: Event) => void }>({
-      onClick: () => {
-        calls.push('initial')
-      },
+      onClick: () => calls.push('local'),
     })
-    const parent = vi.fn(() => calls.push('parent'))
+    const parent = ref<((event: Event) => void) | undefined>(() =>
+      calls.push('parent'),
+    )
     const Child = compile(
       `<template><button v-bind="data" /></template>`,
       local,
     )
     const App = compile(
       `<template><components.Child :onClick="data" /></template>`,
-      ref(parent),
+      parent,
       { Child },
     )
 
     const { host } = define(App).render()
+    const button = host.firstElementChild as HTMLButtonElement
+    button.click()
+    expect(calls).toEqual(['local', 'parent'])
+
+    calls.length = 0
     local.value = {
       onClick(event: Event) {
         calls.push('local')
@@ -1858,10 +1836,14 @@ describe('attribute fallthrough', () => {
       },
     }
     await nextTick()
-    ;(host.firstElementChild as HTMLButtonElement).click()
-
+    button.click()
     expect(calls).toEqual(['local'])
-    expect(parent).not.toHaveBeenCalled()
+
+    calls.length = 0
+    parent.value = undefined
+    await nextTick()
+    button.click()
+    expect(calls).toEqual(['local'])
   })
 
   it('should preserve fallthrough once listeners across updates', async () => {
@@ -1889,24 +1871,13 @@ describe('attribute fallthrough', () => {
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
-  it('should filter functional fallthrough on a component root', () => {
+  it('should filter and remove functional fallthrough on a component root', async () => {
+    const attrs = ref<Record<string, string>>({
+      id: 'blocked',
+      class: 'allowed',
+    })
     const Leaf = compile(`<template><div /></template>`, ref(null))
     const Functional = () => createComponent(Leaf, null, null, true)
-    const App = compile(
-      `<template>
-        <components.Functional id="blocked" class="allowed" />
-      </template>`,
-      ref(null),
-      { Functional },
-    )
-
-    const { host } = define(App).render()
-    expect(host.innerHTML).toBe('<div class="allowed"></div>')
-  })
-
-  it('should remove functional fallthrough when no whitelisted attrs remain', async () => {
-    const attrs = ref<Record<string, string>>({ class: 'parent' })
-    const Functional = () => template('<div></div>', 1)()
     const App = compile(
       `<template><components.Functional v-bind="data" /></template>`,
       attrs,
@@ -1914,7 +1885,7 @@ describe('attribute fallthrough', () => {
     )
 
     const { host } = define(App).render()
-    expect(host.innerHTML).toBe('<div class="parent"></div>')
+    expect(host.innerHTML).toBe('<div class="allowed"></div>')
 
     attrs.value = { id: 'blocked' }
     await nextTick()
@@ -1925,9 +1896,9 @@ describe('attribute fallthrough', () => {
 
   it('should preserve a class token still owned by fallthrough attrs', async () => {
     const childClass = ref('shared')
-    const parentClass = ref('static shared')
+    const parentClass = ref('shared parent')
     const Child = compile(
-      `<template><div class="static" :class="data" /></template>`,
+      `<template><div :class="data" /></template>`,
       childClass,
     )
     const App = compile(
@@ -1938,51 +1909,23 @@ describe('attribute fallthrough', () => {
 
     const { host } = define(App).render()
     const el = host.firstElementChild as HTMLElement
-    expect(el.className).toBe('static shared')
+    expect(el.className).toBe('shared parent')
 
     childClass.value = ''
     await nextTick()
-    expect(el.className).toBe('static shared')
+    expect(el.className).toBe('shared parent')
 
     parentClass.value = ''
     await nextTick()
-    expect(el.className).toBe('static')
+    expect(el.className).toBe('')
   })
 
   it('should preserve fallthrough style precedence across local updates', async () => {
-    const childStyle = ref<Record<string, string>>({ color: 'red' })
+    const childStyle = shallowRef({ color: 'red' })
     const parentStyle = ref<Record<string, string>>({
       color: 'blue',
       background: 'blue',
     })
-    const Child = compile(
-      `<template><div style="background: red" :style="data" /></template>`,
-      childStyle,
-    )
-    const App = compile(
-      `<template><components.Child :style="data" /></template>`,
-      parentStyle,
-      { Child },
-    )
-
-    const { host } = define(App).render()
-    const el = host.firstElementChild as HTMLElement
-    expect(el.style.color).toBe('blue')
-    expect(el.style.background).toBe('blue')
-
-    childStyle.value = { color: 'green' }
-    await nextTick()
-    expect(el.style.color).toBe('blue')
-
-    parentStyle.value = {}
-    await nextTick()
-    expect(el.style.color).toBe('green')
-    expect(el.style.background).toBe('red')
-  })
-
-  it('should update fallthrough style after in-place local mutations', async () => {
-    const childStyle = shallowRef({ color: 'red' })
-    const parentStyle = ref({ background: 'blue' })
     const Child = compile(
       `<template><div :style="data" /></template>`,
       childStyle,
@@ -1995,38 +1938,17 @@ describe('attribute fallthrough', () => {
 
     const { host } = define(App).render()
     const el = host.firstElementChild as HTMLElement
-    expect(el.style.color).toBe('red')
+    expect(el.style.color).toBe('blue')
     expect(el.style.background).toBe('blue')
 
     childStyle.value.color = 'green'
     triggerRef(childStyle)
     await nextTick()
-    expect(el.style.color).toBe('green')
-    expect(el.style.background).toBe('blue')
-  })
-
-  it('should ignore v-show display state when seeding fallthrough style caches', async () => {
-    const visible = ref(false)
-    const Child = compile(`<template><div v-show="data" /></template>`, visible)
-    const attrs = ref<Record<string, any>>({ style: { color: 'red' } })
-    const App = compile(
-      `<template><components.Child v-bind="data" /></template>`,
-      attrs,
-      { Child },
-    )
-
-    const { host } = define(App).render()
-    const el = host.firstElementChild as HTMLElement
-    expect(el.style.display).toBe('none')
-
-    visible.value = true
-    await nextTick()
-    expect(el.style.display).toBe('')
-    expect(el.style.color).toBe('red')
-
-    attrs.value = { style: { color: 'blue' } }
-    await nextTick()
-    expect(el.style.display).toBe('')
     expect(el.style.color).toBe('blue')
+
+    parentStyle.value = {}
+    await nextTick()
+    expect(el.style.color).toBe('green')
+    expect(el.style.background).toBe('')
   })
 })

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1864,6 +1864,31 @@ describe('attribute fallthrough', () => {
     expect(parent).not.toHaveBeenCalled()
   })
 
+  it('should preserve fallthrough once listeners across updates', async () => {
+    const handler = vi.fn()
+    const attrs = ref<Record<string, any>>({
+      onClickOnce: handler,
+      title: 'before',
+    })
+    const Child = compile(`<template><button /></template>`, ref(null))
+    const App = compile(
+      `<template><components.Child v-bind="data" /></template>`,
+      attrs,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    const button = host.firstElementChild as HTMLButtonElement
+    button.click()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    attrs.value = { onClickOnce: handler, title: 'after' }
+    await nextTick()
+    expect(button.title).toBe('after')
+    button.click()
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
   it('should filter functional fallthrough on a component root', () => {
     const Leaf = compile(`<template><div /></template>`, ref(null))
     const Functional = () => createComponent(Leaf, null, null, true)

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -3,6 +3,8 @@ import {
   nextTick,
   onUpdated,
   ref,
+  shallowRef,
+  triggerRef,
   withModifiers,
 } from '@vue/runtime-dom'
 import {
@@ -1729,5 +1731,277 @@ describe('attribute fallthrough', () => {
 
     const { host } = define(App).render()
     expect(host.innerHTML).toBe('<div>class prop = DROPPED</div>')
+  })
+
+  it('should apply attrs added after an initially empty v-bind', async () => {
+    const attrs = ref<Record<string, string>>({})
+    const Child = compile(`<template><div id="child" /></template>`, ref(null))
+    const App = compile(
+      `<template><components.Child v-bind="data" /></template>`,
+      attrs,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    expect(host.innerHTML).toBe('<div id="child"></div>')
+
+    attrs.value = { id: 'parent' }
+    await nextTick()
+    expect(host.innerHTML).toBe('<div id="parent"></div>')
+  })
+
+  it('should restore the latest local value after an attr is removed', async () => {
+    const title = ref('child')
+    const attrs = ref<Record<string, string>>({
+      id: 'parent',
+      title: 'parent',
+      dir: 'rtl',
+    })
+    const Child = compile(
+      `<template><div id="child" :title="data" /></template>`,
+      title,
+    )
+    const App = compile(
+      `<template><components.Child v-bind="data" /></template>`,
+      attrs,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    expect(host.innerHTML).toBe(
+      '<div id="parent" title="parent" dir="rtl"></div>',
+    )
+
+    title.value = 'child-next'
+    await nextTick()
+    expect(host.innerHTML).toBe(
+      '<div id="parent" title="parent" dir="rtl"></div>',
+    )
+
+    attrs.value = {}
+    await nextTick()
+    expect(host.innerHTML).toBe('<div id="child" title="child-next"></div>')
+  })
+
+  it('should apply local and fallthrough dynamic listeners', async () => {
+    const child = vi.fn()
+    const parent = vi.fn()
+    const parentListener = ref<any>(parent)
+    const Child = compile(
+      `<template><button v-bind="data" /></template>`,
+      ref({ onClick: child }),
+    )
+    const App = compile(
+      `<template><components.Child :onClick="data" /></template>`,
+      parentListener,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    ;(host.firstElementChild as HTMLButtonElement).click()
+    expect(child).toHaveBeenCalledTimes(1)
+    expect(parent).toHaveBeenCalledTimes(1)
+
+    parentListener.value = undefined
+    await nextTick()
+    ;(host.firstElementChild as HTMLButtonElement).click()
+    expect(child).toHaveBeenCalledTimes(2)
+    expect(parent).toHaveBeenCalledTimes(1)
+  })
+
+  it('should preserve local listeners when $attrs is merged during render', () => {
+    const child = vi.fn()
+    const parent = vi.fn()
+    const Child = defineVaporComponent({
+      setup(_, { attrs }) {
+        const el = template('<button></button>', 1)() as Element
+        renderEffect(() => setDynamicProps(el, [{ onClick: child }, attrs]))
+        return el
+      },
+    })
+    const App = defineVaporComponent({
+      setup() {
+        return createComponent(Child, { onClick: () => parent })
+      },
+    })
+
+    const { host } = define(App).render()
+    ;(host.firstElementChild as HTMLButtonElement).click()
+
+    expect(child).toHaveBeenCalledTimes(1)
+    expect(parent).toHaveBeenCalledTimes(1)
+  })
+
+  it('should preserve listener order after a local listener update', async () => {
+    const calls: string[] = []
+    const local = ref<{ onClick: (event: Event) => void }>({
+      onClick: () => {
+        calls.push('initial')
+      },
+    })
+    const parent = vi.fn(() => calls.push('parent'))
+    const Child = compile(
+      `<template><button v-bind="data" /></template>`,
+      local,
+    )
+    const App = compile(
+      `<template><components.Child :onClick="data" /></template>`,
+      ref(parent),
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    local.value = {
+      onClick(event: Event) {
+        calls.push('local')
+        event.stopImmediatePropagation()
+      },
+    }
+    await nextTick()
+    ;(host.firstElementChild as HTMLButtonElement).click()
+
+    expect(calls).toEqual(['local'])
+    expect(parent).not.toHaveBeenCalled()
+  })
+
+  it('should filter functional fallthrough on a component root', () => {
+    const Leaf = compile(`<template><div /></template>`, ref(null))
+    const Functional = () => createComponent(Leaf, null, null, true)
+    const App = compile(
+      `<template>
+        <components.Functional id="blocked" class="allowed" />
+      </template>`,
+      ref(null),
+      { Functional },
+    )
+
+    const { host } = define(App).render()
+    expect(host.innerHTML).toBe('<div class="allowed"></div>')
+  })
+
+  it('should remove functional fallthrough when no whitelisted attrs remain', async () => {
+    const attrs = ref<Record<string, string>>({ class: 'parent' })
+    const Functional = () => template('<div></div>', 1)()
+    const App = compile(
+      `<template><components.Functional v-bind="data" /></template>`,
+      attrs,
+      { Functional },
+    )
+
+    const { host } = define(App).render()
+    expect(host.innerHTML).toBe('<div class="parent"></div>')
+
+    attrs.value = { id: 'blocked' }
+    await nextTick()
+    const el = host.firstElementChild as HTMLElement
+    expect(el.className).toBe('')
+    expect(el.hasAttribute('id')).toBe(false)
+  })
+
+  it('should preserve a class token still owned by fallthrough attrs', async () => {
+    const childClass = ref('shared')
+    const parentClass = ref('static shared')
+    const Child = compile(
+      `<template><div class="static" :class="data" /></template>`,
+      childClass,
+    )
+    const App = compile(
+      `<template><components.Child :class="data" /></template>`,
+      parentClass,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    const el = host.firstElementChild as HTMLElement
+    expect(el.className).toBe('static shared')
+
+    childClass.value = ''
+    await nextTick()
+    expect(el.className).toBe('static shared')
+
+    parentClass.value = ''
+    await nextTick()
+    expect(el.className).toBe('static')
+  })
+
+  it('should preserve fallthrough style precedence across local updates', async () => {
+    const childStyle = ref<Record<string, string>>({ color: 'red' })
+    const parentStyle = ref<Record<string, string>>({
+      color: 'blue',
+      background: 'blue',
+    })
+    const Child = compile(
+      `<template><div style="background: red" :style="data" /></template>`,
+      childStyle,
+    )
+    const App = compile(
+      `<template><components.Child :style="data" /></template>`,
+      parentStyle,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    const el = host.firstElementChild as HTMLElement
+    expect(el.style.color).toBe('blue')
+    expect(el.style.background).toBe('blue')
+
+    childStyle.value = { color: 'green' }
+    await nextTick()
+    expect(el.style.color).toBe('blue')
+
+    parentStyle.value = {}
+    await nextTick()
+    expect(el.style.color).toBe('green')
+    expect(el.style.background).toBe('red')
+  })
+
+  it('should update fallthrough style after in-place local mutations', async () => {
+    const childStyle = shallowRef({ color: 'red' })
+    const parentStyle = ref({ background: 'blue' })
+    const Child = compile(
+      `<template><div :style="data" /></template>`,
+      childStyle,
+    )
+    const App = compile(
+      `<template><components.Child :style="data" /></template>`,
+      parentStyle,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    const el = host.firstElementChild as HTMLElement
+    expect(el.style.color).toBe('red')
+    expect(el.style.background).toBe('blue')
+
+    childStyle.value.color = 'green'
+    triggerRef(childStyle)
+    await nextTick()
+    expect(el.style.color).toBe('green')
+    expect(el.style.background).toBe('blue')
+  })
+
+  it('should ignore v-show display state when seeding fallthrough style caches', async () => {
+    const visible = ref(false)
+    const Child = compile(`<template><div v-show="data" /></template>`, visible)
+    const attrs = ref<Record<string, any>>({ style: { color: 'red' } })
+    const App = compile(
+      `<template><components.Child v-bind="data" /></template>`,
+      attrs,
+      { Child },
+    )
+
+    const { host } = define(App).render()
+    const el = host.firstElementChild as HTMLElement
+    expect(el.style.display).toBe('none')
+
+    visible.value = true
+    await nextTick()
+    expect(el.style.display).toBe('')
+    expect(el.style.color).toBe('red')
+
+    attrs.value = { style: { color: 'blue' } }
+    await nextTick()
+    expect(el.style.display).toBe('')
+    expect(el.style.color).toBe('blue')
   })
 })

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -631,7 +631,9 @@ export function setupComponent(
 
 export let isApplyingFallthroughProps = false
 
-function shouldUseFunctionalFallthrough(component: VaporComponent): boolean {
+export function shouldUseFunctionalFallthrough(
+  component: VaporComponent,
+): boolean {
   return (
     isFunction(component) &&
     !(isTransitionEnabled && isVaporTransition(component))

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -312,18 +312,18 @@ export function createComponent(
           ? currentInstance && isVaporTransition(currentInstance!.type)
           : false)) &&
       isVaporComponent(currentInstance) &&
-      currentInstance.type.inheritAttrs !== false &&
-      currentInstance.hasFallthrough
+      forwardsFallthroughAttrs(currentInstance)
     ) {
       // check if we are the single root of the parent
       // if yes, inject parent attrs as dynamic props source
-      const attrs = currentInstance.attrs
+      const owner = currentInstance
+      const getAttrs = () => resolveFallthroughAttrs(owner)
       if (rawProps && rawProps !== EMPTY_OBJ) {
         ;((rawProps as RawProps).$ || ((rawProps as RawProps).$ = [])).push(
-          () => attrs,
+          getAttrs,
         )
       } else {
-        rawProps = { $: [() => attrs] } as RawProps
+        rawProps = { $: [getAttrs] } as RawProps
       }
     }
 
@@ -631,13 +631,25 @@ export function setupComponent(
 
 export let isApplyingFallthroughProps = false
 
-export function shouldUseFunctionalFallthrough(
-  component: VaporComponent,
-): boolean {
+function shouldUseFunctionalFallthrough(component: VaporComponent): boolean {
   return (
     isFunction(component) &&
     !(isTransitionEnabled && isVaporTransition(component))
   )
+}
+
+export function forwardsFallthroughAttrs(
+  instance: VaporComponentInstance,
+): boolean {
+  return instance.hasFallthrough && instance.type.inheritAttrs !== false
+}
+
+function resolveFallthroughAttrs(
+  instance: VaporComponentInstance,
+): Record<string, any> {
+  return shouldUseFunctionalFallthrough(instance.type)
+    ? getFunctionalFallthrough(instance.attrs) || EMPTY_OBJ
+    : instance.attrs
 }
 
 export function applyFallthroughProps(
@@ -1550,17 +1562,10 @@ function handleSetupResult(
   }
 
   // single root, inherit attrs
-  if (
-    instance.hasFallthrough &&
-    component.inheritAttrs !== false &&
-    Object.keys(instance.attrs).length
-  ) {
-    const getFallthroughAttrs = shouldUseFunctionalFallthrough(component)
-      ? () => getFunctionalFallthrough(instance.attrs)
-      : () => instance.attrs
+  if (forwardsFallthroughAttrs(instance)) {
     // attach attrs to the root element, or to root dynamic fragments so they
     // can be (re-)applied during each branch update
-    applyFallthroughAttrs(instance.block, instance, getFallthroughAttrs)
+    applyFallthroughAttrs(instance.block, instance)
   }
 
   if (__DEV__) {
@@ -1575,7 +1580,6 @@ function handleSetupResult(
 function applyFallthroughAttrs(
   block: Block,
   instance: VaporComponentInstance,
-  getFallthroughAttrs: () => Record<string, any> | undefined,
   scope?: EffectScope,
 ): void {
   let hasSlotFragment = false
@@ -1601,28 +1605,22 @@ function applyFallthroughAttrs(
       // slot fragments warn instead of inheriting attrs, skip them
       if (!(frag.__vf & SLOT)) {
         // Nested dynamic fragments need their own fallthrough hook.
-        registerDynamicFragmentFallthroughAttrs(
-          frag,
-          instance,
-          getFallthroughAttrs,
-        )
+        registerDynamicFragmentFallthroughAttrs(frag, instance)
       }
     }
   }
 
   if (root && !hasSlotFragment) {
     const applyEffect = () =>
-      renderEffect(() => {
-        const attrs = getFallthroughAttrs()
-        if (attrs) applyFallthroughProps(root, attrs)
-      })
+      renderEffect(() =>
+        applyFallthroughProps(root, resolveFallthroughAttrs(instance)),
+      )
     // ensure the render effect is cleaned up when the branch scope is stopped
     scope ? scope.run(applyEffect) : applyEffect()
   } else if (__DEV__) {
     const accessedAttrs = instance.accessedAttrs
-    const fallthroughAttrs = getFallthroughAttrs()
+    const fallthroughAttrs = resolveFallthroughAttrs(instance)
     if (
-      fallthroughAttrs &&
       Object.keys(fallthroughAttrs).length &&
       (hasSlotFragment ||
         (dynamicRoot && dynamicRoot.hasNonSingleRoot) ||
@@ -1693,14 +1691,13 @@ function containsTeleportFragment(block: Block): boolean {
 function registerDynamicFragmentFallthroughAttrs(
   frag: DynamicFragment,
   instance: VaporComponentInstance,
-  getFallthroughAttrs: () => Record<string, any> | undefined,
 ): void {
   // avoid registering duplicate hooks
   if (frag.hasFallthroughAttrs) return
 
   frag.hasFallthroughAttrs = true
   ;(frag.onBeforeInsert ||= []).push(nodes =>
-    applyFallthroughAttrs(nodes, instance, getFallthroughAttrs, frag.scope!),
+    applyFallthroughAttrs(nodes, instance, frag.scope!),
   )
 }
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -628,18 +628,18 @@ export function hasFallthroughAttrs(
   comp: VaporComponent,
   rawProps: RawProps | null | undefined,
 ): boolean {
-  if (rawProps) {
-    // determine fallthrough
-    if (rawProps.$ || !comp.props) {
+  if (!rawProps) return false
+
+  // determine fallthrough
+  // A dynamic source can be empty initially and add attrs later, so its
+  // presence alone requires installing the fallthrough effect.
+  if (rawProps.$) return true
+
+  // check if rawProps contains any keys not declared
+  const propsOptions = comp.props && normalizePropsOptions(comp)[0]
+  for (const key in rawProps) {
+    if (!propsOptions || !hasOwn(propsOptions, camelize(key))) {
       return true
-    } else {
-      // check if rawProps contains any keys not declared
-      const propsOptions = normalizePropsOptions(comp)[0]!
-      for (const key in rawProps) {
-        if (!hasOwn(propsOptions, camelize(key))) {
-          return true
-        }
-      }
     }
   }
   return false

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -12,6 +12,18 @@ type EventHandler = (...args: any[]) => any
 type EventHandlerValue = EventHandler | EventHandler[]
 type MaybeEventHandlerValue = EventHandlerValue | null | undefined
 
+type RootEventBinding = [
+  local: MaybeEventHandlerValue,
+  inherited: MaybeEventHandlerValue,
+  merged: MaybeEventHandlerValue,
+  remove: () => void,
+]
+
+type RootEventElement = Element & {
+  // Local and inherited root handlers sharing one stable native listener.
+  $evts?: Record<string, RootEventBinding>
+}
+
 export function addEventListener(
   el: Element,
   event: string,
@@ -48,6 +60,96 @@ export function onBinding(
     if (!handler) return
     const cleanup = addEventListener(el, event, createInvoker(handler), options)
     onEffectCleanup(cleanup)
+  }
+}
+
+function mergeEventHandlers(
+  local: MaybeEventHandlerValue,
+  inherited: MaybeEventHandlerValue,
+): MaybeEventHandlerValue {
+  if (!local) return inherited
+  if (
+    !inherited ||
+    local === inherited ||
+    (isArray(local) && local.includes(inherited as EventHandler))
+  ) {
+    return local
+  }
+  return ([] as EventHandler[]).concat(local as any, inherited as any)
+}
+
+function createRootEventInvoker(binding: RootEventBinding): EventHandler {
+  const instance = currentInstance!
+  return (event: Event) => {
+    const handler = binding[2]
+    if (isArray(handler)) {
+      const originalStop = event.stopImmediatePropagation
+      event.stopImmediatePropagation = () => {
+        originalStop.call(event)
+        ;(event as any)._stopped = true
+      }
+      const handlers = handler.slice()
+      const args = [event]
+      for (let i = 0; i < handlers.length; i++) {
+        if ((event as any)._stopped) break
+        const handler = handlers[i]
+        if (handler) {
+          callWithAsyncErrorHandling(
+            handler,
+            instance,
+            ErrorCodes.NATIVE_EVENT_HANDLER,
+            args,
+          )
+        }
+      }
+    } else if (handler) {
+      callWithAsyncErrorHandling(
+        handler,
+        instance,
+        ErrorCodes.NATIVE_EVENT_HANDLER,
+        [event],
+      )
+    }
+  }
+}
+
+export function onRootBinding(
+  el: RootEventElement,
+  rawName: string,
+  event: string,
+  handler: MaybeEventHandlerValue,
+  options: AddEventListenerOptions | undefined,
+  inherited: boolean,
+): void {
+  let events = el.$evts
+  let binding = events && events[rawName]
+  if (!binding) {
+    if (!handler) return
+    if (!events) events = el.$evts = Object.create(null)
+    binding = events![rawName] = [undefined, undefined, undefined, undefined!]
+    binding[3] = addEventListener(
+      el,
+      event,
+      createRootEventInvoker(binding),
+      options,
+    )
+  }
+
+  const eventMap = events!
+  const index = inherited ? 1 : 0
+  binding[index] = handler
+  binding[2] = mergeEventHandlers(binding[0], binding[1])
+
+  if (handler) {
+    onEffectCleanup(() => {
+      if (eventMap[rawName] !== binding || binding[index] !== handler) return
+      binding[index] = undefined
+      binding[2] = mergeEventHandlers(binding[0], binding[1])
+      if (!binding[2]) {
+        binding[3]()
+        delete eventMap[rawName]
+      }
+    })
   }
 }
 

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -135,21 +135,15 @@ export function onRootBinding(
     )
   }
 
-  const eventMap = events!
+  // Keep the native listener stable across effect reruns, notably for `.once`.
+  // setDynamicProps explicitly clears this slot when the key is removed.
   const index = inherited ? 1 : 0
   binding[index] = handler
   binding[2] = mergeEventHandlers(binding[0], binding[1])
 
-  if (handler) {
-    onEffectCleanup(() => {
-      if (eventMap[rawName] !== binding || binding[index] !== handler) return
-      binding[index] = undefined
-      binding[2] = mergeEventHandlers(binding[0], binding[1])
-      if (!binding[2]) {
-        binding[3]()
-        delete eventMap[rawName]
-      }
-    })
+  if (!binding[2]) {
+    binding[3]()
+    delete events![rawName]
   }
 }
 

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -20,7 +20,8 @@ type RootEventBinding = [
 ]
 
 type RootEventElement = Element & {
-  // Local and inherited root handlers sharing one stable native listener.
+  // Lazily allocated only when dynamic local/fallthrough root handlers share
+  // one stable native listener.
   $evts?: Record<string, RootEventBinding>
 }
 

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -4,6 +4,7 @@ import {
   camelize,
   canSetValueDirectly,
   getEscapedCssVarName,
+  hasOwn,
   includeBooleanAttr,
   isOn,
   isSpecialBooleanAttr,
@@ -16,13 +17,12 @@ import {
   stringifyStyle,
   toDisplayString,
 } from '@vue/shared'
-import { onBinding } from './event'
+import { onBinding, onRootBinding } from './event'
 import {
   type GenericComponentInstance,
   MismatchTypes,
   currentInstance,
   getAttributeMismatch,
-  isFunctionalFallthroughKey,
   isMapEqual,
   isMismatchAllowed,
   isSetEqual,
@@ -37,15 +37,17 @@ import {
   toClassSet,
   toStyleMap,
   unsafeToTrustedHTML,
+  vModelGetValue,
   vShowHidden,
+  vShowOriginalDisplay,
   warn,
   warnPropMismatch,
   xlinkNS,
 } from '@vue/runtime-dom'
 import {
   type VaporComponentInstance,
+  forwardsFallthroughAttrs,
   isApplyingFallthroughProps,
-  shouldUseFunctionalFallthrough,
 } from '../component'
 import {
   isHydrating,
@@ -56,26 +58,107 @@ import { type Block, normalizeBlock } from '../block'
 import type { VaporElement } from '../apiDefineCustomElement'
 
 type TargetElement = Element & {
+  // Inherited dynamic props currently applied through attrs fallthrough.
+  $dprops$?: Record<string, any>
+  // Latest local root props shadowed by fallthrough, restored on removal.
+  $lprops?: Record<string, LocalRootProp>
   $root?: true
   $html?: string
   $cls?: string
   $clsFlags?: number
+  // Local ($clsi/$styi) and inherited ($clsi$/$styi$) incremental caches.
+  $clsi?: string
+  $clsi$?: string
+  $styi?: NormalizedStyle
+  $styi$?: NormalizedStyle
   $sty?: NormalizedStyle | string | undefined
   value?: string
   _value?: any
 }
 
-const shouldSkipFallthroughKey = (el: TargetElement, key: string) => {
-  const instance = currentInstance! as VaporComponentInstance
+const enum LocalPropType {
+  ATTR,
+  DOM_PROP,
+  VALUE,
+}
+
+type LocalRootProp = [
+  type: LocalPropType,
+  value: any,
+  extra?: any,
+  removeAttr?: boolean,
+]
+
+function recordShadowedRootProp(
+  el: TargetElement,
+  key: string,
+  type: LocalPropType,
+  value: any,
+  extra?: any,
+): boolean {
+  const inherited = el.$dprops$
+  if (!isApplyingFallthroughProps && inherited && key in inherited) {
+    ;(el.$lprops || (el.$lprops = Object.create(null)))[key] = [
+      type,
+      value,
+      extra,
+    ]
+    return true
+  }
+  return false
+}
+
+// Keys whose local value flows through setAttr/setDOMProp/setValue — the
+// setters restoreLocalRootProp replays through. class/style/events merge
+// local and inherited values instead of shadowing.
+function isRestorableDynamicProp(key: string): boolean {
   return (
-    !isApplyingFallthroughProps &&
-    el.$root &&
-    instance.hasFallthrough &&
-    instance.type.inheritAttrs !== false &&
-    key in instance.attrs &&
-    (!shouldUseFunctionalFallthrough(instance.type) ||
-      isFunctionalFallthroughKey(key))
+    key[0] !== '.' &&
+    key[0] !== '^' &&
+    key !== 'class' &&
+    key !== 'style' &&
+    !isOn(key) &&
+    key !== 'innerHTML' &&
+    key !== 'textContent'
   )
+}
+
+function captureLocalRootProp(
+  el: TargetElement,
+  key: string,
+  isSVG: boolean,
+): void {
+  const local = el.$lprops || (el.$lprops = Object.create(null))
+  if (key in local) return
+
+  if (key === 'value' && canSetValueDirectly(el.tagName)) {
+    local[key] = [LocalPropType.VALUE, vModelGetValue(el as any)]
+  } else if (hasOwn(el, `$${key}`)) {
+    local[key] = [LocalPropType.ATTR, (el as any)[`$${key}`], isSVG]
+  } else if (el.hasAttribute(key)) {
+    local[key] = [LocalPropType.ATTR, el.getAttribute(key), isSVG]
+  } else if (key in el) {
+    local[key] = [LocalPropType.DOM_PROP, (el as any)[key], undefined, true]
+  } else {
+    local[key] = [LocalPropType.ATTR, null, isSVG]
+  }
+}
+
+function restoreLocalRootProp(el: TargetElement, key: string): boolean {
+  const local = el.$lprops
+  const entry = local && local[key]
+  if (!entry) return false
+
+  delete local[key]
+  if (entry[0] === LocalPropType.ATTR) {
+    setAttr(el, key, entry[1], entry[2])
+  } else if (entry[0] === LocalPropType.DOM_PROP) {
+    setDOMProp(el, key, entry[1], false, entry[2])
+    if (entry[3]) el.removeAttribute(key)
+  } else {
+    setValue(el, entry[1])
+  }
+  return true
 }
 
 export function setProp(el: any, key: string, value: any): void {
@@ -92,7 +175,7 @@ export function setAttr(
   value: any,
   isSVG: boolean = false,
 ): void {
-  if (shouldSkipFallthroughKey(el, key)) {
+  if (recordShadowedRootProp(el, key, LocalPropType.ATTR, value, isSVG)) {
     return
   }
 
@@ -142,7 +225,9 @@ export function setDOMProp(
   forceHydrate: boolean = false,
   attrName?: string,
 ): void {
-  if (shouldSkipFallthroughKey(el, key)) {
+  if (
+    recordShadowedRootProp(el, key, LocalPropType.DOM_PROP, value, attrName)
+  ) {
     return
   }
 
@@ -281,10 +366,25 @@ function setClassIncremental(
       el.classList.add(...nextList)
     }
     if (prev) {
+      const other = isApplyingFallthroughProps ? el.$clsi : el.$clsi$
+      let otherList: string[] | undefined
       for (const cls of prev.split(/\s+/)) {
-        if (!nextList.includes(cls)) el.classList.remove(cls)
+        if (
+          !nextList.includes(cls) &&
+          !(other && (otherList ||= other.split(/\s+/)).includes(cls))
+        ) {
+          el.classList.remove(cls)
+        }
       }
     }
+  }
+}
+
+// Record the classes the element carried before fallthrough first applied
+// (static template classes) so incremental removal keeps them.
+function seedLocalClass(el: TargetElement): void {
+  if (el.$clsi === undefined) {
+    el.$clsi = normalizeClass(el.getAttribute('class'))
   }
 }
 
@@ -351,21 +451,44 @@ export function setStyle(el: TargetElement, value: any): void {
   }
 }
 
-function setStyleIncremental(el: any, value: any): NormalizedStyle | undefined {
+function setStyleIncremental(el: any, value: any): void {
   const cacheKey = `$styi${isApplyingFallthroughProps ? '$' : ''}`
+  const prev = el[cacheKey]
   const normalizedValue = isString(value)
     ? parseStringStyle(value)
     : (normalizeStyle(value) as NormalizedStyle | undefined)
+  el[cacheKey] = normalizedValue
 
   if (isHydrating && !isRecreatedNode(el)) {
     if (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) {
       checkHydrationStyleMismatch(el, value, normalizedValue, true)
     }
-    el[cacheKey] = normalizedValue
     return
   }
 
-  patchStyle(el, el[cacheKey], (el[cacheKey] = normalizedValue))
+  if (!isApplyingFallthroughProps && el.$styi$ === undefined) {
+    patchStyle(el, prev, normalizedValue)
+    return
+  }
+
+  const next = normalizeStyle([el.$styi, el.$styi$]) as NormalizedStyle
+  patchStyle(el, el.$sty, (el.$sty = next))
+}
+
+// Record the styles the element carried before fallthrough first applied
+// (static template styles) so they participate in cache merging. The live
+// display value belongs to v-show when present, so seed the author's
+// display from the directive's own record instead.
+function seedLocalStyle(el: TargetElement): void {
+  if (el.$styi !== undefined) return
+  const style = el.getAttribute('style')
+  const parsed = style ? parseStringStyle(style) : undefined
+  if (parsed && vShowOriginalDisplay in el) {
+    const display = (el as any)[vShowOriginalDisplay]
+    if (display) parsed.display = display
+    else delete parsed.display
+  }
+  el.$sty = el.$styi = parsed
 }
 
 export function setValue(
@@ -373,7 +496,7 @@ export function setValue(
   value: any,
   forceHydrate: boolean = false,
 ): void {
-  if (shouldSkipFallthroughKey(el, 'value')) {
+  if (recordShadowedRootProp(el, 'value', LocalPropType.VALUE, value)) {
     return
   }
 
@@ -482,19 +605,34 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
   if (prevProps) {
     for (const key in prevProps) {
       if (!(key in props)) {
-        setDynamicProp(el, key, null, isSVG)
+        if (
+          !isApplyingFallthroughProps ||
+          !isRestorableDynamicProp(key) ||
+          !restoreLocalRootProp(el, key)
+        ) {
+          setDynamicProp(el, key, null, isSVG)
+        }
       }
     }
   }
 
   for (const key of Object.keys(props)) {
     const value = props[key]
+    const hadKey = prevProps && key in prevProps
     nextProps[key] = value
+    if (isApplyingFallthroughProps && !isHydrating && !hadKey) {
+      if (key === 'class') {
+        seedLocalClass(el)
+      } else if (key === 'style') {
+        seedLocalStyle(el)
+      } else if (isRestorableDynamicProp(key)) {
+        captureLocalRootProp(el, key, !!isSVG)
+      }
+    }
     // Events and objects can have stable identity with mutable internals, so
     // only skip unchanged primitive values.
     if (
-      prevProps &&
-      key in prevProps &&
+      hadKey &&
       !isOn(key) &&
       (value == null || typeof value !== 'object') &&
       Object.is(prevProps[key], value)
@@ -522,10 +660,24 @@ export function setDynamicProp(
   } else if (key === 'style') {
     setStyle(el, value)
   } else if (isOn(key)) {
-    if (shouldSkipFallthroughKey(el, key)) {
-      return
-    }
     const [event, options] = parseEventName(key)
+    if (el.$root) {
+      const instance = currentInstance as VaporComponentInstance | null
+      if (
+        isApplyingFallthroughProps ||
+        (instance && forwardsFallthroughAttrs(instance))
+      ) {
+        onRootBinding(
+          el,
+          key,
+          event,
+          value,
+          options,
+          isApplyingFallthroughProps,
+        )
+        return
+      }
+    }
     onBinding(el, event, value, options)
   } else if (
     // force hydrate v-bind with .prop modifiers
@@ -575,6 +727,8 @@ export function optimizePropertyLookup(): void {
   proto.$root = false
   proto.$clsFlags = undefined
   proto.$html = proto.$cls = proto.$sty = ''
+  proto.$dprops = proto.$dprops$ = proto.$lprops = proto.$evts = undefined
+  proto.$clsi = proto.$clsi$ = proto.$styi = proto.$styi$ = undefined
   // Initialize $txt to undefined instead of empty string to ensure setText()
   // properly updates the text node even when the value is empty string.
   // This prevents issues where setText(node, '') would be skipped because

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -4,7 +4,6 @@ import {
   camelize,
   canSetValueDirectly,
   getEscapedCssVarName,
-  hasOwn,
   includeBooleanAttr,
   isOn,
   isSpecialBooleanAttr,
@@ -23,6 +22,7 @@ import {
   MismatchTypes,
   currentInstance,
   getAttributeMismatch,
+  isFunctionalFallthroughKey,
   isMapEqual,
   isMismatchAllowed,
   isSetEqual,
@@ -37,17 +37,15 @@ import {
   toClassSet,
   toStyleMap,
   unsafeToTrustedHTML,
-  vModelGetValue,
   vShowHidden,
-  vShowOriginalDisplay,
   warn,
   warnPropMismatch,
   xlinkNS,
 } from '@vue/runtime-dom'
 import {
   type VaporComponentInstance,
-  forwardsFallthroughAttrs,
   isApplyingFallthroughProps,
+  shouldUseFunctionalFallthrough,
 } from '../component'
 import {
   isHydrating,
@@ -60,13 +58,17 @@ import type { VaporElement } from '../apiDefineCustomElement'
 type TargetElement = Element & {
   // Inherited dynamic props currently applied through attrs fallthrough.
   $dprops$?: Record<string, any>
-  // Latest local root props shadowed by fallthrough, restored on removal.
+  // Only dynamic root bindings are sources. Static template attrs are DOM
+  // initialization and are intentionally not captured or restored after
+  // fallthrough overwrites them.
   $lprops?: Record<string, LocalRootProp>
   $root?: true
   $html?: string
   $cls?: string
   $clsFlags?: number
-  // Local ($clsi/$styi) and inherited ($clsi$/$styi$) incremental caches.
+  // Local ($clsi/$styi) and inherited ($clsi$/$styi$) dynamic sources.
+  // Pure static class/style is emitted only into the template DOM and never
+  // seeds these caches, so fallthrough does not pay to snapshot or restore it.
   $clsi?: string
   $clsi$?: string
   $styi?: NormalizedStyle
@@ -82,79 +84,45 @@ const enum LocalPropType {
   VALUE,
 }
 
-type LocalRootProp = [
-  type: LocalPropType,
-  value: any,
-  extra?: any,
-  removeAttr?: boolean,
-]
+type LocalRootProp = [type: LocalPropType, value: any, extra?: any]
 
-function recordShadowedRootProp(
+function recordLocalRootProp(
   el: TargetElement,
   key: string,
   type: LocalPropType,
   value: any,
   extra?: any,
 ): boolean {
+  if (isApplyingFallthroughProps) return false
+
+  const instance = currentInstance! as VaporComponentInstance
+  if (
+    !instance.hasFallthrough ||
+    instance.type.inheritAttrs === false ||
+    (shouldUseFunctionalFallthrough(instance.type) &&
+      !isFunctionalFallthroughKey(key))
+  ) {
+    return false
+  }
+
+  ;(el.$lprops || (el.$lprops = Object.create(null)))[key] = [
+    type,
+    value,
+    extra,
+  ]
   const inherited = el.$dprops$
-  if (!isApplyingFallthroughProps && inherited && key in inherited) {
-    ;(el.$lprops || (el.$lprops = Object.create(null)))[key] = [
-      type,
-      value,
-      extra,
-    ]
-    return true
-  }
-  return false
+  return !!(inherited && key in inherited)
 }
 
-// Keys whose local value flows through setAttr/setDOMProp/setValue — the
-// setters restoreLocalRootProp replays through. class/style/events merge
-// local and inherited values instead of shadowing.
-function isRestorableDynamicProp(key: string): boolean {
-  return (
-    key[0] !== '.' &&
-    key[0] !== '^' &&
-    key !== 'class' &&
-    key !== 'style' &&
-    !isOn(key) &&
-    key !== 'innerHTML' &&
-    key !== 'textContent'
-  )
-}
-
-function captureLocalRootProp(
-  el: TargetElement,
-  key: string,
-  isSVG: boolean,
-): void {
-  const local = el.$lprops || (el.$lprops = Object.create(null))
-  if (key in local) return
-
-  if (key === 'value' && canSetValueDirectly(el.tagName)) {
-    local[key] = [LocalPropType.VALUE, vModelGetValue(el as any)]
-  } else if (hasOwn(el, `$${key}`)) {
-    local[key] = [LocalPropType.ATTR, (el as any)[`$${key}`], isSVG]
-  } else if (el.hasAttribute(key)) {
-    local[key] = [LocalPropType.ATTR, el.getAttribute(key), isSVG]
-  } else if (key in el) {
-    local[key] = [LocalPropType.DOM_PROP, (el as any)[key], undefined, true]
-  } else {
-    local[key] = [LocalPropType.ATTR, null, isSVG]
-  }
-}
-
-function restoreLocalRootProp(el: TargetElement, key: string): boolean {
+function applyLocalRootProp(el: TargetElement, key: string): boolean {
   const local = el.$lprops
   const entry = local && local[key]
   if (!entry) return false
 
-  delete local[key]
   if (entry[0] === LocalPropType.ATTR) {
     setAttr(el, key, entry[1], entry[2])
   } else if (entry[0] === LocalPropType.DOM_PROP) {
     setDOMProp(el, key, entry[1], false, entry[2])
-    if (entry[3]) el.removeAttribute(key)
   } else {
     setValue(el, entry[1])
   }
@@ -175,7 +143,10 @@ export function setAttr(
   value: any,
   isSVG: boolean = false,
 ): void {
-  if (recordShadowedRootProp(el, key, LocalPropType.ATTR, value, isSVG)) {
+  if (
+    el.$root &&
+    recordLocalRootProp(el, key, LocalPropType.ATTR, value, isSVG)
+  ) {
     return
   }
 
@@ -226,7 +197,8 @@ export function setDOMProp(
   attrName?: string,
 ): void {
   if (
-    recordShadowedRootProp(el, key, LocalPropType.DOM_PROP, value, attrName)
+    el.$root &&
+    recordLocalRootProp(el, key, LocalPropType.DOM_PROP, value, attrName)
   ) {
     return
   }
@@ -367,24 +339,21 @@ function setClassIncremental(
     }
     if (prev) {
       const other = isApplyingFallthroughProps ? el.$clsi : el.$clsi$
-      let otherList: string[] | undefined
-      for (const cls of prev.split(/\s+/)) {
-        if (
-          !nextList.includes(cls) &&
-          !(other && (otherList ||= other.split(/\s+/)).includes(cls))
-        ) {
-          el.classList.remove(cls)
+      if (other) {
+        const otherList = other.split(/\s+/)
+        for (const cls of prev.split(/\s+/)) {
+          if (!nextList.includes(cls) && !otherList.includes(cls)) {
+            el.classList.remove(cls)
+          }
+        }
+      } else {
+        // Keep the original single-source fast path when no fallthrough class
+        // source is active.
+        for (const cls of prev.split(/\s+/)) {
+          if (!nextList.includes(cls)) el.classList.remove(cls)
         }
       }
     }
-  }
-}
-
-// Record the classes the element carried before fallthrough first applied
-// (static template classes) so incremental removal keeps them.
-function seedLocalClass(el: TargetElement): void {
-  if (el.$clsi === undefined) {
-    el.$clsi = normalizeClass(el.getAttribute('class'))
   }
 }
 
@@ -458,15 +427,23 @@ function setStyleIncremental(el: any, value: any): void {
     ? parseStringStyle(value)
     : (normalizeStyle(value) as NormalizedStyle | undefined)
   el[cacheKey] = normalizedValue
+  const hasInheritedSource = '$styi$' in el
 
   if (isHydrating && !isRecreatedNode(el)) {
     if (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) {
       checkHydrationStyleMismatch(el, value, normalizedValue, true)
     }
+    if (hasInheritedSource) {
+      // Cache the expected merged sources for later updates without reading
+      // the hydrated DOM back as local ownership.
+      el.$sty = normalizeStyle([el.$styi, el.$styi$]) as NormalizedStyle
+    }
     return
   }
 
-  if (!isApplyingFallthroughProps && el.$styi$ === undefined) {
+  if (!hasInheritedSource) {
+    // Preserve the original local-only path until a fallthrough style source
+    // has actually been applied to this element.
     patchStyle(el, prev, normalizedValue)
     return
   }
@@ -475,28 +452,15 @@ function setStyleIncremental(el: any, value: any): void {
   patchStyle(el, el.$sty, (el.$sty = next))
 }
 
-// Record the styles the element carried before fallthrough first applied
-// (static template styles) so they participate in cache merging. The live
-// display value belongs to v-show when present, so seed the author's
-// display from the directive's own record instead.
-function seedLocalStyle(el: TargetElement): void {
-  if (el.$styi !== undefined) return
-  const style = el.getAttribute('style')
-  const parsed = style ? parseStringStyle(style) : undefined
-  if (parsed && vShowOriginalDisplay in el) {
-    const display = (el as any)[vShowOriginalDisplay]
-    if (display) parsed.display = display
-    else delete parsed.display
-  }
-  el.$sty = el.$styi = parsed
-}
-
 export function setValue(
   el: TargetElement,
   value: any,
   forceHydrate: boolean = false,
 ): void {
-  if (recordShadowedRootProp(el, 'value', LocalPropType.VALUE, value)) {
+  if (
+    el.$root &&
+    recordLocalRootProp(el, 'value', LocalPropType.VALUE, value)
+  ) {
     return
   }
 
@@ -603,13 +567,23 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
   const nextProps: Record<string, any> = Object.create(null)
 
   if (prevProps) {
-    for (const key in prevProps) {
-      if (!(key in props)) {
-        if (
-          !isApplyingFallthroughProps ||
-          !isRestorableDynamicProp(key) ||
-          !restoreLocalRootProp(el, key)
-        ) {
+    if (isApplyingFallthroughProps) {
+      for (const key in prevProps) {
+        if (!(key in props) && !applyLocalRootProp(el, key)) {
+          setDynamicProp(el, key, null, isSVG)
+        }
+      }
+    } else if (el.$lprops) {
+      for (const key in prevProps) {
+        if (!(key in props)) {
+          setDynamicProp(el, key, null, isSVG)
+          delete el.$lprops[key]
+        }
+      }
+    } else {
+      // Keep the original removal loop when no local fallthrough source exists.
+      for (const key in prevProps) {
+        if (!(key in props)) {
           setDynamicProp(el, key, null, isSVG)
         }
       }
@@ -620,15 +594,6 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
     const value = props[key]
     const hadKey = prevProps && key in prevProps
     nextProps[key] = value
-    if (isApplyingFallthroughProps && !isHydrating && !hadKey) {
-      if (key === 'class') {
-        seedLocalClass(el)
-      } else if (key === 'style') {
-        seedLocalStyle(el)
-      } else if (isRestorableDynamicProp(key)) {
-        captureLocalRootProp(el, key, !!isSVG)
-      }
-    }
     // Events and objects can have stable identity with mutable internals, so
     // only skip unchanged primitive values.
     if (
@@ -661,11 +626,14 @@ export function setDynamicProp(
     setStyle(el, value)
   } else if (isOn(key)) {
     const [event, options] = parseEventName(key)
+    // Only dynamic root events need source merging. Direct compiled v-on uses
+    // on() instead, so it remains an independent native listener just like
+    // the non-fallthrough path.
     if (el.$root) {
-      const instance = currentInstance as VaporComponentInstance | null
+      const instance = currentInstance! as VaporComponentInstance
       if (
         isApplyingFallthroughProps ||
-        (instance && forwardsFallthroughAttrs(instance))
+        (instance.hasFallthrough && instance.type.inheritAttrs !== false)
       ) {
         onRootBinding(
           el,
@@ -727,8 +695,6 @@ export function optimizePropertyLookup(): void {
   proto.$root = false
   proto.$clsFlags = undefined
   proto.$html = proto.$cls = proto.$sty = ''
-  proto.$dprops = proto.$dprops$ = proto.$lprops = proto.$evts = undefined
-  proto.$clsi = proto.$clsi$ = proto.$styi = proto.$styi$ = undefined
   // Initialize $txt to undefined instead of empty string to ensure setText()
   // properly updates the text node even when the value is empty string.
   // This prevents issues where setText(node, '') would be skipped because


### PR DESCRIPTION
Track dynamic local root bindings separately from inherited attrs so
fallthrough values remain authoritative while present and the latest local
value is reapplied when the inherited source is removed.

Merge dynamic class, style, and event sources while keeping state allocation
and reconciliation scoped to potential-fallthrough roots. Also install
fallthrough effects for initially empty dynamic sources and consistently
filter functional-component attrs across element and component roots.

Keep static template attrs initialization-only and intentionally avoid
snapshotting or restoring them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inheritance and restoration of component attributes and DOM properties.
  * Fixed merging, ordering, and cleanup of local and inherited event handlers.
  * Preserved local classes and styles when inherited values change or are removed.
  * Improved dynamic class/style updates and `v-show` display behavior.
  * Corrected filtering of inherited attributes for functional components.
* **Tests**
  * Added regression coverage for reactive attributes, event handling, styling, value restoration, and visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->