### PR TITLE
fix(server-renderer): handle hasOwnProperty attrs

### DIFF
--- a/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
@@ -108,6 +108,18 @@ describe('ssr: renderAttrs', () => {
     ).toBe(` fooBar="ok"`)
   })
 
+  test('handle attr named hasOwnProperty on custom elements', () => {
+    expect(
+      ssrRenderAttrs(
+        {
+          hasOwnProperty: 'value',
+          id: 'safe',
+        },
+        'my-el',
+      ),
+    ).toBe(` hasOwnProperty="value" id="safe"`)
+  })
+
   test('preserve name on svg elements', () => {
     expect(
       ssrRenderAttrs(

--- a/packages/shared/src/domAttrConfig.ts
+++ b/packages/shared/src/domAttrConfig.ts
@@ -1,4 +1,5 @@
 import { makeMap } from './makeMap'
+import { hasOwn } from './general'
 
 /**
  * On the client we only need to offer special cases for boolean attributes that
@@ -37,7 +38,7 @@ const unsafeAttrCharRE = /[>/="'\u0009\u000a\u000c\u000d\u0020]/
 const attrValidationCache: Record<string, boolean> = {}
 
 export function isSSRSafeAttrName(name: string): boolean {
-  if (attrValidationCache.hasOwnProperty(name)) {
+  if (hasOwn(attrValidationCache, name)) {
     return attrValidationCache[name]
   }
   const isUnsafe = unsafeAttrCharRE.test(name)


### PR DESCRIPTION
## Problem

`isSSRSafeAttrName()` 通过 `attrValidationCache.hasOwnProperty(name)` 判断属性名是否已经缓存。

当 SSR 渲染带有 `hasOwnProperty` 属性的自定义元素时，首次校验会把 `attrValidationCache.hasOwnProperty` 覆盖为布尔值。继续校验同一元素的其他属性时，会因为尝试调用该布尔值而抛出 `TypeError: attrValidationCache.hasOwnProperty is not a function`。

例如：

```ts
await renderToString(
  h('my-element', {
    hasOwnProperty: 'value',
    id: 'safe',
  }),
)
```

## Solution

使用 `@vue/shared` 已有的 `hasOwn()` 工具检查缓存自身属性，避免缓存内容覆盖校验方法。

同时增加 SSR 回归测试，确认自定义元素能够正常渲染名为 `hasOwnProperty` 的属性以及后续属性。

## Tests

- `pnpm exec vitest run packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts --project unit`
- `pnpm exec eslint packages/shared/src/domAttrConfig.ts packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts`
- `pnpm exec prettier --check packages/shared/src/domAttrConfig.ts packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts`
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-rendered custom elements so attributes named `hasOwnProperty` render correctly.
  * Improved attribute validation for names that may conflict with inherited object properties.

* **Tests**
  * Added regression coverage for custom-element attribute rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->