### PR TITLE
refactor(compiler-core): decouple directive transforms from each other

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vMemo.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vMemo.spec.ts.snap
@@ -31,7 +31,7 @@ export function render(_ctx, _cache) {
 `;
 
 exports[`compiler: v-memo transform > on template v-for 1`] = `
-"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, isMemoSame as _isMemoSame, withMemo as _withMemo } from "vue"
+"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, isMemoSame as _isMemoSame } from "vue"
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
@@ -47,7 +47,7 @@ export function render(_ctx, _cache) {
 `;
 
 exports[`compiler: v-memo transform > on template v-for w/ compound key expression 1`] = `
-"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, isMemoSame as _isMemoSame, withMemo as _withMemo } from "vue"
+"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, isMemoSame as _isMemoSame } from "vue"
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
@@ -65,7 +65,7 @@ export function render(_ctx, _cache) {
 `;
 
 exports[`compiler: v-memo transform > on v-for 1`] = `
-"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, isMemoSame as _isMemoSame, withMemo as _withMemo } from "vue"
+"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, isMemoSame as _isMemoSame } from "vue"
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
@@ -83,7 +83,7 @@ export function render(_ctx, _cache) {
 `;
 
 exports[`compiler: v-memo transform > on v-for w/ compound key expression 1`] = `
-"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, isMemoSame as _isMemoSame, withMemo as _withMemo } from "vue"
+"import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, isMemoSame as _isMemoSame } from "vue"
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -119,7 +119,6 @@ export interface TransformContext
   hoist(exp: string | JSChildNode | ArrayExpression): SimpleExpressionNode
   cache(exp: JSChildNode, isVNode?: boolean, inVOnce?: boolean): CacheExpression
   constantCache: WeakMap<TemplateChildNode, ConstantTypes>
-  vForMemoKeyedNodes: WeakSet<ElementNode>
 
   // 2.x Compat only
   filters?: Set<string>
@@ -188,7 +187,6 @@ export function createTransformContext(
     imports: [],
     cached: [],
     constantCache: new WeakMap(),
-    vForMemoKeyedNodes: new WeakSet(),
     temps: 0,
     identifiers: Object.create(null),
     scopes: {

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -11,6 +11,7 @@ import type { NodeTransform, TransformContext } from '../transform'
 import {
   type CompoundExpressionNode,
   ConstantTypes,
+  type ElementNode,
   type ExpressionNode,
   NodeTypes,
   type SimpleExpressionNode,
@@ -24,7 +25,7 @@ import {
   isStaticPropertyKey,
   walkIdentifiers,
 } from '../babelUtils'
-import { advancePositionWithClone, findDir, isSimpleIdentifier } from '../utils'
+import { advancePositionWithClone, isSimpleIdentifier } from '../utils'
 import {
   genPropsAccessExp,
   hasOwn,
@@ -53,39 +54,44 @@ export const transformExpression: NodeTransform = (node, context) => {
       context,
     )
   } else if (node.type === NodeTypes.ELEMENT) {
-    // handle directives on element
-    const memo = findDir(node, 'memo')
-    for (let i = 0; i < node.props.length; i++) {
-      const dir = node.props[i]
-      // do not process for v-on & v-for since they are special handled
-      if (dir.type === NodeTypes.DIRECTIVE && dir.name !== 'for') {
-        const exp = dir.exp
-        const arg = dir.arg
-        // do not process exp if this is v-on:arg - we need special handling
-        // for wrapping inline statements.
-        if (
-          exp &&
-          exp.type === NodeTypes.SIMPLE_EXPRESSION &&
-          !(dir.name === 'on' && arg) &&
-          // key has been processed in transformFor(vMemo + vFor)
-          !(
-            memo &&
-            context.vForMemoKeyedNodes.has(node) &&
-            arg &&
-            arg.type === NodeTypes.SIMPLE_EXPRESSION &&
-            arg.content === 'key'
-          )
-        ) {
-          dir.exp = processExpression(
-            exp,
-            context,
-            // slot args must be processed as function params
-            dir.name === 'slot',
-          )
-        }
-        if (arg && arg.type === NodeTypes.SIMPLE_EXPRESSION && !arg.isStatic) {
-          dir.arg = processExpression(arg, context)
-        }
+    processElementDirectiveExpressions(node, context)
+  }
+}
+
+// Process the directive expressions of an element's props. Also called by
+// structural transforms that replace an element before it is traversed
+// (e.g. <template v-for>, see transformFor).
+export function processElementDirectiveExpressions(
+  node: ElementNode,
+  context: TransformContext,
+): void {
+  for (let i = 0; i < node.props.length; i++) {
+    const dir = node.props[i]
+    if (dir.type === NodeTypes.DIRECTIVE) {
+      const exp = dir.exp
+      const arg = dir.arg
+      // v-for and v-on:arg handle their own expressions
+      // (see processFor / transformOn)
+      if (
+        exp &&
+        exp.type === NodeTypes.SIMPLE_EXPRESSION &&
+        dir.name !== 'for' &&
+        !(dir.name === 'on' && arg)
+      ) {
+        dir.exp = processExpression(
+          exp,
+          context,
+          // slot args must be processed as function params
+          dir.name === 'slot',
+        )
+      }
+      if (
+        arg &&
+        arg.type === NodeTypes.SIMPLE_EXPRESSION &&
+        !arg.isStatic &&
+        dir.name !== 'for'
+      ) {
+        dir.arg = processExpression(arg, context)
       }
     }
   }

--- a/packages/compiler-core/src/transforms/vFor.ts
+++ b/packages/compiler-core/src/transforms/vFor.ts
@@ -16,13 +16,9 @@ import {
   type ForRenderListExpression,
   NodeTypes,
   type PlainElementNode,
-  type RenderSlotCall,
   type SimpleExpressionNode,
-  type SlotOutletNode,
   type VNodeCall,
-  createBlockStatement,
   createCallExpression,
-  createCompoundExpression,
   createFunctionExpression,
   createObjectExpression,
   createObjectProperty,
@@ -32,20 +28,12 @@ import {
   getVNodeHelper,
 } from '../ast'
 import { ErrorCodes, createCompilerError } from '../errors'
+import { findProp, injectProp, isTemplateNode } from '../utils'
+import { FRAGMENT, OPEN_BLOCK, RENDER_LIST } from '../runtimeHelpers'
 import {
-  findDir,
-  findProp,
-  injectProp,
-  isSlotOutlet,
-  isTemplateNode,
-} from '../utils'
-import {
-  FRAGMENT,
-  IS_MEMO_SAME,
-  OPEN_BLOCK,
-  RENDER_LIST,
-} from '../runtimeHelpers'
-import { processExpression } from './transformExpression'
+  processElementDirectiveExpressions,
+  processExpression,
+} from './transformExpression'
 import { validateBrowserExpression } from '../validateExpression'
 import { PatchFlags } from '@vue/shared'
 
@@ -60,10 +48,16 @@ export const transformFor: NodeTransform = createStructuralDirectiveTransform(
         forNode.source,
       ]) as ForRenderListExpression
       const isTemplate = isTemplateNode(node)
-      const memo = findDir(node, 'memo')
+      if (!__BROWSER__ && isTemplate) {
+        // #2085 / #5288 the template node is replaced by the ForNode below
+        // and never traversed, so its remaining binding expressions (e.g.
+        // :key, v-memo) won't be processed by the normal transforms. Run the
+        // shared prop processing here, while the v-for scope aliases are
+        // still registered.
+        processElementDirectiveExpressions(node, context)
+      }
       const keyProp = findProp(node, `key`, false, true)
-      const isDirKey = keyProp && keyProp.type === NodeTypes.DIRECTIVE
-      let keyExp =
+      const keyExp =
         keyProp &&
         (keyProp.type === NodeTypes.ATTRIBUTE
           ? keyProp.value
@@ -72,31 +66,6 @@ export const transformFor: NodeTransform = createStructuralDirectiveTransform(
           : keyProp.exp)
 
       const keyProperty = keyExp ? createObjectProperty(`key`, keyExp) : null
-
-      if (!__BROWSER__) {
-        // #2085 / #5288 process :key and v-memo expressions need to be
-        // processed on `<template v-for>`. In this case the node is discarded
-        // and never traversed so its binding expressions won't be processed
-        // by the normal transforms.
-        if (isTemplate && memo) {
-          memo.exp = processExpression(
-            memo.exp! as SimpleExpressionNode,
-            context,
-          )
-        }
-        if ((isTemplate || memo) && keyProperty && isDirKey) {
-          keyExp =
-            keyProp.exp =
-            keyProperty.value =
-              processExpression(
-                keyProperty.value as SimpleExpressionNode,
-                context,
-              )
-          if (memo) {
-            context.vForMemoKeyedNodes.add(node)
-          }
-        }
-      }
 
       const isStableFragment =
         forNode.source.type === NodeTypes.SIMPLE_EXPRESSION &&
@@ -146,24 +115,8 @@ export const transformFor: NodeTransform = createStructuralDirectiveTransform(
 
         const needFragmentWrapper =
           children.length !== 1 || children[0].type !== NodeTypes.ELEMENT
-        const slotOutlet = isSlotOutlet(node)
-          ? node
-          : isTemplate &&
-              node.children.length === 1 &&
-              isSlotOutlet(node.children[0])
-            ? (node.children[0] as SlotOutletNode) // api-extractor somehow fails to infer this
-            : null
 
-        if (slotOutlet) {
-          // <slot v-for="..."> or <template v-for="..."><slot/></template>
-          childBlock = slotOutlet.codegenNode as RenderSlotCall
-          if (isTemplate && keyProperty) {
-            // <template v-for="..." :key="..."><slot/></template>
-            // we need to inject the key to the renderSlot() call.
-            // the props for renderSlot is passed as the 3rd argument.
-            injectProp(childBlock, keyProperty, context)
-          }
-        } else if (needFragmentWrapper) {
+        if (needFragmentWrapper) {
           // <template v-for="..."> with text or multi-elements
           // should generate a fragment block for each loop
           childBlock = createVNodeCall(
@@ -179,16 +132,22 @@ export const transformFor: NodeTransform = createStructuralDirectiveTransform(
             false /* isComponent */,
           )
         } else {
-          // Normal element v-for. Directly use the child's codegenNode
-          // but mark it as a block.
+          // Normal element (or slot outlet) v-for. Directly use the child's
+          // codegenNode but mark it as a block. A slot outlet produces a
+          // renderSlot() call instead of a VNodeCall - it is already a
+          // block root, so it skips the block conversion below.
           childBlock = (children[0] as PlainElementNode)
             .codegenNode as VNodeCall
           if (isTemplate && keyProperty) {
             injectProp(childBlock, keyProperty, context)
           }
           const shouldUseBlock =
-            !isStableFragment || childBlock.isBlockRequired === true
-          if (childBlock.isBlock !== shouldUseBlock) {
+            childBlock.type === NodeTypes.VNODE_CALL &&
+            (!isStableFragment || childBlock.isBlockRequired === true)
+          if (
+            childBlock.type === NodeTypes.VNODE_CALL &&
+            childBlock.isBlock !== shouldUseBlock
+          ) {
             if (childBlock.isBlock) {
               // switch from block to vnode
               removeHelper(OPEN_BLOCK)
@@ -202,54 +161,28 @@ export const transformFor: NodeTransform = createStructuralDirectiveTransform(
               )
             }
           }
-          childBlock.isBlock = shouldUseBlock
-          if (childBlock.isBlock) {
-            helper(OPEN_BLOCK)
-            helper(getVNodeBlockHelper(context.inSSR, childBlock.isComponent))
-          } else {
-            helper(getVNodeHelper(context.inSSR, childBlock.isComponent))
-            if (childBlock.needsPatch) {
-              childBlock.patchFlag = ((childBlock.patchFlag ?? 0) |
-                PatchFlags.NEED_PATCH) as PatchFlags
+          if (childBlock.type === NodeTypes.VNODE_CALL) {
+            childBlock.isBlock = shouldUseBlock
+            if (childBlock.isBlock) {
+              helper(OPEN_BLOCK)
+              helper(getVNodeBlockHelper(context.inSSR, childBlock.isComponent))
+            } else {
+              helper(getVNodeHelper(context.inSSR, childBlock.isComponent))
+              if (childBlock.needsPatch) {
+                childBlock.patchFlag = ((childBlock.patchFlag ?? 0) |
+                  PatchFlags.NEED_PATCH) as PatchFlags
+              }
             }
           }
         }
 
-        if (memo) {
-          const loop = createFunctionExpression(
-            createForLoopParams(forNode.parseResult, [
-              createSimpleExpression(`_cached`),
-            ]),
-          )
-          loop.body = createBlockStatement([
-            createCompoundExpression([`const _memo = (`, memo.exp!, `)`]),
-            createCompoundExpression([
-              `if (_cached && _cached.el`,
-              ...(keyExp ? [` && _cached.key === `, keyExp] : []),
-              ` && ${context.helperString(
-                IS_MEMO_SAME,
-              )}(_cached, _memo)) return _cached`,
-            ]),
-            createCompoundExpression([`const _item = `, childBlock as any]),
-            createSimpleExpression(`_item.memo = _memo`),
-            createSimpleExpression(`return _item`),
-          ])
-          renderExp.arguments.push(
-            loop as ForIteratorExpression,
-            createSimpleExpression(`_cache`),
-            createSimpleExpression(String(context.cached.length)),
-          )
-          // increment cache count
-          context.cached.push(null)
-        } else {
-          renderExp.arguments.push(
-            createFunctionExpression(
-              createForLoopParams(forNode.parseResult),
-              childBlock,
-              true /* force newline */,
-            ) as ForIteratorExpression,
-          )
-        }
+        renderExp.arguments.push(
+          createFunctionExpression(
+            createForLoopParams(forNode.parseResult),
+            childBlock,
+            true /* force newline */,
+          ) as ForIteratorExpression,
+        )
       }
     })
   },

--- a/packages/compiler-core/src/transforms/vIf.ts
+++ b/packages/compiler-core/src/transforms/vIf.ts
@@ -33,9 +33,9 @@ import { validateBrowserExpression } from '../validateExpression'
 import { cloneLoc } from '../parser'
 import { CREATE_COMMENT, FRAGMENT } from '../runtimeHelpers'
 import {
-  findDir,
   findProp,
   getMemoedVNodeCall,
+  hasStructuralDirective,
   injectProp,
   isCommentOrWhitespace,
 } from '../utils'
@@ -210,7 +210,11 @@ function createIfBranch(node: ElementNode, dir: DirectiveNode): IfBranchNode {
     type: NodeTypes.IF_BRANCH,
     loc: node.loc,
     condition: dir.name === 'else' ? undefined : dir.exp,
-    children: isTemplateIf && !findDir(node, 'for') ? node.children : [node],
+    // lift the template's children only when no other structural
+    // directive remains on it - such a directive (e.g. v-for) will consume
+    // the template itself during its own transform
+    children:
+      isTemplateIf && !hasStructuralDirective(node) ? node.children : [node],
     userKey: findProp(node, `key`),
     isTemplateIf,
   }

--- a/packages/compiler-core/src/transforms/vMemo.ts
+++ b/packages/compiler-core/src/transforms/vMemo.ts
@@ -1,15 +1,25 @@
-import type { NodeTransform } from '../transform'
-import { findDir } from '../utils'
+import type { NodeTransform, TransformContext } from '../transform'
+import { findDir, findProp } from '../utils'
 import {
+  type BlockCodegenNode,
+  type ElementNode,
   ElementTypes,
+  type ExpressionNode,
+  type ForIteratorExpression,
+  type ForNode,
+  type ForRenderListExpression,
   type MemoExpression,
   NodeTypes,
   type PlainElementNode,
   convertToBlock,
+  createBlockStatement,
   createCallExpression,
+  createCompoundExpression,
   createFunctionExpression,
+  createSimpleExpression,
 } from '../ast'
-import { WITH_MEMO } from '../runtimeHelpers'
+import { IS_MEMO_SAME, WITH_MEMO } from '../runtimeHelpers'
+import { createForLoopParams } from './vFor'
 
 const seen = new WeakSet()
 
@@ -20,7 +30,24 @@ export const transformMemo: NodeTransform = (node, context) => {
       return
     }
     seen.add(node)
+
     return () => {
+      // When the host element was also the target of v-for, it has been
+      // replaced by a ForNode whose renderList call is complete by now
+      // (v-for's exit callback runs before this one due to the transform
+      // registration order). The memo cache must wrap the renderList
+      // *iterator* instead of the element's own vnode, so rewrite the
+      // finished iterator in place.
+      if (context.currentNode && context.currentNode.type === NodeTypes.FOR) {
+        rewriteForIterator(
+          node,
+          dir.exp!,
+          context.currentNode as ForNode,
+          context,
+        )
+        return
+      }
+
       const codegenNode =
         node.codegenNode ||
         (context.currentNode as PlainElementNode).codegenNode
@@ -40,4 +67,56 @@ export const transformMemo: NodeTransform = (node, context) => {
       }
     }
   }
+}
+
+function rewriteForIterator(
+  node: ElementNode,
+  memoExp: ExpressionNode,
+  forNode: ForNode,
+  context: TransformContext,
+): void {
+  const renderList = forNode.codegenNode!.children as ForRenderListExpression
+  const childBlock = (renderList.arguments[1] as ForIteratorExpression)
+    .returns as BlockCodegenNode
+
+  // the key expression has been processed by the time this runs (during
+  // <template v-for> entry for templates, or during child traversal
+  // otherwise)
+  const keyProp = findProp(node, `key`, false, true)
+  const keyExp =
+    keyProp && keyProp.type === NodeTypes.ATTRIBUTE
+      ? keyProp.value
+        ? createSimpleExpression(keyProp.value.content, true)
+        : undefined
+      : keyProp
+        ? keyProp.exp
+        : undefined
+
+  const loop = createFunctionExpression(
+    createForLoopParams(forNode.parseResult, [
+      createSimpleExpression(`_cached`),
+    ]),
+  )
+  loop.body = createBlockStatement([
+    createCompoundExpression([`const _memo = (`, memoExp, `)`]),
+    createCompoundExpression([
+      `if (_cached && _cached.el`,
+      ...(keyExp ? [` && _cached.key === `, keyExp] : []),
+      ` && ${context.helperString(
+        IS_MEMO_SAME,
+      )}(_cached, _memo)) return _cached`,
+    ]),
+    createCompoundExpression([`const _item = `, childBlock as any]),
+    createSimpleExpression(`_item.memo = _memo`),
+    createSimpleExpression(`return _item`),
+  ])
+  renderList.arguments.splice(
+    1,
+    1,
+    loop as ForIteratorExpression,
+    createSimpleExpression(`_cache`),
+    createSimpleExpression(String(context.cached.length)),
+  )
+  // increment cache count
+  context.cached.push(null)
 }

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -280,6 +280,16 @@ export function assert(condition: boolean, msg?: string): void {
   }
 }
 
+// Matches directives that manipulate the structural position of their
+// host element (v-if / v-else-if / v-else / v-for).
+const structuralDirNameRE = /^(?:if|else|else-if|for)$/
+
+export function hasStructuralDirective(node: ElementNode): boolean {
+  return node.props.some(
+    p => p.type === NodeTypes.DIRECTIVE && structuralDirNameRE.test(p.name),
+  )
+}
+
 export function findDir(
   node: ElementNode,
   name: string | RegExp,


### PR DESCRIPTION
## Summary

This PR reduces cross-directive knowledge inside `compiler-core` transforms so each directive's transform focuses on its own logic. It is a pure refactor: generated code is byte-identical except one cleanup noted below.

## What changed

**`transformFor` no longer knows about `v-memo` or slot outlets**

- The `v-memo` cached-loop iterator generation (`_cached` param, `_memo` comparison, `IS_MEMO_SAME`, cache index bookkeeping) moved out of `transformFor` into `transformMemo`. `transformFor` now always emits a plain iterator; `transformMemo` detects (via `context.currentNode` being a `ForNode`) that its host was consumed by `v-for` and rewrites the finished `renderList` iterator in its exit callback.
- The `<slot>`-outlet special case in the child-block selection was removed: a `renderSlot()` call is simply not a `VNodeCall`, so it skips block conversion via a type check, and injected keys already route through `injectProp` uniformly.
- On `<template v-for>`, remaining binding expressions (`:key`, `v-memo`) are now processed by calling the shared `processElementDirectiveExpressions` (extracted from `transformExpression`) instead of hand-rolled `processExpression` calls.

**Side channels removed**

- `TransformContext.vForMemoKeyedNodes` (a `WeakSet` consulted by `transformExpression` to skip `:key` expressions already processed by `transformFor` in the `v-for` + `v-memo` case) is gone.

**`transformIf`**

- `createIfBranch` uses a shared `hasStructuralDirective` predicate instead of `findDir(node, 'for')` when deciding whether to lift a template's children.

## Behavior change

Exactly one, and it is a bug-shaped cleanup: in the previous `v-for` + `v-memo` output, the `withMemo` helper was imported but never used, and an extra cache slot was consumed by an orphaned `WITH_MEMO` wrap of the already-consumed element. This PR removes both (4 snapshot updates in `vMemo.spec.ts.snap`, function bodies unchanged).

## Rationale

The `v-memo`/`v-for` combination relied on `transformFor` generating the cached-loop form and on a context-level `WeakSet` so `transformExpression` would not double-process `:key`. This inverted the dependency (the consumer of the cached form now owns its construction) and removed the inter-transform protocol, which should make future work on either directive cheaper to reason about.

---

*This pull request was created with assistance from a code agent.*