### PR TITLE
refactor(vapor): simplify template ref entry points

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformTemplateRef.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformTemplateRef.spec.ts.snap
@@ -53,7 +53,7 @@ export function render(_ctx) {
 exports[`compiler: template ref transform > dynamic ref (inline mode) 1`] = `
 "
   const n0 = t0()
-  _setTemplateRefBinding(n0, () => foo, undefined, undefined, "foo")
+  _setTemplateRefBinding(n0, () => foo, undefined, "foo")
   return n0
 "
 `;
@@ -84,15 +84,14 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: template ref transform > dynamic ref in slot uses owner setter 1`] = `
-"import { createTemplateRefSetter as _createTemplateRefSetter, setTemplateRefBinding as _setTemplateRefBinding, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+exports[`compiler: template ref transform > dynamic ref in slot needs no owner setter 1`] = `
+"import { setTemplateRefBinding as _setTemplateRefBinding, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
-  const _setTemplateRef = _createTemplateRefSetter()
   const n1 = _createAssetComponent("Comp", null, () => {
     const n0 = t0()
-    _setTemplateRefBinding(n0, () => _ctx.refName, _setTemplateRef)
+    _setTemplateRefBinding(n0, () => _ctx.refName)
     return n0
   }, true)
   return n1
@@ -135,15 +134,14 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: template ref transform > multiple static refs 1`] = `
-"import { createTemplateRefSetter as _createTemplateRefSetter, template as _template } from 'vue';
+"import { setStaticTemplateRef as _setStaticTemplateRef, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
-  const _setTemplateRef = _createTemplateRefSetter()
   const n0 = t0()
   const n1 = t0()
-  _setTemplateRef(n0, "foo")
-  _setTemplateRef(n1, "bar")
+  _setStaticTemplateRef(n0, "foo")
+  _setStaticTemplateRef(n1, "bar")
   return [n0, n1]
 }"
 `;
@@ -164,14 +162,13 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: template ref transform > ref + v-if 1`] = `
-"import { createTemplateRefSetter as _createTemplateRefSetter, createIf as _createIf, template as _template } from 'vue';
+"import { setStaticTemplateRef as _setStaticTemplateRef, createIf as _createIf, template as _template } from 'vue';
 const t0 = _template("<div>", 1)
 
 export function render(_ctx) {
-  const _setTemplateRef = _createTemplateRefSetter()
   const n0 = _createIf(() => (true), () => {
     const n2 = t0()
-    _setTemplateRef(n2, "foo")
+    _setStaticTemplateRef(n2, "foo")
     return n2
   }, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)
   return n0
@@ -221,15 +218,14 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: template ref transform > static ref in slot uses owner setter 1`] = `
-"import { createTemplateRefSetter as _createTemplateRefSetter, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+exports[`compiler: template ref transform > static ref in slot uses the stateless helper 1`] = `
+"import { setStaticTemplateRef as _setStaticTemplateRef, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
 const t0 = _template("<div>")
 
 export function render(_ctx) {
-  const _setTemplateRef = _createTemplateRefSetter()
   const n1 = _createAssetComponent("Comp", null, () => {
     const n0 = t0()
-    _setTemplateRef(n0, "foo")
+    _setStaticTemplateRef(n0, "foo")
     return n0
   }, true)
   return n1

--- a/packages/compiler-vapor/__tests__/transforms/transformTemplateRef.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformTemplateRef.spec.ts
@@ -67,10 +67,11 @@ describe('compiler: template ref transform', () => {
       `<div ref="foo" /><div ref="bar" />`,
     )
     expect(code).matchSnapshot()
-    expect(code).contains('const _setTemplateRef = _createTemplateRefSetter()')
-    expect(code).contains('_setTemplateRef(n0, "foo")')
-    expect(code).contains('_setTemplateRef(n1, "bar")')
-    expect(code).not.contains('_setStaticTemplateRef')
+    // every static ref lowers to the stateless helper, regardless of how many
+    // other operations the block has
+    expect(code).contains('_setStaticTemplateRef(n0, "foo")')
+    expect(code).contains('_setStaticTemplateRef(n1, "bar")')
+    expect(code).not.contains('_createTemplateRefSetter')
     expect(code).not.contains('_setTemplateRefBinding')
   })
 
@@ -149,7 +150,7 @@ describe('compiler: template ref transform', () => {
     })
     expect(code).matchSnapshot()
     expect(code).contains(
-      '_setTemplateRefBinding(n0, () => foo, undefined, undefined, "foo")',
+      '_setTemplateRefBinding(n0, () => foo, undefined, "foo")',
     )
     expect(code).not.contains('_createTemplateRefSetter')
   })
@@ -178,25 +179,24 @@ describe('compiler: template ref transform', () => {
     expect(code).not.contains('_setTemplateRefBinding')
   })
 
-  test('dynamic ref in slot uses owner setter', () => {
+  test('dynamic ref in slot needs no owner setter', () => {
     const { code } = compileWithTransformRef(
       `<Comp><div :ref="refName" /></Comp>`,
     )
 
     expect(code).toMatchSnapshot()
-    expect(code).contains('const _setTemplateRef = _createTemplateRefSetter()')
-    expect(code).contains(
-      '_setTemplateRefBinding(n0, () => _ctx.refName, _setTemplateRef)',
-    )
+    // the helper resolves the ref owner at runtime via getScopeOwner(), so the
+    // owner's setter no longer has to be allocated and threaded into the slot
+    expect(code).contains('_setTemplateRefBinding(n0, () => _ctx.refName)')
+    expect(code).not.contains('_createTemplateRefSetter')
   })
 
-  test('static ref in slot uses owner setter', () => {
+  test('static ref in slot uses the stateless helper', () => {
     const { code } = compileWithTransformRef(`<Comp><div ref="foo" /></Comp>`)
 
     expect(code).toMatchSnapshot()
-    expect(code).contains('const _setTemplateRef = _createTemplateRefSetter()')
-    expect(code).contains('_setTemplateRef(n0, "foo")')
-    expect(code).not.contains('_setStaticTemplateRef')
+    expect(code).contains('_setStaticTemplateRef(n0, "foo")')
+    expect(code).not.contains('_createTemplateRefSetter')
   })
 
   test('simple function ref', () => {
@@ -268,8 +268,8 @@ describe('compiler: template ref transform', () => {
       },
     ])
     expect(code).matchSnapshot()
-    expect(code).contains('const _setTemplateRef = _createTemplateRefSetter()')
-    expect(code).contains('_setTemplateRef(n2, "foo")')
+    expect(code).contains('_setStaticTemplateRef(n2, "foo")')
+    expect(code).not.contains('_createTemplateRefSetter')
   })
 
   test('ref + v-for', () => {

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -3,14 +3,7 @@ import type {
   BaseCodegenResult,
   SimpleExpressionNode,
 } from '@vue/compiler-dom'
-import type {
-  BlockIRNode,
-  CoreHelper,
-  RootIRNode,
-  SetTemplateRefIRNode,
-  VaporHelper,
-} from './ir'
-import { IRNodeTypes } from './ir'
+import type { BlockIRNode, CoreHelper, RootIRNode, VaporHelper } from './ir'
 import { extend, remove } from '@vue/shared'
 import { genBlockContent } from './generators/block'
 import { genTemplates } from './generators/template'
@@ -43,7 +36,6 @@ export class CodegenContext {
   helpers: Map<string, string> = new Map()
 
   needsTemplateRefSetter: boolean = false
-  staticTemplateRefHelperCandidate?: SetTemplateRefIRNode
   inSlotBlock: boolean = false
 
   helper = (name: CoreHelper | VaporHelper): string => {
@@ -232,9 +224,6 @@ export class CodegenContext {
         : [],
     )
     this.initNextIdMap()
-    this.staticTemplateRefHelperCandidate = getStaticTemplateRefHelperCandidate(
-      ir.block,
-    )
   }
 }
 
@@ -337,20 +326,4 @@ function genAssetImports({ ir }: CodegenContext) {
     imports += `import ${name} from '${assetImport.path}';\n`
   }
   return imports
-}
-
-function getStaticTemplateRefHelperCandidate(
-  block: BlockIRNode,
-): SetTemplateRefIRNode | undefined {
-  if (block.operation.length !== 1) return
-
-  const operation = block.operation[0]
-  if (
-    operation.type === IRNodeTypes.SET_TEMPLATE_REF &&
-    !operation.effect &&
-    !operation.refFor &&
-    operation.value.isStatic
-  ) {
-    return operation
-  }
 }

--- a/packages/compiler-vapor/src/generators/templateRef.ts
+++ b/packages/compiler-vapor/src/generators/templateRef.ts
@@ -11,7 +11,10 @@ export function genSetTemplateRef(
   context: CodegenContext,
 ): CodeFragment[] {
   const [refValue, refKey] = genRefValue(oper.value, context)
-  if (context.staticTemplateRefHelperCandidate === oper) {
+  // A ref with a static value and no `ref_for` array membership never changes,
+  // so it needs no old-ref tracking: lower it to the stateless helper and skip
+  // the shared setter (and its per-element state map) entirely.
+  if (!oper.effect && !oper.refFor && oper.value.isStatic) {
     return genSetStaticTemplateRef(oper, refValue, refKey, context)
   }
 
@@ -51,19 +54,16 @@ export function genSetTemplateRefBinding(
   context: CodegenContext,
 ): CodeFragment[] {
   const [refValue, refKey] = genRefValue(oper.value, context)
-  const setter = context.inSlotBlock && setTemplateRefIdent
-  if (context.inSlotBlock) {
-    context.needsTemplateRefSetter = true
-  }
+  // No slot-block special case: the helper resolves the ref owner at runtime
+  // via `getScopeOwner()`, so slot content no longer has to be threaded through
+  // the owner's shared setter.
   return [
     NEWLINE,
     ...genCall(
       [context.helper('setTemplateRefBinding'), 'undefined'],
       `n${oper.element}`,
       ['() => ', ...refValue],
-      ...(setter || oper.refFor || refKey
-        ? [setter, oper.refFor && 'true', refKey]
-        : []),
+      ...(oper.refFor || refKey ? [oper.refFor && 'true', refKey] : []),
     ),
   ]
 }

--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -1,5 +1,6 @@
 import {
   KeepAlive,
+  type Ref,
   Suspense,
   createApp,
   createSSRApp,
@@ -14,6 +15,7 @@ import {
   reactive,
   ref,
 } from '@vue/runtime-dom'
+import type { Block } from '../../src/block'
 import {
   VaporKeepAlive,
   VaporTeleport,
@@ -21,6 +23,8 @@ import {
   createComponent,
   createDynamicComponent,
   createFor,
+  createIf,
+  createSlot,
   createTemplateRefSetter,
   defineVaporComponent,
   renderEffect,
@@ -414,6 +418,206 @@ describe('effects in pending branches', () => {
 
     await nextTick()
     expect(elementRef.value).toBe(null)
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(elementRef.value).toBeInstanceOf(HTMLDivElement)
+    app.unmount()
+  })
+
+  // A branch that first renders during an update goes through
+  // runWithRenderCtx(), which has to restore the Suspense boundary the
+  // fragment renders into - otherwise the branch's post-render effects land on
+  // the global queue and the ref is applied while the boundary is still
+  // pending. VDOM defers it; Vapor must too.
+  test('late branch template ref uses the rendering suspense boundary', async () => {
+    const asyncSetup = deferred()
+    const show = ref(false)
+    const elementRef = ref<Element | null>(null)
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const VaporChild = defineVaporComponent({
+      setup() {
+        const setRef = createTemplateRefSetter()
+        return createIf(
+          () => show.value,
+          () => {
+            const el = template('<div>branch</div>')() as Element
+            setRef(el, elementRef)
+            return el
+          },
+        )
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    // the boundary has never resolved: flipping the branch on renders it
+    // inside the still-pending boundary
+    show.value = true
+    await nextTick()
+    await nextTick()
+    expect(elementRef.value).toBe(null)
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(elementRef.value).toBeInstanceOf(HTMLDivElement)
+    app.unmount()
+  })
+
+  function lateBranchRef(
+    show: Ref<boolean>,
+    elementRef: Ref<Element | null>,
+  ): Block {
+    const setRef = createTemplateRefSetter()
+    return createIf(
+      () => show.value,
+      () => {
+        const el = template('<div>branch</div>')() as Element
+        setRef(el, elementRef)
+        return el
+      },
+    )
+  }
+
+  test('late branch in slot content rendered inside a vdom suspense', async () => {
+    const asyncSetup = deferred()
+    const show = ref(false)
+    const elementRef = ref<Element | null>(null)
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    // the boundary lives in the child; the slot content is declared by the
+    // vapor owner *outside* it
+    const VDomHost = defineComponent({
+      setup(_, { slots }) {
+        return () =>
+          h(Suspense, null, {
+            default: () => h('div', [slots.default!(), h(AsyncSibling)]),
+            fallback: () => h('span', 'loading'),
+          })
+      },
+    })
+    const VaporOwner = defineVaporComponent({
+      setup() {
+        return createComponent(VDomHost as any, null, {
+          default: () => lateBranchRef(show, elementRef),
+        })
+      },
+    })
+
+    const host = document.createElement('div')
+    const app = createApp({ render: () => h(VaporOwner as any) })
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    show.value = true
+    await nextTick()
+    await nextTick()
+    expect(elementRef.value).toBe(null)
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(elementRef.value).toBeInstanceOf(HTMLDivElement)
+    app.unmount()
+  })
+
+  test('late branch under a vdom suspense hosted by a vapor app', async () => {
+    const asyncSetup = deferred()
+    const show = ref(false)
+    const elementRef = ref<Element | null>(null)
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const VaporInner = defineVaporComponent({
+      setup: () => lateBranchRef(show, elementRef),
+    })
+    const VDomBridge = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporInner as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const VaporRoot = defineVaporComponent({
+      setup: () => createComponent(VDomBridge as any),
+    })
+
+    const host = document.createElement('div')
+    const app = runtimeVapor.createVaporApp(VaporRoot)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    show.value = true
+    await nextTick()
+    await nextTick()
+    expect(elementRef.value).toBe(null)
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(elementRef.value).toBeInstanceOf(HTMLDivElement)
+    app.unmount()
+  })
+
+  test('late branch in a vapor child rendering vdom slot content', async () => {
+    const asyncSetup = deferred()
+    const show = ref(false)
+    const elementRef = ref<Element | null>(null)
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const VaporChild = defineVaporComponent({
+      setup: () => [createSlot('default'), lateBranchRef(show, elementRef)],
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () =>
+            h('div', [
+              h(VaporChild as any, null, {
+                default: () => h('em', 'from vdom owner'),
+              }),
+              h(AsyncSibling),
+            ]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    show.value = true
+    await nextTick()
+    await nextTick()
+    expect(elementRef.value).toBe(null)
+
     asyncSetup.resolve()
     await flushResolution(asyncSetup.promise)
     expect(elementRef.value).toBeInstanceOf(HTMLDivElement)

--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -859,11 +859,12 @@ describe('api: template ref', () => {
         }
       },
       render() {
-        const setRef = createTemplateRefSetter()
         const n0 = createComponent(Child, null, {
           default: () => {
             n = document.createElement('div')
-            setTemplateRefBinding(n, () => refName.value, setRef)
+            // no owner setter threaded in: the helper resolves the ref owner
+            // itself via getScopeOwner()
+            setTemplateRefBinding(n, () => refName.value)
             return n
           },
         })
@@ -931,6 +932,48 @@ describe('api: template ref', () => {
 
     render()
     expect(r!.value).toBe(n)
+  })
+
+  // Compiled counterparts of the hand-written slot cases above: these exercise
+  // the real codegen path, where the ref owner is resolved at runtime by
+  // getScopeOwner() rather than threaded in from the owner's render scope.
+  test('compiled static ref inside slots binds to the owner', () => {
+    const data = ref(0)
+    const Child = compile(`<template><slot /></template>`, data)
+    const Parent = compile(
+      `<template>
+        <components.Child><div ref="foo">slotted</div></components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+
+    const { instance, host } = define(Parent).render()
+    const el = host.querySelector('div')
+    expect(el).not.toBe(null)
+    expect((instance as any).refs.foo).toBe(el)
+  })
+
+  test('compiled dynamic ref inside slots binds to the owner', async () => {
+    const data = ref({ name: 'foo' })
+    const Child = compile(`<template><slot /></template>`, data)
+    const Parent = compile(
+      `<template>
+        <components.Child><div :ref="data.name">slotted</div></components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+
+    const { instance, host } = define(Parent).render()
+    const el = host.querySelector('div')
+    const refs = (instance as any).refs
+    expect(refs.foo).toBe(el)
+
+    data.value = { name: 'bar' }
+    await nextTick()
+    expect(refs.foo).toBe(null)
+    expect(refs.bar).toBe(el)
   })
 
   test('work with dynamic component', async () => {
@@ -1860,6 +1903,41 @@ describe('interop: template ref', () => {
     expect(container.innerHTML).toBe(
       `<div><button class="btn"></button><div>bar</div></div>`,
     )
+  })
+
+  // Slot content declared by a Vapor owner but rendered by a VDOM child: the
+  // ref must land on the owner, not on the component executing the slot.
+  test('vapor app: ref in slot passed to vdom child binds to the owner', async () => {
+    const { container } = await testTemplateRefInterop(
+      `<script setup>
+        import { useTemplateRef } from 'vue'
+        const components = _components;
+        const elRef = useTemplateRef('el')
+        function click() {
+          elRef.value.textContent = 'changed'
+        }
+      </script>
+      <template>
+        <button class="btn" @click="click"></button>
+        <components.VdomChild><div ref="el">slotted</div></components.VdomChild>
+      </template>`,
+      {
+        VdomChild: {
+          code: `
+          <template>
+            <slot/>
+          </template>`,
+          vapor: false,
+        },
+      },
+      {},
+      { vapor: true },
+    )
+
+    expect(container.innerHTML).contains('slotted')
+    triggerEvent('click', container.querySelector('.btn')!)
+    await nextTick()
+    expect(container.innerHTML).contains('changed')
   })
 
   test('vapor app: static ref with vdom child', async () => {

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -1,7 +1,6 @@
 import { type Ref, isRef, onScopeDispose } from '@vue/reactivity'
 import {
   type VaporComponentInstance,
-  currentInstance,
   getExposed,
   isVaporComponent,
 } from './component'
@@ -34,6 +33,7 @@ import {
   isFragment,
 } from './fragment'
 import { isInteropEnabled } from './vdomInteropState'
+import { getScopeOwner } from './componentSlots'
 import {
   type RefCleanupState,
   invalidatePendingRef,
@@ -58,7 +58,7 @@ export type setRefFn = (
   ref: NodeRef,
   refFor?: boolean,
   refKey?: string,
-) => NodeRef | undefined
+) => void
 
 interface TemplateRefState {
   suspense: SuspenseBoundary | null
@@ -77,6 +77,32 @@ function getTemplateRefUpdateFragment(el: RefEl): DynamicFragment | undefined {
   }
 }
 
+/**
+ * Async/dynamic component targets swap their inner block on update, so the ref
+ * has to be re-applied after the fragment settles. Registration is idempotent
+ * per (el, owner) pair: `getTemplateRefUpdateFragment` reads the async
+ * wrapper's mutable `block`, so the resolved fragment is compared by identity
+ * rather than with a "registered once" flag.
+ */
+function registerFragmentRefUpdate(
+  el: RefEl,
+  registeredFrag: DynamicFragment | undefined,
+  reapply: () => void,
+): DynamicFragment | undefined {
+  const frag = getTemplateRefUpdateFragment(el)
+  if (frag && registeredFrag !== frag) {
+    ;(frag.onUpdated ||= []).push(() => {
+      // KeepAlive clears refs on deactivation but keeps this fragment update
+      // callback alive. Skip re-applying refs for async/offscreen updates
+      // until the component is activated again.
+      if (isVaporComponent(el) && el.isDeactivated) return
+      reapply()
+    })
+    return frag
+  }
+  return registeredFrag
+}
+
 function ensureCleanup(el: RefEl): RefCleanupState {
   let cleanupRef = refCleanups.get(el)
   if (!cleanupRef) {
@@ -91,7 +117,7 @@ function ensureCleanup(el: RefEl): RefCleanupState {
 }
 
 export function createTemplateRefSetter(): setRefFn {
-  const instance = currentInstance as VaporComponentInstance
+  const instance = getScopeOwner()!
   const stateMap = new WeakMap<RefEl, TemplateRefState>()
 
   return (el, ref, refFor, refKey) => {
@@ -99,19 +125,7 @@ export function createTemplateRefSetter(): setRefFn {
     if (!state) {
       stateMap.set(el, (state = { ref, suspense: parentSuspense }))
     }
-    return setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
-  }
-}
-
-function createSingleTemplateRefSetter(): setRefFn {
-  const instance = currentInstance as VaporComponentInstance
-  let state: TemplateRefState | undefined
-
-  return (el, ref, refFor, refKey) => {
-    if (!state) {
-      state = { ref, suspense: parentSuspense }
-    }
-    return setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
+    setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
   }
 }
 
@@ -122,21 +136,16 @@ function setTemplateRefWithState(
   ref: NodeRef,
   refFor?: boolean,
   refKey?: string,
-): NodeRef | undefined {
+): void {
   state.ref = ref
   state.refFor = refFor
   state.refKey = refKey
 
-  // Re-apply refs after DynamicFragment updates.
-  const frag = getTemplateRefUpdateFragment(el)
-  if (frag && state.registeredFrag !== frag) {
-    state.registeredFrag = frag
-    ;(frag.onUpdated ||= []).push(() => {
-      // KeepAlive clears refs on deactivation but keeps this fragment update
-      // callback alive. Skip re-applying refs for async/offscreen updates
-      // until the component is activated again.
-      if (isVaporComponent(el) && el.isDeactivated) return
-      state.oldRef = setRef(
+  state.registeredFrag = registerFragmentRefUpdate(
+    el,
+    state.registeredFrag,
+    () => {
+      setRef(
         instance,
         state.suspense,
         el,
@@ -146,11 +155,12 @@ function setTemplateRefWithState(
         state.refKey,
         state.oldRefKey,
       )
-      state.oldRefKey = state.oldRef != null ? state.refKey : undefined
-    })
-  }
+      state.oldRef = state.ref
+      state.oldRefKey = state.ref != null ? state.refKey : undefined
+    },
+  )
 
-  const oldRef = setRef(
+  setRef(
     instance,
     state.suspense,
     el,
@@ -160,40 +170,46 @@ function setTemplateRefWithState(
     refKey,
     state.oldRefKey,
   )
-  state.oldRef = oldRef
-  state.oldRefKey = oldRef != null ? refKey : undefined
-  return oldRef
+  state.oldRef = ref
+  state.oldRefKey = ref != null ? refKey : undefined
 }
 
+/**
+ * Static refs never change value, so they need no old-ref tracking and no
+ * per-element state - only the fragment re-apply hook shared with the
+ * stateful path.
+ */
 export function setStaticTemplateRef(
   el: RefEl,
   ref: NodeRef,
   refFor?: boolean,
   refKey?: string,
-): NodeRef | undefined {
-  const instance = currentInstance as VaporComponentInstance
+): void {
+  const instance = getScopeOwner()!
   const suspense = parentSuspense
-  const oldRef = setRef(instance, suspense, el, ref, undefined, refFor, refKey)
-  const frag = getTemplateRefUpdateFragment(el)
-  if (frag) {
-    // Static refs do not need old-ref tracking, but async/dynamic component
-    // targets still need to re-apply the same ref after their fragment updates.
-    ;(frag.onUpdated ||= []).push(() => {
-      if (isVaporComponent(el) && el.isDeactivated) return
-      setRef(instance, suspense, el, ref, oldRef, refFor, refKey)
-    })
-  }
-  return oldRef
+  setRef(instance, suspense, el, ref, undefined, refFor, refKey)
+  registerFragmentRefUpdate(el, undefined, () => {
+    setRef(instance, suspense, el, ref, ref, refFor, refKey)
+  })
 }
 
 export function setTemplateRefBinding(
   el: RefEl,
   getter: () => any,
-  setter: setRefFn = createSingleTemplateRefSetter(),
   refFor?: boolean,
   refKey?: string,
 ): void {
-  renderEffect(() => setter(el, getter(), refFor, refKey))
+  // A single binding site targets a single element, so its state lives in this
+  // closure - no per-element map needed. The owner is captured here, during the
+  // synchronous block render, where `getScopeOwner()` still resolves the
+  // component that declared the ref rather than the one rendering it.
+  const instance = getScopeOwner()!
+  let state: TemplateRefState | undefined
+  renderEffect(() => {
+    const ref = getter()
+    if (!state) state = { ref, suspense: parentSuspense }
+    setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
+  })
 }
 
 /**
@@ -208,7 +224,9 @@ function setRef(
   refFor = false,
   refKey?: string,
   oldRefKey?: string,
-): NodeRef | undefined {
+): void {
+  // Single no-op guard for every path into ref application, including the
+  // fragment `onUpdated` callbacks that can fire after teardown.
   if (!instance || instance.isUnmounted) return
 
   const setupState: any = __DEV__ ? instance.setupState || {} : null
@@ -224,7 +242,7 @@ function setRef(
           : null
     if (target) {
       target.setRef!(instance, ref, refFor, refKey)
-      return ref
+      return
     }
   }
 
@@ -275,7 +293,7 @@ function setRef(
   }
 
   // dynamic ref can become null / undefined and should only clear old ref
-  if (ref == null) return ref
+  if (ref == null) return
 
   if (isFunction(ref)) {
     const invokeRefSetter = (value?: Element | Record<string, any> | null) => {
@@ -370,7 +388,6 @@ function setRef(
       warn('Invalid template ref type:', ref, `(${typeof ref})`)
     }
   }
-  return ref
 }
 
 const getRefValue = (el: RefEl) => {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -38,6 +38,11 @@ import {
 } from './dom/hydration'
 import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
 import {
+  isSuspenseEnabled,
+  parentSuspense,
+  setParentSuspense,
+} from './suspense'
+import {
   applyScopeIdOwners,
   currentSlotScopeIds,
   setCurrentSlotScopeIds,
@@ -146,6 +151,14 @@ export class RenderContextFragment<
   readonly slotOwner: VaporComponentInstance | null = currentSlotOwner
   readonly keepAliveCtx?: VaporKeepAliveContext | null
   readonly slotBoundary: SlotBoundaryContext | null = currentSlotBoundary
+  // The Suspense boundary this fragment renders *into*. Unlike
+  // `renderInstance.suspense` (the boundary its owner was mounted in), slot
+  // content can be declared outside a boundary and rendered inside one, so this
+  // has to be the ambient value at construction time. Restored alongside the
+  // other fragment-owned ambient state in `runWithFragmentCtxOnly`, so
+  // branches that first render during an update queue their post-render
+  // effects on the right boundary instead of the global queue.
+  readonly renderSuspense?: SuspenseBoundary | null
   // Captured by reference: slot outlets replace this with their merged id cell
   // right after construction, so late renders (branch switches, deferred
   // fallbacks) create their DOM under the outlet's slot scope context.
@@ -155,6 +168,9 @@ export class RenderContextFragment<
     super(nodes, flags)
     if (isKeepAliveEnabled) {
       this.keepAliveCtx = getKeepAliveContext(currentInstance)
+    }
+    if (__FEATURE_SUSPENSE__ && isSuspenseEnabled) {
+      this.renderSuspense = parentSuspense
     }
   }
 
@@ -184,7 +200,14 @@ export function runWithFragmentCtxOnly<R>(
 ): R {
   // When ambient fragment context already matches, no ambient state needs
   // restoring. This keeps ordinary branch renders on the cheap path.
+  const suspense =
+    __FEATURE_SUSPENSE__ && isSuspenseEnabled
+      ? fragment.renderSuspense || null
+      : null
+  const restoreSuspense =
+    __FEATURE_SUSPENSE__ && isSuspenseEnabled && parentSuspense !== suspense
   if (
+    !restoreSuspense &&
     currentSlotOwner === fragment.slotOwner &&
     currentSlotBoundary === fragment.slotBoundary &&
     currentSlotScopeIds === fragment.slotScopeIds
@@ -192,6 +215,7 @@ export function runWithFragmentCtxOnly<R>(
     return fn()
   }
 
+  const prevSuspense = restoreSuspense ? setParentSuspense(suspense) : null
   const prevSlotOwner = setCurrentSlotOwner(fragment.slotOwner)
   const prevBoundary = setCurrentSlotBoundary(fragment.slotBoundary)
   const prevSlotScopeIds = setCurrentSlotScopeIds(fragment.slotScopeIds)
@@ -201,6 +225,7 @@ export function runWithFragmentCtxOnly<R>(
     setCurrentSlotScopeIds(prevSlotScopeIds)
     setCurrentSlotBoundary(prevBoundary)
     setCurrentSlotOwner(prevSlotOwner)
+    if (restoreSuspense) setParentSuspense(prevSuspense)
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template refs in static content, slots, conditional branches, and dynamic refs.
  * Ensured refs resolve to the correct owner across VDOM/Vapor and slot boundaries.
  * Fixed refs to remain unset while Suspense content is pending and apply correctly after resolution.
  * Improved ref updates for asynchronous components and deactivated content.
* **Tests**
  * Added coverage for multiple refs, slot refs, conditional rendering, Suspense boundaries, and VDOM/Vapor interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->