### PR TITLE
fix(runtime-vapor): align attrs fallthrough semantics with vdom

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -276,6 +276,7 @@ export interface VdomInVaporInterface {
   mountVNode: (
     vnode: VNode,
     parentComponent: any, // VaporComponentInstance
+    getFallthroughAttrs?: () => Record<string, any>,
   ) => any
 }
 

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -363,7 +363,10 @@ export const getFunctionalFallthrough = (attrs: Data): Data | undefined => {
   return res
 }
 
-const filterModelListeners = (attrs: Data, props: NormalizedProps): Data => {
+export const filterModelListeners = (
+  attrs: Data,
+  props: NormalizedProps,
+): Data => {
   const res: Data = {}
   for (const key in attrs) {
     if (!isModelListener(key) || !(key.slice(9) in props)) {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -705,6 +705,7 @@ export {
   warnExtraneousAttributes,
   getFunctionalFallthrough,
   isFunctionalFallthroughKey,
+  filterModelListeners,
   shouldUpdateComponent,
 } from './componentRenderUtils'
 

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1730,4 +1730,142 @@ describe('attribute fallthrough', () => {
     const { host } = define(App).render()
     expect(host.innerHTML).toBe('<div>class prop = DROPPED</div>')
   })
+
+  it('should apply dynamic attrs that appear after mount', async () => {
+    const t0 = template('<div>', 1)
+    const { component: Child } = define({
+      setup() {
+        return t0()
+      },
+    })
+
+    const attrs = ref<Record<string, any>>({})
+    const { host } = define({
+      setup() {
+        return createComponent(Child, { $: [() => attrs.value] }, null, true)
+      },
+    }).render()
+    expect(host.innerHTML).toBe('<div></div>')
+
+    attrs.value = { id: 'late' }
+    await nextTick()
+    expect(host.innerHTML).toBe('<div id="late"></div>')
+
+    attrs.value = {}
+    await nextTick()
+    expect(host.innerHTML).toBe('<div></div>')
+  })
+
+  it('should clean up functional fallthrough when allowed keys are removed', async () => {
+    const attrs = ref<Record<string, any>>({ class: 'foo' })
+    const Fn = () => template('<div>', 1)()
+    const { host } = define({
+      setup() {
+        return createComponent(
+          Fn as any,
+          { $: [() => attrs.value] },
+          null,
+          true,
+        )
+      },
+    }).render()
+    const node = host.children[0] as HTMLElement
+    expect(node.className).toBe('foo')
+
+    // class removed; id is not a functional fallthrough key, so the
+    // resolved fallthrough set becomes empty and must still diff away
+    // the previously applied class
+    attrs.value = { id: 'x' }
+    await nextTick()
+    expect(node.className).toBe('')
+    expect(node.getAttribute('id')).toBe(null)
+  })
+
+  it('should filter functional fallthrough forwarded to a component root', () => {
+    const t0 = template('<div>', 1)
+    const { component: Inner } = define({
+      setup() {
+        return t0()
+      },
+    })
+    const Fn = () => createComponent(Inner, null, null, true)
+    const { host } = define({
+      setup() {
+        return createComponent(
+          Fn as any,
+          { id: () => 'x', class: () => 'c' },
+          null,
+          true,
+        )
+      },
+    }).render()
+    const node = host.children[0] as HTMLElement
+    expect(node.getAttribute('class')).toBe('c')
+    expect(node.getAttribute('id')).toBe(null)
+  })
+
+  it('should not fallthrough v-model listeners with a declared prop', () => {
+    const declared = vi.fn()
+    const undeclared = vi.fn()
+    const t0 = template('<div>', 1)
+    const { component: Child } = define({
+      props: ['foo'],
+      setup() {
+        return t0()
+      },
+    })
+    const { host } = define({
+      setup() {
+        return createComponent(
+          Child,
+          {
+            'onUpdate:foo': () => declared,
+            'onUpdate:bar': () => undeclared,
+            id: () => 'x',
+          },
+          null,
+          true,
+        )
+      },
+    }).render()
+    const node = host.children[0] as HTMLElement
+    expect(node.getAttribute('id')).toBe('x')
+    node.dispatchEvent(new CustomEvent('update:foo'))
+    expect(declared).not.toHaveBeenCalled()
+    node.dispatchEvent(new CustomEvent('update:bar'))
+    expect(undeclared).toHaveBeenCalled()
+  })
+
+  it('should not forward declared v-model listeners into a component root', () => {
+    const handler = vi.fn()
+    const t0 = template('<div>', 1)
+    const { component: Child } = define({
+      setup() {
+        return t0()
+      },
+    })
+    const { component: Middle } = define({
+      props: ['foo'],
+      setup() {
+        return createComponent(Child, null, null, true)
+      },
+    })
+    const { host } = define({
+      setup() {
+        return createComponent(
+          Middle,
+          {
+            'onUpdate:foo': () => handler,
+            id: () => 'x',
+          },
+          null,
+          true,
+        )
+      },
+    }).render()
+    const node = host.children[0] as HTMLElement
+    expect(node.getAttribute('id')).toBe('x')
+    node.dispatchEvent(new CustomEvent('update:foo'))
+    expect(handler).not.toHaveBeenCalled()
+  })
 })

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1608,7 +1608,6 @@ describe('attribute fallthrough', () => {
 
   it('does not warn for filtered functional fallthrough on a text root', () => {
     const { component: Child } = define(() => template('child')())
-    Child.props = ['foo']
     const Parent = compile(
       `<template><components.Child v-text="data" /></template>`,
       ref('foo'),
@@ -1618,6 +1617,22 @@ describe('attribute fallthrough', () => {
     const { host } = define(Parent).render()
     expect(host.textContent).toBe('child')
     expect(`Extraneous non-props attributes`).not.toHaveBeenWarned()
+  })
+
+  it('warns for unfiltered functional fallthrough on a text root when props are declared', () => {
+    const { component: Child } = define(() => template('child')())
+    Child.props = ['foo']
+    const Parent = compile(
+      `<template><components.Child v-text="data" /></template>`,
+      ref('foo'),
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.textContent).toBe('child')
+    // a functional component with declared props receives full fallthrough,
+    // and a text root cannot accept it — align with vdom's warning
+    expect(`Extraneous non-props attributes`).toHaveBeenWarned()
   })
 
   it('applies v-text fallthrough after switching dynamic components', async () => {
@@ -2045,6 +2060,38 @@ describe('attribute fallthrough', () => {
     expect(second.getAttribute('id')).toBe('b')
     // the replaced root's effect died with its branch scope
     expect(first.getAttribute('id')).toBe('a')
+  })
+
+  it('should allow all attrs on a bare functional component with declared props', async () => {
+    const Fn = ((props: any) => {
+      const n0 = template('<div>', 1)() as Element
+      renderEffect(() => setElementText(n0, props.foo))
+      return n0
+    }) as any
+    Fn.props = ['foo']
+
+    const id = ref('a')
+    const { host } = define({
+      setup() {
+        return createComponent(
+          Fn,
+          { foo: () => 1, id: () => id.value },
+          null,
+          true,
+        )
+      },
+    }).render()
+
+    const node = host.children[0] as HTMLElement
+    // vdom: a functional component that declares props receives full
+    // fallthrough, not just the class/style/listener whitelist
+    expect(node.getAttribute('id')).toBe('a')
+    expect(node.getAttribute('foo')).toBe(null) // declared prop
+    expect(node.textContent).toBe('1')
+
+    id.value = 'b'
+    await nextTick()
+    expect(node.getAttribute('id')).toBe('b')
   })
 
   it('should freeze fallthrough on KeepAlive-cached components and catch up on reactivation', async () => {

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -2140,4 +2140,38 @@ describe('attribute fallthrough', () => {
     expect(oneEl.isConnected).toBe(true)
     expect(oneEl.getAttribute('id')).toBe('b')
   })
+
+  it('should not inherit attrs into a dynamic branch inside slot content', async () => {
+    const show = ref(true)
+    const Child = compile(`<template><slot /></template>`, ref(null))
+    const Middle = compile(
+      `<script setup vapor>
+        const Child = _components.Child
+        const show = _data
+      </script>
+      <template>
+        <Child>
+          <div v-if="show">if</div>
+          <span v-else>else</span>
+        </Child>
+      </template>`,
+      show,
+      { Child },
+    )
+    const App = compile(
+      `<template><components.Middle class="parent" /></template>`,
+      ref(null),
+      { Middle },
+    )
+
+    const { host } = define(App).render()
+    // a slot outlet root cannot receive fallthrough attrs
+    expect(host.querySelector('div')!.className).toBe('')
+    expect(`Extraneous non-props attributes (class)`).toHaveBeenWarnedTimes(1)
+
+    // the slot boundary still holds after the inner branch switches
+    show.value = false
+    await nextTick()
+    expect(host.querySelector('span')!.className).toBe('')
+  })
 })

--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -6,10 +6,12 @@ import {
   withModifiers,
 } from '@vue/runtime-dom'
 import {
+  VaporKeepAlive,
   VaporTeleport,
   createComponent,
   createDynamicComponent,
   createIf,
+  createKeyedFragment,
   createSlot,
   defineVaporComponent,
   delegateEvents,
@@ -22,7 +24,12 @@ import {
   template,
 } from '../src'
 import { compile, makeRender } from './_utils'
-import { VaporDynamicComponentFlags, stringifyStyle } from '@vue/shared'
+import {
+  VaporBlockShape,
+  VaporDynamicComponentFlags,
+  VaporIfFlags,
+  stringifyStyle,
+} from '@vue/shared'
 import { setElementText } from '../src/dom/prop'
 
 const define = makeRender<any>()
@@ -1867,5 +1874,223 @@ describe('attribute fallthrough', () => {
     expect(node.getAttribute('id')).toBe('x')
     node.dispatchEvent(new CustomEvent('update:foo'))
     expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('should stop updating fallthrough attrs on a root detached by branch switch', async () => {
+    const show = ref(true)
+    const id = ref('a')
+    const t0 = template('<div>foo</div>', 1)
+    const { component: Child } = define({
+      setup() {
+        return createIf(
+          () => show.value,
+          () => t0(),
+        )
+      },
+    })
+    const { host } = define({
+      setup() {
+        return createComponent(Child, { id: () => id.value }, null, true)
+      },
+    }).render()
+
+    const initialRoot = host.querySelector('div')!
+    expect(initialRoot.getAttribute('id')).toBe('a')
+
+    show.value = false
+    await nextTick()
+    expect(initialRoot.isConnected).toBe(false)
+
+    id.value = 'b'
+    await nextTick()
+    // the branch scope owns the effect, so the detached root is not updated
+    expect(initialRoot.getAttribute('id')).toBe('a')
+
+    show.value = true
+    await nextTick()
+    expect(host.innerHTML).toBe('<div id="b">foo</div><!--if-->')
+  })
+
+  it('should stop updating fallthrough attrs on a detached nested branch root', async () => {
+    const outer = ref(true)
+    const inner = ref(true)
+    const id = ref('a')
+    const t0 = template('<div>outer</div>', 1)
+    const t1 = template('<p>inner</p>', 1)
+    const t2 = template('<span>inner-else</span>', 1)
+    const { component: Child } = define({
+      setup() {
+        return createIf(
+          () => outer.value,
+          () => t0(),
+          () =>
+            createIf(
+              () => inner.value,
+              () => t1(),
+              () => t2(),
+            ),
+        )
+      },
+    })
+    const { host } = define({
+      setup() {
+        return createComponent(Child, { id: () => id.value }, null, true)
+      },
+    }).render()
+
+    outer.value = false
+    await nextTick()
+    const innerEl = host.querySelector('p')!
+    expect(innerEl.getAttribute('id')).toBe('a')
+
+    // switching only the inner branch stops the inner branch scope, which
+    // owns the effect for the inner root
+    inner.value = false
+    await nextTick()
+    expect(innerEl.isConnected).toBe(false)
+
+    id.value = 'b'
+    await nextTick()
+    expect(innerEl.getAttribute('id')).toBe('a')
+    expect(host.querySelector('span')!.getAttribute('id')).toBe('b')
+  })
+
+  it('should scope fallthrough for no-scope nested branch roots', async () => {
+    const outer = ref(true)
+    const inner = ref(true)
+    const id = ref('a')
+    const t0 = template('<div>outer</div>', 1)
+    const t1 = template('<p>inner</p>', 1)
+    const t2 = template('<span>inner-else</span>', 1)
+    const noScopeIfElse =
+      VaporBlockShape.SINGLE_ROOT |
+      (VaporBlockShape.SINGLE_ROOT << 2) |
+      VaporIfFlags.TRUE_NO_SCOPE |
+      VaporIfFlags.FALSE_NO_SCOPE
+    const { component: Child } = define({
+      setup() {
+        return createIf(
+          () => outer.value,
+          () => t0(),
+          () =>
+            createIf(
+              () => inner.value,
+              () => t1(),
+              () => t2(),
+              noScopeIfElse,
+            ),
+        )
+      },
+    })
+    const { host } = define({
+      setup() {
+        return createComponent(Child, { id: () => id.value }, null, true)
+      },
+    }).render()
+
+    outer.value = false
+    await nextTick()
+    const innerEl = host.querySelector('p')!
+    expect(innerEl.getAttribute('id')).toBe('a')
+
+    // the no-scope inner branch received a retrofitted scope owning the
+    // effect; switching it stops that scope
+    inner.value = false
+    await nextTick()
+    expect(innerEl.isConnected).toBe(false)
+    id.value = 'b'
+    await nextTick()
+    expect(innerEl.getAttribute('id')).toBe('a')
+    const spanEl = host.querySelector('span')!
+    expect(spanEl.getAttribute('id')).toBe('b')
+
+    // switching the outer branch tears the nested chain down with it
+    outer.value = true
+    await nextTick()
+    expect(spanEl.isConnected).toBe(false)
+    id.value = 'c'
+    await nextTick()
+    expect(spanEl.getAttribute('id')).toBe('b')
+    expect(host.querySelector('div')!.getAttribute('id')).toBe('c')
+  })
+
+  it('should reapply fallthrough attrs across keyed root re-renders', async () => {
+    const key = ref(0)
+    const id = ref('a')
+    const t0 = template('<div>keyed</div>', 1)
+    const { component: Child } = define({
+      setup() {
+        return createKeyedFragment(
+          () => key.value,
+          () => t0(),
+        )
+      },
+    })
+    const { host } = define({
+      setup() {
+        return createComponent(Child, { id: () => id.value }, null, true)
+      },
+    }).render()
+    const first = host.querySelector('div')!
+    expect(first.getAttribute('id')).toBe('a')
+
+    key.value++
+    await nextTick()
+    const second = host.querySelector('div')!
+    expect(second).not.toBe(first)
+    expect(second.getAttribute('id')).toBe('a')
+
+    id.value = 'b'
+    await nextTick()
+    expect(second.getAttribute('id')).toBe('b')
+    // the replaced root's effect died with its branch scope
+    expect(first.getAttribute('id')).toBe('a')
+  })
+
+  it('should freeze fallthrough on KeepAlive-cached components and catch up on reactivation', async () => {
+    const current = ref('one')
+    const id = ref('a')
+    const One = defineVaporComponent({
+      name: 'One',
+      setup() {
+        return template('<div>one</div>', 1)()
+      },
+    })
+    const Two = defineVaporComponent({
+      name: 'Two',
+      setup() {
+        return template('<span>two</span>', 1)()
+      },
+    })
+    const views: Record<string, any> = { one: One, two: Two }
+    const { host } = define({
+      setup() {
+        return createComponent(VaporKeepAlive as any, null, {
+          default: () =>
+            createDynamicComponent(() => views[current.value], {
+              id: () => id.value,
+            }),
+        })
+      },
+    }).render()
+
+    const oneEl = host.querySelector('div')!
+    expect(oneEl.getAttribute('id')).toBe('a')
+
+    current.value = 'two'
+    await nextTick()
+    expect(oneEl.isConnected).toBe(false)
+
+    id.value = 'b'
+    await nextTick()
+    // cached: committed inputs are frozen, the cached root must not update
+    expect(oneEl.getAttribute('id')).toBe('a')
+    expect(host.querySelector('span')!.getAttribute('id')).toBe('b')
+
+    current.value = 'one'
+    await nextTick()
+    // reactivated: committed inputs resume and the effect catches up
+    expect(oneEl.isConnected).toBe(true)
+    expect(oneEl.getAttribute('id')).toBe('b')
   })
 })

--- a/packages/runtime-vapor/__tests__/if.spec.ts
+++ b/packages/runtime-vapor/__tests__/if.spec.ts
@@ -290,9 +290,11 @@ describe('createIf', () => {
     ).render()
 
     expect(host.innerHTML).toBe('<div id="a">foo</div><!--if-->')
-    expect(frag.scope).toBeUndefined()
+    // branch-owned from the first render on: the no-scope branch gets a
+    // retrofitted scope so the fallthrough effect dies with the branch
+    expect(frag.scope).toBeDefined()
     expect((frag as any).attrs).toBeUndefined()
-    expect((frag as any).hasFallthroughAttrs).toBe(true)
+    expect((frag as any).fallthrough).toBeTruthy()
 
     id.value = 'b'
     await nextTick()

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -3333,6 +3333,56 @@ describe('vdomInterop', () => {
       await nextTick()
       expect(html()).toBe('<div data-msg="bar">bar</div>')
     })
+
+    it('should fallthrough attrs to a vnode root rendered by a dynamic component', async () => {
+      const id = ref('a')
+      const VaporChild = compile(
+        `<template><component :is="data" /></template>`,
+        ref(h('div', null, 'vnode')),
+      )
+
+      const { html } = define({
+        setup() {
+          return () => h(VaporChild as any, { id: id.value })
+        },
+      }).render()
+
+      expect(html()).toBe('<div id="a">vnode</div><!--dynamic-component-->')
+
+      id.value = 'b'
+      await nextTick()
+      expect(html()).toBe('<div id="b">vnode</div><!--dynamic-component-->')
+    })
+
+    it('should fallthrough attrs to a component vnode root and keep its state', async () => {
+      const id = ref('a')
+      const VDomChild = defineComponent({
+        setup() {
+          const n = ref(0)
+          return () => h('div', { onClick: () => n.value++ }, String(n.value))
+        },
+      })
+      const VaporChild = compile(
+        `<template><component :is="data" /></template>`,
+        ref(h(VDomChild)),
+      )
+
+      const { html, host } = define({
+        setup() {
+          return () => h(VaporChild as any, { id: id.value })
+        },
+      }).render()
+
+      expect(html()).toBe('<div id="a">0</div><!--dynamic-component-->')
+      ;(host.children[0] as HTMLElement).click()
+      await nextTick()
+      expect(html()).toBe('<div id="a">1</div><!--dynamic-component-->')
+
+      // an attrs update must patch, not remount: the inner state survives
+      id.value = 'b'
+      await nextTick()
+      expect(html()).toBe('<div id="b">1</div><!--dynamic-component-->')
+    })
   })
 
   describe('async component', () => {

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -14,6 +14,8 @@ import {
   type VaporComponentInstance,
   createComponentWithFallback,
   emptyContext,
+  isVaporComponent,
+  resolveFallthroughAttrs,
 } from './component'
 import { renderEffect } from './renderEffect'
 import type { RawProps } from './componentProps'
@@ -101,7 +103,21 @@ export function createDynamicComponent(
           if (frag) return frag
         }
 
-        const frag = appContext.vdom.mountVNode(value, currentInstance)
+        // A vnode standing in as this component's effective root inherits
+        // fallthrough attrs; the normal component path folds them into
+        // rawProps at creation, this one merges them into the vnode's props.
+        const owner =
+          isSingleRoot &&
+          isVaporComponent(currentInstance) &&
+          currentInstance.hasFallthrough &&
+          currentInstance.type.inheritAttrs !== false
+            ? currentInstance
+            : undefined
+        const frag = appContext.vdom.mountVNode(
+          value,
+          currentInstance,
+          owner && (() => resolveFallthroughAttrs(owner)),
+        )
         if (isHydrating) {
           locateHydrationNode(shouldConsumeFragmentStart(value))
           frag.hydrate()

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -488,8 +488,6 @@ export const createFor = (
     }
 
     if (parent) {
-      const onBeforeInsert = frag.onBeforeInsert
-      if (onBeforeInsert) onBeforeInsert.forEach(fn => fn(block.nodes))
       insertForBlock(block, anchor)
     }
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -24,6 +24,7 @@ import {
   currentInstance,
   endMeasure,
   expose,
+  filterModelListeners,
   getComponentName,
   getFunctionalFallthrough,
   invalidateMount,
@@ -63,6 +64,7 @@ import {
   invokeArrayFns,
   isArray,
   isFunction,
+  isModelListener,
   isPromise,
   isString,
 } from '@vue/shared'
@@ -326,14 +328,17 @@ export function createComponent(
       currentInstance.hasFallthrough
     ) {
       // check if we are the single root of the parent
-      // if yes, inject parent attrs as dynamic props source
-      const attrs = currentInstance.attrs
+      // if yes, inject parent attrs as dynamic props source.
+      // capture the owner: dynamic sources can be resolved from read paths
+      // that do not restore the parent as currentInstance.
+      const owner = currentInstance
+      const source = () => resolveFallthroughAttrs(owner)
       if (rawProps && rawProps !== EMPTY_OBJ) {
         ;((rawProps as RawProps).$ || ((rawProps as RawProps).$ = [])).push(
-          () => attrs,
+          source,
         )
       } else {
-        rawProps = { $: [() => attrs] } as RawProps
+        rawProps = { $: [source] } as RawProps
       }
     }
 
@@ -652,6 +657,41 @@ export function shouldUseFunctionalFallthrough(
     isFunction(component) &&
     !(isTransitionEnabled && isVaporTransition(component))
   )
+}
+
+/**
+ * The single source of truth for the attrs a component may fall through to
+ * its effective root — used both for the root element render effect and for
+ * forwarding into a root component's props. Functional components without
+ * declared props only pass class / style / event listeners; v-model
+ * listeners with a corresponding declared prop never fall through (the
+ * component handles the v-model itself — #1543, #1643, #1989). Never
+ * returns undefined so consumers can always diff away stale keys.
+ */
+export function resolveFallthroughAttrs(
+  instance: VaporComponentInstance,
+): Record<string, any> {
+  const attrs = shouldUseFunctionalFallthrough(instance.type)
+    ? getFunctionalFallthrough(instance.attrs) || EMPTY_OBJ
+    : instance.attrs
+  const propsOptions = normalizePropsOptions(instance.type)[0]
+  if (propsOptions) {
+    for (const key in attrs) {
+      if (isModelListener(key)) {
+        return filterModelListeners(attrs, propsOptions)
+      }
+    }
+  }
+  return attrs
+}
+
+export function isDeclaredModelListener(
+  instance: VaporComponentInstance,
+  key: string,
+): boolean {
+  if (!isModelListener(key)) return false
+  const propsOptions = normalizePropsOptions(instance.type)[0]
+  return !!propsOptions && key.slice(9) in propsOptions
 }
 
 export function applyFallthroughProps(
@@ -1650,18 +1690,13 @@ function handleSetupResult(
     instance.block = setupResult as Block
   }
 
-  // single root, inherit attrs
-  if (
-    instance.hasFallthrough &&
-    component.inheritAttrs !== false &&
-    Object.keys(instance.attrs).length
-  ) {
-    const getFallthroughAttrs = shouldUseFunctionalFallthrough(component)
-      ? () => getFunctionalFallthrough(instance.attrs)
-      : () => instance.attrs
+  // single root, inherit attrs. Gate on fallthrough *potential* only:
+  // attrs may be empty now and gain keys later, so emptiness is handled
+  // reactively inside the render effect.
+  if (instance.hasFallthrough && component.inheritAttrs !== false) {
     // attach attrs to the root element, or to root dynamic fragments so they
     // can be (re-)applied during each branch update
-    applyFallthroughAttrs(instance.block, instance, getFallthroughAttrs)
+    applyFallthroughAttrs(instance.block, instance)
   }
 
   if (__DEV__) {
@@ -1676,7 +1711,6 @@ function handleSetupResult(
 function applyFallthroughAttrs(
   block: Block,
   instance: VaporComponentInstance,
-  getFallthroughAttrs: () => Record<string, any> | undefined,
   scope?: EffectScope,
 ): void {
   let hasSlotFragment = false
@@ -1701,28 +1735,22 @@ function applyFallthroughAttrs(
       // slot fragments warn instead of inheriting attrs, skip them
       if (!(frag.__vf & SLOT)) {
         // Nested dynamic fragments need their own fallthrough hook.
-        registerDynamicFragmentFallthroughAttrs(
-          frag,
-          instance,
-          getFallthroughAttrs,
-        )
+        registerDynamicFragmentFallthroughAttrs(frag, instance)
       }
     }
   }
 
   if (root && !hasSlotFragment) {
     const applyEffect = () =>
-      renderEffect(() => {
-        const attrs = getFallthroughAttrs()
-        if (attrs) applyFallthroughProps(root, attrs)
-      })
+      renderEffect(() =>
+        applyFallthroughProps(root, resolveFallthroughAttrs(instance)),
+      )
     // ensure the render effect is cleaned up when the branch scope is stopped
     scope ? scope.run(applyEffect) : applyEffect()
   } else if (__DEV__) {
     const accessedAttrs = instance.accessedAttrs
-    const fallthroughAttrs = getFallthroughAttrs()
+    const fallthroughAttrs = resolveFallthroughAttrs(instance)
     if (
-      fallthroughAttrs &&
       Object.keys(fallthroughAttrs).length &&
       (hasSlotFragment ||
         (dynamicRoot && dynamicRoot.hasNonSingleRoot) ||
@@ -1793,14 +1821,13 @@ function containsTeleportFragment(block: Block): boolean {
 function registerDynamicFragmentFallthroughAttrs(
   frag: DynamicFragment,
   instance: VaporComponentInstance,
-  getFallthroughAttrs: () => Record<string, any> | undefined,
 ): void {
   // avoid registering duplicate hooks
   if (frag.hasFallthroughAttrs) return
 
   frag.hasFallthroughAttrs = true
   ;(frag.onBeforeInsert ||= []).push(nodes =>
-    applyFallthroughAttrs(nodes, instance, getFallthroughAttrs, frag.scope!),
+    applyFallthroughAttrs(nodes, instance, frag.scope!),
   )
 }
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1715,12 +1715,20 @@ function applyFallthroughAttrs(
 ): void {
   let hasSlotFragment = false
   let dynamicFragments: DynamicFragment[] | undefined
+  // The innermost dynamic fragment on the descent path owns the current
+  // root's residency, so the fallthrough effect must live in its branch
+  // scope. Track the nearest enclosing branch scope alongside it as the
+  // lifecycle parent for scopes retrofitted onto no-scope branches.
+  let innermost: DynamicFragment | undefined
+  let parentScope = scope
   const root = getRootElement(block, {
     onDynamicFragment: frag => {
       if (frag.__vf & SLOT) {
         hasSlotFragment = true
       } else {
         ;(dynamicFragments ||= []).push(frag)
+        if (innermost && innermost.scope) parentScope = innermost.scope
+        innermost = frag
       }
     },
     shallow: true,
@@ -1741,12 +1749,22 @@ function applyFallthroughAttrs(
   }
 
   if (root && !hasSlotFragment) {
+    let ownerScope = scope
+    if (innermost) {
+      // A compiler-proven no-scope branch may have rendered without a scope;
+      // create one so the effect dies with the branch — parented under the
+      // nearest enclosing branch scope so hierarchical pause/resume
+      // (KeepAlive caching) reaches it.
+      ownerScope = innermost.scope ||= parentScope
+        ? parentScope.run(() => new EffectScope())!
+        : new EffectScope()
+    }
     const applyEffect = () =>
       renderEffect(() =>
         applyFallthroughProps(root, resolveFallthroughAttrs(instance)),
       )
     // ensure the render effect is cleaned up when the branch scope is stopped
-    scope ? scope.run(applyEffect) : applyEffect()
+    ownerScope ? ownerScope.run(applyEffect) : applyEffect()
   } else if (__DEV__) {
     const accessedAttrs = instance.accessedAttrs
     const fallthroughAttrs = resolveFallthroughAttrs(instance)
@@ -1822,13 +1840,12 @@ function registerDynamicFragmentFallthroughAttrs(
   frag: DynamicFragment,
   instance: VaporComponentInstance,
 ): void {
-  // avoid registering duplicate hooks
-  if (frag.hasFallthroughAttrs) return
+  // one application per fragment: attrs fold at component boundaries, so
+  // only the first registering instance can sit on this fragment's chain
+  if (frag.fallthrough) return
 
-  frag.hasFallthroughAttrs = true
-  ;(frag.onBeforeInsert ||= []).push(nodes =>
-    applyFallthroughAttrs(nodes, instance, frag.scope!),
-  )
+  frag.fallthrough = nodes =>
+    applyFallthroughAttrs(nodes, instance, frag.scope!)
 }
 
 export interface DeferredKeepAliveUpdates {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1787,9 +1787,13 @@ function resolveFallthroughRoot(
 
   if (isFragment(block) && !(isTeleportEnabled && isTeleportFragment(block))) {
     if (isDynamicFragment(block)) {
-      // slot fragments warn instead of inheriting attrs
+      // Slot outlets warn instead of inheriting attrs, and the descent stops
+      // there: slot content is rendered by the parent, so fragments inside it
+      // must not register a fallthrough hook — a later branch switch would
+      // re-apply from the branch alone, with the slot boundary out of view.
       if (block.__vf & SLOT) {
         state.hasSlotFragment = true
+        return
       } else {
         ;(state.fragments ||= []).push(block)
         if (state.innermost && state.innermost.scope) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1525,11 +1525,12 @@ export function getExposed(
 }
 
 /**
- * The single traversal of the effective-root chain. Every consumer of the
- * chain — root element resolution, scope id owner registration, interop
- * carrier publication, fallthrough attrs — walks through here so the chain
- * rules (teleport exclusion, slot outlet breaks, comment-filtered arrays,
- * component descent) are encoded exactly once.
+ * The shared traversal of the effective-root chain — root element
+ * resolution, scope id owner registration, interop carrier publication —
+ * encoding the chain rules (teleport exclusion, slot outlet breaks,
+ * comment-filtered arrays, component descent) once. Fallthrough attrs use
+ * their own component-bounded resolver (resolveFallthroughRoot), which
+ * mirrors these rules but stops at component boundaries.
  */
 export interface RootChainVisitor {
   onDynamicFragment?: (frag: DynamicFragment) => void
@@ -1539,8 +1540,6 @@ export interface RootChainVisitor {
   // Fired at a vnode-backed interop fragment, terminating the descent there
   // (the fragment carries the chain across into vdom).
   onInteropFragment?: (frag: InteropFragment) => void
-  // Do not descend into nested components.
-  shallow?: boolean
   // Slot outlets break the effective-root chain for scope id inheritance.
   excludeSlotOutlets?: boolean
 }
@@ -1554,10 +1553,7 @@ export function getRootElement(
   }
 
   if (isVaporComponent(block)) {
-    if (visitor) {
-      if (visitor.onComponent) visitor.onComponent(block)
-      if (visitor.shallow) return
-    }
+    if (visitor && visitor.onComponent) visitor.onComponent(block)
     return getRootElement(block.block, visitor)
   }
 
@@ -1707,47 +1703,25 @@ function handleSetupResult(
   }
 }
 
-// Attach fallthrough attrs to the single root element. When the root is a
-// dynamic fragment (e.g. v-if), the attrs are (re-)applied on each branch
-// update via its insert hook. Slots and teleports warn instead of receiving
-// the attrs, consistent with VDOM behavior.
+// Attach fallthrough attrs to the single root element. When the root sits
+// under dynamic fragments (e.g. v-if), the attrs are (re-)applied on each
+// branch update via the fragments' fallthrough hook. Slots and teleports
+// warn instead of receiving the attrs, consistent with VDOM behavior.
 function applyFallthroughAttrs(
   block: Block,
   instance: VaporComponentInstance,
   scope?: EffectScope,
 ): void {
-  let hasSlotFragment = false
-  let dynamicFragments: DynamicFragment[] | undefined
-  // The innermost dynamic fragment on the descent path owns the current
-  // root's residency, so the fallthrough effect must live in its branch
-  // scope. Track the nearest enclosing branch scope alongside it as the
-  // lifecycle parent for scopes retrofitted onto no-scope branches.
-  let innermost: DynamicFragment | undefined
-  let parentScope = scope
-  const root = getRootElement(block, {
-    onDynamicFragment: frag => {
-      if (frag.__vf & SLOT) {
-        hasSlotFragment = true
-      } else {
-        ;(dynamicFragments ||= []).push(frag)
-        if (innermost && innermost.scope) parentScope = innermost.scope
-        innermost = frag
-      }
-    },
-    shallow: true,
-  })
+  const state: FallthroughResolveState = { parentScope: scope }
+  const root = resolveFallthroughRoot(block, state)
+  const { fragments, innermost, hasSlotFragment } = state
 
-  const dynamicRoot = root ? undefined : getSingleDynamicRootChain(block)
-  const fragmentsToRegister = root
-    ? dynamicFragments
-    : dynamicRoot && dynamicRoot.fragments
-  if (fragmentsToRegister) {
-    for (const frag of fragmentsToRegister) {
-      // slot fragments warn instead of inheriting attrs, skip them
-      if (!(frag.__vf & SLOT)) {
-        // Nested dynamic fragments need their own fallthrough hook.
-        registerDynamicFragmentFallthroughAttrs(frag, instance)
-      }
+  if (fragments) {
+    for (const frag of fragments) {
+      // Nested dynamic fragments need their own fallthrough hook. The chain
+      // keeps its registration even when the current branch has no element
+      // root, so future branch updates can still apply.
+      registerDynamicFragmentFallthroughAttrs(frag, instance)
     }
   }
 
@@ -1758,8 +1732,8 @@ function applyFallthroughAttrs(
       // create one so the effect dies with the branch — parented under the
       // nearest enclosing branch scope so hierarchical pause/resume
       // (KeepAlive caching) reaches it.
-      ownerScope = innermost.scope ||= parentScope
-        ? parentScope.run(() => new EffectScope())!
+      ownerScope = innermost.scope ||= state.parentScope
+        ? state.parentScope.run(() => new EffectScope())!
         : new EffectScope()
     }
     const applyEffect = () =>
@@ -1774,7 +1748,7 @@ function applyFallthroughAttrs(
     if (
       Object.keys(fallthroughAttrs).length &&
       (hasSlotFragment ||
-        (dynamicRoot && dynamicRoot.hasNonSingleRoot) ||
+        (fragments && state.hasNonSingleRoot) ||
         (isTeleportEnabled && containsTeleportFragment(block)) ||
         (!accessedAttrs &&
           (block instanceof Text || (isArray(block) && block.length))))
@@ -1784,48 +1758,73 @@ function applyFallthroughAttrs(
   }
 }
 
-interface DynamicRootChain {
-  fragments: DynamicFragment[]
-  hasNonSingleRoot: boolean
+interface FallthroughResolveState {
+  // non-slot dynamic fragments on the effective-root path, outermost first
+  fragments?: DynamicFragment[]
+  // the innermost of those — its branch scope owns the fallthrough effect
+  innermost?: DynamicFragment
+  // nearest enclosing branch scope; lifecycle parent for retrofitted scopes
+  parentScope?: EffectScope
+  hasSlotFragment?: boolean
+  // the innermost fragment's current branch is multi-root: fragments stay
+  // registered for future branches while the current render warns
+  hasNonSingleRoot?: boolean
 }
 
-// Resolve the chain of dynamic fragments leading to a single root candidate.
-// Used when getRootElement finds no element root, so fallthrough attrs are
-// registered only for true single-root components rather than for any dynamic
-// fragment seen during traversal. Dynamic root branches that are currently
-// non-single-root still keep the outer fragment hook for future branch updates,
-// but report hasNonSingleRoot so the current render can warn.
-function getSingleDynamicRootChain(block: Block): DynamicRootChain | undefined {
-  if (isDynamicFragment(block)) {
-    const { nodes } = block
-    const nested = getSingleDynamicRootChain(nodes)
-    return {
-      fragments: nested ? [block, ...nested.fragments] : [block],
-      hasNonSingleRoot: nested
-        ? nested.hasNonSingleRoot
-        : isArray(nodes) && nodes.some(child => !(child instanceof Comment)),
-    }
+// Single-pass effective-root resolution for fallthrough: descends the same
+// effective-root rules as getRootElement, but stops at components (their
+// attrs fold at their own creation boundary) and collects the dynamic
+// fragment chain, scope ownership, and warning inputs along the way.
+function resolveFallthroughRoot(
+  block: Block,
+  state: FallthroughResolveState,
+): Element | undefined {
+  if (block instanceof Element) {
+    return block
   }
+
+  if (isVaporComponent(block)) return
 
   if (isFragment(block) && !(isTeleportEnabled && isTeleportFragment(block))) {
-    return getSingleDynamicRootChain(block.nodes)
+    if (isDynamicFragment(block)) {
+      // slot fragments warn instead of inheriting attrs
+      if (block.__vf & SLOT) {
+        state.hasSlotFragment = true
+      } else {
+        ;(state.fragments ||= []).push(block)
+        if (state.innermost && state.innermost.scope) {
+          state.parentScope = state.innermost.scope
+        }
+        state.innermost = block
+      }
+    }
+    const { nodes } = block
+    if (nodes instanceof Element && (nodes as any).$root) {
+      return nodes
+    }
+    const el = resolveFallthroughRoot(nodes, state)
+    if (!el && state.innermost === block) {
+      state.hasNonSingleRoot =
+        isArray(nodes) && nodes.some(child => !(child instanceof Comment))
+    }
+    return el
   }
 
+  // multi-root arrays have no effective root; only a lone eligible branch
+  // alongside comments can hold one (vdom comment-filtering alignment)
   if (isArray(block)) {
-    let singleRoot: DynamicRootChain | undefined
+    let single: Block | undefined
     let hasComment = false
-    for (const child of block) {
-      if (child instanceof Comment) {
+    for (const b of block) {
+      if (b instanceof Comment) {
         hasComment = true
         continue
       }
-      const childRoot = getSingleDynamicRootChain(child)
-      if (!childRoot || singleRoot) {
-        return
-      }
-      singleRoot = childRoot
+      if (single !== undefined) return
+      single = b
     }
-    return hasComment ? singleRoot : undefined
+    if (!hasComment || single === undefined) return
+    return resolveFallthroughRoot(single, state)
   }
 }
 

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -655,6 +655,9 @@ export function shouldUseFunctionalFallthrough(
 ): boolean {
   return (
     isFunction(component) &&
+    // functional components that declare props receive full fallthrough,
+    // matching vdom (`Component.props ? attrs : getFunctionalFallthrough`)
+    !component.props &&
     !(isTransitionEnabled && isVaporTransition(component))
   )
 }

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -629,16 +629,17 @@ export function hasFallthroughAttrs(
   rawProps: RawProps | null | undefined,
 ): boolean {
   if (rawProps) {
-    // determine fallthrough
-    if (rawProps.$ || !comp.props) {
+    // dynamic sources can produce attrs keys at any time
+    if (rawProps.$) {
       return true
-    } else {
-      // check if rawProps contains any keys not declared
-      const propsOptions = normalizePropsOptions(comp)[0]!
-      for (const key in rawProps) {
-        if (!hasOwn(propsOptions, camelize(key))) {
-          return true
-        }
+    }
+    // otherwise fallthrough potential requires an undeclared static key —
+    // static keys are fixed at creation, so an empty rawProps can never
+    // produce attrs later
+    const propsOptions = comp.props ? normalizePropsOptions(comp)[0]! : null
+    for (const key in rawProps) {
+      if (!propsOptions || !hasOwn(propsOptions, camelize(key))) {
+        return true
       }
     }
   }

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -213,8 +213,6 @@ export class TeleportFragment extends RenderContextFragment {
     remove(this.nodes, mountState.container)
     // mount new nodes
     this.nodes = children
-    const onBeforeInsert = this.onBeforeInsert
-    if (onBeforeInsert) onBeforeInsert.forEach(fn => fn(this.nodes))
     insert(children, mountState.container, mountState.anchor)
     this.bindChildren(this.nodes)
     this.updateCssVars()
@@ -237,8 +235,6 @@ export class TeleportFragment extends RenderContextFragment {
     if (this.mountState.location !== TeleportMountLocation.None) {
       move(this.nodes, parent, anchor, MoveType.REORDER)
     } else {
-      const onBeforeInsert = this.onBeforeInsert
-      if (onBeforeInsert) onBeforeInsert.forEach(fn => fn(this.nodes))
       insert(this.nodes, parent, anchor)
     }
     this.mountState = { location, container: parent, anchor }

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -45,6 +45,7 @@ import {
 import {
   type VaporComponentInstance,
   isApplyingFallthroughProps,
+  isDeclaredModelListener,
   shouldUseFunctionalFallthrough,
 } from '../component'
 import {
@@ -73,6 +74,9 @@ const shouldSkipFallthroughKey = (el: TargetElement, key: string) => {
     instance.hasFallthrough &&
     instance.type.inheritAttrs !== false &&
     key in instance.attrs &&
+    // skip only keys fallthrough will actually write: v-model listeners
+    // with a declared prop are filtered out of the fallthrough set
+    !isDeclaredModelListener(instance, key) &&
     (!shouldUseFunctionalFallthrough(instance.type) ||
       isFunctionalFallthroughKey(key))
   )

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -121,7 +121,6 @@ export class VaporFragment<
   ) => void
 
   // hooks
-  onBeforeInsert?: ((nodes: Block) => void)[]
   onRemove?: (() => void)[]
   onBeforeUpdate?: (() => void)[]
   onUpdated?: ((nodes?: Block) => void)[]
@@ -273,8 +272,12 @@ export class DynamicFragment extends RenderContextFragment {
   // dev-mode comment text and must not double as a category signal.
   nativeChildren?: boolean
   inTransition?: boolean
-  // Fallthrough attrs hooks register branch-owned effects on insert.
-  hasFallthroughAttrs?: true
+  // Fallthrough (re-)application for this fragment's branches, installed by
+  // the owning component when the fragment sits on its fallthrough root
+  // chain. Invoked inside the branch render ctx so created effects capture
+  // the correct instance and land in branch scopes; its presence also forces
+  // scopes for compiler-proven no-scope branches.
+  fallthrough?: (nodes: Block) => void
   // Ancestor instances whose root-only scope ids resolve through this
   // fragment; branch switches re-apply them to the new root before insertion.
   scopeIdOwners?: VaporComponentInstance[]
@@ -421,18 +424,23 @@ export class DynamicFragment extends RenderContextFragment {
       const keepAliveCtx = isKeepAliveEnabled ? this.keepAliveCtx : null
       // A compiler-proven static branch can skip its own EffectScope, but attrs
       // fallthrough still registers branch-owned cleanup.
-      const useScope = !noScope || !!this.hasFallthroughAttrs
+      const useScope = !noScope || !!this.fallthrough
       if (!keepAliveCtx) {
         this.scope = useScope ? new EffectScope() : undefined
       }
 
       const renderBranch = () => {
         try {
-          this.nodes = this.runWithRenderCtx(
-            () =>
-              (useScope ? this.scope!.run(render) : render()) || EMPTY_BLOCK,
-            this.scope,
-          )
+          this.nodes = this.runWithRenderCtx(() => {
+            const nodes =
+              (useScope ? this.scope!.run(render) : render()) || EMPTY_BLOCK
+            // (Re-)apply fallthrough attrs for the new branch inside the
+            // render ctx, before insertion. Disconnected renders are skipped
+            // on purpose: the enclosing application traverses into them and
+            // owns their first application.
+            if (parent && this.fallthrough) this.fallthrough(nodes)
+            return nodes
+          }, this.scope)
         } finally {
           // Inherit the fragment key without overriding a child's own key.
           const key = this.keyed ? this.current : this.$key
@@ -464,10 +472,6 @@ export class DynamicFragment extends RenderContextFragment {
       if (this.scopeIdOwners) applyScopeIdOwners(this.scopeIdOwners)
 
       if (parent) {
-        const onBeforeInsert = this.onBeforeInsert
-        if (onBeforeInsert) {
-          onBeforeInsert.forEach(hook => hook(this.nodes))
-        }
         insert(this.nodes, parent, this.anchor)
         if (removePrevious && keepAliveCtx) {
           // Publish the new cache entry only after it has been mounted.

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -24,6 +24,7 @@ import {
   VaporSlot as VaporSlotVNode,
   type VdomInVaporInterface,
   callWithAsyncErrorHandling,
+  cloneVNode,
   createCommentVNode,
   createInternalObject,
   createVNode,
@@ -1031,8 +1032,10 @@ function createVNodeFragment(vnode: VNode): {
   // boundary to recheck; starting invalid would instead mount-then-teardown the
   // fallback on every interop mount. Hydration starts resolved (SSR nodes exist).
   let contentResolved = isHydrating
+  // reads `frag.vnode` rather than the captured argument so it follows a
+  // fallthrough re-clone (see mountVNode)
   const syncNodes = () => {
-    frag.nodes = resolveVNodeNodes(vnode)
+    frag.nodes = resolveVNodeNodes(frag.vnode!)
     contentResolved = true
   }
   frag.isBlockValid = componentAsValid =>
@@ -1056,12 +1059,23 @@ function mountVNode(
   internals: RendererInternals,
   vnode: VNode,
   parentComponent: VaporComponentInstance | null,
+  getFallthroughAttrs?: () => Record<string, any>,
 ): VaporFragment {
   let suspense =
     currentParentSuspense || (parentComponent && parentComponent.suspense)
+  // A vnode standing in as a component's effective root inherits fallthrough
+  // attrs the same way VDOM does it — merged into the vnode's props
+  // (`cloneVNode` -> `mergeProps`), so mount and patch apply them natively
+  // instead of writing the DOM behind the renderer's back.
+  const baseVNode = vnode
+  if (getFallthroughAttrs) {
+    vnode = cloneVNode(baseVNode, getFallthroughAttrs())
+  }
   const { frag, syncNodes } = createVNodeFragment(vnode)
 
   let isMounted = false
+  let mountedParentNode: ParentNode | undefined
+  let mountedAnchor: Node | null = null
   const unmount = (parentNode?: ParentNode, transition?: TransitionHooks) => {
     if (transition) setVNodeTransitionHooks(vnode, transition)
     const parentSuspense = resolveUnmountSuspense(suspense)
@@ -1158,9 +1172,49 @@ function mountVNode(
         )
       }
       simpleSetCurrentInstance(prev)
+      mountedParentNode = parentNode
+      mountedAnchor = anchor
     }
     syncNodes()
     if (isMounted && frag.onUpdated) frag.onUpdated.forEach(m => m())
+  }
+
+  if (getFallthroughAttrs) {
+    // Re-clone and let VDOM patch the change through, mirroring how a VDOM
+    // parent re-renders its root with fresh fallthrough attrs. The first run
+    // only establishes the dependency — the initial clone above already
+    // carries those attrs into the mount.
+    let applied = false
+    renderEffect(() => {
+      // clone on every run: merging the attrs is what reads them, and that
+      // read is the dependency this effect tracks
+      const next = cloneVNode(baseVNode, getFallthroughAttrs())
+      if (!applied) {
+        // the eager clone above already carries these attrs into the mount
+        applied = true
+        return
+      }
+      if (!isMounted || !mountedParentNode) return
+      const previous = vnode
+      vnode = next
+      trackFragmentVNodeUpdates(frag, vnode, syncNodes)
+      frag.vnode = vnode
+      frag.$key = vnode.key
+      const prevInstance = currentInstance
+      simpleSetCurrentInstance(parentComponent)
+      internals.p(
+        previous,
+        vnode,
+        mountedParentNode,
+        mountedAnchor,
+        parentComponent as any,
+        suspense,
+        undefined, // namespace
+        frag.slotScopeIds,
+      )
+      simpleSetCurrentInstance(prevInstance)
+      syncNodes()
+    })
   }
 
   frag.remove = unmount


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute forwarding for Vapor components, including functional components and components with declared props.
  * Correctly filters declared `v-model` listeners so they are not forwarded as regular attributes.
  * Improved attribute updates and cleanup across dynamic branches, keyed roots, and component reactivation.
  * Fixed fallthrough behavior for fragments, slots, and multi-root components.
  * Stabilized Teleport and branch insertion behavior during mounting and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->