### PR TITLE
fix(runtime-core): resolve $el for dev root comment fragment

### DIFF
--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -1,5 +1,6 @@
 import {
   Fragment,
+  Suspense,
   TestNodeTypes,
   createApp,
   createCommentVNode,
@@ -201,6 +202,78 @@ describe('component: proxy', () => {
     render(h(Outer), nodeOps.createElement('div'))
     expect(instanceProxy.$el.type).toBe(TestNodeTypes.ELEMENT)
     expect(instanceProxy.$el.tag).toBe('div')
+  })
+
+  test('$el access should be safe while a root child component is mounting', () => {
+    const Child = {
+      setup() {
+        getCurrentInstance()!.parent!.proxy!.$el
+        return () => h('div')
+      },
+    }
+    const Parent = {
+      setup: () => () => h(Child),
+    }
+
+    expect(() => render(h(Parent), nodeOps.createElement('div'))).not.toThrow()
+  })
+
+  test('$el should resolve through a Suspense root', () => {
+    let instanceProxy: any
+    const Inner = {
+      setup() {
+        return () => (
+          openBlock(),
+          createElementBlock(
+            Fragment,
+            null,
+            [createCommentVNode(' comment '), h('div', 'inner root')],
+            PatchFlags.STABLE_FRAGMENT | PatchFlags.DEV_ROOT_FRAGMENT,
+          )
+        )
+      },
+    }
+    const Outer = {
+      setup() {
+        return () =>
+          h(Suspense, null, {
+            default: () => h(Inner),
+          })
+      },
+      mounted() {
+        instanceProxy = this
+      },
+    }
+
+    render(h(Outer), nodeOps.createElement('div'))
+    expect(instanceProxy.$el.type).toBe(TestNodeTypes.ELEMENT)
+    expect(instanceProxy.$el.tag).toBe('div')
+  })
+
+  test('$el should preserve the unresolved async root value without a dev root fragment', () => {
+    let instance: ComponentInternalInstance
+    let instanceProxy: any
+    const Child = {
+      name: 'Child',
+      async setup() {
+        await new Promise(() => {})
+      },
+    }
+    const Parent = {
+      setup: () => () => h(Child),
+      mounted() {
+        instance = getCurrentInstance()!
+        instanceProxy = this
+      },
+    }
+
+    render(h(Parent), nodeOps.createElement('div'))
+
+    expect(
+      `A component with async setup() must be nested in a <Suspense>`,
+    ).toHaveBeenWarned()
+    expect(instance!.vnode.el).toBeNull()
+    expect(instanceProxy.$el === instance!.vnode.el).toBe(true)
   })
 
   test('user attached properties', async () => {

--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -1,9 +1,14 @@
 import {
+  Fragment,
+  TestNodeTypes,
   createApp,
+  createCommentVNode,
+  createElementBlock,
   defineComponent,
   getCurrentInstance,
   h,
   nodeOps,
+  openBlock,
   render,
   shallowReadonly,
 } from '@vue/runtime-test'
@@ -11,6 +16,7 @@ import type {
   ComponentInternalInstance,
   ComponentOptions,
 } from '../src/component'
+import { PatchFlags } from '@vue/shared'
 
 describe('component: proxy', () => {
   test('data', () => {
@@ -105,6 +111,30 @@ describe('component: proxy', () => {
       return this
     })
     expect(nextTickThis).toBe(instanceProxy)
+  })
+
+  // #12680
+  test('$el should resolve to the real root element when root is a dev comment + single element fragment', () => {
+    let instanceProxy: any
+    const Comp = {
+      setup() {
+        return () => (
+          openBlock(),
+          createElementBlock(
+            Fragment,
+            null,
+            [createCommentVNode(' comment '), h('div', 'real root')],
+            PatchFlags.DEV_ROOT_FRAGMENT,
+          )
+        )
+      },
+      mounted() {
+        instanceProxy = this
+      },
+    }
+    render(h(Comp), nodeOps.createElement('div'))
+    expect(instanceProxy.$el.type).toBe(TestNodeTypes.ELEMENT)
+    expect(instanceProxy.$el.tag).toBe('div')
   })
 
   test('user attached properties', async () => {

--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -124,7 +124,7 @@ describe('component: proxy', () => {
             Fragment,
             null,
             [createCommentVNode(' comment '), h('div', 'real root')],
-            PatchFlags.DEV_ROOT_FRAGMENT,
+            PatchFlags.STABLE_FRAGMENT | PatchFlags.DEV_ROOT_FRAGMENT,
           )
         )
       },
@@ -133,6 +133,72 @@ describe('component: proxy', () => {
       },
     }
     render(h(Comp), nodeOps.createElement('div'))
+    expect(instanceProxy.$el.type).toBe(TestNodeTypes.ELEMENT)
+    expect(instanceProxy.$el.tag).toBe('div')
+  })
+
+  // #12680
+  test('$el should resolve through a single-root child component to its real root element', () => {
+    let instanceProxy: any
+    const Inner = {
+      setup() {
+        return () => (
+          openBlock(),
+          createElementBlock(
+            Fragment,
+            null,
+            [createCommentVNode(' comment '), h('div', 'inner root')],
+            PatchFlags.STABLE_FRAGMENT | PatchFlags.DEV_ROOT_FRAGMENT,
+          )
+        )
+      },
+    }
+    const Outer = {
+      setup() {
+        return () => h(Inner)
+      },
+      mounted() {
+        instanceProxy = this
+      },
+    }
+    render(h(Outer), nodeOps.createElement('div'))
+    expect(instanceProxy.$el.type).toBe(TestNodeTypes.ELEMENT)
+    expect(instanceProxy.$el.tag).toBe('div')
+  })
+
+  // #12680
+  test('$el should resolve through nested dev comment fragments across component boundaries', () => {
+    let instanceProxy: any
+    const Inner = {
+      setup() {
+        return () => (
+          openBlock(),
+          createElementBlock(
+            Fragment,
+            null,
+            [createCommentVNode(' comment '), h('div', 'inner root')],
+            PatchFlags.STABLE_FRAGMENT | PatchFlags.DEV_ROOT_FRAGMENT,
+          )
+        )
+      },
+    }
+    const Outer = {
+      setup() {
+        return () => (
+          openBlock(),
+          createElementBlock(
+            Fragment,
+            null,
+            [createCommentVNode(' comment '), h(Inner)],
+            PatchFlags.STABLE_FRAGMENT | PatchFlags.DEV_ROOT_FRAGMENT,
+          )
+        )
+      },
+      mounted() {
+        instanceProxy = this
+      },
+    }
+    render(h(Outer), nodeOps.createElement('div'))
     expect(instanceProxy.$el.type).toBe(TestNodeTypes.ELEMENT)
     expect(instanceProxy.$el.tag).toBe('div')
   })

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -17,6 +17,7 @@ import {
   EMPTY_OBJ,
   type IfAny,
   NOOP,
+  PatchFlags,
   type Prettify,
   type UnionToIntersection,
   extend,
@@ -51,11 +52,12 @@ import {
 } from './componentOptions'
 import type { EmitFn, EmitsOptions } from './componentEmits'
 import type { SlotsType, UnwrapSlotsType } from './componentSlots'
-import { markAttrsAccessed } from './componentRenderUtils'
+import { filterSingleRoot, markAttrsAccessed } from './componentRenderUtils'
 import { currentRenderingInstance } from './componentRenderContext'
 import { warn } from './warning'
 import { installCompatInstanceProperties } from './compat/instance'
 import type { Directive } from './directives'
+import { Fragment, type VNodeArrayChildren } from './vnode'
 
 /**
  * Custom properties added to component instances in any way and can be accessed through `this`
@@ -358,12 +360,33 @@ const getPublicInstance = (
   return getPublicInstance(i.parent)
 }
 
+// dev only: in dev mode, a leading comment before a component's single root
+// element is preserved and turns the root into a `DEV_ROOT_FRAGMENT`, whose
+// `vnode.el` is the fragment's anchor rather than the actual rendered
+// element. Resolve through to the real root here, mirroring the resolution
+// already done for attrs/scopeId fallthrough in `renderComponentRoot`.
+const getDevRootFragmentEl = (i: ComponentInternalInstance) => {
+  const { subTree } = i
+  if (
+    subTree &&
+    subTree.type === Fragment &&
+    subTree.patchFlag > 0 &&
+    subTree.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
+  ) {
+    const realRoot = filterSingleRoot(subTree.children as VNodeArrayChildren)
+    if (realRoot) {
+      return realRoot.el
+    }
+  }
+  return i.vnode.el
+}
+
 export const publicPropertiesMap: PublicPropertiesMap =
   // Move PURE marker to new line to workaround compiler discarding it
   // due to type annotation
   /*@__PURE__*/ extend(Object.create(null), {
     $: i => i,
-    $el: i => i.vnode.el,
+    $el: i => (__DEV__ ? getDevRootFragmentEl(i) : i.vnode.el),
     $data: i => i.data,
     $props: i => (__DEV__ ? shallowReadonly(i.props) : i.props),
     $attrs: i => (__DEV__ ? shallowReadonly(i.attrs) : i.attrs),

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -19,7 +19,6 @@ import {
   NOOP,
   PatchFlags,
   type Prettify,
-  ShapeFlags,
   type UnionToIntersection,
   extend,
   hasOwn,
@@ -58,7 +57,7 @@ import { currentRenderingInstance } from './componentRenderContext'
 import { warn } from './warning'
 import { installCompatInstanceProperties } from './compat/instance'
 import type { Directive } from './directives'
-import { Fragment, type VNode, type VNodeArrayChildren } from './vnode'
+import type { VNode, VNodeArrayChildren } from './vnode'
 
 /**
  * Custom properties added to component instances in any way and can be accessed through `this`
@@ -361,31 +360,43 @@ const getPublicInstance = (
   return getPublicInstance(i.parent)
 }
 
-// dev only: in dev mode, a leading comment before a component's single root
-// element is preserved and turns the root into a `DEV_ROOT_FRAGMENT`, whose
-// `vnode.el` is the fragment's anchor rather than the actual rendered
-// element. In addition, the real root may itself be a single-root component
-// (or another `DEV_ROOT_FRAGMENT`), so both layers need to be unwrapped
-// recursively to reach the actual rendered element, mirroring the resolution
-// already done for attrs/scopeId fallthrough in `renderComponentRoot`.
-const resolveRootEl = (vnode: VNode): any => {
-  if (
-    vnode.type === Fragment &&
-    vnode.patchFlag > 0 &&
-    vnode.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
-  ) {
-    const realRoot = filterSingleRoot(vnode.children as VNodeArrayChildren)
-    if (realRoot) {
-      return resolveRootEl(realRoot)
+// Component and Suspense roots can hide a dev root fragment. Only return a
+// resolved element after finding one so other root chains keep their existing
+// `$el` semantics.
+const resolveDevRootEl = (vnode: VNode): VNode['el'] | undefined => {
+  let found = false
+
+  while (true) {
+    if (vnode.patchFlag > 0 && vnode.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT) {
+      const root = filterSingleRoot(vnode.children as VNodeArrayChildren)
+      if (!root) {
+        return
+      }
+      vnode = root
+      found = true
+      continue
     }
-  } else if (vnode.shapeFlag & ShapeFlags.COMPONENT && vnode.component) {
-    return resolveRootEl(vnode.component.subTree)
+
+    const component = vnode.component
+    if (component && component.subTree) {
+      vnode = component.subTree
+      continue
+    }
+
+    const suspense = vnode.suspense
+    if (suspense && suspense.activeBranch) {
+      vnode = suspense.activeBranch
+      continue
+    }
+
+    return found ? vnode.el : undefined
   }
-  return vnode.el
 }
 
-const getDevRootFragmentEl = (i: ComponentInternalInstance) =>
-  i.subTree ? resolveRootEl(i.subTree) : i.vnode.el
+const getDevRootFragmentEl = (i: ComponentInternalInstance) => {
+  const el = i.subTree && resolveDevRootEl(i.subTree)
+  return el === undefined ? i.vnode.el : el
+}
 
 export const publicPropertiesMap: PublicPropertiesMap =
   // Move PURE marker to new line to workaround compiler discarding it

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -19,6 +19,7 @@ import {
   NOOP,
   PatchFlags,
   type Prettify,
+  ShapeFlags,
   type UnionToIntersection,
   extend,
   hasOwn,
@@ -57,7 +58,7 @@ import { currentRenderingInstance } from './componentRenderContext'
 import { warn } from './warning'
 import { installCompatInstanceProperties } from './compat/instance'
 import type { Directive } from './directives'
-import { Fragment, type VNodeArrayChildren } from './vnode'
+import { Fragment, type VNode, type VNodeArrayChildren } from './vnode'
 
 /**
  * Custom properties added to component instances in any way and can be accessed through `this`
@@ -363,23 +364,28 @@ const getPublicInstance = (
 // dev only: in dev mode, a leading comment before a component's single root
 // element is preserved and turns the root into a `DEV_ROOT_FRAGMENT`, whose
 // `vnode.el` is the fragment's anchor rather than the actual rendered
-// element. Resolve through to the real root here, mirroring the resolution
+// element. In addition, the real root may itself be a single-root component
+// (or another `DEV_ROOT_FRAGMENT`), so both layers need to be unwrapped
+// recursively to reach the actual rendered element, mirroring the resolution
 // already done for attrs/scopeId fallthrough in `renderComponentRoot`.
-const getDevRootFragmentEl = (i: ComponentInternalInstance) => {
-  const { subTree } = i
+const resolveRootEl = (vnode: VNode): any => {
   if (
-    subTree &&
-    subTree.type === Fragment &&
-    subTree.patchFlag > 0 &&
-    subTree.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
+    vnode.type === Fragment &&
+    vnode.patchFlag > 0 &&
+    vnode.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
   ) {
-    const realRoot = filterSingleRoot(subTree.children as VNodeArrayChildren)
+    const realRoot = filterSingleRoot(vnode.children as VNodeArrayChildren)
     if (realRoot) {
-      return realRoot.el
+      return resolveRootEl(realRoot)
     }
+  } else if (vnode.shapeFlag & ShapeFlags.COMPONENT && vnode.component) {
+    return resolveRootEl(vnode.component.subTree)
   }
-  return i.vnode.el
+  return vnode.el
 }
+
+const getDevRootFragmentEl = (i: ComponentInternalInstance) =>
+  i.subTree ? resolveRootEl(i.subTree) : i.vnode.el
 
 export const publicPropertiesMap: PublicPropertiesMap =
   // Move PURE marker to new line to workaround compiler discarding it


### PR DESCRIPTION
close #12680

In dev mode, Vue preserves HTML comments written in a template. When a component's root is a single element preceded by a leading comment, e.g.:

```html
<!-- a comment -->
<div>real element</div>

...the compiler wraps the root in a fragment flagged DEV_ROOT_FRAGMENT, since there are technically two root-level nodes.

instance.$el (and any template ref pointing at the component) simply read instance.vnode.el, which for this
fragment is the fragment's anchor node — silently resolves to a useless anchor nodeinstead of the real rendered element, in dev only.

Fix

$el now resolves through to the real sing— the same helper renderComponentRootalready uses to resolve attrs/scopeId fallthrough for this exact DEV_ROOT_FRAGMENT case. Only active in __DEV__; production builds strip comments from templates so this scenario doesn't exist there, and the change is a no-op for non-fragment roots.

Test plan

- Added a regression test in packages/runtime-core/__tests__/componentPublicInstance.spec.ts that mounts a
component whose root is [comment, <div>] sserts $el is the real element node (notthe anchor). Verified it fails without the fix and passes with it.
- pnpm test-unit passes locally for runtime-core, runtime-dom, and vue.

close #12680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed component `$el` references in development mode when elements are wrapped in single-root or nested fragments.
- `$el` now correctly resolves to the rendered root element across child components and Suspense boundaries.
- Improved `$el` behavior while child components are mounting.
- Preserved expected fallback behavior for unresolved asynchronous roots.
- Production behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->