### PR TITLE
fix(shared): correctly compare Map and Set values

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1590,4 +1590,32 @@ describe('vModel', () => {
     await nextTick()
     expect(foo.checked).toEqual(false)
   })
+
+  // #15320
+  it('selects the matching option when values are maps', () => {
+    const mapA = new Map([['id', 1]])
+    const mapB = new Map([['id', 2]])
+    const value = ref(mapB)
+    const component = defineComponent(
+      () => () =>
+        withVModel(
+          h(
+            'select',
+            {
+              'onUpdate:modelValue': (val: Map<string, number>) =>
+                (value.value = val),
+            },
+            [
+              h('option', { value: mapA }, 'A'),
+              h('option', { value: mapB }, 'B'),
+            ],
+          ),
+          value.value,
+        ),
+    )
+
+    render(h(component), root)
+
+    expect(root.querySelector('select').selectedIndex).toBe(1)
+  })
 })

--- a/packages/shared/__tests__/looseEqual.spec.ts
+++ b/packages/shared/__tests__/looseEqual.spec.ts
@@ -233,4 +233,59 @@ describe('utils/looseEqual', () => {
     expect(looseEqual(arr1, arr5)).toBe(false)
     expect(looseEqual(arr5, arr1)).toBe(false)
   })
+
+  test('compares maps correctly', () => {
+    const map = new Map<any, any>([
+      [{ id: 1 }, { value: '1' }],
+      ['foo', 'bar'],
+    ])
+
+    expect(looseEqual(map, map)).toBe(true)
+    expect(
+      looseEqual(
+        map,
+        new Map<any, any>([
+          ['foo', 'bar'],
+          [{ id: '1' }, { value: 1 }],
+        ]),
+      ),
+    ).toBe(true)
+    expect(looseEqual(map, new Map([['foo', 'bar']]))).toBe(false)
+    expect(looseEqual(new Map([['a', 1]]), new Map([['b', 2]]))).toBe(false)
+    expect(
+      looseEqual(
+        new Map<any, any>([
+          ['a', 1],
+          ['b', 2],
+        ]),
+        new Map<any, any>([
+          ['a', 2],
+          ['b', 1],
+        ]),
+      ),
+    ).toBe(false)
+    expect(
+      looseEqual(
+        new Map<any, any>([
+          [1, 'value'],
+          ['1', 'value'],
+        ]),
+        new Map<any, any>([
+          [1, 'value'],
+          [2, 'value'],
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  test('compares sets correctly', () => {
+    const set = new Set<any>([{ id: 1 }, 'foo'])
+
+    expect(looseEqual(set, set)).toBe(true)
+    expect(looseEqual(set, new Set(['foo', { id: '1' }]))).toBe(true)
+    expect(looseEqual(set, new Set(['foo']))).toBe(false)
+    expect(looseEqual(new Set([1]), new Set([2]))).toBe(false)
+    expect(looseEqual(new Set<any>([1, '1']), new Set<any>([1, 2]))).toBe(false)
+    expect(looseEqual(new Set(), new Map())).toBe(false)
+  })
 })

--- a/packages/shared/src/looseEqual.ts
+++ b/packages/shared/src/looseEqual.ts
@@ -14,11 +14,18 @@ function looseCompareCollections(
   b: Map<any, any> | Set<any>,
 ) {
   if (a.size !== b.size) return false
-  const unmatched = Array.from(b)
+  const candidates = Array.from(b)
+  const matched = new Uint8Array(candidates.length)
   for (const item of a) {
-    const index = unmatched.findIndex(other => looseEqual(item, other))
+    let index = -1
+    for (let i = 0; i < candidates.length; i++) {
+      if (!matched[i] && looseEqual(item, candidates[i])) {
+        index = i
+        break
+      }
+    }
     if (index < 0) return false
-    unmatched.splice(index, 1)
+    matched[index] = 1
   }
   return true
 }

--- a/packages/shared/src/looseEqual.ts
+++ b/packages/shared/src/looseEqual.ts
@@ -1,4 +1,4 @@
-import { isArray, isDate, isObject, isSymbol } from './general'
+import { isArray, isDate, isMap, isObject, isSet, isSymbol } from './general'
 
 function looseCompareArrays(a: any[], b: any[]) {
   if (a.length !== b.length) return false
@@ -7,6 +7,20 @@ function looseCompareArrays(a: any[], b: any[]) {
     equal = looseEqual(a[i], b[i])
   }
   return equal
+}
+
+function looseCompareCollections(
+  a: Map<any, any> | Set<any>,
+  b: Map<any, any> | Set<any>,
+) {
+  if (a.size !== b.size) return false
+  const unmatched = Array.from(b)
+  for (const item of a) {
+    const index = unmatched.findIndex(other => looseEqual(item, other))
+    if (index < 0) return false
+    unmatched.splice(index, 1)
+  }
+  return true
 }
 
 export function looseEqual(a: any, b: any): boolean {
@@ -31,6 +45,16 @@ export function looseEqual(a: any, b: any): boolean {
   if (aValidType || bValidType) {
     if (!aValidType || !bValidType) {
       return false
+    }
+    aValidType = isMap(a)
+    bValidType = isMap(b)
+    if (aValidType || bValidType) {
+      return aValidType && bValidType ? looseCompareCollections(a, b) : false
+    }
+    aValidType = isSet(a)
+    bValidType = isSet(b)
+    if (aValidType || bValidType) {
+      return aValidType && bValidType ? looseCompareCollections(a, b) : false
     }
     const aKeysCount = Object.keys(a).length
     const bKeysCount = Object.keys(b).length


### PR DESCRIPTION
Closes #15320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved value comparison for `Map` and `Set` data, including reordered entries and loosely equal keys or values.
  * Fixed `v-model` selection when the bound value is a `Map`, ensuring the matching option is selected correctly.

* **Tests**
  * Added coverage for `Map` and `Set` comparisons and `v-model` behavior with mapped values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->