### PR TITLE
refactor(runtime-vapor): creation-time scope id model

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -213,6 +213,7 @@ export interface VaporInVdomInterface {
     anchor: any,
     parentComponent: ComponentInternalInstance | null,
     parentSuspense: SuspenseBoundary | null,
+    slotScopeIds: string[] | null,
   ): void
   hydrate(
     vnode: VNode,
@@ -229,6 +230,7 @@ export interface VaporInVdomInterface {
     node: any,
     parentComponent: ComponentInternalInstance | null,
     parentSuspense: SuspenseBoundary | null,
+    slotScopeIds: string[] | null,
   ): Node
   activate(
     vnode: VNode,

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -287,6 +287,7 @@ export function createHydrationFunctions(
           node,
           parentComponent,
           parentSuspense,
+          slotScopeIds,
         )
         break
       default:
@@ -837,7 +838,7 @@ export function createHydrationFunctions(
       slotScopeIds,
     )
     // the component vnode's el should be updated when a mismatch occurs.
-    if (parentComponent) {
+    if (parentComponent && parentComponent.vnode) {
       parentComponent.vnode.el = vnode.el
       updateHOCHostEl(parentComponent, vnode.el)
     }
@@ -881,7 +882,7 @@ export function createHydrationFunctions(
     // update vnode
     let parent = parentComponent
     while (parent) {
-      if (parent.vnode.el === oldNode) {
+      if (parent.vnode && parent.vnode.el === oldNode) {
         parent.vnode.el = parent.subTree.el = newNode
       }
       parent = parent.parent as ComponentInternalInstance

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -467,6 +467,7 @@ function baseCreateRenderer(
           anchor,
           parentComponent,
           parentSuspense,
+          slotScopeIds,
         )
         break
       default:
@@ -3002,6 +3003,7 @@ export function isVaporComponent(type: ConcreteComponent): boolean | undefined {
 export function getInheritedScopeIds(
   vnode: VNode,
   parentComponent: GenericComponentInstance | null,
+  includeVaporRootIds = true,
 ): string[] {
   const inheritedScopeIds: string[] = []
 
@@ -3042,6 +3044,13 @@ export function getInheritedScopeIds(
     } else {
       break
     }
+  }
+
+  // Where the chain tops out, append root-only ids published by the vapor
+  // interop so they land before insertion.
+  const vaporScopeIds = includeVaporRootIds && currentVNode.vaporScopeIds
+  if (vaporScopeIds) {
+    inheritedScopeIds.push(...vaporScopeIds)
   }
 
   return inheritedScopeIds

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -195,6 +195,13 @@ export interface VNode<
    * @internal
    */
   slotScopeIds: string[] | null
+  /**
+   * Root-only scope ids published by the vapor interop onto vnodes serving
+   * as a vapor component's effective root; consumed by getInheritedScopeIds
+   * where the effective-root chain tops out (before insertion).
+   * @internal
+   */
+  vaporScopeIds?: string[]
   children: VNodeNormalizedChildren
   component: ComponentInternalInstance | null
   dirs: DirectiveBinding[] | null

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -23,6 +23,7 @@ import {
   nextTick,
   reactive,
   ref,
+  renderSlot,
   withDirectives,
 } from '@vue/runtime-dom'
 import { BindingTypes } from '@vue/compiler-dom'
@@ -39,6 +40,7 @@ import {
 import {
   currentHydrationNode,
   hydrateNode,
+  isHydrating,
   setIsHydratingEnabled,
   validateHydrationTarget,
   withDeferredHydrationBoundary,
@@ -16009,5 +16011,458 @@ describe('placeholder unit alignment', () => {
     expect(container.innerHTML).toBe(
       `<div><h1>h</h1><!--[--><li>x</li><li>y</li><li>z</li><!--]--><p>t2</p></div>`,
     )
+  })
+})
+
+describe('scopeId hydration writes', () => {
+  test('writes inherited scopeId to a recreated hydration root', () => {
+    const msg = ref('base')
+    const Child = defineVaporComponent({
+      __scopeId: 'child',
+      render: compileToVaporRender(`<div>{{ msg }}</div>`, {
+        bindingMetadata: {
+          msg: BindingTypes.SETUP_REF,
+        },
+        scopeId: 'child',
+      }),
+      setup() {
+        return { msg }
+      },
+    })
+    const Parent = defineVaporComponent({
+      __scopeId: 'parent',
+      setup() {
+        return createComponent(Child)
+      },
+    })
+    const container = document.createElement('div')
+    container.innerHTML = `<span child="" parent="">base</span>`
+    document.body.appendChild(container)
+
+    const app = createVaporSSRApp(Parent)
+    app.mount(container)
+
+    expect(container.innerHTML).toBe(`<div child="" parent="">base</div>`)
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+    app.unmount()
+  })
+
+  test('writes recreated plain element scopeId without breaking hydration', () => {
+    let restored: boolean | undefined
+    const App = defineVaporComponent({
+      __scopeId: 'parent',
+      setup() {
+        const element = createPlainElement('div')
+        // scope id writes on a recreated element must not knock the runtime
+        // out of hydration mode for subsequent siblings
+        restored = isHydrating
+        return element
+      },
+    })
+    const container = document.createElement('div')
+    container.innerHTML = `<span parent=""></span>`
+    document.body.appendChild(container)
+
+    const app = createVaporSSRApp(App)
+    app.mount(container)
+
+    expect(container.innerHTML).toBe(`<div parent=""></div>`)
+    expect(restored).toBe(true)
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+    app.unmount()
+  })
+
+  // renders App with interop on the "server", then rebuilds the markup in a
+  // fresh container ready for client hydration
+  function renderToHydrationContainer(App: any): HTMLElement {
+    const serverContainer = document.createElement('div')
+    const serverApp = runtimeDom
+      .createApp(App)
+      .use(runtimeVapor.vaporInteropPlugin)
+    serverApp.mount(serverContainer)
+    const html = serverContainer.innerHTML
+    serverApp.unmount()
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    return container
+  }
+
+  test('applies slotted scopeId before hydrating recreated VDOM content', () => {
+    const useDiv = ref(false)
+    const Receiver = compileVaporComponent(`<slot />`, useDiv)
+    Receiver.__scopeId = 'receiver'
+    const App = compile(
+      `<script setup>
+        const data = _data
+        const components = _components
+      </script>
+      <template>
+        <components.Receiver>
+          <div v-if="data">content</div>
+          <span v-else>content</span>
+        </components.Receiver>
+      </template>`,
+      useDiv,
+      { Receiver },
+      { vapor: false },
+    )
+    App.__scopeId = 'owner'
+
+    const container = renderToHydrationContainer(App)
+
+    useDiv.value = true
+    const clientApp = createSSRApp(App).use(runtimeVapor.vaporInteropPlugin)
+    clientApp.mount(container)
+
+    expect(container.querySelector('div')!.hasAttribute('owner')).toBe(true)
+    expect(container.querySelector('div')!.hasAttribute('receiver-s')).toBe(
+      true,
+    )
+    expect(container.querySelector('div')!.hasAttribute('receiver')).toBe(false)
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+    clientApp.unmount()
+    container.remove()
+  })
+
+  test('does not hydrate root-only component scopeId through a slot outlet', async () => {
+    const hasContent = ref(true)
+    const useDiv = ref(false)
+    const VDOMChild = defineComponent({
+      setup(_: unknown, { slots }) {
+        return () =>
+          renderSlot(slots, 'default', {}, () => [h('em', 'fallback')])
+      },
+    })
+    const VaporChild = compileVaporComponent(`<slot><em>fallback</em></slot>`)
+    const createParent = (Child: any) =>
+      defineComponent({
+        setup() {
+          return () => {
+            const child = h(Child, null, {
+              default: () =>
+                hasContent.value
+                  ? h(useDiv.value ? 'div' : 'span', 'content')
+                  : [],
+            })
+            child.scopeId = 'external'
+            return child
+          }
+        },
+      })
+
+    const VDOMApp = createParent(VDOMChild)
+    const VaporApp = createParent(VaporChild)
+    const vdomContainer = renderToHydrationContainer(VDOMApp)
+    const vaporContainer = renderToHydrationContainer(VaporApp)
+
+    useDiv.value = true
+    const vdomApp = createSSRApp(VDOMApp)
+    const vaporApp = createSSRApp(VaporApp).use(runtimeVapor.vaporInteropPlugin)
+    vdomApp.mount(vdomContainer)
+    vaporApp.mount(vaporContainer)
+    await nextTick()
+
+    expect(vdomContainer.innerHTML).toBe(`<div>content</div>`)
+    expect(vaporContainer.innerHTML).toBe(vdomContainer.innerHTML)
+    expect(vaporContainer.firstElementChild!.hasAttribute('external')).toBe(
+      false,
+    )
+
+    hasContent.value = false
+    await nextTick()
+    expect(vdomContainer.innerHTML).toBe(`<em>fallback</em>`)
+    expect(vaporContainer.innerHTML).toBe(vdomContainer.innerHTML)
+    expect(vaporContainer.firstElementChild!.hasAttribute('external')).toBe(
+      false,
+    )
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+    vdomApp.unmount()
+    vaporApp.unmount()
+    vdomContainer.remove()
+    vaporContainer.remove()
+  })
+
+  test('recreated mismatch nodes in a VDOM outlet fallback carry both slotted ids', async () => {
+    const data = ref(false)
+
+    const makeComponents = (ssr: boolean, fallbackTag: string) => {
+      const components: any = {}
+      const Outlet = compile(
+        `<script setup>const data = _data; const components = _components;</script>` +
+          `<template><slot><${fallbackTag}>fallback</${fallbackTag}></slot></template>`,
+        data,
+        components,
+        { vapor: false, ssr },
+      )
+      Outlet.__scopeId = 'outlet'
+      const Child = compile(
+        `<template><components.Outlet><slot/></components.Outlet></template>`,
+        data,
+        { Outlet },
+        { vapor: true, ssr },
+      )
+      ;(Child as any).__scopeId = 'child'
+      return { Child }
+    }
+
+    const appCode =
+      `<script setup>const data = _data; const components = _components;</script>` +
+      `<template><components.Child><b v-if="data">content</b></components.Child></template>`
+
+    // server renders the fallback as <b>, client expects <span> → mismatch
+    const ServerApp = compile(appCode, data, makeComponents(true, 'b'), {
+      vapor: false,
+      ssr: true,
+    })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(ServerApp).use(runtimeVapor.vaporInteropPlugin),
+    )
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML = html
+
+    const ClientApp = compile(appCode, data, makeComponents(false, 'span'), {
+      vapor: false,
+      ssr: false,
+    })
+    const app = runtimeDom
+      .createSSRApp(ClientApp)
+      .use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    // the recreated node gets both the requesting outlet's and the providing
+    // outlet's slotted ids as part of its creation context (CSR control:
+    // <span child-s outlet-s>fallback</span>)
+    const span = container.querySelector('span')!
+    expect(span).toBeTruthy()
+    expect(span.hasAttribute('child-s')).toBe(true)
+    expect(span.hasAttribute('outlet-s')).toBe(true)
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+    app.unmount()
+    container.remove()
+  })
+
+  test('does not propagate slotted ids through an adopted VDOM fallback component', async () => {
+    const data = ref(false)
+
+    const makeApp = (ssr: boolean) => {
+      const Fallback = compile(
+        `<template><span><i>inside</i></span></template>`,
+        data,
+        {},
+        { vapor: false, ssr },
+      )
+      Fallback.__scopeId = 'fallback'
+      const Outlet = compile(
+        `<script setup>const components = _components;</script>` +
+          `<template><slot><components.Fallback /></slot></template>`,
+        data,
+        { Fallback },
+        { vapor: false, ssr },
+      )
+      Outlet.__scopeId = 'outlet'
+      const Child = compile(
+        `<template><components.Outlet><slot/></components.Outlet></template>`,
+        data,
+        { Outlet },
+        { vapor: true, ssr },
+      )
+      ;(Child as any).__scopeId = 'child'
+      return compile(
+        `<script setup>const components = _components;</script>` +
+          `<template><components.Child /></template>`,
+        data,
+        { Child },
+        { vapor: false, ssr },
+      )
+    }
+
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom
+        .createSSRApp(makeApp(true))
+        .use(runtimeVapor.vaporInteropPlugin),
+    )
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML = html
+    const serverRoot = container.querySelector('span')!
+    // __scopeId is assigned after compilation in this test helper, so stamp
+    // the attributes that a real scoped SSR build would emit.
+    serverRoot.setAttribute('child-s', '')
+    serverRoot.setAttribute('outlet-s', '')
+
+    const setAttribute = vi.spyOn(Element.prototype, 'setAttribute')
+    const app = runtimeDom
+      .createSSRApp(makeApp(false))
+      .use(runtimeVapor.vaporInteropPlugin)
+    try {
+      app.mount(container)
+
+      const span = container.querySelector('span')!
+      expect(span).toBe(serverRoot)
+      expect(setAttribute).not.toHaveBeenCalledWith('child-s', '')
+      expect(setAttribute).not.toHaveBeenCalledWith('outlet-s', '')
+      expect(span.hasAttribute('child-s')).toBe(true)
+      expect(span.hasAttribute('outlet-s')).toBe(true)
+      expect(span.querySelector('i')!.hasAttribute('child-s')).toBe(false)
+      expect(span.querySelector('i')!.hasAttribute('outlet-s')).toBe(false)
+      app.unmount()
+    } finally {
+      setAttribute.mockRestore()
+      container.remove()
+    }
+  })
+
+  test('applies slotted id to recovered teleport children when the target has no markers', async () => {
+    const data = ref(0)
+
+    const Child = compile(`<template><slot/></template>`, data, {}, {})
+    ;(Child as any).__scopeId = 'c'
+    const App = compile(
+      `<template><components.Child><Teleport to="#hydration-scope-modal"><div>x</div></Teleport></components.Child></template>`,
+      data,
+      { Child },
+    )
+
+    // client-side teleport target exists but carries no SSR markers, so the
+    // teleport takes the hydration recovery path and creates its children
+    const target = document.createElement('div')
+    target.id = 'hydration-scope-modal'
+    document.body.appendChild(target)
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML =
+      '<!--[--><!--teleport start--><!--teleport end--><!--]-->'
+
+    const app = createVaporSSRApp(App)
+    app.mount(container)
+
+    try {
+      const div = target.querySelector('div')!
+      expect(div).toBeTruthy()
+      expect(div.hasAttribute('c-s')).toBe(true)
+      expect(`Hydration children mismatch`).toHaveBeenWarned()
+    } finally {
+      app.unmount()
+      target.remove()
+      container.remove()
+    }
+  })
+
+  test('hydrated vdom component in vapor slot content keeps the slot context', async () => {
+    const show = ref(false)
+    const makeApp = (ssr: boolean) => {
+      const VdomInner = compile(
+        `<script setup>const data = _data</script>` +
+          `<template><b v-if="data">out</b><i v-else>in</i></template>`,
+        show,
+        {},
+        { vapor: false, ssr },
+      )
+      const Receiver = compile(
+        `<template><slot/></template>`,
+        show,
+        {},
+        {
+          vapor: true,
+          ssr,
+        },
+      )
+      ;(Receiver as any).__scopeId = 'child'
+      const Parent = compile(
+        `<template><components.Receiver><components.VdomInner/></components.Receiver></template>`,
+        show,
+        { Receiver, VdomInner },
+        { vapor: true, ssr },
+      )
+      return compile(
+        `<script setup>const components = _components</script>` +
+          `<template><components.Parent/></template>`,
+        show,
+        { Parent },
+        { vapor: false, ssr },
+      )
+    }
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom
+        .createSSRApp(makeApp(true))
+        .use(runtimeVapor.vaporInteropPlugin),
+    )
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML = html
+    const app = runtimeDom
+      .createSSRApp(makeApp(false))
+      .use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    // a branch mounted after hydration must observe the creation-time slot
+    // context — core hydration overwrites vnode.slotScopeIds, so the interop
+    // fragment has to hand its captured cell back in
+    show.value = true
+    await nextTick()
+    const b = container.querySelector('b')!
+    expect(b).toBeTruthy()
+    expect(b.hasAttribute('child-s')).toBe(true)
+    app.unmount()
+    container.remove()
+  })
+
+  test('hydrated forwarded vapor slot keeps the outer vdom slot context', async () => {
+    const show = ref(false)
+    const makeApp = (ssr: boolean) => {
+      const Outer = compile(
+        `<template><div><slot/></div></template>`,
+        show,
+        {},
+        { vapor: false, ssr },
+      )
+      ;(Outer as any).__scopeId = 'outer'
+      const Middle = compile(
+        `<template><components.Outer><slot/></components.Outer></template>`,
+        show,
+        { Outer },
+        { vapor: false, ssr },
+      )
+      const Sender = compile(
+        `<template><components.Middle><b v-if="data">on</b><i v-else>off</i></components.Middle></template>`,
+        show,
+        { Middle },
+        { vapor: true, ssr },
+      )
+      return compile(
+        `<script setup>const components = _components</script>` +
+          `<template><components.Sender/></template>`,
+        show,
+        { Sender },
+        { vapor: false, ssr },
+      )
+    }
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom
+        .createSSRApp(makeApp(true))
+        .use(runtimeVapor.vaporInteropPlugin),
+    )
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML = html
+    const app = runtimeDom
+      .createSSRApp(makeApp(false))
+      .use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    // the outer vdom outlet's ambient context must survive the VaporSlot
+    // hydration dispatch so client-mounted branches inside the forwarded
+    // vapor content still carry it
+    show.value = true
+    await nextTick()
+    const b = container.querySelector('b')!
+    expect(b).toBeTruthy()
+    expect(b.hasAttribute('outer-s')).toBe(true)
+    app.unmount()
+    container.remove()
   })
 })

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -9359,7 +9359,9 @@ describe('Vapor Mode hydration', () => {
       container.innerHTML = '<my-element-7203></my-element-7203>'
       const app = createVaporSSRApp({
         setup() {
-          return createPlainElement('my-element-7203', { foo: () => msg.value })
+          return createPlainElement('my-element-7203', {
+            foo: () => msg.value,
+          })
         },
       })
       app.mount(container)
@@ -16045,6 +16047,7 @@ describe('scopeId hydration writes', () => {
     expect(container.innerHTML).toBe(`<div child="" parent="">base</div>`)
     expect(`Hydration node mismatch`).toHaveBeenWarned()
     app.unmount()
+    container.remove()
   })
 
   test('writes recreated plain element scopeId without breaking hydration', () => {
@@ -16070,6 +16073,7 @@ describe('scopeId hydration writes', () => {
     expect(restored).toBe(true)
     expect(`Hydration node mismatch`).toHaveBeenWarned()
     app.unmount()
+    container.remove()
   })
 
   // renders App with interop on the "server", then rebuilds the markup in a

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -2070,16 +2070,15 @@ describe('vdom interop', () => {
       { Child },
     )
 
-    const { html } = define(Parent).render()
-    expect(html()).toContain('fb')
-    expect(html()).toContain('child-s')
+    const { app, host } = define(Parent).render()
+    expect(host.querySelector('i')!.hasAttribute('child-s')).toBe(true)
 
     data.value = true
     await nextTick()
     // content parked behind the active fallback still received the slot's
     // ids, so re-exposing it yields the same DOM as VDOM (<em child-s>)
-    expect(html()).toContain('<em')
-    expect(html()).toContain('child-s')
+    expect(host.querySelector('em')!.hasAttribute('child-s')).toBe(true)
+    app.unmount()
   })
 
   describe('slotted scope id depth parity with VDOM', () => {
@@ -2099,14 +2098,21 @@ describe('vdom interop', () => {
     const strip = (html: string) =>
       html.replace(/<!--[^>]*-->/g, '').replace(/ receiver=""/g, '')
 
-    const mountPair = (
-      makeSide: (vapor: boolean) => any,
-    ): { vdomHost: HTMLElement; host: HTMLElement } => {
+    const mountPair = (makeSide: (vapor: boolean) => any) => {
       const vdomHost = document.createElement('div')
-      createApp(makeSide(false)).mount(vdomHost)
+      const vdomApp = createApp(makeSide(false))
+      vdomApp.mount(vdomHost)
       const host = document.createElement('div')
-      createVaporApp(makeSide(true)).mount(host)
-      return { vdomHost, host }
+      const app = createVaporApp(makeSide(true))
+      app.mount(host)
+      return {
+        vdomHost,
+        host,
+        unmount: () => {
+          vdomApp.unmount()
+          app.unmount()
+        },
+      }
     }
 
     const makeSides =
@@ -2130,25 +2136,27 @@ describe('vdom interop', () => {
       }
 
     test('slotted id reaches nested elements but not component internals', () => {
-      let { vdomHost, host } = mountPair(
+      let { vdomHost, host, unmount } = mountPair(
         makeSides(
           `<template><components.Receiver><div><span>x</span></div></components.Receiver></template>`,
         ),
       )
       expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
       expect(strip(host.innerHTML)).toContain('<span receiver-s="">x</span>')
-      ;({ vdomHost, host } = mountPair(
+      unmount()
+      ;({ vdomHost, host, unmount } = mountPair(
         makeSides(
           `<template><components.Receiver><div><components.Comp/></div></components.Receiver></template>`,
           { components: { Comp: `<template><b><u>x</u></b></template>` } },
         ),
       ))
       expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
+      unmount()
     })
 
     test('v-if / v-for content added after mount carries ids at depth', async () => {
       const show = ref(false)
-      let { vdomHost, host } = mountPair(
+      let { vdomHost, host, unmount } = mountPair(
         makeSides(
           `<template><components.Receiver><div v-if="data"><span>x</span></div></components.Receiver></template>`,
           { data: show },
@@ -2158,9 +2166,10 @@ describe('vdom interop', () => {
       await nextTick()
       expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
       expect(strip(host.innerHTML)).toContain('receiver-s')
+      unmount()
 
       const count = ref(0)
-      ;({ vdomHost, host } = mountPair(
+      ;({ vdomHost, host, unmount } = mountPair(
         makeSides(
           `<template><components.Receiver><div v-for="i in data"><span>{{ i }}</span></div></components.Receiver></template>`,
           { data: count },
@@ -2170,16 +2179,18 @@ describe('vdom interop', () => {
       await nextTick()
       expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
       expect(strip(host.innerHTML)).toContain('receiver-s')
+      unmount()
     })
 
     test('fallback content carries ids at depth', () => {
-      const { vdomHost, host } = mountPair(
+      const { vdomHost, host, unmount } = mountPair(
         makeSides(`<template><components.Receiver/></template>`, {
           receiver: `<template><slot><div><span>fb</span></div></slot></template>`,
         }),
       )
       expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
       expect(strip(host.innerHTML)).toContain('receiver-s')
+      unmount()
     })
   })
 
@@ -2312,31 +2323,38 @@ describe('vdom interop', () => {
         { vapor },
       )
       const root = document.createElement('div')
-      ;(vapor ? createVaporApp(Parent) : createApp(Parent)).mount(root)
+      const app = vapor ? createVaporApp(Parent) : createApp(Parent)
+      app.mount(root)
 
       data.value = 1
       await nextTick()
-      return root
+      return { root, app }
     }
 
     for (const vapor of [false, true]) {
       // late v-if branch
-      let root = await runCase(vapor, `<span v-if="data">late</span>`)
+      let { root, app } = await runCase(vapor, `<span v-if="data">late</span>`)
       expect(root.querySelector('span')!.hasAttribute('receiver-s')).toBe(true)
+      app.unmount()
 
       // component whose future root appears late: ids reach the new root
       // but not its internals
-      root = await runCase(
+      ;({ root, app } = await runCase(
         vapor,
         `<components.Inner />`,
         `<template><span v-if="data"><u>late</u></span><i v-else>initial</i></template>`,
-      )
+      ))
       expect(root.querySelector('span')!.hasAttribute('receiver-s')).toBe(true)
       expect(root.querySelector('u')!.hasAttribute('receiver-s')).toBe(false)
+      app.unmount()
 
       // late v-for item
-      root = await runCase(vapor, `<span v-for="i in data">late</span>`)
+      ;({ root, app } = await runCase(
+        vapor,
+        `<span v-for="i in data">late</span>`,
+      ))
       expect(root.querySelector('span')!.hasAttribute('receiver-s')).toBe(true)
+      app.unmount()
     }
   })
 

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -2218,6 +2218,38 @@ describe('vdom interop', () => {
     app.unmount()
   })
 
+  test('does not publish root-only scope id to branches of a multi-root vapor child', () => {
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return [
+          createDynamicComponent(
+            () => h('div', 'a'),
+            null,
+            null,
+            VaporDynamicComponentFlags.SINGLE_ROOT,
+          ),
+          createDynamicComponent(
+            () => h('span', 'b'),
+            null,
+            null,
+            VaporDynamicComponentFlags.SINGLE_ROOT,
+          ),
+        ] as any
+      },
+    })
+    const root = document.createElement('div')
+    const app = createApp({
+      __scopeId: 'external',
+      render: () => h(VaporChild as any),
+    }).use(vaporInteropPlugin)
+    app.mount(root)
+    // VDOM control: a multi-root child inherits nothing. Publishing to a
+    // branch carrier before the multi-root verdict leaked [true, false].
+    expect(root.querySelector('div')!.hasAttribute('external')).toBe(false)
+    expect(root.querySelector('span')!.hasAttribute('external')).toBe(false)
+    app.unmount()
+  })
+
   test('applies inherited root-only scope id to an async-resolved interop Suspense root', async () => {
     const makeSide = () => {
       let resolveSetup: (() => void) | undefined

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -1,4 +1,8 @@
 import {
+  Fragment,
+  Suspense,
+  Teleport,
+  cloneVNode,
   createApp,
   h,
   nextTick,
@@ -16,10 +20,9 @@ import {
   createFor,
   createIf,
   createSlot,
+  createVaporApp,
   defineVaporAsyncComponent,
   defineVaporComponent,
-  renderEffect,
-  setElementText,
   setInsertionState,
   template,
   vaporInteropPlugin,
@@ -27,22 +30,6 @@ import {
 import { compile, compileToVaporRender, makeRender } from './_utils'
 
 const define = makeRender()
-const slottedScopeProbeConnections = ((
-  globalThis as any
-).__slottedScopeProbeConnections ||= []) as boolean[]
-
-function defineSlottedScopeProbe() {
-  if (!customElements.get('slotted-scope-probe')) {
-    customElements.define(
-      'slotted-scope-probe',
-      class extends HTMLElement {
-        connectedCallback() {
-          slottedScopeProbeConnections.push(this.hasAttribute('child-s'))
-        }
-      },
-    )
-  }
-}
 
 describe('scopeId', () => {
   test('should attach scopeId to child component', () => {
@@ -52,7 +39,6 @@ describe('scopeId', () => {
         return template('<div child></div>', 1)()
       },
     })
-
     const { html } = define({
       __scopeId: 'parent',
       setup() {
@@ -140,7 +126,8 @@ describe('scopeId', () => {
     expect(html()).toBe(`<div child="" parent="" app=""></div>`)
   })
 
-  test('should not attach scopeId to nested multiple root components', () => {
+  test('should not attach scopeId to nested multiple root components', async () => {
+    const show = ref(false)
     const Child = defineVaporComponent({
       __scopeId: 'child',
       setup() {
@@ -152,8 +139,12 @@ describe('scopeId', () => {
       __scopeId: 'parent',
       setup() {
         const n0 = template('<div parent></div>')()
-        const n1 = createComponent(Child)
-        return [n0, n1]
+        const n1 = createIf(
+          () => show.value,
+          () => template('<span parent></span>', 1)(),
+        )
+        const n2 = createComponent(Child)
+        return [n0, n1, n2]
       },
     })
 
@@ -163,7 +154,16 @@ describe('scopeId', () => {
         return createComponent(Parent)
       },
     }).render()
-    expect(html()).toBe(`<div parent=""></div><div child="" parent=""></div>`)
+    expect(html()).toBe(
+      `<div parent=""></div><!--if--><div child="" parent=""></div>`,
+    )
+
+    show.value = true
+    await nextTick()
+
+    expect(html()).toBe(
+      `<div parent=""></div><span parent=""></span><!--if--><div child="" parent=""></div>`,
+    )
   })
 
   test('should attach scopeId to nested child component with insertion state', () => {
@@ -322,7 +322,7 @@ describe('scopeId', () => {
         // - scopeId from template context
         // - slotted scopeId from slot owner
         // - its own scopeId
-        `<span child2="" child-s="" parent=""></span>` +
+        `<span child2="" parent="" child-s=""></span>` +
         `<!--slot-->` +
         `</div>`,
     )
@@ -386,9 +386,9 @@ describe('scopeId', () => {
   })
 
   test(':slotted on dynamic slot outlet update', async () => {
-    const data = ref({ slotName: 'one' })
+    const data = ref({ slotName: 'missing' })
     const Child = compile(
-      `<template><slot :name="data.slotName" /></template>`,
+      `<template><slot :name="data.slotName"><span>fallback</span></slot></template>`,
       data,
     )
     Child.__scopeId = 'child'
@@ -404,14 +404,31 @@ describe('scopeId', () => {
       { Child },
     )
 
-    const { html } = define(Parent).render()
+    const { app, html } = define(Parent).render()
+    const setAttribute = vi.spyOn(Element.prototype, 'setAttribute')
 
-    expect(html()).toBe(`<div child-s="">one</div><!--slot-->`)
+    try {
+      expect(html()).toBe(`<span child-s="">fallback</span><!--slot-->`)
 
-    data.value = { slotName: 'two' }
-    await nextTick()
+      data.value = { slotName: 'one' }
+      await nextTick()
 
-    expect(html()).toBe(`<section child-s="">two</section><!--slot-->`)
+      expect(html()).toBe(`<div child-s="">one</div><!--slot-->`)
+      expect(
+        setAttribute.mock.calls.filter(([name]) => name === 'child-s'),
+      ).toHaveLength(1)
+
+      data.value = { slotName: 'two' }
+      await nextTick()
+
+      expect(html()).toBe(`<section child-s="">two</section><!--slot-->`)
+      expect(
+        setAttribute.mock.calls.filter(([name]) => name === 'child-s'),
+      ).toHaveLength(2)
+    } finally {
+      setAttribute.mockRestore()
+      app.unmount()
+    }
   })
 
   test(':slotted on v-for content added after mount', async () => {
@@ -443,48 +460,6 @@ describe('scopeId', () => {
 
     expect(html()).toBe(
       `<div child-s="">item</div><div child-s="">item</div><!--for--><!--slot-->`,
-    )
-  })
-
-  test(':slotted on v-for content applies scope id before insertion', async () => {
-    defineSlottedScopeProbe()
-    slottedScopeProbeConnections.length = 0
-
-    const count = ref(0)
-    const Child = defineVaporComponent({
-      __scopeId: 'child',
-      setup() {
-        return createSlot('default')
-      },
-    })
-
-    const { html } = define({
-      setup() {
-        return createComponent(
-          Child,
-          null,
-          {
-            default: () =>
-              createFor(
-                () => count.value,
-                () =>
-                  template(
-                    '<slotted-scope-probe>item</slotted-scope-probe>',
-                    1,
-                  )(),
-              ),
-          },
-          true,
-        )
-      },
-    }).render()
-
-    count.value++
-    await nextTick()
-
-    expect(slottedScopeProbeConnections).toEqual([true])
-    expect(html()).toBe(
-      `<slotted-scope-probe child-s="">item</slotted-scope-probe><!--for--><!--slot-->`,
     )
   })
 
@@ -743,6 +718,35 @@ describe('scopeId', () => {
         `<!--slot--></div>`,
     )
   })
+
+  test(':slotted on dynamic content inside v-for', async () => {
+    const data = ref([true])
+    const Child = compile(`<template><slot /></template>`, data)
+    Child.__scopeId = 'child'
+
+    const Parent = compile(
+      `<template>
+        <components.Child>
+          <template v-for="show in data">
+            <div v-if="show">on</div>
+            <span v-else>off</span>
+          </template>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+
+    const { app, host } = define(Parent).render()
+    expect(host.firstElementChild!.tagName).toBe('DIV')
+    expect(host.firstElementChild!.hasAttribute('child-s')).toBe(true)
+
+    data.value = [false]
+    await nextTick()
+    expect(host.firstElementChild!.tagName).toBe('SPAN')
+    expect(host.firstElementChild!.hasAttribute('child-s')).toBe(true)
+    app.unmount()
+  })
 })
 
 describe('vdom interop', () => {
@@ -942,92 +946,7 @@ describe('vdom interop', () => {
 
     expect(root.innerHTML).toBe(
       `<div vdom-slot-owner="" vdom-parent="">` +
-        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s=""></button>` +
-        `</div>`,
-    )
-  })
-
-  test('vdom slot owner > vapor slot content preserves slot scopeIds on same root update', async () => {
-    function mount(initialNoSlotted: boolean) {
-      const noSlotted = ref(initialNoSlotted)
-      const count = ref(0)
-      const VaporChild = defineVaporComponent({
-        props: {
-          count: Number,
-        },
-        setup(props: any) {
-          const n0 = template('<button></button>', 1)()
-          renderEffect(() => setElementText(n0, props.count))
-          return n0
-        },
-      })
-
-      const VdomSlotOwner = {
-        __scopeId: 'vdom-slot-owner',
-        setup(_props: unknown, { slots }: any) {
-          return () =>
-            h(
-              'div',
-              null,
-              renderSlot(slots, 'default', {}, undefined, noSlotted.value),
-            )
-        },
-      }
-
-      const VdomParent = {
-        __scopeId: 'vdom-parent',
-        setup() {
-          return () =>
-            h(VdomSlotOwner, null, {
-              default: () => h(VaporChild as any, { count: count.value }),
-            })
-        },
-      }
-
-      const App = {
-        setup() {
-          return () => h(VdomParent)
-        },
-      }
-
-      const root = document.createElement('div')
-      createApp(App).use(vaporInteropPlugin).mount(root)
-      return { count, noSlotted, root }
-    }
-
-    const noSlottedRoot = mount(true)
-
-    expect(noSlottedRoot.root.innerHTML).toBe(
-      `<div vdom-slot-owner="" vdom-parent="">` +
-        `<button vdom-slot-owner="" vdom-parent="">0</button>` +
-        `</div>`,
-    )
-
-    noSlottedRoot.noSlotted.value = false
-    noSlottedRoot.count.value++
-    await nextTick()
-
-    expect(noSlottedRoot.root.innerHTML).toBe(
-      `<div vdom-slot-owner="" vdom-parent="">` +
-        `<button vdom-slot-owner="" vdom-parent="">1</button>` +
-        `</div>`,
-    )
-
-    const slottedRoot = mount(false)
-
-    expect(slottedRoot.root.innerHTML).toBe(
-      `<div vdom-slot-owner="" vdom-parent="">` +
-        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">0</button>` +
-        `</div>`,
-    )
-
-    slottedRoot.noSlotted.value = true
-    slottedRoot.count.value++
-    await nextTick()
-
-    expect(slottedRoot.root.innerHTML).toBe(
-      `<div vdom-slot-owner="" vdom-parent="">` +
-        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">1</button>` +
+        `<button vdom-parent="" vdom-slot-owner-s=""></button>` +
         `</div>`,
     )
   })
@@ -1072,7 +991,7 @@ describe('vdom interop', () => {
 
     expect(root.innerHTML).toBe(
       `<div vdom-slot-owner="" vdom-parent="">` +
-        `<button vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">base</button><!--if-->` +
+        `<button vdom-parent="" vdom-slot-owner-s="">base</button><!--if-->` +
         `</div>`,
     )
 
@@ -1081,7 +1000,7 @@ describe('vdom interop', () => {
 
     expect(root.innerHTML).toBe(
       `<div vdom-slot-owner="" vdom-parent="">` +
-        `<span vdom-slot-owner="" vdom-parent="" vdom-slot-owner-s="">alt</span><!--if-->` +
+        `<span vdom-parent="" vdom-slot-owner-s="">alt</span><!--if-->` +
         `</div>`,
     )
   })
@@ -1270,7 +1189,7 @@ describe('vdom interop', () => {
 
     expect(onLeave).toHaveBeenCalledTimes(1)
     expect(root.innerHTML).toBe(
-      `<section class="v-enter-from v-enter-active" vdom-parent="">B</section><!--if-->`,
+      `<section vdom-parent="" class="v-enter-from v-enter-active">B</section><!--if-->`,
     )
     expect(interopVnode.el).toBe(root.firstChild)
   })
@@ -1691,5 +1610,833 @@ describe('vdom interop', () => {
         `<!--slot-->` +
         `</div>`,
     )
+  })
+
+  test('does not apply root-only component scopeId to VDOM slot content or a late VDOM fallback', async () => {
+    const mountCase = (VaporChild: any, slotFn: () => any) => {
+      const App = {
+        setup() {
+          return () => {
+            const child = h(VaporChild, null, { default: slotFn })
+            child.scopeId = 'external'
+            return child
+          }
+        },
+      }
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
+      return { root, app }
+    }
+
+    // swapped slot content
+    const showAlt = ref(false)
+    let { root, app } = mountCase(
+      defineVaporComponent({
+        setup() {
+          return createSlot('default') as any
+        },
+      }),
+      () => (showAlt.value ? h('section', 'alt') : h('div', 'base')),
+    )
+    expect(root.innerHTML).toBe(`<div>base</div>`)
+    showAlt.value = true
+    await nextTick()
+    expect(root.innerHTML).toBe(`<section>alt</section>`)
+    app.unmount()
+
+    // VDOM fallback created later, through a forwarded outlet
+    const show = ref(true)
+    const VDomOutlet = {
+      setup(_: unknown, { slots }: any) {
+        return () =>
+          renderSlot(slots, 'default', {}, () => [h('span', 'fallback')])
+      },
+    }
+    ;({ root, app } = mountCase(
+      defineVaporComponent({
+        setup() {
+          return createComponent(
+            VDomOutlet as any,
+            null,
+            {
+              default: () =>
+                createSlot(
+                  'default',
+                  null,
+                  undefined,
+                  VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK,
+                ),
+            },
+            true,
+          )
+        },
+      }),
+      () => (show.value ? h('div', 'content') : []),
+    ))
+    expect(root.innerHTML).toBe(`<div>content</div>`)
+    show.value = false
+    await nextTick()
+    expect(root.innerHTML).toBe(`<span>fallback</span>`)
+    app.unmount()
+  })
+
+  test('matches VDOM root-only scopeId behavior for slot content and fallback', async () => {
+    const show = ref(true)
+    const VDOMChild = {
+      setup(_: unknown, { slots }: any) {
+        return () =>
+          renderSlot(slots, 'default', {}, () => [h('span', 'fallback')])
+      },
+    }
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createSlot(
+          'default',
+          null,
+          () => template('<span>fallback</span>')(),
+          VaporSlotFlags.SLOT_ROOT,
+        ) as any
+      },
+    })
+    const createParent = (Child: any) => ({
+      setup() {
+        return () => {
+          const child = h(Child, null, {
+            default: () => (show.value ? h('div', 'content') : []),
+          })
+          child.scopeId = 'external'
+          return child
+        }
+      },
+    })
+
+    const vdomRoot = document.createElement('div')
+    const vdomApp = createApp(createParent(VDOMChild))
+    vdomApp.mount(vdomRoot)
+    const vaporRoot = document.createElement('div')
+    const vaporApp = createApp(createParent(VaporChild)).use(vaporInteropPlugin)
+    vaporApp.mount(vaporRoot)
+
+    expect(vdomRoot.innerHTML).toBe(`<div>content</div>`)
+    expect(vaporRoot.innerHTML).toBe(vdomRoot.innerHTML)
+
+    show.value = false
+    await nextTick()
+    expect(vdomRoot.innerHTML).toBe(`<span>fallback</span>`)
+    expect(vaporRoot.innerHTML).toBe(vdomRoot.innerHTML)
+
+    vdomApp.unmount()
+    vaporApp.unmount()
+  })
+
+  test.each([
+    ['a single child', 1],
+    ['multiple children', 2],
+  ] as const)(
+    'matches VDOM component scopeId behavior for a Fragment with %s',
+    (_, childCount) => {
+      const renderFragment = () =>
+        h(Fragment, null, childCount === 1 ? [h('div')] : [h('div'), h('span')])
+      const VDOMChild = {
+        setup: () => renderFragment,
+      }
+      const VaporChild = defineVaporComponent({
+        setup() {
+          return createDynamicComponent(
+            renderFragment,
+            null,
+            null,
+            VaporDynamicComponentFlags.SINGLE_ROOT,
+          )
+        },
+      })
+      const createParent = (Child: any) => ({
+        __scopeId: 'external',
+        setup() {
+          return () => h(Child)
+        },
+      })
+
+      const vdomRoot = document.createElement('div')
+      const vdomApp = createApp(createParent(VDOMChild))
+      vdomApp.mount(vdomRoot)
+      expect(vdomRoot.children).toHaveLength(childCount)
+      for (const child of vdomRoot.children) {
+        expect(child.hasAttribute('external')).toBe(false)
+      }
+
+      const vaporRoot = document.createElement('div')
+      const vaporApp = createApp(createParent(VaporChild)).use(
+        vaporInteropPlugin,
+      )
+      vaporApp.mount(vaporRoot)
+      expect(vaporRoot.children).toHaveLength(childCount)
+      for (const child of vaporRoot.children) {
+        expect(child.hasAttribute('external')).toBe(false)
+      }
+
+      vdomApp.unmount()
+      vaporApp.unmount()
+    },
+  )
+
+  test('VDOM Teleport children receive slotted ids but not root-only scopeId', () => {
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const mountApp = (App: any) => {
+      const root = document.createElement('div')
+      const app = createApp(App).use(vaporInteropPlugin)
+      app.mount(root)
+      return app
+    }
+
+    // root-only component scopeId does not reach teleported children
+    const VaporChild = defineVaporComponent({
+      setup() {
+        const vnode = h(Teleport, { to: target }, h('div'))
+        return createDynamicComponent(
+          () => vnode,
+          null,
+          null,
+          VaporDynamicComponentFlags.SINGLE_ROOT,
+        )
+      },
+    })
+    let app = mountApp({
+      __scopeId: 'external',
+      setup() {
+        return () => h(VaporChild as any)
+      },
+    })
+    expect(target.firstElementChild!.hasAttribute('external')).toBe(false)
+    app.unmount()
+
+    // slotted ids do
+    const Receiver = defineVaporComponent({
+      __scopeId: 'receiver',
+      setup() {
+        return createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT)
+      },
+    })
+    app = mountApp({
+      setup() {
+        return () =>
+          h(Receiver as any, null, {
+            default: () => h(Teleport, { to: target }, h('div')),
+          })
+      },
+    })
+    expect(target.firstElementChild!.hasAttribute('receiver-s')).toBe(true)
+    expect(target.firstElementChild!.hasAttribute('receiver')).toBe(false)
+    app.unmount()
+    target.remove()
+  })
+
+  test('does not retain fragment context when cloning a component VNode', () => {
+    const VDOMChild = {
+      setup() {
+        return () => h('div')
+      },
+    }
+    const source = h(VDOMChild)
+    const Receiver = defineVaporComponent({
+      __scopeId: 'receiver',
+      setup() {
+        return createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT)
+      },
+    })
+    const ScopedApp = {
+      setup() {
+        return () =>
+          h(Receiver as any, null, {
+            default: () => h(Fragment, null, [source]),
+          })
+      },
+    }
+    const firstRoot = document.createElement('div')
+    const firstApp = createApp(ScopedApp).use(vaporInteropPlugin)
+    firstApp.mount(firstRoot)
+    expect(firstRoot.firstElementChild!.hasAttribute('receiver-s')).toBe(true)
+
+    const cloned = cloneVNode(source)
+    firstApp.unmount()
+    const PlainChild = defineVaporComponent({
+      setup() {
+        return createDynamicComponent(
+          () => cloned,
+          null,
+          null,
+          VaporDynamicComponentFlags.SINGLE_ROOT,
+        )
+      },
+    })
+    const PlainApp = {
+      setup() {
+        return () => h(PlainChild as any)
+      },
+    }
+    const secondRoot = document.createElement('div')
+    const secondApp = createApp(PlainApp).use(vaporInteropPlugin)
+    secondApp.mount(secondRoot)
+
+    expect(secondRoot.querySelector('div')!.hasAttribute('receiver-s')).toBe(
+      false,
+    )
+    secondApp.unmount()
+  })
+
+  test('applies slotted scopeId to forwarded vapor slot content', () => {
+    const Receiver = defineVaporComponent({
+      __scopeId: 'receiver',
+      setup() {
+        return createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT)
+      },
+    })
+
+    // VDOM middle component forwarding the vapor-origin slots object, so the
+    // slot content reaching Receiver is a bare VaporSlot VNode.
+    const Middle = {
+      setup(_props: unknown, { slots }: any) {
+        return () => h(Receiver as any, null, slots)
+      },
+    }
+
+    const VaporSender = defineVaporComponent({
+      setup() {
+        return createComponent(Middle as any, null, {
+          default: () => template('<div class="content">content</div>', 1)(),
+        })
+      },
+    })
+
+    const App = {
+      setup() {
+        return () => h(VaporSender as any)
+      },
+    }
+
+    const root = document.createElement('div')
+    const app = createApp(App).use(vaporInteropPlugin)
+    app.mount(root)
+
+    const content = root.querySelector('.content')!
+    expect(content.hasAttribute('receiver-s')).toBe(true)
+    expect(content.hasAttribute('receiver')).toBe(false)
+    app.unmount()
+  })
+
+  test('matches VDOM root-only scopeId behavior for a root slot', async () => {
+    const data = ref({ show: true })
+    const makeApp = (vapor: boolean) => {
+      const source = (template: string) =>
+        vapor
+          ? template
+          : `<script setup>
+              const data = _data
+              const components = _components
+            </script>${template}`
+      const Receiver = compile(
+        source(`<template><slot><span>fallback</span></slot></template>`),
+        data,
+        {},
+        { vapor },
+      )
+      const Middle = compile(
+        source(`<template>
+          <components.Receiver>
+            <div v-if="data.show">content</div>
+          </components.Receiver>
+        </template>`),
+        data,
+        { Receiver },
+        { vapor },
+      )
+      const App = compile(
+        source(`<template><components.Middle /></template>`),
+        data,
+        { Middle },
+        { vapor },
+      )
+      App.__scopeId = 'grand'
+      return App
+    }
+
+    const vdomRoot = document.createElement('div')
+    const vdomApp = createApp(makeApp(false))
+    vdomApp.mount(vdomRoot)
+    const vaporRoot = document.createElement('div')
+    const vaporApp = createVaporApp(makeApp(true))
+    vaporApp.mount(vaporRoot)
+
+    expect(vdomRoot.firstElementChild!.tagName).toBe('DIV')
+    expect(vaporRoot.firstElementChild!.tagName).toBe('DIV')
+    expect(vdomRoot.firstElementChild!.hasAttribute('grand')).toBe(false)
+    expect(vaporRoot.firstElementChild!.hasAttribute('grand')).toBe(false)
+
+    data.value = { show: false }
+    await nextTick()
+    expect(vdomRoot.firstElementChild!.tagName).toBe('SPAN')
+    expect(vaporRoot.firstElementChild!.tagName).toBe('SPAN')
+    expect(vdomRoot.firstElementChild!.hasAttribute('grand')).toBe(false)
+    expect(vaporRoot.firstElementChild!.hasAttribute('grand')).toBe(false)
+
+    vdomApp.unmount()
+    vaporApp.unmount()
+
+    // positive control: with an element root above the outlet, the same
+    // chain does deliver the id, so the negatives cannot pass vacuously
+    const makeControlApp = (vapor: boolean) => {
+      const source = (template: string) =>
+        vapor
+          ? template
+          : `<script setup>
+              const data = _data
+              const components = _components
+            </script>${template}`
+      const Receiver = compile(
+        source(`<template><slot><span>fallback</span></slot></template>`),
+        data,
+        {},
+        { vapor },
+      )
+      const Middle = compile(
+        source(`<template>
+          <div class="wrapper"><components.Receiver>
+            <div v-if="data.show">content</div>
+          </components.Receiver></div>
+        </template>`),
+        data,
+        { Receiver },
+        { vapor },
+      )
+      const App = compile(
+        source(`<template><components.Middle /></template>`),
+        data,
+        { Middle },
+        { vapor },
+      )
+      App.__scopeId = 'grand'
+      return App
+    }
+    const vdomControlRoot = document.createElement('div')
+    const vdomControlApp = createApp(makeControlApp(false))
+    vdomControlApp.mount(vdomControlRoot)
+    const vaporControlRoot = document.createElement('div')
+    const vaporControlApp = createVaporApp(makeControlApp(true))
+    vaporControlApp.mount(vaporControlRoot)
+    expect(
+      vdomControlRoot.querySelector('.wrapper')!.hasAttribute('grand'),
+    ).toBe(true)
+    expect(
+      vaporControlRoot.querySelector('.wrapper')!.hasAttribute('grand'),
+    ).toBe(true)
+    vdomControlApp.unmount()
+    vaporControlApp.unmount()
+  })
+
+  test('applies slotted scope id to interop content under an adopted slot anchor', () => {
+    const data = ref(0)
+    const Child = compile(
+      `<template><div><span/><slot/><b/></div></template>`,
+      data,
+    )
+    ;(Child as any).__scopeId = 'child'
+    const Parent = defineVaporComponent({
+      setup() {
+        return createComponent(Child as any, null, {
+          default: () => createDynamicComponent(() => h('p', 'x')),
+        })
+      },
+    })
+    const root = document.createElement('div')
+    const app = createApp({ render: () => h(Parent as any) }).use(
+      vaporInteropPlugin,
+    )
+    app.mount(root)
+    // the outlet adopts an in-DOM anchor, so the interop child mounts during
+    // the slot render — before the outlet's post-render id application
+    expect(root.querySelector('p')!.hasAttribute('child-s')).toBe(true)
+    app.unmount()
+  })
+
+  test(':slotted reaches slot content revealed after starting behind fallback', async () => {
+    const data = ref(false)
+    const Child = compile(`<template><slot><i>fb</i></slot></template>`, data)
+    ;(Child as any).__scopeId = 'child'
+    const Parent = compile(
+      `<template><components.Child><em v-if="data">c</em></components.Child></template>`,
+      data,
+      { Child },
+    )
+
+    const { html } = define(Parent).render()
+    expect(html()).toContain('fb')
+    expect(html()).toContain('child-s')
+
+    data.value = true
+    await nextTick()
+    // content parked behind the active fallback still received the slot's
+    // ids, so re-exposing it yields the same DOM as VDOM (<em child-s>)
+    expect(html()).toContain('<em')
+    expect(html()).toContain('child-s')
+  })
+
+  describe('slotted scope id depth parity with VDOM', () => {
+    const vdomCompile = (template: string, data: any, components: any = {}) =>
+      compile(
+        `<script setup>const data = _data; const components = _components;</script>` +
+          template,
+        data,
+        components,
+        { vapor: false },
+      )
+
+    // strip anchors, and the lexical scope attr the VDOM side applies at
+    // runtime from post-compile __scopeId (vapor bakes lexical ids at compile
+    // time, which the test compile helper does not do) — only slotted (-s)
+    // parity is under test
+    const strip = (html: string) =>
+      html.replace(/<!--[^>]*-->/g, '').replace(/ receiver=""/g, '')
+
+    const mountPair = (
+      makeSide: (vapor: boolean) => any,
+    ): { vdomHost: HTMLElement; host: HTMLElement } => {
+      const vdomHost = document.createElement('div')
+      createApp(makeSide(false)).mount(vdomHost)
+      const host = document.createElement('div')
+      createVaporApp(makeSide(true)).mount(host)
+      return { vdomHost, host }
+    }
+
+    const makeSides =
+      (
+        parentTemplate: string,
+        {
+          receiver = `<template><slot/></template>`,
+          data = ref<any>(0),
+          components = {} as Record<string, string>,
+        } = {},
+      ) =>
+      (vapor: boolean) => {
+        const c = vapor ? compile : vdomCompile
+        const compiled: Record<string, any> = {}
+        for (const name in components) {
+          compiled[name] = c(components[name], data)
+        }
+        const Receiver = c(receiver, data)
+        Receiver.__scopeId = 'receiver'
+        return c(parentTemplate, data, { Receiver, ...compiled })
+      }
+
+    test('slotted id reaches nested elements but not component internals', () => {
+      let { vdomHost, host } = mountPair(
+        makeSides(
+          `<template><components.Receiver><div><span>x</span></div></components.Receiver></template>`,
+        ),
+      )
+      expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
+      expect(strip(host.innerHTML)).toContain('<span receiver-s="">x</span>')
+      ;({ vdomHost, host } = mountPair(
+        makeSides(
+          `<template><components.Receiver><div><components.Comp/></div></components.Receiver></template>`,
+          { components: { Comp: `<template><b><u>x</u></b></template>` } },
+        ),
+      ))
+      expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
+    })
+
+    test('v-if / v-for content added after mount carries ids at depth', async () => {
+      const show = ref(false)
+      let { vdomHost, host } = mountPair(
+        makeSides(
+          `<template><components.Receiver><div v-if="data"><span>x</span></div></components.Receiver></template>`,
+          { data: show },
+        ),
+      )
+      show.value = true
+      await nextTick()
+      expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
+      expect(strip(host.innerHTML)).toContain('receiver-s')
+
+      const count = ref(0)
+      ;({ vdomHost, host } = mountPair(
+        makeSides(
+          `<template><components.Receiver><div v-for="i in data"><span>{{ i }}</span></div></components.Receiver></template>`,
+          { data: count },
+        ),
+      ))
+      count.value = 2
+      await nextTick()
+      expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
+      expect(strip(host.innerHTML)).toContain('receiver-s')
+    })
+
+    test('fallback content carries ids at depth', () => {
+      const { vdomHost, host } = mountPair(
+        makeSides(`<template><components.Receiver/></template>`, {
+          receiver: `<template><slot><div><span>fb</span></div></slot></template>`,
+        }),
+      )
+      expect(strip(host.innerHTML)).toBe(strip(vdomHost.innerHTML))
+      expect(strip(host.innerHTML)).toContain('receiver-s')
+    })
+  })
+
+  test('applies inherited root-only scope id to the interop element root only', () => {
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createDynamicComponent(
+          () => h('div', [h('span', 'x')]),
+          null,
+          null,
+          VaporDynamicComponentFlags.SINGLE_ROOT,
+        )
+      },
+    })
+    const root = document.createElement('div')
+    const app = createApp({
+      __scopeId: 'external',
+      render: () => h(VaporChild as any),
+    }).use(vaporInteropPlugin)
+    app.mount(root)
+    // VDOM control renders <div external><span>x</span></div>: the id stops
+    // at the effective root instead of broadcasting to descendants
+    expect(root.querySelector('div')!.hasAttribute('external')).toBe(true)
+    expect(root.querySelector('span')!.hasAttribute('external')).toBe(false)
+    app.unmount()
+  })
+
+  test('applies inherited root-only scope id to an async-resolved interop Suspense root', async () => {
+    const makeSide = () => {
+      let resolveSetup: (() => void) | undefined
+      const AsyncInner = {
+        async setup() {
+          await new Promise<void>(r => (resolveSetup = r))
+          return () => h('section', 'done')
+        },
+      }
+      const suspenseVNode = () =>
+        h(Suspense, null, {
+          default: () => h(AsyncInner),
+          fallback: () => h('div', 'loading'),
+        })
+      return { suspenseVNode, resolve: () => resolveSetup!() }
+    }
+
+    const vdomSide = makeSide()
+    const vdomRoot = document.createElement('div')
+    const vdomApp = createApp({
+      __scopeId: 'external',
+      render: () => h({ render: vdomSide.suspenseVNode }),
+    })
+    vdomApp.mount(vdomRoot)
+
+    const vaporSide = makeSide()
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createDynamicComponent(
+          vaporSide.suspenseVNode,
+          null,
+          null,
+          VaporDynamicComponentFlags.SINGLE_ROOT,
+        )
+      },
+    })
+    const vaporRoot = document.createElement('div')
+    const vaporApp = createApp({
+      __scopeId: 'external',
+      render: () => h(VaporChild as any),
+    }).use(vaporInteropPlugin)
+    vaporApp.mount(vaporRoot)
+
+    // the fallback is the current effective root and inherits the id
+    expect(vdomRoot.querySelector('div')!.hasAttribute('external')).toBe(true)
+    expect(vaporRoot.querySelector('div')!.hasAttribute('external')).toBe(true)
+
+    vdomSide.resolve()
+    vaporSide.resolve()
+    await new Promise(r => setTimeout(r))
+    await nextTick()
+
+    // the resolved branch becomes the effective root and inherits the id
+    expect(vdomRoot.querySelector('section')).toBeTruthy()
+    expect(vdomRoot.querySelector('section')!.hasAttribute('external')).toBe(
+      true,
+    )
+    expect(vaporRoot.querySelector('section')).toBeTruthy()
+    expect(vaporRoot.querySelector('section')!.hasAttribute('external')).toBe(
+      true,
+    )
+
+    vdomApp.unmount()
+    vaporApp.unmount()
+  })
+
+  // Full lifecycle matrix for slot scope context transitions under a stable
+  // slot function: every supported component-root representation, both
+  // future-root kinds, both context directions, always compared against the
+  // pure VDOM result. Invariant per cell: existing DOM keeps its mount-time
+  // ids, anything mounted afterwards receives the latest ids.
+
+  test('matches VDOM slotted scopeId for late content inside a static element', async () => {
+    // 0 → 1 flips the v-if branch, mounts one v-for item, and swaps the
+    // Inner component's future root
+    const runCase = async (
+      vapor: boolean,
+      parentContent: string,
+      innerTemplate?: string,
+    ) => {
+      const data = ref<any>(0)
+      const source = (template: string) =>
+        vapor
+          ? template
+          : `<script setup>const data = _data; const components = _components;</script>${template}`
+      const Receiver = compile(
+        source(`<template><slot /></template>`),
+        data,
+        {},
+        { vapor },
+      )
+      Receiver.__scopeId = 'receiver'
+      const components: any = { Receiver }
+      if (innerTemplate) {
+        components.Inner = compile(source(innerTemplate), data, {}, { vapor })
+      }
+      const Parent = compile(
+        source(
+          `<template><components.Receiver><div>${parentContent}</div></components.Receiver></template>`,
+        ),
+        data,
+        components,
+        { vapor },
+      )
+      const root = document.createElement('div')
+      ;(vapor ? createVaporApp(Parent) : createApp(Parent)).mount(root)
+
+      data.value = 1
+      await nextTick()
+      return root
+    }
+
+    for (const vapor of [false, true]) {
+      // late v-if branch
+      let root = await runCase(vapor, `<span v-if="data">late</span>`)
+      expect(root.querySelector('span')!.hasAttribute('receiver-s')).toBe(true)
+
+      // component whose future root appears late: ids reach the new root
+      // but not its internals
+      root = await runCase(
+        vapor,
+        `<components.Inner />`,
+        `<template><span v-if="data"><u>late</u></span><i v-else>initial</i></template>`,
+      )
+      expect(root.querySelector('span')!.hasAttribute('receiver-s')).toBe(true)
+      expect(root.querySelector('u')!.hasAttribute('receiver-s')).toBe(false)
+
+      // late v-for item
+      root = await runCase(vapor, `<span v-for="i in data">late</span>`)
+      expect(root.querySelector('span')!.hasAttribute('receiver-s')).toBe(true)
+    }
+  })
+
+  test('does not publish root-only scope id onto vapor-teleported interop content', async () => {
+    const showAlt = ref(false)
+    const scopeId = ref('external')
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const VdomInner = {
+      setup() {
+        return () => (showAlt.value ? h('section', 'alt') : h('div', 'base'))
+      },
+    }
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createComponent(
+          VaporTeleport,
+          { to: () => target },
+          { default: () => createComponent(VdomInner as any) },
+        )
+      },
+    })
+    const App = {
+      setup() {
+        return () => {
+          const child = h(VaporChild as any)
+          child.scopeId = scopeId.value
+          return child
+        }
+      },
+    }
+    const root = document.createElement('div')
+    const app = createApp(App).use(vaporInteropPlugin)
+    app.mount(root)
+    expect(target.querySelector('div')!.hasAttribute('external')).toBe(false)
+
+    // An update-path republish runs after the teleport children exist — the
+    // walk must still stop at the teleport boundary instead of publishing
+    // onto the teleported interop content.
+    scopeId.value = 'external2'
+    await nextTick()
+
+    // teleported content is never the vapor component's effective root, so a
+    // root materialized after the republish must not read a wrongly
+    // published carrier (VDOM Teleport parity).
+    showAlt.value = true
+    await nextTick()
+    expect(target.querySelector('section')).toBeTruthy()
+    expect(target.querySelector('section')!.hasAttribute('external')).toBe(
+      false,
+    )
+    expect(target.querySelector('section')!.hasAttribute('external2')).toBe(
+      false,
+    )
+
+    app.unmount()
+    target.remove()
+  })
+
+  test('publishes ancestor scope ids across a fragment link in the root chain', async () => {
+    const showAlt = ref(false)
+    const VdomInner = {
+      setup() {
+        return () => (showAlt.value ? h('section', 'alt') : h('div', 'base'))
+      },
+    }
+    const Middle = defineVaporComponent({
+      setup() {
+        return createComponent(VdomInner as any, null, null, true)
+      },
+    })
+    const Outer = defineVaporComponent({
+      setup() {
+        // the chain passes through a fragment: Outer.block is the v-if
+        // fragment, not the Middle instance
+        return createIf(
+          () => true,
+          () => createComponent(Middle, null, null, true),
+        )
+      },
+    })
+    const App = {
+      setup() {
+        return () => {
+          const child = h(Outer as any)
+          child.scopeId = 'outer-a'
+          return child
+        }
+      },
+    }
+    const root = document.createElement('div')
+    const app = createApp(App).use(vaporInteropPlugin)
+    app.mount(root)
+    expect(root.querySelector('div')!.hasAttribute('outer-a')).toBe(true)
+
+    // a root materialized later reads the published carrier, whose canonical
+    // derivation must climb across the fragment link
+    showAlt.value = true
+    await nextTick()
+    expect(root.querySelector('section')!.hasAttribute('outer-a')).toBe(true)
+    app.unmount()
   })
 })

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -33,6 +33,7 @@ import {
   currentSlotOwner,
   setCurrentSlotOwner,
 } from './componentSlots'
+import { currentSlotScopeIds, setCurrentSlotScopeIds } from './scopeId'
 import { renderEffect } from './renderEffect'
 import { VaporVForFlags } from '@vue/shared'
 import {
@@ -150,6 +151,7 @@ export const createFor = (
 
   const slotOwner = currentSlotOwner
   const slotBoundary = currentSlotBoundary
+  const slotScopeIds = currentSlotScopeIds
 
   if (__DEV__ && !instance) {
     warn('createFor() can only be used inside setup()')
@@ -645,9 +647,11 @@ export const createFor = (
       const prevBoundary = restoreBoundary
         ? setCurrentSlotBoundary(slotBoundary)
         : null
+      const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
       try {
         renderList()
       } finally {
+        setCurrentSlotScopeIds(prevSlotScopeIds)
         if (restoreBoundary) setCurrentSlotBoundary(prevBoundary)
         setCurrentSlotOwner(prevOwner)
       }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -102,6 +102,7 @@ import {
   exitHydrationCursor,
   isComment,
   isHydrating,
+  isRecreatedNode,
   locateEndAnchor,
   markHydrationAnchor,
   nextLogicalSibling,
@@ -129,7 +130,14 @@ import type {
   DefineVaporComponent,
   VaporRenderResult,
 } from './apiDefineComponent'
-import { DynamicFragment, isDynamicFragment, isFragment } from './fragment'
+import {
+  DynamicFragment,
+  type InteropFragment,
+  isDynamicFragment,
+  isFragment,
+  isInteropFragment,
+  isSlotOutletFragment,
+} from './fragment'
 import { SLOT } from './fragmentFlags'
 import { resolvePendingSlotContent } from './dom/hydrateFragment'
 import type { VaporElement } from './apiDefineCustomElement'
@@ -142,10 +150,12 @@ import {
 } from './suspense'
 import { isInteropEnabled } from './vdomInteropState'
 import {
+  applyComponentScopeIds,
+  currentSlotScopeIds,
   getCurrentScopeId,
-  setComponentScopeId,
-  setScopeId,
-  trackComponentScopeId,
+  hydrateComponentScopeIds,
+  setCurrentSlotScopeIds,
+  setElementScopeIds,
 } from './scopeId'
 import { isTransitionEnabled, isVaporTransition } from './transition'
 
@@ -444,6 +454,9 @@ export function createComponent(
 
     // reset currentSlotOwner to null to avoid affecting the child components
     const prevSlotOwner = setCurrentSlotOwner(null)
+    // Slot scope ids stop at component boundaries; the instance captured
+    // them above for root-only application.
+    const prevSlotScopeIds = setCurrentSlotScopeIds(null)
     let hasWarningContext = false
     let hasInitMeasure = false
     try {
@@ -516,6 +529,7 @@ export function createComponent(
           endMeasure(instance, 'init')
         }
       }
+      setCurrentSlotScopeIds(prevSlotScopeIds)
       setCurrentSlotOwner(prevSlotOwner)
       if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && hasParentSuspense) {
         setParentSuspense(prevSuspense)
@@ -758,6 +772,9 @@ export class VaporComponentInstance<
   slots: Slots
 
   scopeId?: string | null
+  // The slot scope context this instance was created in, applied to the
+  // effective root only (VDOM `-s` inheritance semantics).
+  slotScopeIds?: string[] | null
 
   // to hold vnode props / slots in vdom interop mode
   rawPropsRef?: ShallowRef<any>
@@ -936,6 +953,7 @@ export class VaporComponentInstance<
     ) as Slots
 
     this.scopeId = getCurrentScopeId()
+    this.slotScopeIds = currentSlotScopeIds
 
     // apply custom element special handling
     if (ce) {
@@ -1091,9 +1109,12 @@ export function createPlainElement(
   // mark single root
   ;(el as any).$root = isSingleRoot
 
-  if (!isHydrating) {
+  // Adopted elements already carry SSR scope attrs; mismatch-recreated ones
+  // were client-built and stamp like a client render.
+  if (!isHydrating || isRecreatedNode(el)) {
     const scopeId = getCurrentScopeId()
-    if (scopeId) setScopeId(el, [scopeId])
+    if (scopeId) el.setAttribute(scopeId, '')
+    if (currentSlotScopeIds) setElementScopeIds(el, currentSlotScopeIds)
   }
 
   if (rawProps) {
@@ -1314,15 +1335,15 @@ export function mountComponent(
   }
   if (instance.bm) invokeArrayFns(instance.bm)
   if (!isHydrating) {
+    // Root-only ids (stamp + interop carriers) land before insertion; see
+    // applyRootScopeIds for the delegation rule.
+    applyComponentScopeIds(instance)
     // pass the owning suspense so enter transitions are skipped while
     // mounting into a pending suspense's hidden container (vdom parity);
     // the enter runs when the resolved branch is moved into the real tree.
     insert(instance.block, parent, anchor, instance.suspense)
-    setComponentScopeId(instance)
   } else {
-    // Hydrated roots already have SSR scope attrs. Track dynamic roots so
-    // client-only branch switches keep inherited scope ids.
-    trackComponentScopeId(instance)
+    hydrateComponentScopeIds(instance)
   }
   if (instance.m) {
     queuePostRenderEffect(instance.m!, undefined, instance.suspense)
@@ -1460,28 +1481,65 @@ export function getExposed(
   }
 }
 
+/**
+ * The single traversal of the effective-root chain. Every consumer of the
+ * chain — root element resolution, scope id owner registration, interop
+ * carrier publication, fallthrough attrs — walks through here so the chain
+ * rules (teleport exclusion, slot outlet breaks, comment-filtered arrays,
+ * component descent) are encoded exactly once.
+ */
+export interface RootChainVisitor {
+  onDynamicFragment?: (frag: DynamicFragment) => void
+  // Fired on component descent, including an entry block that is itself a
+  // component.
+  onComponent?: (instance: VaporComponentInstance) => void
+  // Fired at a vnode-backed interop fragment, terminating the descent there
+  // (the fragment carries the chain across into vdom).
+  onInteropFragment?: (frag: InteropFragment) => void
+  // Do not descend into nested components.
+  shallow?: boolean
+  // Slot outlets break the effective-root chain for scope id inheritance.
+  excludeSlotOutlets?: boolean
+}
+
 export function getRootElement(
   block: Block,
-  onDynamicFragment?: (frag: DynamicFragment) => void,
-  recurse: boolean = true,
+  visitor?: RootChainVisitor,
 ): Element | undefined {
   if (block instanceof Element) {
     return block
   }
 
-  if (recurse && isVaporComponent(block)) {
-    return getRootElement(block.block, onDynamicFragment, recurse)
+  if (isVaporComponent(block)) {
+    if (visitor) {
+      if (visitor.onComponent) visitor.onComponent(block)
+      if (visitor.shallow) return
+    }
+    return getRootElement(block.block, visitor)
   }
 
   if (isFragment(block) && !(isTeleportEnabled && isTeleportFragment(block))) {
-    if (isDynamicFragment(block) && onDynamicFragment) {
-      onDynamicFragment(block)
+    if (visitor) {
+      if (visitor.excludeSlotOutlets && isSlotOutletFragment(block)) {
+        return
+      }
+      if (isDynamicFragment(block) && visitor.onDynamicFragment) {
+        visitor.onDynamicFragment(block)
+      }
+      if (
+        visitor.onInteropFragment &&
+        isInteropFragment(block) &&
+        block.vnode
+      ) {
+        visitor.onInteropFragment(block)
+        return
+      }
     }
     const { nodes } = block
     if (nodes instanceof Element && (nodes as any).$root) {
       return nodes
     }
-    return getRootElement(nodes, onDynamicFragment, recurse)
+    return getRootElement(nodes, visitor)
   }
 
   // The root node contains comments. It is necessary to filter out
@@ -1495,7 +1553,7 @@ export function getRootElement(
         hasComment = true
         continue
       }
-      const thisRoot = getRootElement(b, onDynamicFragment, recurse)
+      const thisRoot = getRootElement(b, visitor)
       // only return root if there is exactly one eligible root in the array
       if (!thisRoot || singleRoot) {
         return
@@ -1503,6 +1561,46 @@ export function getRootElement(
       singleRoot = thisRoot
     }
     return hasComment ? singleRoot : undefined
+  }
+}
+
+/**
+ * Descends the same effective-root rules as getRootElement but stops at the
+ * first component instead of resolving an element. Used to verify `child`
+ * sits on `parent`'s root chain when the chain passes through fragments
+ * (where `parent.block === child` cannot see the link).
+ */
+export function getRootChainComponent(
+  block: Block,
+): VaporComponentInstance | undefined {
+  while (true) {
+    if (isVaporComponent(block)) return block
+    if (
+      isFragment(block) &&
+      !(isTeleportEnabled && isTeleportFragment(block))
+    ) {
+      if (isSlotOutletFragment(block)) return
+      block = block.nodes
+      continue
+    }
+    if (isArray(block)) {
+      let single: Block | undefined
+      let hasComment = false
+      for (const b of block) {
+        if (b instanceof Comment) {
+          hasComment = true
+          continue
+        }
+        if (single !== undefined) return
+        single = b
+      }
+      if (hasComment && single !== undefined) {
+        block = single
+        continue
+      }
+      return
+    }
+    return
   }
 }
 
@@ -1580,17 +1678,16 @@ function applyFallthroughAttrs(
 ): void {
   let hasSlotFragment = false
   let dynamicFragments: DynamicFragment[] | undefined
-  const root = getRootElement(
-    block,
-    frag => {
+  const root = getRootElement(block, {
+    onDynamicFragment: frag => {
       if (frag.__vf & SLOT) {
         hasSlotFragment = true
       } else {
         ;(dynamicFragments ||= []).push(frag)
       }
     },
-    false,
-  )
+    shallow: true,
+  })
 
   const dynamicRoot = root ? undefined : getSingleDynamicRootChain(block)
   const fragmentsToRegister = root

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1527,6 +1527,7 @@ export function getRootElement(
         visitor.onDynamicFragment(block)
       }
       if (
+        isInteropEnabled &&
         visitor.onInteropFragment &&
         isInteropFragment(block) &&
         block.vnode
@@ -1546,21 +1547,23 @@ export function getRootElement(
   // the comment nodes and return a single root node.
   // align with vdom behavior
   if (isArray(block)) {
-    let singleRoot: Element | undefined
+    // Structure first, visit after: a multi-root array has no effective
+    // root, and firing the visitor on a branch before that verdict would
+    // leak side effects (owner registration, carrier publication) that
+    // multi-root semantics forbid.
+    let single: Block | undefined
     let hasComment = false
     for (const b of block) {
       if (b instanceof Comment) {
         hasComment = true
         continue
       }
-      const thisRoot = getRootElement(b, visitor)
-      // only return root if there is exactly one eligible root in the array
-      if (!thisRoot || singleRoot) {
-        return
-      }
-      singleRoot = thisRoot
+      // only a lone eligible branch alongside comments can hold the root
+      if (single !== undefined) return
+      single = b
     }
-    return hasComment ? singleRoot : undefined
+    if (!hasComment || single === undefined) return
+    return getRootElement(single, visitor)
   }
 }
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -45,7 +45,12 @@ import { currentSlotBoundary, withSlotBoundary } from './slotBoundary'
 import { createElement } from './dom/node'
 import { setDynamicProps } from './dom/prop'
 import { isInteropEnabled } from './vdomInteropState'
-import { setScopeId, trackScopeIdFragment } from './scopeId'
+import {
+  currentSlotScopeIds,
+  renderWithSlotScopeIds,
+  setCurrentSlotScopeIds,
+  setElementScopeIds,
+} from './scopeId'
 import { withHydratingSlotBoundary } from './dom/hydrateFragment'
 
 /**
@@ -61,19 +66,6 @@ export function withOnceSlot<T>(fn: () => T, value = true): T {
     return fn()
   } finally {
     inOnceSlot = prev
-  }
-}
-
-/**
- * Current slot scopeIds for vdom interop
- */
-export let currentSlotScopeIds: string[] | null = null
-
-function setCurrentSlotScopeIds(scopeIds: string[] | null): string[] | null {
-  try {
-    return currentSlotScopeIds
-  } finally {
-    currentSlotScopeIds = scopeIds
   }
 }
 
@@ -280,7 +272,15 @@ export function createSlot(
   const rawSlots = instance.rawSlots
   const scopeId =
     !(flags & VaporSlotFlags.NO_SLOTTED) && instance.type.__scopeId
-  const slotScopeIds = scopeId ? [`${scopeId}-s`] : null
+  // The outlet's id cell: its own `-s` id merged onto the outer slot context,
+  // so forwarded slot content accumulates every level's ids (VDOM
+  // processFragment concat semantics).
+  const outerSlotScopeIds = currentSlotScopeIds
+  const slotScopeIds = scopeId
+    ? outerSlotScopeIds
+      ? [...outerSlotScopeIds, `${scopeId}-s`]
+      : [`${scopeId}-s`]
+    : outerSlotScopeIds
   const once = !!(flags & VaporSlotFlags.ONCE)
   const slotRoot = !!(flags & VaporSlotFlags.SLOT_ROOT)
   const sharedFallback = !!(flags & VaporSlotFlags.SHARED_FALLBACK)
@@ -300,18 +300,25 @@ export function createSlot(
   let isCustomElementSlot = false
   if (isRef(rawSlots._) && isInteropEnabled) {
     if (isHydrating) hydrationCursor = enterHydrationCursor()
-    fragment = instance.appContext.vdom!.slot(
-      rawSlots._,
-      name,
-      slotProps,
-      instance,
-      fallback,
-      once,
-      slotRoot,
-      sharedFallback,
-      inheritFallback,
-      _insertionAnchor,
-    )
+    // Establish the outlet cell as the creation ambient; the interop slot
+    // captures it as the base patch context for the vdom-rendered content.
+    const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
+    try {
+      fragment = instance.appContext.vdom!.slot(
+        rawSlots._,
+        name,
+        slotProps,
+        instance,
+        fallback,
+        once,
+        slotRoot,
+        sharedFallback,
+        inheritFallback,
+        _insertionAnchor,
+      )
+    } finally {
+      setCurrentSlotScopeIds(prevSlotScopeIds)
+    }
   } else {
     if (isHydrating) hydrationCursor = captureHydrationCursor()
     isCustomElementSlot = !!(
@@ -349,6 +356,9 @@ export function createSlot(
       )
       fragment = dynamicFragment
     }
+    // Replace the construction-time capture with the outlet cell so late
+    // renders (fallbacks, branch switches) run under the merged context.
+    ;(fragment as SlotFragment | DynamicFragment).slotScopeIds = slotScopeIds
 
     const isDynamicName = isFunction(name)
 
@@ -360,6 +370,7 @@ export function createSlot(
       // replaced by injected content
       if (isCustomElementSlot) {
         const el = createElement('slot')
+        if (slotScopeIds) setElementScopeIds(el, slotScopeIds)
         const setSlotProps = () => {
           setDynamicProps(el, [
             slotProps,
@@ -371,14 +382,22 @@ export function createSlot(
         if (once) setSlotProps()
         else renderEffect(setSlotProps)
         if (fallback) {
-          withSlotBoundary(slotFragment!.slotBoundary, () => {
-            const fallbackBlock = fallback()
-            // Keep the live fallback block on the SlotFragment itself. The
-            // native slot outlet is temporary and gets removed by CE slot
-            // replacement, but the fragment remains Vapor's long-lived owner.
-            slotFragment!.customElementFallback = fallbackBlock
-            insert(fallbackBlock, el)
-          })
+          // The fallback renders outside the fragment's own render seam, so
+          // establish the outlet cell explicitly around it.
+          const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
+          try {
+            withSlotBoundary(slotFragment!.slotBoundary, () => {
+              const fallbackBlock = fallback()
+              // Keep the live fallback block on the SlotFragment itself. The
+              // native slot outlet is temporary and gets removed by CE slot
+              // replacement, but the fragment remains Vapor's long-lived
+              // owner.
+              slotFragment!.customElementFallback = fallbackBlock
+              insert(fallbackBlock, el)
+            })
+          } finally {
+            setCurrentSlotScopeIds(prevSlotScopeIds)
+          }
         }
         fragment.nodes = el
         return
@@ -418,14 +437,12 @@ export function createSlot(
     const getBoundSlot = (slot: VaporSlot): VaporSlot => {
       if (slot !== cachedSlot) {
         cachedSlot = slot
-        cachedBoundSlot = () => {
-          const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
-          try {
-            return once ? withOnceSlot(() => slot(slotProps)) : slot(slotProps)
-          } finally {
-            setCurrentSlotScopeIds(prevSlotScopeIds)
-          }
-        }
+        // Re-establishes the outlet cell (interop may invoke the slot outside
+        // the fragment's render seam) and catches up out-of-window content.
+        cachedBoundSlot = () =>
+          renderWithSlotScopeIds(slotScopeIds, () =>
+            once ? withOnceSlot(() => slot(slotProps)) : slot(slotProps),
+          )
       }
       return cachedBoundSlot!
     }
@@ -439,10 +456,6 @@ export function createSlot(
   }
 
   if (!isHydrating) {
-    if (slotScopeIds) {
-      setScopeId(fragment, slotScopeIds)
-    }
-
     // Custom-element outlets assign their native <slot> directly instead of
     // rendering through update(), so they still need this initial insertion
     // after adopting the template anchor.
@@ -456,11 +469,6 @@ export function createSlot(
   } else {
     if (isInteropEnabled && isInteropFragment(fragment)) {
       fragment.hydrate!()
-    }
-    // Hydrated slot roots already have SSR scope attrs. Only register tracking
-    // so future client-inserted slot branches receive the same ids.
-    if (slotScopeIds) {
-      trackScopeIdFragment(fragment, slotScopeIds)
     }
     exitHydrationCursor(hydrationCursor)
   }

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -27,6 +27,16 @@ import { remove } from '../block'
 
 const START_TAG_RE = /^<([^\s/>]+)/
 
+// In-place stamp installed by the scope id module while slotted ids are
+// live: mismatch-recreated subtrees stamp like a client mount.
+export let mismatchStampHook: ((node: Node) => void) | null = null
+
+export function setMismatchStampHook(
+  hook: ((node: Node) => void) | null,
+): void {
+  mismatchStampHook = hook
+}
+
 export let isHydratingEnabled = false
 
 export function setIsHydratingEnabled(value: boolean): void {
@@ -410,6 +420,9 @@ function handleMismatch(
     for (let i = 0; i < descendants.length; i++) {
       markRecreatedNode(descendants[i])
     }
+    // Recreated nodes carry no SSR scope attrs; run the same creation-time
+    // stamping a client render would, before server children are adopted in.
+    if (mismatchStampHook) mismatchStampHook(newNode)
   }
   if (adoptChildren && node.nodeType === 1 && !newNode.firstChild) {
     let child = node.firstChild

--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -14,6 +14,17 @@ import { resolvePendingSlotContent } from './hydrateFragment'
 
 let t: HTMLTemplateElement
 
+// Clone provider installed by the scope id module while slotted ids are live
+// (this module imports no scope machinery; the common path is one null
+// check). Serves clones carrying the active ids from a stamped-variant cache.
+export let templateCloneHook: ((prototype: Node) => Node) | null = null
+
+export function setTemplateCloneHook(
+  hook: ((prototype: Node) => Node) | null,
+): void {
+  templateCloneHook = hook
+}
+
 /*@__NO_SIDE_EFFECTS__*/
 export function template(html: string, flags: number = 0, ns?: Namespace) {
   const root = !!(flags & TemplateFlags.ROOT)
@@ -64,7 +75,9 @@ export function template(html: string, flags: number = 0, ns?: Namespace) {
     }
 
     if (node) {
-      const ret = node.cloneNode(true)
+      const ret = templateCloneHook
+        ? templateCloneHook(node)
+        : node.cloneNode(true)
       if (root) (ret as any).$root = true
       return ret
     }
@@ -82,7 +95,9 @@ export function template(html: string, flags: number = 0, ns?: Namespace) {
       t.innerHTML = html
       node = _child(t.content)
     }
-    const ret = node.cloneNode(true)
+    const ret = templateCloneHook
+      ? templateCloneHook(node)
+      : node.cloneNode(true)
     if (root) (ret as any).$root = true
     return ret
   }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -38,6 +38,11 @@ import {
 } from './dom/hydration'
 import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
 import {
+  applyScopeIdOwners,
+  currentSlotScopeIds,
+  setCurrentSlotScopeIds,
+} from './scopeId'
+import {
   type SlotBoundaryContext,
   currentSlotBoundary,
   hasSlotFallback,
@@ -81,6 +86,7 @@ import {
   FRAGMENT,
   SLOT,
   SLOT_FRAGMENT,
+  SLOT_OUTLET,
   VDOM,
 } from './fragmentFlags'
 
@@ -141,6 +147,10 @@ export class RenderContextFragment<
   readonly slotOwner: VaporComponentInstance | null = currentSlotOwner
   readonly keepAliveCtx?: VaporKeepAliveContext | null
   readonly slotBoundary: SlotBoundaryContext | null = currentSlotBoundary
+  // Captured by reference: slot outlets replace this with their merged id cell
+  // right after construction, so late renders (branch switches, deferred
+  // fallbacks) create their DOM under the outlet's slot scope context.
+  slotScopeIds: string[] | null = currentSlotScopeIds
 
   constructor(nodes: T, flags: number = FRAGMENT) {
     super(nodes, flags)
@@ -177,16 +187,19 @@ export function runWithFragmentCtxOnly<R>(
   // restoring. This keeps ordinary branch renders on the cheap path.
   if (
     currentSlotOwner === fragment.slotOwner &&
-    currentSlotBoundary === fragment.slotBoundary
+    currentSlotBoundary === fragment.slotBoundary &&
+    currentSlotScopeIds === fragment.slotScopeIds
   ) {
     return fn()
   }
 
   const prevSlotOwner = setCurrentSlotOwner(fragment.slotOwner)
   const prevBoundary = setCurrentSlotBoundary(fragment.slotBoundary)
+  const prevSlotScopeIds = setCurrentSlotScopeIds(fragment.slotScopeIds)
   try {
     return fn()
   } finally {
+    setCurrentSlotScopeIds(prevSlotScopeIds)
     setCurrentSlotBoundary(prevBoundary)
     setCurrentSlotOwner(prevSlotOwner)
   }
@@ -262,6 +275,9 @@ export class DynamicFragment extends RenderContextFragment {
   inTransition?: boolean
   // Fallthrough attrs hooks register branch-owned effects on insert.
   hasFallthroughAttrs?: true
+  // Ancestor instances whose root-only scope ids resolve through this
+  // fragment; branch switches re-apply them to the new root before insertion.
+  scopeIdOwners?: VaporComponentInstance[]
   // Whether update() ran before. The very first update renders as part of
   // the mount and must not fire onUpdated hooks; with an adopted template
   // anchor `parent` is non-null even then, so mount status can no longer be
@@ -443,6 +459,10 @@ export class DynamicFragment extends RenderContextFragment {
           )
         : renderBranch()
 
+      // Root-only inherited ids must land on the new branch's effective root
+      // before insertion so custom element callbacks observe them.
+      if (this.scopeIdOwners) applyScopeIdOwners(this.scopeIdOwners)
+
       if (parent) {
         const onBeforeInsert = this.onBeforeInsert
         if (onBeforeInsert) {
@@ -545,6 +565,7 @@ export class SlotFragment
       parent: this.inheritFallback ? this.slotBoundary : null,
       getFallback: () => this.localFallback,
       run: (fn, scope) => this.runWithRenderCtx(fn, scope),
+      getScopeIds: () => this.slotScopeIds,
       markDirty: force => markSlotResolutionDirty(this, force),
       onContentInvalid: this.onContentInvalid,
     })
@@ -833,12 +854,17 @@ export function isFragment(val: unknown): val is VaporFragment {
   return !!(val && (val as any).__vf)
 }
 
-export type InteropFragment<T extends Block = Block> = VaporFragment<T> & {
-  vnode: VNode | null
-}
+export type InteropFragment<T extends Block = Block> =
+  RenderContextFragment<T> & {
+    vnode: VNode | null
+  }
 
 export function isInteropFragment(val: unknown): val is InteropFragment {
   return !!(val && (val as any).__vf & VDOM)
+}
+
+export function isSlotOutletFragment(val: unknown): boolean {
+  return !!(val && (val as any).__vf & SLOT_OUTLET)
 }
 
 export function isDynamicFragment(val: unknown): val is DynamicFragment {

--- a/packages/runtime-vapor/src/fragmentFlags.ts
+++ b/packages/runtime-vapor/src/fragmentFlags.ts
@@ -5,5 +5,6 @@ export const FOR: number = 1 << 3
 export const FOR_ITEM: number = 1 << 4
 export const TELEPORT: number = 1 << 5
 export const VDOM: number = 1 << 6
+export const SLOT_OUTLET: number = 1 << 7
 
-export const SLOT_FRAGMENT: number = DYNAMIC | SLOT
+export const SLOT_FRAGMENT: number = DYNAMIC | SLOT | SLOT_OUTLET

--- a/packages/runtime-vapor/src/hmr.ts
+++ b/packages/runtime-vapor/src/hmr.ts
@@ -13,6 +13,7 @@ import {
   mountComponent,
   unmountComponent,
 } from './component'
+import { applyComponentScopeIds, setCurrentSlotScopeIds } from './scopeId'
 
 export function hmrRerender(instance: VaporComponentInstance): void {
   const { parentNode, nextNode: anchor } = findBlockBoundary(instance.block)
@@ -24,12 +25,17 @@ export function hmrRerender(instance: VaporComponentInstance): void {
   remove(instance.block, parent)
   const prev = setCurrentInstance(instance)
   pushWarningContext(instance)
+  // The rerender recreates the component's own template window, where slot
+  // scope ids never apply; root-only ids are re-applied below.
+  const prevSlotScopeIds = setCurrentSlotScopeIds(null)
   try {
     devRender(instance)
   } finally {
+    setCurrentSlotScopeIds(prevSlotScopeIds)
     popWarningContext()
     restoreCurrentInstance(prev)
   }
+  applyComponentScopeIds(instance)
   insert(instance.block, parent, anchor)
 }
 

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -109,7 +109,10 @@ function stampSlotContent(block: Block, scopeIds: string[]): void {
     }
   } else if (isArray(block)) {
     for (const b of block) stampSlotContent(b, scopeIds)
-  } else if (isFragment(block) && !isInteropFragment(block)) {
+  } else if (
+    isFragment(block) &&
+    !(isInteropEnabled && isInteropFragment(block))
+  ) {
     stampSlotContent(block.nodes, scopeIds)
   }
 }

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -1,171 +1,280 @@
-import { isArray } from '@vue/shared'
 import {
   type VaporComponentInstance,
+  getRootChainComponent,
   getRootElement,
   isVaporComponent,
 } from './component'
-import { getInheritedScopeIds } from '@vue/runtime-dom'
-import {
-  type DynamicFragment,
-  type InteropFragment,
-  type VaporFragment,
-  isFragment,
-  isInteropFragment,
-} from './fragment'
+import { type DynamicFragment, isFragment, isInteropFragment } from './fragment'
 import type { Block } from './block'
+import { isArray } from '@vue/shared'
 import { isInteropEnabled } from './vdomInteropState'
 import { getScopeOwner } from './componentSlots'
+import { setTemplateCloneHook } from './dom/template'
+import {
+  isHydrating,
+  isRecreatedNode,
+  setMismatchStampHook,
+} from './dom/hydration'
 
-export function setScopeId(block: Block, scopeIds: string[]): void {
-  if (block instanceof Element) {
-    for (const id of scopeIds) {
-      block.setAttribute(id, '')
+/**
+ * Ambient slot scope ids (the `-s` variants) active while creating DOM for
+ * slot content — the vapor counterpart of the renderer's `slotScopeIds` patch
+ * context. Cleared around child setup (the child captures it for root-only
+ * inheritance). Mounted DOM is never retroactively re-stamped (VDOM parity).
+ */
+export let currentSlotScopeIds: string[] | null = null
+
+export function setCurrentSlotScopeIds(
+  scopeIds: string[] | null,
+): string[] | null {
+  const prev = currentSlotScopeIds
+  if (scopeIds !== prev) {
+    currentSlotScopeIds = scopeIds
+    // Install the creation-seam hooks only on null↔non-null flips: the hooks
+    // read the live ambient, and non-slotted hot paths stay a single null check.
+    if (!prev || !scopeIds) {
+      if (scopeIds) {
+        setTemplateCloneHook(cloneStampedTemplate)
+        setMismatchStampHook(stampSlotScopeIds)
+      } else {
+        setTemplateCloneHook(null)
+        setMismatchStampHook(null)
+      }
     }
-  } else if (isVaporComponent(block)) {
-    setScopeId(block.block, scopeIds)
-  } else if (isArray(block)) {
-    for (const b of block) {
-      setScopeId(b, scopeIds)
-    }
-  } else if (isFragment(block)) {
-    trackScopeIdFragment(block, scopeIds, false)
-    setScopeId(block.nodes, scopeIds)
+  }
+  return prev
+}
+
+function stampSlotScopeIds(node: Node): void {
+  if (node.nodeType === 1 /* Node.ELEMENT_NODE */) {
+    setElementScopeIdsDeep(node as Element, currentSlotScopeIds!)
   }
 }
 
-const trackedScopeIdFragments = new WeakMap<VaporFragment, Set<string>>()
+/**
+ * Stamped-variant cache: ids are written once per (template prototype × id
+ * cell) and clones inherit them via cloneNode. Never stale because scope ids
+ * are compile-time constants; entries are freed with their cell (WeakMap key).
+ */
+const stampedTemplates = new WeakMap<Node, WeakMap<string[], Node>>()
 
-export function trackScopeIdFragment(
-  frag: VaporFragment,
-  scopeIds: string[],
-  recursive = true,
-): void {
-  // VDOM interop fragments apply scope ids through their backing VNode instead
-  // of the fragment insert hook.
-  if (isInteropEnabled && isInteropFragment(frag)) {
-    setInteropFragmentScopeIds(frag, scopeIds)
-  } else if (trackFragmentScopeIds(frag, scopeIds)) {
-    ;(frag.onBeforeInsert ||= []).push(nodes => setScopeId(nodes, scopeIds))
+function cloneStampedTemplate(prototype: Node): Node {
+  if (prototype.nodeType !== 1 /* Node.ELEMENT_NODE */) {
+    return prototype.cloneNode(true)
   }
-  if (recursive) {
-    trackScopeIdsInBlock(frag.nodes, scopeIds)
+  const scopeIds = currentSlotScopeIds!
+  let variants = stampedTemplates.get(prototype)
+  if (!variants) {
+    stampedTemplates.set(prototype, (variants = new WeakMap()))
+  }
+  let stamped = variants.get(scopeIds)
+  if (!stamped) {
+    stamped = prototype.cloneNode(true)
+    setElementScopeIdsDeep(stamped as Element, scopeIds)
+    variants.set(scopeIds, stamped)
+  }
+  return stamped.cloneNode(true)
+}
+
+// Template clones contain no component boundaries and fresh clones carry no
+// runtime scope ids yet — plain setAttribute, no exists-check.
+function setElementScopeIdsDeep(el: Element, scopeIds: string[]): void {
+  setElementScopeIds(el, scopeIds)
+  let child = el.firstElementChild
+  while (child) {
+    setElementScopeIdsDeep(child, scopeIds)
+    child = child.nextElementSibling
   }
 }
 
-function trackFragmentScopeIds(
-  frag: VaporFragment,
-  scopeIds: string[],
-): boolean {
-  const key = scopeIds.join(' ')
-  let trackedScopeIds = trackedScopeIdFragments.get(frag)
-  if (!trackedScopeIds) {
-    trackedScopeIds = new Set()
-    trackedScopeIdFragments.set(frag, trackedScopeIds)
-  } else if (trackedScopeIds.has(key)) {
-    return false
-  }
-  trackedScopeIds.add(key)
-  return true
-}
-
-function setInteropFragmentScopeIds(
-  frag: InteropFragment,
-  scopeIds: string[],
-): void {
-  const vnode = frag.vnode
-  if (!vnode) return
-  const existing = vnode.slotScopeIds
-  if (!existing) {
-    vnode.slotScopeIds = scopeIds
-    return
-  }
+export function setElementScopeIds(el: Element, scopeIds: string[]): void {
   for (let i = 0; i < scopeIds.length; i++) {
-    if (!existing.includes(scopeIds[i])) {
-      existing.push(scopeIds[i])
-    }
+    el.setAttribute(scopeIds[i], '')
   }
 }
 
-function trackScopeIdsInBlock(block: Block, scopeIds: string[]): void {
-  if (isVaporComponent(block)) {
-    trackScopeIdsInBlock(block.block, scopeIds)
+/**
+ * Catch-up for slot content DOM created outside the ambient window (eager
+ * template clones, hand-built elements). Shallow on purpose: element subtrees
+ * can contain mounted component internals, so descendants are left to the
+ * creation-time ambient. Interop fragments derive their ids through the vdom
+ * patch context and are skipped.
+ */
+function stampSlotContent(block: Block, scopeIds: string[]): void {
+  if (block instanceof Element) {
+    for (let i = 0; i < scopeIds.length; i++) {
+      if (!block.hasAttribute(scopeIds[i])) {
+        block.setAttribute(scopeIds[i], '')
+      }
+    }
   } else if (isArray(block)) {
-    for (const b of block) {
-      trackScopeIdsInBlock(b, scopeIds)
-    }
-  } else if (isFragment(block)) {
-    trackScopeIdFragment(block, scopeIds)
+    for (const b of block) stampSlotContent(b, scopeIds)
+  } else if (isFragment(block) && !isInteropFragment(block)) {
+    stampSlotContent(block.nodes, scopeIds)
   }
 }
 
-const trackedInheritedScopeIdFragments = new WeakMap<
-  DynamicFragment,
-  WeakSet<VaporComponentInstance>
->()
-
-function trackInheritedScopeIdFragment(
-  instance: VaporComponentInstance,
-  frag: DynamicFragment,
-): void {
-  // A dynamic root can inherit scope ids from multiple ancestor component
-  // instances, so the de-dupe key must include the instance, not just the frag.
-  let trackedInstances = trackedInheritedScopeIdFragments.get(frag)
-  if (!trackedInstances) {
-    trackedInstances = new WeakSet()
-    trackedInheritedScopeIdFragments.set(frag, trackedInstances)
-  } else if (trackedInstances.has(instance)) {
-    return
-  }
-  trackedInstances.add(instance)
-  ;(frag.onUpdated ||= []).push(() => applyInheritedScopeIdToRoot(instance))
-}
-
-function applyInheritedScopeIdToRoot(
-  instance: VaporComponentInstance,
-): Element | undefined {
-  const { scopeId } = instance
-  if (!scopeId) return
-  // Re-resolve the effective single root on each dynamic update. This keeps
-  // comment roots and multi-root branches aligned with VDOM root semantics.
-  const root = getRootElement(instance, frag =>
-    trackInheritedScopeIdFragment(instance, frag),
-  )
-  if (root) {
-    root.setAttribute(scopeId, '')
-  }
-  return root
-}
-
-export function trackComponentScopeId(instance: VaporComponentInstance): void {
-  const { parent, scopeId } = instance
-  if (!parent || !scopeId) return
-  getRootElement(instance, frag =>
-    trackInheritedScopeIdFragment(instance, frag),
-  )
-}
-
-export function setComponentScopeId(instance: VaporComponentInstance): void {
-  const { parent, scopeId } = instance
-  if (!parent || !scopeId) return
-
-  const root = applyInheritedScopeIdToRoot(instance)
-
-  // inherit scopeId from vdom parent
-  if (
-    isInteropEnabled &&
-    root &&
-    parent.subTree &&
-    (parent.subTree.component as any) === instance &&
-    parent.vnode!.scopeId
-  ) {
-    root.setAttribute(parent.vnode!.scopeId, '')
-    const inheritedScopeIds = getInheritedScopeIds(parent.vnode!, parent.parent)
-    for (let i = 0; i < inheritedScopeIds.length; i++) {
-      root.setAttribute(inheritedScopeIds[i], '')
-    }
+// Runs a slot render with `scopeIds` as the creation ambient, then catches up
+// out-of-window content DOM — except during hydration, where adopted nodes
+// already carry their SSR attrs.
+export function renderWithSlotScopeIds(
+  scopeIds: string[] | null,
+  render: () => Block,
+): Block {
+  const prev = setCurrentSlotScopeIds(scopeIds)
+  try {
+    const block = render()
+    if (scopeIds && !isHydrating) stampSlotContent(block, scopeIds)
+    return block
+  } finally {
+    setCurrentSlotScopeIds(prev)
   }
 }
+
 export function getCurrentScopeId(): string | undefined {
   const scopeOwner = getScopeOwner()
   return scopeOwner ? scopeOwner.type.__scopeId : undefined
+}
+
+function registerScopeIdOwner(
+  instance: VaporComponentInstance,
+  frag: DynamicFragment,
+): void {
+  // A dynamic root can be the effective root of multiple ancestor instances.
+  const owners = (frag.scopeIdOwners ||= [])
+  if (!owners.includes(instance)) owners.push(instance)
+}
+
+// Effective-root resolution for scope ids: slot outlets break the chain
+// (VDOM parity). Walks instance.block, so onComponent reports only NESTED
+// chain components, not the entry.
+function resolveScopeIdRoot(
+  instance: VaporComponentInstance,
+  onComponent?: (instance: VaporComponentInstance) => void,
+): Element | undefined {
+  return getRootElement(instance.block, {
+    onDynamicFragment: frag => registerScopeIdOwner(instance, frag),
+    onComponent,
+    excludeSlotOutlets: true,
+  })
+}
+
+// Re-applies root-only ids after a dynamic fragment rendered a new branch —
+// before insertion, so custom element connectedCallback observes them.
+export function applyScopeIdOwners(owners: VaporComponentInstance[]): void {
+  for (let i = 0; i < owners.length; i++) {
+    applyRootScopeIds(owners[i])
+  }
+}
+
+// Interop hook (installed by the vdom interop plugin): publishes root-only
+// ids onto the backing interop vnode so core applies them natively at its
+// own pre-insertion mount (element roots, pending Suspense branches).
+export let publishInteropScopeIds:
+  | ((block: Block, scopeIds: string[]) => void)
+  | null = null
+
+export function setPublishInteropScopeIds(
+  fn: (block: Block, scopeIds: string[]) => void,
+): void {
+  publishInteropScopeIds = fn
+}
+
+function pushOwnRootScopeIds(
+  instance: VaporComponentInstance,
+  ids: string[] | null,
+): string[] | null {
+  const { scopeId, slotScopeIds } = instance
+  if (scopeId) (ids ||= []).push(scopeId)
+  // Interop mounts already fold the vdom parent chain into these channels
+  // (setInteropComponentScopeIds) — no cross-boundary re-derivation here.
+  if (slotScopeIds) (ids ||= []).push(...slotScopeIds)
+  return ids
+}
+
+function hasOwnRootScopeIds(instance: VaporComponentInstance): boolean {
+  return !!(instance.parent && (instance.scopeId || instance.slotScopeIds))
+}
+
+/**
+ * The instance's root-only ids, climbing the effective-root chain so the
+ * innermost owner's collection carries every ancestor's contribution.
+ * Assigned parent blocks ground the climb: a null parent block means an
+ * in-setup mount, where the mounting component is never the root.
+ */
+export function collectRootScopeIds(
+  instance: VaporComponentInstance,
+): string[] | null {
+  let ids = pushOwnRootScopeIds(instance, null)
+  let current = instance
+  while (
+    current.parent &&
+    isVaporComponent(current.parent) &&
+    isRootChainChild(current.parent as VaporComponentInstance, current)
+  ) {
+    current = current.parent as VaporComponentInstance
+    ids = pushOwnRootScopeIds(current, ids)
+  }
+  return ids
+}
+
+// The chain can pass through fragments (e.g. a v-if root whose branch
+// renders the child), where block identity cannot see the link; fall back to
+// descending the parent's chain to its first component.
+function isRootChainChild(
+  parent: VaporComponentInstance,
+  child: VaporComponentInstance,
+): boolean {
+  return (
+    parent.block === child ||
+    (!!parent.block && getRootChainComponent(parent.block) === child)
+  )
+}
+
+/**
+ * Resolves the effective root, registers owners along the chain, and applies
+ * the instance's root-only ids: element roots are stamped, vnode-backed roots
+ * are published for core to apply at its own mount. When the chain crosses a
+ * nested component with its own root ids, the outer owner delegates — the
+ * innermost owner's collect climbs every ancestor, so one pre-insert
+ * application preserves both custom element connectedCallback timing and
+ * VDOM's innermost-first attribute order.
+ */
+function applyRootScopeIds(instance: VaporComponentInstance): void {
+  let delegated = false
+  const root = resolveScopeIdRoot(instance, nested => {
+    if (hasOwnRootScopeIds(nested)) delegated = true
+  })
+  if (delegated) return
+  const scopeIds = collectRootScopeIds(instance)
+  if (!scopeIds) return
+  if (root) setElementScopeIds(root, scopeIds)
+  if (isInteropEnabled && publishInteropScopeIds) {
+    publishInteropScopeIds(instance.block, scopeIds)
+  }
+}
+
+export function applyComponentScopeIds(instance: VaporComponentInstance): void {
+  if (!hasOwnRootScopeIds(instance)) return
+  applyRootScopeIds(instance)
+}
+
+/**
+ * Hydration counterpart of applyComponentScopeIds: hydrated roots already
+ * carry SSR scope attrs, so the walk only registers dynamic root tracking,
+ * publishes interop carriers, and stamps mismatch-recreated roots
+ * (client-built DOM without SSR attrs).
+ */
+export function hydrateComponentScopeIds(
+  instance: VaporComponentInstance,
+): void {
+  if (!hasOwnRootScopeIds(instance)) return
+  const root = resolveScopeIdRoot(instance)
+  const stampRoot = root && isRecreatedNode(root) ? root : undefined
+  const publish = isInteropEnabled && publishInteropScopeIds
+  if (!stampRoot && !publish) return
+  const scopeIds = collectRootScopeIds(instance)
+  if (!scopeIds) return
+  if (stampRoot) setElementScopeIds(stampRoot, scopeIds)
+  if (publish) publish(instance.block, scopeIds)
 }

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -13,6 +13,10 @@ export interface SlotBoundaryContext {
   // late renders such as fallback bodies, and runs them in the provided effect
   // scope when one is provided.
   run<R>(fn: () => R, scope?: EffectScope): R
+  // The owning outlet's slot scope id cell. Fallback resolution renders under
+  // the REQUESTING outlet's cell (VDOM semantics: an inherited fallback gets
+  // the requester's slotted ids, which are a superset of every provider's).
+  getScopeIds?: () => string[] | null
   // Notifies the owning slot that the validity of a dynamic branch rendered
   // under this boundary may have changed; routes into the slot resolution
   // state machine (markSlotResolutionDirty).

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -8,6 +8,7 @@ import {
   removeAttachedNodes,
 } from './block'
 import { isHydrating } from './dom/hydration'
+import { renderWithSlotScopeIds } from './scopeId'
 import {
   type SlotBoundaryContext,
   hasSlotFallback,
@@ -52,6 +53,11 @@ function renderSlotFallback(
   scope: EffectScope,
 ): RenderedSlotFallback | undefined {
   let result: RenderedSlotFallback | undefined
+  // Fallbacks render with the REQUESTING outlet's slot scope ids (VDOM
+  // semantics for inherited fallbacks; the requester's cell already merges
+  // every provider's ids), while `run` keeps the provider's lexical context.
+  const scopeIds =
+    boundary && boundary.getScopeIds ? boundary.getScopeIds() : null
 
   while (boundary) {
     const current = boundary
@@ -60,6 +66,9 @@ function renderSlotFallback(
     if (localFallback) {
       let selected = false
       const onContentInvalid: (() => void)[] = []
+      const renderFallback = scopeIds
+        ? () => renderWithSlotScopeIds(scopeIds, localFallback)
+        : localFallback
       const content = current.run(
         () =>
           withSlotBoundary(
@@ -79,7 +88,7 @@ function renderSlotFallback(
                   !!force || (!selected && hasSlotFallback(current.parent)),
                 ),
             },
-            localFallback,
+            renderFallback,
           ),
         scope,
       )

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -74,7 +74,12 @@ import {
   mountComponent,
   unmountComponent,
 } from './component'
-import { getCurrentScopeId, setScopeId } from './scopeId'
+import {
+  collectRootScopeIds,
+  currentSlotScopeIds,
+  getCurrentScopeId,
+  setPublishInteropScopeIds,
+} from './scopeId'
 import type { LooseRawSlots } from './componentSlots'
 import {
   type Block,
@@ -105,7 +110,6 @@ import {
 } from './componentProps'
 import type { RawSlots, VaporSlot } from './componentSlots'
 import {
-  currentSlotScopeIds,
   dynamicSlotsProxyHandlers,
   getSlot,
   withOnceSlot,
@@ -135,7 +139,7 @@ import {
   runWithFragmentCtxOnly,
   runWithRenderCtx,
 } from './fragment'
-import { VDOM } from './fragmentFlags'
+import { SLOT_OUTLET, VDOM } from './fragmentFlags'
 import {
   type SlotBoundaryContext,
   hasSlotFallback,
@@ -363,13 +367,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
     instance.rawPropsRef = propsRef
     instance.rawSlotsRef = slotsRef
     const vnodeHookState = ensureVNodeHookState(instance, vnode)
-    const applyScopeId = (vnode: VNode) =>
-      setInteropVnodeScopeId(
-        instance,
-        vnode,
-        instance.parent as ComponentInternalInstance | null,
-      )
-    vnodeHookState.postRootSyncHooks.push(applyScopeId)
+    setInteropComponentScopeIds(instance, vnode)
 
     // copy the shape flag from the vdom component if inside a keep-alive
     if (parentComponent && isKeepAlive(parentComponent)) {
@@ -393,7 +391,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
       setParentSuspense(prevSuspense)
     }
 
-    const rootEl = getRootElement(instance)
+    const rootEl = resolveInteropRootEl(instance)
     if (rootEl) {
       vnode.el = rootEl
     }
@@ -415,7 +413,6 @@ const vaporInteropImpl: VaporInVdomInterface = {
     }
 
     mountComponent(instance, container, selfAnchor)
-    if (!isHydrating) applyScopeId(vnodeHookState.vnode)
 
     simpleSetCurrentInstance(prev)
     return instance
@@ -453,11 +450,6 @@ const vaporInteropImpl: VaporInVdomInterface = {
       instance.rawSlotsRef!.value = normalizeInteropSlots(n2.children)
       queuePostFlushCb(() => {
         syncVNodeEl(n2, instance)
-        setInteropVnodeScopeId(
-          instance,
-          n2,
-          instance.parent as ComponentInternalInstance | null,
-        )
         if (!instance.isUpdating) {
           vnodeHookState.skipVnodeHooks = false
         }
@@ -546,10 +538,16 @@ const vaporInteropImpl: VaporInVdomInterface = {
     anchor,
     parentComponent,
     parentSuspense,
+    slotScopeIds,
   ) {
     if (!n1) {
       // mount
-      const slotBlock = renderVaporSlot(n2, parentComponent, parentSuspense)
+      const slotBlock = renderVaporSlot(
+        n2,
+        parentComponent,
+        parentSuspense,
+        slotScopeIds,
+      )
       const selfAnchor =
         // use fragment's anchor when possible
         (isFragment(slotBlock) ? slotBlock.anchor : undefined) ||
@@ -579,7 +577,12 @@ const vaporInteropImpl: VaporInVdomInterface = {
         // remove old vapor block
         remove(n1.vb!, parent)
         stopVaporSlotScope(n1)
-        const slotBlock = renderVaporSlot(n2, parentComponent, parentSuspense)
+        const slotBlock = renderVaporSlot(
+          n2,
+          parentComponent,
+          parentSuspense,
+          slotScopeIds,
+        )
         let newAnchor = isFragment(slotBlock) ? slotBlock.anchor : undefined
         let insertAnchor = nextSibling as Node
         if (newAnchor) {
@@ -679,7 +682,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
     return anchor
   },
 
-  hydrateSlot(vnode, node, parentComponent, parentSuspense) {
+  hydrateSlot(vnode, node, parentComponent, parentSuspense, slotScopeIds) {
     if (!isHydrating && !isVdomHydrating && !isVdomHydratingEnabled) {
       return node
     }
@@ -687,7 +690,12 @@ const vaporInteropImpl: VaporInVdomInterface = {
     let createdAnchor = false
     let resumeNode: Node | null = null
     vaporHydrateNode(node, () => {
-      vnode.vb = renderVaporSlot(vnode, parentComponent, parentSuspense)
+      vnode.vb = renderVaporSlot(
+        vnode,
+        parentComponent,
+        parentSuspense,
+        slotScopeIds,
+      )
       const fragmentAnchor = isFragment(vnode.vb) && vnode.vb.anchor
       let anchor = fragmentAnchor || currentHydrationNode!
       const wrapped = isComment(node, '[') && isComment(anchor, ']')
@@ -976,7 +984,12 @@ function appendVnodeHook(
   key: 'onVnodeBeforeUpdate' | 'onVnodeUpdated',
   hook: () => void,
 ): void {
-  const props = (vnode.props ||= {})
+  let props = vnode.props
+  // The shared EMPTY_OBJ (frozen in dev only) and user-frozen props both need
+  // replacing with the vnode's own object.
+  if (!props || props === EMPTY_OBJ || !Object.isExtensible(props)) {
+    props = vnode.props = extend({}, props)
+  }
   const existing = props[key]
   props[key] = existing
     ? isArray(existing)
@@ -1006,7 +1019,7 @@ function trackFragmentVNodeUpdates(
 }
 
 function createVNodeFragment(vnode: VNode): {
-  frag: VaporFragment<Block>
+  frag: RenderContextFragment<Block>
   syncNodes: () => void
 } {
   const frag = createInteropFragment(EMPTY_BLOCK, vnode)
@@ -1080,7 +1093,7 @@ function mountVNode(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    hydrateVNode(vnode, parentComponent as any)
+    hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
     onScopeDispose(unmount, true)
     isMounted = true
     syncNodes()
@@ -1126,7 +1139,7 @@ function mountVNode(
           parentComponent as any,
           operationSuspense,
           undefined, // namespace
-          vnode.slotScopeIds,
+          frag.slotScopeIds,
         )
         onScopeDispose(unmount, true)
         isMounted = true
@@ -1294,7 +1307,7 @@ function createVDOMComponent(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    hydrateVNode(vnode, parentComponent as any)
+    hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
     isMounted = true
     syncNodes()
   }
@@ -1567,7 +1580,9 @@ function renderVDOMSlot(
   adoptAnchor?: Node,
 ): VaporFragment {
   let suspense = currentParentSuspense || parentComponent.suspense
-  const frag = createInteropFragment()
+  // frag.slotScopeIds is the outlet's id cell (the ambient createSlot
+  // establishes around this call) — the base patch context for content patches.
+  const frag = createInteropFragment(EMPTY_BLOCK, null, SLOT_OUTLET)
   const isDirectSlotRoot = !!(slotRoot || sharedFallback || inheritFallback)
   // `isBlockValid` below reports VDOM-side validity (`contentState.valid`), not
   // `isValidBlock(frag.nodes)`: `frag.nodes` tracks the active fallback when one
@@ -1637,6 +1652,7 @@ function renderVDOMSlot(
     parent: inheritFallback ? slotBoundary : null,
     getFallback: (): BlockFn | undefined => localFallback,
     run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
+    getScopeIds: () => frag.slotScopeIds,
     markDirty: force => markSlotResolutionDirty(slotResolutionState, force),
     onContentInvalid,
   }
@@ -1783,7 +1799,7 @@ function renderVDOMSlot(
       parentComponent as any,
       suspense,
       undefined,
-      slotScopeIds,
+      concatInteropScopeIds(frag.slotScopeIds, slotScopeIds),
     )
     setRenderedContent(next, valid)
     finishContentUpdate()
@@ -2029,9 +2045,12 @@ function renderVDOMSlot(
                   hydrateVNode(
                     hydrationVNode,
                     parentComponent as any,
-                    hydrationVNode === hydratedContent
-                      ? null
-                      : hydratedContent.slotScopeIds,
+                    concatInteropScopeIds(
+                      frag.slotScopeIds,
+                      hydrationVNode === hydratedContent
+                        ? null
+                        : hydratedContent.slotScopeIds,
+                    ),
                   )
                 }
                 // Remember the slot outlet insertion point outside the hydrated VNode range.
@@ -2389,6 +2408,7 @@ export const vaporInteropPlugin: Plugin = app => {
     getInteropTransitionElement,
   )
   setInteropEnabled()
+  setPublishInteropScopeIds(publishVaporScopeIds)
   app._context.vapor = vaporInteropImpl
   const internals = ensureRenderer().internals
   app._context.vdom = {
@@ -2520,6 +2540,9 @@ function renderVaporSlot(
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null,
   parentSuspense: SuspenseBoundary | null,
+  // the raw slot patch context; kept off the vnode so cached/cloned VaporSlot
+  // vnodes never accumulate it
+  contextSlotScopeIds: string[] | null,
 ): Block {
   const prev = currentInstance
   let prevSuspense: SuspenseBoundary | null = null
@@ -2532,12 +2555,18 @@ function renderVaporSlot(
       return EMPTY_BLOCK
     }
     const slotState = resolveInteropVaporSlotState(vnode)
-    const scopeIds = getInteropVaporSlotScopeIds(vnode, parentComponent)
     // Most of the interop setup is shared, but slots that start with a local
     // VDOM fallback still need to let an inner SlotFragment own the active
     // fallback lifecycle. Forcing the interop wrapper to own that branch breaks
     // fallback blocks that can later resolve to an empty vnode list.
-    const frag = createInteropFragment()
+    const frag = createInteropFragment(EMPTY_BLOCK, null, SLOT_OUTLET)
+    // The vnode-derived slot context becomes the creation ambient for the
+    // vapor-rendered content, restored via the fragment's render seam.
+    frag.slotScopeIds = getInteropVaporSlotScopeIds(
+      vnode,
+      parentComponent,
+      contextSlotScopeIds,
+    )
     // Optimistic until content resolves into `frag.nodes`; see createVNodeFragment.
     let contentResolved = isHydrating
     frag.isBlockValid = componentAsValid =>
@@ -2590,6 +2619,7 @@ function renderVaporSlot(
       getFallback: () =>
         slotState.outletFallback.value ? outletFallback : undefined,
       run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
+      getScopeIds: () => frag.slotScopeIds,
       markDirty: markInteropSlotResolutionDirty,
     }
     const localFallbackBoundary: SlotBoundaryContext = {
@@ -2599,6 +2629,7 @@ function renderVaporSlot(
       getFallback: () =>
         slotState.localFallback.value ? localFallback : undefined,
       run: (fn, scope) => runWithRenderCtx(frag, fn, scope),
+      getScopeIds: () => frag.slotScopeIds,
       markDirty: markInteropSlotResolutionDirty,
       onContentInvalid,
     }
@@ -2672,9 +2703,6 @@ function renderVaporSlot(
       const finalizeResolvedContent = (
         resolvedContent: Block | undefined,
       ): Block | undefined => {
-        if (resolvedContent && scopeIds) {
-          setScopeId(resolvedContent, scopeIds)
-        }
         if (hasInteropFallback && isSlotFragment(resolvedContent)) {
           finishHydratingContent(true)
           return resolvedContent
@@ -2803,8 +2831,18 @@ function invokeVaporSlot(vnode: VNode): Block {
   }
 }
 
+// The tracking callback keeps el-sync registered on any dynamic fragments
+// along the effective-root chain, including ones a root switch introduced.
+function resolveInteropRootEl(
+  instance: VaporComponentInstance,
+): Element | undefined {
+  return getRootElement(instance, {
+    onDynamicFragment: frag => registerInteropRootSync(instance, frag),
+  })
+}
+
 function syncVNodeEl(vnode: VNode, instance: VaporComponentInstance): void {
-  const rootEl = getRootElement(instance)
+  const rootEl = resolveInteropRootEl(instance)
   if (rootEl) {
     vnode.el = rootEl
   } else {
@@ -2817,16 +2855,11 @@ function syncInteropRoot(instance: VaporComponentInstance): void {
   const state = vnodeHookStateMap.get(instance)
   if (!state) return
   syncVNodeEl(state.vnode, instance)
-  const hooks = state.postRootSyncHooks
-  for (let i = 0; i < hooks.length; i++) {
-    hooks[i](state.vnode)
-  }
 }
 
 interface VNodeHookState {
   vnode: VNode
   skipVnodeHooks: boolean
-  postRootSyncHooks: ((vnode: VNode) => void)[]
 }
 
 const vnodeHookStateMap = new WeakMap<VaporComponentInstance, VNodeHookState>()
@@ -2840,7 +2873,6 @@ function ensureVNodeHookState(
     state = {
       vnode,
       skipVnodeHooks: false,
-      postRootSyncHooks: [],
     }
     vnodeHookStateMap.set(instance, state)
     ;(instance.bu ||= []).push(() => {
@@ -2959,7 +2991,9 @@ function createVNodeChildrenFragment(
           const nextChildren = render()
           notifyBeforeUpdate()
           if (isHydrating) {
-            nextChildren.forEach(vnode => hydrateVNode(vnode, parentComponent))
+            nextChildren.forEach(vnode =>
+              hydrateVNode(vnode, parentComponent, frag.slotScopeIds),
+            )
             currentChildren = nextChildren
             currentVNode = createVNode(Fragment, null, nextChildren)
             currentParentNode = currentHydrationNode!.parentNode as ParentNode
@@ -3004,7 +3038,7 @@ function createVNodeChildrenFragment(
                 parentComponent,
                 suspense,
                 undefined,
-                null,
+                frag.slotScopeIds,
                 false,
               )
             }
@@ -3025,7 +3059,7 @@ function createVNodeChildrenFragment(
               parentComponent,
               suspense,
               undefined,
-              null,
+              frag.slotScopeIds,
               false,
             )
             currentChildren = nextChildren
@@ -3083,7 +3117,7 @@ function createVNodeChildrenFragment(
           parentComponent,
           suspense,
           undefined,
-          null,
+          frag.slotScopeIds,
           false,
         )
       }
@@ -3265,71 +3299,103 @@ function createInteropRawSlots(slotsRef: ShallowRef<Slots>): RawSlots {
   return rawSlots as RawSlots
 }
 
-const interopScopeIdRootMap = new WeakMap<VaporComponentInstance, Element>()
-const interopScopeIdFragmentMap = new WeakMap<
+// vnode.el of an interop-mounted vapor component must follow its dynamic
+// root across branch switches.
+const interopRootSyncFragmentMap = new WeakMap<
   DynamicFragment,
   VaporComponentInstance
 >()
 
-function trackInteropScopeIdFragment(
+function registerInteropRootSync(
   instance: VaporComponentInstance,
   frag: DynamicFragment,
 ): void {
-  if (interopScopeIdFragmentMap.get(frag) === instance) return
-  interopScopeIdFragmentMap.set(frag, instance)
+  if (interopRootSyncFragmentMap.get(frag) === instance) return
+  interopRootSyncFragmentMap.set(frag, instance)
   ;(frag.onUpdated ||= []).push(() => syncInteropRoot(instance))
 }
 
-function setInteropVnodeScopeId(
+/**
+ * Stores the vnode-derived root-only ids on the instance. Metadata only:
+ * mountComponent and dynamic branch renders apply them pre-insert to roots
+ * that mount afterwards; kept roots keep their mount-time ids (VDOM parity).
+ */
+function setInteropComponentScopeIds(
   instance: VaporComponentInstance,
   vnode: VNode,
-  parentComponent: ComponentInternalInstance | null,
 ): void {
-  const root = getRootElement(instance, frag =>
-    trackInteropScopeIdFragment(instance, frag),
+  instance.scopeId = vnode.scopeId
+  const inherited = getInheritedScopeIds(
+    vnode,
+    instance.parent as ComponentInternalInstance | null,
   )
-  if (!root) {
-    interopScopeIdRootMap.delete(instance)
-    return
-  }
-  // VDOM applies scope ids when an element is mounted, not on same-root patch.
-  if (interopScopeIdRootMap.get(instance) === root) return
-  interopScopeIdRootMap.set(instance, root)
-
-  const scopeIds = getInteropVnodeScopeIds(vnode, parentComponent)
-  if (!scopeIds) return
-
-  for (let i = 0; i < scopeIds.length; i++) {
-    root.setAttribute(scopeIds[i], '')
-  }
+  instance.slotScopeIds = concatInteropScopeIds(
+    vnode.slotScopeIds,
+    inherited.length ? inherited : null,
+  )
 }
 
-function getInteropVnodeScopeIds(
-  vnode: VNode,
-  parentComponent: ComponentInternalInstance | null,
-): string[] | undefined {
-  const scopeIds: string[] = []
-  if (vnode.scopeId) scopeIds.push(vnode.scopeId)
-  if (vnode.slotScopeIds) scopeIds.push(...vnode.slotScopeIds)
-  scopeIds.push(...getInheritedScopeIds(vnode, parentComponent))
-  return scopeIds.length ? scopeIds : undefined
+function concatInteropScopeIds(
+  base: string[] | null,
+  own: string[] | null | undefined,
+): string[] | null {
+  // identity guard: a content vnode's recorded context can BE the base cell
+  // (stored by reference through the patch context) — self-concat would
+  // duplicate every id
+  return base
+    ? own && own.length && own !== base
+      ? base.concat(own)
+      : base
+    : own || null
 }
 
+/**
+ * Publishes root-only ids onto the interop vnode backing a vapor component's
+ * effective root, for core to apply at its own pre-insertion mount. A nested
+ * component crossed during the descent re-collects canonically — its climb
+ * carries every ancestor's contribution — superseding the caller's subset.
+ */
+function publishVaporScopeIds(block: Block, scopeIds: string[]): void {
+  let currentScopeIds = scopeIds
+  getRootElement(block, {
+    onComponent: instance => {
+      currentScopeIds = collectRootScopeIds(instance) || []
+    },
+    onInteropFragment: frag => {
+      setVNodeVaporScopeIds(frag.vnode!, currentScopeIds)
+    },
+    excludeSlotOutlets: true,
+  })
+}
+
+function setVNodeVaporScopeIds(vnode: VNode, scopeIds: string[]): void {
+  vnode.vaporScopeIds = scopeIds
+  // Pending suspense branches mount through core with no vapor seam between;
+  // forward so both branches inherit at their own mount.
+  if (vnode.ssContent) setVNodeVaporScopeIds(vnode.ssContent, scopeIds)
+  if (vnode.ssFallback) setVNodeVaporScopeIds(vnode.ssFallback, scopeIds)
+}
+
+// The single merge point for a vapor slot's id cell: raw patch context, the
+// vnode's own ids, then deep slot-content inheritance (root-only excluded).
 function getInteropVaporSlotScopeIds(
   vnode: VNode,
   parentComponent: ComponentInternalInstance | null,
-): string[] | undefined {
-  const scopeIds: string[] = []
-  if (vnode.slotScopeIds) scopeIds.push(...vnode.slotScopeIds)
-  scopeIds.push(...getInheritedScopeIds(vnode, parentComponent))
-  return scopeIds.length ? scopeIds : undefined
+  contextSlotScopeIds: string[] | null,
+): string[] | null {
+  const inherited = getInheritedScopeIds(vnode, parentComponent, false)
+  return concatInteropScopeIds(
+    concatInteropScopeIds(contextSlotScopeIds, vnode.slotScopeIds),
+    inherited.length ? inherited : null,
+  )
 }
 
 function createInteropFragment(
   nodes: Block = EMPTY_BLOCK,
   vnode: VNode | null = null,
+  extraFlags = 0,
 ): RenderContextFragment<Block> {
-  const frag = new RenderContextFragment<Block>(nodes, VDOM)
+  const frag = new RenderContextFragment<Block>(nodes, VDOM | extraFlags)
   frag.vnode = vnode
   return frag
 }


### PR DESCRIPTION
Replace the post-render scope id walkers with a creation-time ambient model aligned with VDOM semantics. Scope ids are compile-time constants: elements receive their attributes when created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scoped-slot styling and `:slotted` behavior across nested components, fragments, fallbacks, Teleport, Suspense, and dynamic content.
  * Fixed scope metadata propagation between Vapor and VDOM rendering.
  * Improved hydration recovery and node recreation while preserving slot context.
  * Prevented scope information from leaking through incompatible fallback components.

* **Tests**
  * Expanded coverage for scoped slots, hydration, interop rendering, and dynamic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->