### PR TITLE
perf(runtime-vapor): trim v-for hot-path allocations

### DIFF
--- a/packages-private/benchmark/client/AppVapor.vue
+++ b/packages-private/benchmark/client/AppVapor.vue
@@ -94,13 +94,13 @@ const globalThis = window
     id="control"
     style="display: flex; flex-direction: column; width: fit-content; gap: 6px"
   >
-    <button @click="bench">Benchmark mounting</button>
-    <button id="run" @click="run">Create 1,000 rows</button>
-    <button id="runlots" @click="runLots">Create 10,000 rows</button>
-    <button id="add" @click="add">Append 1,000 rows</button>
-    <button id="update" @click="update">Update every 10th row</button>
-    <button id="clear" @click="clear">Clear</button>
-    <button id="swaprows" @click="swapRows">Swap Rows</button>
+    <button @click.delegate="bench">Benchmark mounting</button>
+    <button id="run" @click.delegate="run">Create 1,000 rows</button>
+    <button id="runlots" @click.delegate="runLots">Create 10,000 rows</button>
+    <button id="add" @click.delegate="add">Append 1,000 rows</button>
+    <button id="update" @click.delegate="update">Update every 10th row</button>
+    <button id="clear" @click.delegate="clear">Clear</button>
+    <button id="swaprows" @click.delegate="swapRows">Swap Rows</button>
   </div>
   <div id="time"></div>
   <table class="table table-hover table-striped test-data">
@@ -112,10 +112,10 @@ const globalThis = window
       >
         <td class="col-md-1">{{ row.id }}</td>
         <td class="col-md-4">
-          <a @click="select(row.id)">{{ row.label.value }}</a>
+          <a @click.delegate="select(row.id)">{{ row.label.value }}</a>
         </td>
         <td class="col-md-1">
-          <a @click="remove(row.id)">
+          <a @click.delegate="remove(row.id)">
             <span class="glyphicon glyphicon-remove" aria-hidden="true">x</span>
           </a>
         </td>

--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -1895,6 +1895,44 @@ test('should not duplicate main-view anchors when keyed list reorders teleport r
   expect(countAnchors('end')).toBe(2)
 })
 
+test('should anchor mid-list reorders on the teleport main-view placeholder', async () => {
+  const target = document.createElement('div')
+  const items = ref([
+    { id: 'one', text: 'one' },
+    { id: 'two', text: 'two' },
+    { id: 'three', text: 'three' },
+  ])
+
+  const { host } = define(() =>
+    createFor(
+      () => items.value,
+      item =>
+        createComponent(
+          VaporTeleport,
+          { to: () => target },
+          { default: () => template(item.value.text)() },
+        ),
+      item => item.id,
+    ),
+  ).render()
+
+  const countAnchors = (label: 'start' | 'end') =>
+    (host.innerHTML.match(new RegExp(`<!--teleport ${label}-->`, 'g')) || [])
+      .length
+
+  expect(countAnchors('start')).toBe(3)
+  expect(target.textContent).toBe('onetwothree')
+
+  // the moved row must resolve its anchor through the following teleport
+  // row's main-view placeholder, not its teleported content
+  items.value = [items.value[1], items.value[0], items.value[2]]
+  await nextTick()
+
+  expect(countAnchors('start')).toBe(3)
+  expect(countAnchors('end')).toBe(3)
+  expect(target.textContent).toBe('onetwothree')
+})
+
 test('should not move target children when keyed list reorders enabled teleport roots', async () => {
   const target = document.createElement('div')
   const items = ref([

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -2329,6 +2329,8 @@ describe('createFor', () => {
       expect(await countMoves(range(50), to)).toBe(1)
     })
 
+    // coverage guards: already optimal before the LIS rewrite, kept so a
+    // regression in forward moves / 2-element swaps stays caught
     test('moving a row forward performs a single move', async () => {
       const to = range(50)
       to.push(to.shift()!)
@@ -2339,6 +2341,32 @@ describe('createFor', () => {
       const to = range(50)
       ;[to[1], to[48]] = [to[48], to[1]]
       expect(await countMoves(range(50), to)).toBe(2)
+    })
+
+    test('reordering past a row that renders nothing keeps rows anchored', async () => {
+      const list = ref([1, 2, 3])
+      const { host } = define(() =>
+        createFor(
+          () => list.value,
+          item => {
+            if (item.value === 2) return [] as any
+            const span = document.createElement('span')
+            renderEffect(() => {
+              span.textContent = `${item.value}`
+            })
+            return span
+          },
+          item => item,
+        ),
+      ).render()
+
+      expect(host.innerHTML).toBe('<span>1</span><span>3</span><!--for-->')
+
+      // the empty block yields no anchor node; rows must still land inside
+      // the v-for range instead of being appended past its anchor
+      list.value = [3, 2, 1]
+      await nextTick()
+      expect(host.innerHTML).toBe('<span>3</span><span>1</span><!--for-->')
     })
   })
 })

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -2277,6 +2277,70 @@ describe('createFor', () => {
       )
     })
   })
+
+  describe('minimal DOM moves', () => {
+    // Reordering must only move the blocks that are out of relative order
+    // (LIS-style), not every block between the old and new position.
+    async function countMoves(from: number[], to: number[]) {
+      const list = ref(from)
+      const { host } = define(() =>
+        createFor(
+          () => list.value,
+          item => {
+            const span = document.createElement('span')
+            renderEffect(() => {
+              span.textContent = `${item.value}`
+            })
+            return span
+          },
+          item => item,
+        ),
+      ).render()
+
+      const original = host.insertBefore.bind(host)
+      let count = 0
+      host.insertBefore = ((node: Node, anchor: Node | null) => {
+        count++
+        return original(node, anchor)
+      }) as any
+
+      list.value = to
+      await nextTick()
+      expect(
+        Array.from(host.querySelectorAll('span')).map(s =>
+          Number(s.textContent),
+        ),
+      ).toEqual(to)
+      return count
+    }
+
+    const range = (n: number) => Array.from({ length: n }, (_, i) => i)
+
+    test('moving a row backward performs a single move', async () => {
+      const to = range(50)
+      to.unshift(to.pop()!)
+      expect(await countMoves(range(50), to)).toBe(1)
+    })
+
+    test('moving a middle row to the front performs a single move', async () => {
+      const to = range(50)
+      const [x] = to.splice(25, 1)
+      to.unshift(x)
+      expect(await countMoves(range(50), to)).toBe(1)
+    })
+
+    test('moving a row forward performs a single move', async () => {
+      const to = range(50)
+      to.push(to.shift()!)
+      expect(await countMoves(range(50), to)).toBe(1)
+    })
+
+    test('swapping two rows moves only those rows', async () => {
+      const to = range(50)
+      ;[to[1], to[48]] = [to[48], to[1]]
+      expect(await countMoves(range(50), to)).toBe(2)
+    })
+  })
 })
 
 function getEffectsCount(scope: { deps: any }) {

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -2354,6 +2354,16 @@ describe('createFor', () => {
       ).toBe(5)
     })
 
+    // a removal can leave an in-place match to the right of the moved row:
+    // the plan has to cover it, or the row is judged already in order
+    test('moving a reused row before a stationary one while removing', async () => {
+      expect(await countMoves([0, 1, 2], [2, 1])).toBe(1)
+    })
+
+    test('keeps a reused run in place when the row after it moves', async () => {
+      expect(await countMoves([0, 1, 2, 3, 4], [3, 4, 2])).toBe(1)
+    })
+
     test('reordering past a row that renders nothing keeps rows anchored', async () => {
       const list = ref([1, 2, 3])
       const { host } = define(() =>

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -2278,7 +2278,7 @@ describe('createFor', () => {
     })
   })
 
-  describe('minimal DOM moves', () => {
+  describe('no cascading DOM moves', () => {
     // Reordering must only move the blocks that are out of relative order
     // (LIS-style), not every block between the old and new position.
     async function countMoves(from: number[], to: number[]) {
@@ -2341,6 +2341,17 @@ describe('createFor', () => {
       const to = range(50)
       ;[to[1], to[48]] = [to[48], to[1]]
       expect(await countMoves(range(50), to)).toBe(2)
+    })
+
+    // reviewer's counterexample: a coincidental in-place match in the middle
+    // of a shuffled range used to split the plan and cost ~2x the moves
+    test('a stationary row in the middle does not cascade moves', async () => {
+      expect(
+        await countMoves(
+          [0, 1, 2, 3, 4, 5, 6, 7, 8],
+          [5, 6, 7, 8, 4, 0, 1, 2, 3],
+        ),
+      ).toBe(5)
     })
 
     test('reordering past a row that renders nothing keeps rows anchored', async () => {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -27,7 +27,7 @@ import {
   removeNode,
 } from './block'
 import { queuePostFlushCb, warn } from '@vue/runtime-dom'
-import { currentInstance } from './component'
+import { currentInstance, isVaporComponent } from './component'
 import {
   type DynamicSlot,
   type VaporSlot,
@@ -255,11 +255,12 @@ export const createFor = (
 
         const commonLength = Math.min(oldLength, newLength)
         // parallel arrays holding blocks that need a mount or a move, in
-        // ascending index order. `queuedReuse[q]` distinguishes them after
-        // the reuse pass: a ForBlock means move, undefined means mount.
+        // ascending index order. After the reuse pass `queuedOldIndex[q]`
+        // distinguishes them: the block's old position for a reuse (its
+        // ForBlock is already in `newBlocks`), or -1 for a fresh mount.
         const queuedIndices: number[] = new Array(newLength)
         const queuedItems: any[] = new Array(newLength)
-        const queuedReuse: (ForBlock | undefined)[] = new Array(newLength)
+        const queuedOldIndex: number[] = new Array(newLength)
 
         let endOffset = 0
         let queuedLength = 0
@@ -316,9 +317,9 @@ export const createFor = (
               sourceKeys ? sourceKeys[index] : index,
               sourceKeys ? index : undefined,
             )
-            queuedReuse[q] = reusedBlock
+            queuedOldIndex[q] = oldIndex
           } else {
-            queuedReuse[q] = undefined
+            queuedOldIndex[q] = -1
             mountCounter++
           }
         }
@@ -341,80 +342,111 @@ export const createFor = (
           parent!.appendChild(parentAnchor)
         }
 
-        if (mountCounter === queuedLength) {
-          // mounts only, no moves: mount back-to-front so each row can
-          // anchor on the one after it
-          for (let q = queuedLength - 1; q >= 0; q--) {
-            const index = queuedIndices[q]
-            mount(
-              source,
-              index,
-              index < newLength - 1
-                ? getBlockFirstNode(newBlocks[index + 1].nodes)
-                : parentAnchor,
-              queuedItems[q],
-              newKeys![index],
-            )
-          }
-        } else if (queuedLength) {
-          let anchor = oldBlocks[0]
-          let blocksTail: ForBlock | undefined
-          for (let i = 0; i < oldLength; i++) {
-            const block = oldBlocks[i]
-            if (oldKeyIndexMap.has(block.key)) {
-              continue
+        // Decide which reused blocks may stay in place. In-place matched
+        // (stationary) blocks partition the queued indices into segments of
+        // consecutive positions; within a segment, the longest increasing
+        // subsequence of old indices — bounded by the old positions of the
+        // stationary neighbors — is already in relative order, so only the
+        // blocks outside it need a DOM move. This is move-count optimal
+        // (like vdom's LIS) but works on the queued set alone, so an
+        // untouched majority (e.g. a swap of two rows) costs O(queued),
+        // not O(length).
+        let keep: boolean[] | undefined
+        if (mountCounter !== queuedLength) {
+          keep = new Array(queuedLength)
+          const tailValues: number[] = []
+          const tailPositions: number[] = []
+          const lisParent: number[] = new Array(queuedLength)
+          let seg = 0
+          while (seg < queuedLength) {
+            let segEnd = seg
+            while (
+              segEnd + 1 < queuedLength &&
+              queuedIndices[segEnd + 1] === queuedIndices[segEnd] + 1
+            ) {
+              segEnd++
             }
-            block.prevAnchor = anchor
-            anchor = oldBlocks[i + 1]
-            if (blocksTail !== undefined) {
-              blocksTail.next = block
-              block.prev = blocksTail
-            }
-            blocksTail = block
-          }
-          for (let q = queuedLength - 1; q >= 0; q--) {
-            const index = queuedIndices[q]
-            const reused = queuedReuse[q]
-            if (index < newLength - 1) {
-              const nextBlock = newBlocks[index + 1]
-              let anchorNode = getBlockFirstNode(nextBlock.prevAnchor!.nodes)
-              if (!anchorNode.parentNode)
-                anchorNode = getBlockFirstNode(nextBlock.nodes)
-              if (reused === undefined) {
-                const block = mount(
-                  source,
-                  index,
-                  anchorNode,
-                  queuedItems[q],
-                  newKeys![index],
-                )
-                moveLink(block, nextBlock.prev, nextBlock)
-              } else if (reused.next !== nextBlock) {
-                insertForBlock(reused, anchorNode)
-                moveLink(reused, nextBlock.prev, nextBlock)
+            // prefix stationaries sit at their own index in both lists; the
+            // first suffix stationary (index e3) sits at old index e2. With
+            // no bounding stationary the bounds are -1 / e2 == oldLength.
+            const lowerBound = queuedIndices[seg] - 1
+            const nextIndex = queuedIndices[segEnd] + 1
+            const upperBound = nextIndex < e3 ? nextIndex : e2
+            tailValues.length = tailPositions.length = 0
+            for (let q = seg; q <= segEnd; q++) {
+              keep[q] = false
+              const oldIndex = queuedOldIndex[q]
+              if (
+                oldIndex <= lowerBound ||
+                oldIndex >= upperBound ||
+                oldIndex < 0
+              ) {
+                continue
               }
-            } else if (reused === undefined) {
-              const block = mount(
-                source,
-                index,
-                parentAnchor,
-                queuedItems[q],
-                newKeys![index],
-              )
-              moveLink(block, blocksTail)
-              blocksTail = block
-            } else if (reused.next !== undefined) {
-              let anchorNode = anchor
-                ? getBlockFirstNode(anchor.nodes)
-                : parentAnchor
-              if (!anchorNode.parentNode) anchorNode = parentAnchor
-              insertForBlock(reused, anchorNode)
-              moveLink(reused, blocksTail)
-              blocksTail = reused
+              let lo = 0
+              let hi = tailValues.length
+              while (lo < hi) {
+                const mid = (lo + hi) >> 1
+                if (tailValues[mid] < oldIndex) lo = mid + 1
+                else hi = mid
+              }
+              tailValues[lo] = oldIndex
+              lisParent[q] = lo > 0 ? tailPositions[lo - 1] : -1
+              tailPositions[lo] = q
+            }
+            for (
+              let q = tailValues.length
+                ? tailPositions[tailValues.length - 1]
+                : -1;
+              q !== -1;
+              q = lisParent[q]
+            ) {
+              keep[q] = true
+            }
+            seg = segEnd + 1
+          }
+        }
+
+        // Under TransitionGroup, removed rows stay in the DOM while their
+        // leave transition runs. Match vdom ordering: rows moving or
+        // mounting next to such a ghost land in front of it, so the ghost
+        // is the one displaced (and FLIP-moved), not the live row.
+        let ghostNodes: Set<Node> | undefined
+        if (keep && isTransitionEnabled && frag.$transition) {
+          for (const leftoverIndex of oldKeyIndexMap.values()) {
+            const nodes = oldBlocks[leftoverIndex].nodes
+            if (isSingleNode) {
+              ;(ghostNodes ||= new Set()).add(nodes as Node)
+            } else {
+              collectBlockNodes(nodes, (ghostNodes ||= new Set()))
             }
           }
-          for (const block of newBlocks) {
-            block.prevAnchor = block.next = block.prev = undefined
+        }
+
+        // apply back-to-front so every block can anchor on the finalized
+        // block after it (kept blocks count as finalized: relative order
+        // among all unmoved blocks is already correct)
+        for (let q = queuedLength - 1; q >= 0; q--) {
+          const isReuse = queuedOldIndex[q] >= 0
+          if (isReuse && keep![q]) continue
+          const index = queuedIndices[q]
+          let anchorNode =
+            index < newLength - 1
+              ? getBlockFirstNode(newBlocks[index + 1].nodes)
+              : parentAnchor
+          if (ghostNodes) {
+            // step in front of the contiguous run of leaving ghosts that
+            // precedes the target position
+            let prev = anchorNode.previousSibling
+            while (prev && ghostNodes.has(prev)) {
+              anchorNode = prev
+              prev = prev.previousSibling
+            }
+          }
+          if (isReuse) {
+            insertForBlock(newBlocks[index], anchorNode)
+          } else {
+            mount(source, index, anchorNode, queuedItems[q], newKeys![index])
           }
         }
       }
@@ -795,20 +827,19 @@ export function createSelector(source: () => any): ForSelector {
   return register
 }
 
-function moveLink(block: ForBlock, newPrev?: ForBlock, newNext?: ForBlock) {
-  const { prev: oldPrev, next: oldNext } = block
-  if (oldPrev) oldPrev.next = oldNext
-  if (oldNext) {
-    oldNext.prev = oldPrev
-    if (block.prevAnchor !== block) {
-      oldNext.prevAnchor = block.prevAnchor
+function collectBlockNodes(block: Block, set: Set<Node>): void {
+  if (block instanceof Node) {
+    set.add(block)
+  } else if (isArray(block)) {
+    for (let i = 0; i < block.length; i++) {
+      collectBlockNodes(block[i], set)
     }
+  } else if (isVaporComponent(block)) {
+    if (block.block) collectBlockNodes(block.block, set)
+  } else {
+    collectBlockNodes(block.nodes, set)
+    if (block.anchor) set.add(block.anchor)
   }
-  if (newPrev) newPrev.next = block
-  if (newNext) newNext.prev = block
-  block.prev = newPrev
-  block.next = newNext
-  block.prevAnchor = block
 }
 
 function stopBlockScopes(blocks: ForBlock[]): void {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -71,6 +71,7 @@ import {
   resetInsertionState,
 } from './insertionState'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
+import { isTeleportEnabled, isTeleportFragment } from './teleport'
 import { setBlockKey } from './helpers/setKey'
 import { currentSlotBoundary, setCurrentSlotBoundary } from './slotBoundary'
 
@@ -254,14 +255,6 @@ export const createFor = (
         }
 
         const commonLength = Math.min(oldLength, newLength)
-        // parallel arrays holding blocks that need a mount or a move, in
-        // ascending index order. After the reuse pass `queuedOldIndex[q]`
-        // distinguishes them: the block's old position for a reuse (its
-        // ForBlock is already in `newBlocks`), or -1 for a fresh mount.
-        const queuedIndices: number[] = new Array(newLength)
-        const queuedItems: any[] = new Array(newLength)
-        const queuedOldIndex: number[] = new Array(newLength)
-
         let endOffset = 0
         let queuedLength = 0
 
@@ -279,6 +272,14 @@ export const createFor = (
         const e2 = oldLength - endOffset
         const e3 = newLength - endOffset
 
+        // parallel arrays holding blocks that need a mount or a move, in
+        // ascending index order; the suffix scan above already excluded
+        // everything from e3 on. After the reuse pass `queuedOldIndex[q]`
+        // distinguishes them: the block's old position for a reuse (its
+        // ForBlock is already in `newBlocks`), or -1 for a fresh mount.
+        const queuedIndices: number[] = new Array(e3)
+        const queuedOldIndex: number[] = new Array(e3)
+
         const oldKeyIndexMap = new Map<any, number>()
 
         for (let i = 0; i < e1; i++) {
@@ -287,8 +288,7 @@ export const createFor = (
           if (oldBlock.key === currentKey) {
             updateAt((newBlocks[i] = oldBlock), source, i)
           } else {
-            queuedIndices[queuedLength] = i
-            queuedItems[queuedLength++] = getItemValue(source, i)
+            queuedIndices[queuedLength++] = i
             oldKeyIndexMap.set(oldBlock.key, i)
           }
         }
@@ -298,8 +298,7 @@ export const createFor = (
         }
 
         for (let i = e1; i < e3; i++) {
-          queuedIndices[queuedLength] = i
-          queuedItems[queuedLength++] = getItemValue(source, i)
+          queuedIndices[queuedLength++] = i
         }
 
         let mountCounter = 0
@@ -311,12 +310,7 @@ export const createFor = (
           if (oldIndex !== undefined) {
             oldKeyIndexMap.delete(key)
             const reusedBlock = (newBlocks[index] = oldBlocks[oldIndex])
-            update(
-              reusedBlock,
-              queuedItems[q],
-              sourceKeys ? sourceKeys[index] : index,
-              sourceKeys ? index : undefined,
-            )
+            updateAt(reusedBlock, source, index)
             queuedOldIndex[q] = oldIndex
           } else {
             queuedOldIndex[q] = -1
@@ -347,10 +341,14 @@ export const createFor = (
         // consecutive positions; within a segment, the longest increasing
         // subsequence of old indices — bounded by the old positions of the
         // stationary neighbors — is already in relative order, so only the
-        // blocks outside it need a DOM move. This is move-count optimal
-        // (like vdom's LIS) but works on the queued set alone, so an
-        // untouched majority (e.g. a swap of two rows) costs O(queued),
-        // not O(length).
+        // blocks outside it need a DOM move.
+        //
+        // This is a heuristic, not a minimum: pinning every stationary block
+        // is what keeps the cost O(queued) rather than O(length), so a
+        // near-untouched list (a two-row swap, a single removal) does almost
+        // no work here — but a coincidental in-place match inside an
+        // otherwise heavily shuffled range splits a segment and can cost
+        // more moves than vdom's unpinned whole-range LIS.
         let keep: boolean[] | undefined
         if (mountCounter !== queuedLength) {
           keep = new Array(queuedLength)
@@ -407,21 +405,18 @@ export const createFor = (
           }
         }
 
-        // Under TransitionGroup, removed rows stay in the DOM while their
-        // leave transition runs. Match vdom ordering: rows moving or
-        // mounting next to such a ghost land in front of it, so the ghost
-        // is the one displaced (and FLIP-moved), not the live row.
-        let ghostNodes: Set<Node> | undefined
-        if (keep && isTransitionEnabled && frag.$transition) {
-          for (const leftoverIndex of oldKeyIndexMap.values()) {
-            const nodes = oldBlocks[leftoverIndex].nodes
-            if (isSingleNode) {
-              ;(ghostNodes ||= new Set()).add(nodes as Node)
-            } else {
-              collectBlockNodes(nodes, (ghostNodes ||= new Set()))
-            }
-          }
-        }
+        // Rows removed under a leave transition stay in the DOM until the
+        // animation ends. Only the tail needs special handling: a row landing
+        // at the end would otherwise be inserted at `parentAnchor`, i.e.
+        // *after* those still-animating rows, which reorders them relative to
+        // a surviving neighbor they used to follow. Mid-list insertions anchor
+        // on the next live row, matching vdom (which never steps over leaving
+        // elements either), so ghosts keep their place there.
+        // Only a row landing at the tail while a leave transition is running
+        // needs the ghost set, so it is built on first use rather than per
+        // patch (lists without <TransitionGroup> never build it at all).
+        const hasGhosts = isTransitionEnabled && !!frag.$transition
+        let tailGhostNodes: Set<Node> | undefined
 
         // apply back-to-front so every block can anchor on the finalized
         // block after it (kept blocks count as finalized: relative order
@@ -430,23 +425,52 @@ export const createFor = (
           const isReuse = queuedOldIndex[q] >= 0
           if (isReuse && keep![q]) continue
           const index = queuedIndices[q]
-          let anchorNode =
-            index < newLength - 1
-              ? getBlockFirstNode(newBlocks[index + 1].nodes)
-              : parentAnchor
-          if (ghostNodes) {
-            // step in front of the contiguous run of leaving ghosts that
-            // precedes the target position
-            let prev = anchorNode.previousSibling
-            while (prev && ghostNodes.has(prev)) {
-              anchorNode = prev
-              prev = prev.previousSibling
+
+          // A block that renders nothing has no first node, so look past it
+          // for the next attached one.
+          let anchorNode: Node | undefined
+          for (let i = index + 1; i < newLength; i++) {
+            const node = getBlockFirstNode(newBlocks[i].nodes)
+            if (node && node.parentNode) {
+              anchorNode = node
+              break
             }
           }
+
+          if (anchorNode === undefined) {
+            // landing at the tail: step in front of rows still leaving, which
+            // `parentAnchor` alone would place this row after
+            anchorNode = parentAnchor
+            if (hasGhosts) {
+              if (!tailGhostNodes) {
+                tailGhostNodes = new Set()
+                for (const leftoverIndex of oldKeyIndexMap.values()) {
+                  const nodes = oldBlocks[leftoverIndex].nodes
+                  if (isSingleNode) {
+                    tailGhostNodes.add(nodes as Node)
+                  } else {
+                    collectBlockNodes(nodes, tailGhostNodes)
+                  }
+                }
+              }
+              let prev = anchorNode.previousSibling
+              while (prev && tailGhostNodes.has(prev)) {
+                anchorNode = prev
+                prev = prev.previousSibling
+              }
+            }
+          }
+
           if (isReuse) {
             insertForBlock(newBlocks[index], anchorNode)
           } else {
-            mount(source, index, anchorNode, queuedItems[q], newKeys![index])
+            mount(
+              source,
+              index,
+              anchorNode,
+              getItemValue(source, index),
+              newKeys![index],
+            )
           }
         }
       }
@@ -827,8 +851,12 @@ export function createSelector(source: () => any): ForSelector {
   return register
 }
 
+// Collects a block's own nodes in the main view, so a sibling walk can tell
+// which nodes belong to a row that is still leaving.
 function collectBlockNodes(block: Block, set: Set<Node>): void {
-  if (block instanceof Node) {
+  if (!block) {
+    return
+  } else if (block instanceof Node) {
     set.add(block)
   } else if (isArray(block)) {
     for (let i = 0; i < block.length; i++) {
@@ -836,6 +864,11 @@ function collectBlockNodes(block: Block, set: Set<Node>): void {
     }
   } else if (isVaporComponent(block)) {
     if (block.block) collectBlockNodes(block.block, set)
+  } else if (isTeleportEnabled && isTeleportFragment(block)) {
+    // teleported content lives in the target container; only the main-view
+    // markers can appear as siblings here
+    if (block.placeholder) set.add(block.placeholder)
+    if (block.anchor) set.add(block.anchor)
   } else {
     collectBlockNodes(block.nodes, set)
     if (block.anchor) set.add(block.anchor)

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -6,6 +6,7 @@ import {
   isShallow,
   onScopeDispose,
   setActiveSub,
+  setCurrentScope,
   shallowReadArray,
   shallowRef,
   toReactive,
@@ -168,6 +169,7 @@ export const createFor = (
 
   const renderList = () => {
     const source = normalizeSource(src())
+    const sourceKeys = source.keys
     const newLength = source.values.length
     const oldLength = oldBlocks.length
     newBlocks = new Array(newLength)
@@ -179,7 +181,9 @@ export const createFor = (
     if (getKey) {
       newKeys = new Array(newLength)
       for (let i = 0; i < newLength; i++) {
-        newKeys[i] = getKey(...getItem(source, i))
+        newKeys[i] = sourceKeys
+          ? getKey(getItemValue(source, i), sourceKeys[i], i)
+          : getKey(getItemValue(source, i), i, undefined)
       }
     }
 
@@ -195,17 +199,13 @@ export const createFor = (
       if (isHydrating) {
         hydrateList(source, newLength)
       } else {
-        for (let i = 0; i < newLength; i++) {
-          mount(source, i)
-        }
+        mountAll(source, newLength)
       }
     } else {
       parent = parentAnchor!.parentNode
       if (!oldLength) {
         // fast path for all new
-        for (let i = 0; i < newLength; i++) {
-          mount(source, i)
-        }
+        mountAll(source, newLength)
       } else if (!newLength) {
         // fast path for clearing all.
         // Fire reset listeners BEFORE per-item unmount so attached selectors
@@ -227,11 +227,10 @@ export const createFor = (
         // unkeyed fast path
         const commonLength = Math.min(newLength, oldLength)
         for (let i = 0; i < commonLength; i++) {
-          const item = getItem(source, i)
-          update((newBlocks[i] = oldBlocks[i]), ...item)
+          updateAt((newBlocks[i] = oldBlocks[i]), source, i)
         }
         for (let i = oldLength; i < newLength; i++) {
-          mount(source, i)
+          mountAt(source, i)
         }
         for (let i = newLength; i < oldLength; i++) {
           unmount(oldBlocks[i])
@@ -255,24 +254,22 @@ export const createFor = (
         }
 
         const commonLength = Math.min(oldLength, newLength)
-        const oldKeyIndexPairs: [any, number][] = new Array(oldLength)
-        const queuedBlocks: [
-          index: number,
-          item: ReturnType<typeof getItem>,
-          key: any,
-        ][] = new Array(newLength)
+        // parallel arrays holding blocks that need a mount or a move, in
+        // ascending index order. `queuedReuse[q]` distinguishes them after
+        // the reuse pass: a ForBlock means move, undefined means mount.
+        const queuedIndices: number[] = new Array(newLength)
+        const queuedItems: any[] = new Array(newLength)
+        const queuedReuse: (ForBlock | undefined)[] = new Array(newLength)
 
         let endOffset = 0
-        let queuedBlocksLength = 0
-        let oldKeyIndexPairsLength = 0
+        let queuedLength = 0
 
         while (endOffset < commonLength) {
           const index = newLength - endOffset - 1
-          const item = getItem(source, index)
           const key = newKeys![index]
           const existingBlock = oldBlocks[oldLength - endOffset - 1]
           if (existingBlock.key !== key) break
-          update(existingBlock, ...item)
+          updateAt(existingBlock, source, index)
           newBlocks[index] = existingBlock
           endOffset++
         }
@@ -281,60 +278,48 @@ export const createFor = (
         const e2 = oldLength - endOffset
         const e3 = newLength - endOffset
 
+        const oldKeyIndexMap = new Map<any, number>()
+
         for (let i = 0; i < e1; i++) {
-          const currentItem = getItem(source, i)
           const currentKey = newKeys![i]
           const oldBlock = oldBlocks[i]
-          const oldKey = oldBlock.key
-          if (oldKey === currentKey) {
-            update((newBlocks[i] = oldBlock), ...currentItem)
+          if (oldBlock.key === currentKey) {
+            updateAt((newBlocks[i] = oldBlock), source, i)
           } else {
-            queuedBlocks[queuedBlocksLength++] = [i, currentItem, currentKey]
-            oldKeyIndexPairs[oldKeyIndexPairsLength++] = [oldKey, i]
+            queuedIndices[queuedLength] = i
+            queuedItems[queuedLength++] = getItemValue(source, i)
+            oldKeyIndexMap.set(oldBlock.key, i)
           }
         }
 
         for (let i = e1; i < e2; i++) {
-          oldKeyIndexPairs[oldKeyIndexPairsLength++] = [oldBlocks[i].key, i]
+          oldKeyIndexMap.set(oldBlocks[i].key, i)
         }
 
         for (let i = e1; i < e3; i++) {
-          const blockItem = getItem(source, i)
-          const blockKey = newKeys![i]
-          queuedBlocks[queuedBlocksLength++] = [i, blockItem, blockKey]
+          queuedIndices[queuedLength] = i
+          queuedItems[queuedLength++] = getItemValue(source, i)
         }
-
-        queuedBlocks.length = queuedBlocksLength
-        oldKeyIndexPairs.length = oldKeyIndexPairsLength
-
-        interface MountOper {
-          source: ResolvedSource
-          index: number
-          item: ReturnType<typeof getItem>
-          key: any
-        }
-        interface MoveOper {
-          index: number
-          block: ForBlock
-        }
-
-        const oldKeyIndexMap = new Map(oldKeyIndexPairs)
-        const opers: (MountOper | MoveOper)[] = new Array(queuedBlocks.length)
 
         let mountCounter = 0
-        let opersLength = 0
 
-        for (let i = queuedBlocks.length - 1; i >= 0; i--) {
-          const [index, item, key] = queuedBlocks[i]
+        for (let q = queuedLength - 1; q >= 0; q--) {
+          const index = queuedIndices[q]
+          const key = newKeys![index]
           const oldIndex = oldKeyIndexMap.get(key)
           if (oldIndex !== undefined) {
             oldKeyIndexMap.delete(key)
             const reusedBlock = (newBlocks[index] = oldBlocks[oldIndex])
-            update(reusedBlock, ...item)
-            opers[opersLength++] = { index, block: reusedBlock }
+            update(
+              reusedBlock,
+              queuedItems[q],
+              sourceKeys ? sourceKeys[index] : index,
+              sourceKeys ? index : undefined,
+            )
+            queuedReuse[q] = reusedBlock
           } else {
+            queuedReuse[q] = undefined
             mountCounter++
-            opers[opersLength++] = { source, index, item, key }
           }
         }
 
@@ -356,19 +341,22 @@ export const createFor = (
           parent!.appendChild(parentAnchor)
         }
 
-        if (opers.length === mountCounter) {
-          for (const { source, index, item, key } of opers as MountOper[]) {
+        if (mountCounter === queuedLength) {
+          // mounts only, no moves: mount back-to-front so each row can
+          // anchor on the one after it
+          for (let q = queuedLength - 1; q >= 0; q--) {
+            const index = queuedIndices[q]
             mount(
               source,
               index,
               index < newLength - 1
                 ? getBlockFirstNode(newBlocks[index + 1].nodes)
                 : parentAnchor,
-              item,
-              key,
+              queuedItems[q],
+              newKeys![index],
             )
           }
-        } else if (opers.length) {
+        } else if (queuedLength) {
           let anchor = oldBlocks[0]
           let blocksTail: ForBlock | undefined
           for (let i = 0; i < oldLength; i++) {
@@ -384,34 +372,45 @@ export const createFor = (
             }
             blocksTail = block
           }
-          for (const action of opers) {
-            const { index } = action
+          for (let q = queuedLength - 1; q >= 0; q--) {
+            const index = queuedIndices[q]
+            const reused = queuedReuse[q]
             if (index < newLength - 1) {
               const nextBlock = newBlocks[index + 1]
               let anchorNode = getBlockFirstNode(nextBlock.prevAnchor!.nodes)
               if (!anchorNode.parentNode)
                 anchorNode = getBlockFirstNode(nextBlock.nodes)
-              if ('source' in action) {
-                const { item, key } = action
-                const block = mount(source, index, anchorNode, item, key)
+              if (reused === undefined) {
+                const block = mount(
+                  source,
+                  index,
+                  anchorNode,
+                  queuedItems[q],
+                  newKeys![index],
+                )
                 moveLink(block, nextBlock.prev, nextBlock)
-              } else if (action.block.next !== nextBlock) {
-                insertForBlock(action.block, anchorNode)
-                moveLink(action.block, nextBlock.prev, nextBlock)
+              } else if (reused.next !== nextBlock) {
+                insertForBlock(reused, anchorNode)
+                moveLink(reused, nextBlock.prev, nextBlock)
               }
-            } else if ('source' in action) {
-              const { item, key } = action
-              const block = mount(source, index, parentAnchor, item, key)
+            } else if (reused === undefined) {
+              const block = mount(
+                source,
+                index,
+                parentAnchor,
+                queuedItems[q],
+                newKeys![index],
+              )
               moveLink(block, blocksTail)
               blocksTail = block
-            } else if (action.block.next !== undefined) {
+            } else if (reused.next !== undefined) {
               let anchorNode = anchor
                 ? getBlockFirstNode(anchor.nodes)
                 : parentAnchor
               if (!anchorNode.parentNode) anchorNode = parentAnchor
-              insertForBlock(action.block, anchorNode)
-              moveLink(action.block, blocksTail)
-              blocksTail = action.block
+              insertForBlock(reused, anchorNode)
+              moveLink(reused, blocksTail)
+              blocksTail = reused
             }
           }
           for (const block of newBlocks) {
@@ -452,24 +451,29 @@ export const createFor = (
   const mount = (
     source: ResolvedSource,
     idx: number,
-    anchor: Node | undefined = parentAnchor,
-    [item, key, index] = getItem(source, idx),
-    key2 = newKeys ? newKeys[idx] : getKey && getKey(item, key, index),
+    anchor: Node | undefined,
+    item: any,
+    key2: any,
   ): ForBlock => {
+    const keys = source.keys
     const itemRef = shallowRef(item)
     // avoid creating refs if the render fn doesn't need it
-    const keyRef = needKey ? shallowRef(key) : undefined
-    const indexRef = needIndex ? shallowRef(index) : undefined
+    const keyRef = needKey ? shallowRef(keys ? keys[idx] : idx) : undefined
+    const indexRef = needIndex ? shallowRef(keys ? idx : undefined) : undefined
 
     let nodes: Block
     const scope = new EffectScope(true)
+    const prevScope = setCurrentScope(scope)
     try {
-      nodes = scope.run(() =>
-        renderItem(itemRef, keyRef as any, indexRef as any),
-      )!
+      nodes = renderItem(itemRef, keyRef as any, indexRef as any)
     } catch (err) {
+      // restore before stopping so scope cleanups never observe the dying
+      // scope as current (matches the previous scope.run() ordering)
+      setCurrentScope(prevScope)
       scope.stop()
       throw err
+    } finally {
+      setCurrentScope(prevScope)
     }
 
     const block = (newBlocks[idx] = new ForBlock(
@@ -494,6 +498,35 @@ export const createFor = (
     return block
   }
 
+  const mountAt = (source: ResolvedSource, idx: number): ForBlock =>
+    mount(
+      source,
+      idx,
+      parentAnchor,
+      getItemValue(source, idx),
+      newKeys ? newKeys[idx] : undefined,
+    )
+
+  const mountAll = (source: ResolvedSource, newLength: number): void => {
+    for (let i = 0; i < newLength; i++) {
+      mountAt(source, i)
+    }
+  }
+
+  const updateAt = (
+    block: ForBlock,
+    source: ResolvedSource,
+    idx: number,
+  ): void => {
+    const keys = source.keys
+    update(
+      block,
+      getItemValue(source, idx),
+      keys ? keys[idx] : idx,
+      keys ? idx : undefined,
+    )
+  }
+
   function hydrateList(source: ResolvedSource, newLength: number): void {
     const hydrationStart = currentHydrationNode!
     let exitHydrationBoundary: (() => void) | undefined
@@ -513,7 +546,7 @@ export const createFor = (
       if (emptyLocalRange && newLength) {
         reuseBoundaryClose(hydrationStart)
         for (let i = 0; i < newLength; i++) {
-          mount(source, i)
+          mountAt(source, i)
         }
         setCurrentHydrationNode(parentAnchor)
       } else {
@@ -524,7 +557,7 @@ export const createFor = (
           } else {
             nextNode = nextLogicalSibling(currentHydrationNode!)
           }
-          mount(source, i)
+          mountAt(source, i)
           if (nextNode) setCurrentHydrationNode(nextNode)
         }
 
@@ -943,17 +976,24 @@ function normalizeSource(source: any): ResolvedSource {
   }
 }
 
-function getItem(
-  { keys, values, needsWrap, isReadonlySource }: ResolvedSource,
+function getItemValue(
+  { values, needsWrap, isReadonlySource }: ResolvedSource,
   idx: number,
-): [item: any, key: any, index?: number] {
-  const value = needsWrap
+): any {
+  return needsWrap
     ? isReadonlySource
       ? toReadonly(toReactive(values[idx]))
       : toReactive(values[idx])
     : values[idx]
-  if (keys) {
-    return [value, keys[idx], idx]
+}
+
+function getItem(
+  source: ResolvedSource,
+  idx: number,
+): [item: any, key: any, index?: number] {
+  const value = getItemValue(source, idx)
+  if (source.keys) {
+    return [value, source.keys[idx], idx]
   } else {
     return [value, idx, undefined]
   }

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -13,7 +13,13 @@ import {
   toReadonly,
   watch,
 } from '@vue/reactivity'
-import { getSequence, isArray, isObject, isString } from '@vue/shared'
+import {
+  EMPTY_ARR,
+  getSequence,
+  isArray,
+  isObject,
+  isString,
+} from '@vue/shared'
 import { createComment, createTextNode } from './dom/node'
 import {
   type Block,
@@ -181,9 +187,10 @@ export const createFor = (
     if (getKey) {
       newKeys = new Array(newLength)
       for (let i = 0; i < newLength; i++) {
+        const value = getItemValue(source, i)
         newKeys[i] = sourceKeys
-          ? getKey(getItemValue(source, i), sourceKeys[i], i)
-          : getKey(getItemValue(source, i), i, undefined)
+          ? getKey(value, sourceKeys[i], i)
+          : getKey(value, i, undefined)
       }
     }
 
@@ -275,15 +282,11 @@ export const createFor = (
         const queuedIndices: number[] = []
         const oldKeyIndexMap = new Map<any, number>()
 
-        // in-place matches, remembered so a dense reorder can pull them into
-        // the move plan (they sit at the same index in both lists)
-        let stationaryIndices: number[] | undefined
         for (let i = 0; i < e1; i++) {
           const currentKey = newKeys![i]
           const oldBlock = oldBlocks[i]
           if (oldBlock.key === currentKey) {
             updateAt((newBlocks[i] = oldBlock), source, i)
-            ;(stationaryIndices ||= []).push(i)
           } else {
             queuedIndices.push(i)
             oldKeyIndexMap.set(oldBlock.key, i)
@@ -304,16 +307,16 @@ export const createFor = (
         // marks a fresh mount). The bounds filter below zeroes reuses that may
         // not stay put; the apply pass tells move from mount by
         // `newBlocks[index]`, which the reuse pass has already filled in.
-        const sources: number[] = new Array(queuedLength)
+        let sources: number[] = EMPTY_ARR as unknown as number[]
         let mountCounter = 0
 
         if (oldKeyIndexMap.size === 0) {
-          // pure append/replace: nothing to pair up. Plain loop over fill():
-          // the inlined monomorphic store beats the generic builtin on a
-          // freshly allocated (holey) array.
-          for (let q = 0; q < queuedLength; q++) sources[q] = 0
+          // pure append/replace: nothing to pair up, so every queued index is
+          // a mount, the planner below is skipped and `sources` is never
+          // read - don't build it
           mountCounter = queuedLength
         } else {
+          sources = new Array(queuedLength)
           for (let q = queuedLength - 1; q >= 0; q--) {
             const index = queuedIndices[q]
             const key = newKeys![index]
@@ -337,114 +340,28 @@ export const createFor = (
         if (useFastRemove && frag.resetListeners) {
           for (const fn of frag.resetListeners) fn()
         }
-        for (const leftoverIndex of oldKeyIndexMap.values()) {
-          unmount(
-            oldBlocks[leftoverIndex],
-            !(useFastRemove && canUseFastRemove),
-          )
+        if (oldKeyIndexMap.size) {
+          for (const leftoverIndex of oldKeyIndexMap.values()) {
+            unmount(
+              oldBlocks[leftoverIndex],
+              !(useFastRemove && canUseFastRemove),
+            )
+          }
         }
         if (useFastRemove && canUseFastRemove) {
           parent!.textContent = ''
           parent!.appendChild(parentAnchor)
         }
 
-        // Decide which reused blocks may stay in place: the longest
-        // increasing subsequence of old indices is already in relative order,
-        // so only the blocks outside it need a DOM move.
-        //
-        // Two planners, picked by how dense the change is across the range it
-        // touches:
-        //
-        // - dense (the changed indices cover at least half their own span):
-        //   pull the in-place matches inside that span into the plan too and
-        //   run an unbounded LIS, which is move-count minimal like vdom's.
-        //   `span <= 2 * queuedLength` here, so this stays O(queued).
-        // - sparse (a couple of rows moved across an otherwise untouched
-        //   list, e.g. a far swap): keep the in-place matches pinned, which
-        //   costs nothing but bounds each segment's LIS by its stationary
-        //   neighbours. Not minimal in general, but it never walks the
-        //   untouched majority.
         let sequence: number[] | undefined
-        let allKept = false
-        if (mountCounter !== queuedLength) {
-          const span = queuedIndices[queuedLength - 1] - queuedIndices[0] + 1
-          if (stationaryIndices && queuedLength * 2 >= span) {
-            // dense: merge the stationaries inside the span into the plan,
-            // keeping both parallel arrays in ascending index order
-            const firstIndex = queuedIndices[0]
-            const lastIndex = queuedIndices[queuedLength - 1]
-            for (let i = 0; i < stationaryIndices.length; i++) {
-              const index = stationaryIndices[i]
-              if (index > firstIndex && index < lastIndex) {
-                queuedIndices.push(index)
-                // a prefix stationary sits at the same index in both lists
-                sources.push(index + 1)
-              }
-            }
-            if (queuedIndices.length !== queuedLength) {
-              sortQueueByIndex(queuedIndices, sources)
-              queuedLength = queuedIndices.length
-            }
-          }
-
-          let eligible = 0
-          // if the eligible old positions already ascend, they are all in
-          // relative order and every one of them stays put — no LIS needed
-          let moved = false
-          let maxSource = 0
-          if (queuedLength * 2 >= span) {
-            // dense: no bounds, every reuse competes for the LIS
-            for (let q = 0; q < queuedLength; q++) {
-              const value = sources[q]
-              if (value !== 0) {
-                eligible++
-                if (value < maxSource) moved = true
-                else maxSource = value
-              }
-            }
-          } else {
-            // sparse: in-place matches partition the queued indices into
-            // segments of consecutive positions, and bound each segment's
-            // eligible old indices. Because those bounds never overlap
-            // between segments, one whole-array LIS still yields the same
-            // answer as running it per segment.
-            let seg = 0
-            while (seg < queuedLength) {
-              let segEnd = seg
-              while (
-                segEnd + 1 < queuedLength &&
-                queuedIndices[segEnd + 1] === queuedIndices[segEnd] + 1
-              ) {
-                segEnd++
-              }
-              // prefix stationaries sit at their own index in both lists; the
-              // first suffix stationary (index e3) sits at old index e2. With
-              // no bounding stationary the bounds are -1 / e2 == oldLength.
-              const lowerBound = queuedIndices[seg] - 1
-              const nextIndex = queuedIndices[segEnd] + 1
-              const upperBound = nextIndex < e3 ? nextIndex : e2
-              for (let q = seg; q <= segEnd; q++) {
-                const value = sources[q]
-                const oldIndex = value - 1
-                if (
-                  oldIndex < 0 ||
-                  oldIndex <= lowerBound ||
-                  oldIndex >= upperBound
-                ) {
-                  sources[q] = 0
-                } else {
-                  eligible++
-                  if (value < maxSource) moved = true
-                  else maxSource = value
-                }
-              }
-              seg = segEnd + 1
-            }
-          }
-
-          if (eligible && moved) sequence = getSequence(sources)
-          else if (eligible) allKept = true
+        const hasReuse = mountCounter !== queuedLength
+        if (hasReuse) {
+          sequence = planMoves(queuedIndices, sources, e2, e3)
+          // the dense planner expands both arrays in place
+          queuedLength = queuedIndices.length
         }
+        // reuses exist and none of them moved: every one of them stays put
+        const allKept = hasReuse && sequence === undefined
 
         // apply back-to-front so every block can anchor on the finalized
         // block after it (kept blocks count as finalized: relative order
@@ -464,6 +381,10 @@ export const createFor = (
             // a leading entry that was never selected; skip that marker
             isKept = sources[q] !== 0
           }
+          // `scanFrom`/`cachedAnchor` stay where they are: the next block
+          // that does move rescans the wider range, and each position is
+          // still visited at most once.
+          if (isKept) continue
 
           // A block that renders nothing has no first node, so look past it
           // for the next attached one.
@@ -504,9 +425,9 @@ export const createFor = (
           scanFrom = index + 1
           cachedAnchor = anchorNode
 
-          if (isKept) continue
-          if (newBlocks[index] !== undefined) {
-            insertForBlock(newBlocks[index], anchorNode)
+          const block = newBlocks[index]
+          if (block !== undefined) {
+            insertForBlock(block, anchorNode)
           } else {
             mount(source, index, anchorNode)
           }
@@ -514,10 +435,12 @@ export const createFor = (
       }
     }
 
-    frag.nodes = [(oldBlocks = newBlocks)]
-    if (parentAnchor) frag.nodes.push(parentAnchor)
+    oldBlocks = newBlocks
+    frag.nodes = parentAnchor ? [newBlocks, parentAnchor] : [newBlocks]
 
-    if (wasMounted && frag.onUpdated) frag.onUpdated.forEach(m => m())
+    if (wasMounted && frag.onUpdated) {
+      for (const fn of frag.onUpdated) fn()
+    }
     setActiveSub(prevSub)
   }
 
@@ -627,9 +550,7 @@ export const createFor = (
     try {
       if (emptyLocalRange && newLength) {
         reuseBoundaryClose(hydrationStart)
-        for (let i = 0; i < newLength; i++) {
-          mount(source, i, parentAnchor)
-        }
+        mountAll(source, newLength)
         setCurrentHydrationNode(parentAnchor)
       } else {
         for (let i = 0; i < newLength; i++) {
@@ -877,22 +798,112 @@ export function createSelector(source: () => any): ForSelector {
   return register
 }
 
-// Restores ascending index order after the dense planner appended the
-// stationaries; both arrays move together. The appended tail is itself sorted
-// and usually short, so insertion sort runs near-linearly here.
-function sortQueueByIndex(indices: number[], oldIndices: number[]): void {
-  for (let i = 1; i < indices.length; i++) {
-    const index = indices[i]
-    const oldIndex = oldIndices[i]
-    let j = i - 1
-    while (j >= 0 && indices[j] > index) {
-      indices[j + 1] = indices[j]
-      oldIndices[j + 1] = oldIndices[j]
-      j--
+/**
+ * Decides which reused blocks may stay where they are: the longest increasing
+ * subsequence of their old indices is already in relative order, so only the
+ * blocks outside it need a DOM move. Returns that subsequence as indices into
+ * `sources`, or `undefined` when no reused block has to move at all.
+ *
+ * Two planners, picked by how dense the change is across the range it touches:
+ *
+ * - dense (the queued indices cover at least half of the range they span):
+ *   pull the in-place matches in that range into the plan too and run an
+ *   unbounded LIS, which is move-count minimal like vdom's. The range is at
+ *   most `2 * queuedIndices.length` wide here, so this stays O(queued).
+ * - sparse (a couple of rows moved across an otherwise untouched list, e.g. a
+ *   far swap): keep the in-place matches pinned, which costs nothing but
+ *   bounds each segment's LIS by its stationary neighbours. Not minimal in
+ *   general, but it never walks the untouched majority.
+ *
+ * Both arrays are expanded in place on the dense path.
+ */
+function planMoves(
+  queuedIndices: number[],
+  sources: number[],
+  e2: number,
+  e3: number,
+): number[] | undefined {
+  let queuedLength = queuedIndices.length
+  // The dense range runs from the first queued index to the start of the
+  // synchronized suffix: an in-place match on either side of a queued block
+  // still constrains where it may land, so the plan has to cover them all,
+  // not just the ones between the first and last queued index.
+  const firstIndex = queuedIndices[0]
+  const denseLength = e3 - firstIndex
+  const isDense = queuedLength * 2 >= denseLength
+
+  // if the eligible old positions already ascend, they are all in relative
+  // order and every one of them stays put - no LIS needed
+  let moved = false
+  let maxSource = 0
+
+  if (isDense) {
+    // Expand in place, back to front so the tail writes never clobber entries
+    // still to be read. Every position in the range that is not queued is a
+    // same-index in-place match, so it needs no lookup.
+    let read = queuedLength - 1
+    queuedIndices.length = sources.length = denseLength
+    for (
+      let write = denseLength - 1, index = e3 - 1;
+      write >= 0;
+      write--, index--
+    ) {
+      if (read >= 0 && queuedIndices[read] === index) {
+        sources[write] = sources[read--]
+      } else {
+        sources[write] = index + 1
+      }
+      queuedIndices[write] = index
     }
-    indices[j + 1] = index
-    oldIndices[j + 1] = oldIndex
+    queuedLength = denseLength
+
+    // no bounds: every reuse competes for the LIS
+    for (let q = 0; q < queuedLength; q++) {
+      const value = sources[q]
+      if (value !== 0) {
+        if (value < maxSource) moved = true
+        else maxSource = value
+      }
+    }
+  } else {
+    // in-place matches partition the queued indices into segments of
+    // consecutive positions, and bound each segment's eligible old indices.
+    // Because those bounds never overlap between segments, one whole-array
+    // LIS still yields the same answer as running it per segment.
+    let seg = 0
+    while (seg < queuedLength) {
+      let segEnd = seg
+      while (
+        segEnd + 1 < queuedLength &&
+        queuedIndices[segEnd + 1] === queuedIndices[segEnd] + 1
+      ) {
+        segEnd++
+      }
+      // prefix stationaries sit at their own index in both lists; the first
+      // suffix stationary (index e3) sits at old index e2. With no bounding
+      // stationary the bounds are -1 / e2 == oldLength.
+      const lowerBound = queuedIndices[seg] - 1
+      const nextIndex = queuedIndices[segEnd] + 1
+      const upperBound = nextIndex < e3 ? nextIndex : e2
+      for (let q = seg; q <= segEnd; q++) {
+        const value = sources[q]
+        // a mount has value 0, i.e. an old index of -1, which the lower
+        // bound (>= -1) already rejects
+        const oldIndex = value - 1
+        if (oldIndex <= lowerBound || oldIndex >= upperBound) {
+          sources[q] = 0
+        } else {
+          if (value < maxSource) moved = true
+          else maxSource = value
+        }
+      }
+      seg = segEnd + 1
+    }
   }
+
+  // `moved` can only be set by the second non-zero value onwards, so it
+  // already implies there is something to keep
+  return moved ? getSequence(sources) : undefined
 }
 
 function stopBlockScopes(blocks: ForBlock[]): void {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -279,11 +279,15 @@ export const createFor = (
         const queuedIndices: number[] = []
         const oldKeyIndexMap = new Map<any, number>()
 
+        // in-place matches, remembered so a dense reorder can pull them into
+        // the move plan (they sit at the same index in both lists)
+        let stationaryIndices: number[] | undefined
         for (let i = 0; i < e1; i++) {
           const currentKey = newKeys![i]
           const oldBlock = oldBlocks[i]
           if (oldBlock.key === currentKey) {
             updateAt((newBlocks[i] = oldBlock), source, i)
+            ;(stationaryIndices ||= []).push(i)
           } else {
             queuedIndices.push(i)
             oldKeyIndexMap.set(oldBlock.key, i)
@@ -298,7 +302,7 @@ export const createFor = (
           queuedIndices.push(i)
         }
 
-        const queuedLength = queuedIndices.length
+        let queuedLength = queuedIndices.length
         const queuedOldIndex: number[] = new Array(queuedLength)
         let mountCounter = 0
 
@@ -343,60 +347,96 @@ export const createFor = (
           parent!.appendChild(parentAnchor)
         }
 
-        // Decide which reused blocks may stay in place. In-place matched
-        // (stationary) blocks partition the queued indices into segments of
-        // consecutive positions; within a segment, the longest increasing
-        // subsequence of old indices — bounded by the old positions of the
-        // stationary neighbors — is already in relative order, so only the
-        // blocks outside it need a DOM move.
+        // Decide which reused blocks may stay in place: the longest
+        // increasing subsequence of old indices is already in relative order,
+        // so only the blocks outside it need a DOM move.
         //
-        // This is a heuristic, not a minimum: pinning every stationary block
-        // is what keeps the cost O(queued) rather than O(length), so a
-        // near-untouched list (a two-row swap, a single removal) does almost
-        // no work here — but a coincidental in-place match inside an
-        // otherwise heavily shuffled range splits a segment and can cost
-        // more moves than vdom's unpinned whole-range LIS.
+        // Two planners, picked by how dense the change is across the range it
+        // touches:
+        //
+        // - dense (the changed indices cover at least half their own span):
+        //   pull the in-place matches inside that span into the plan too and
+        //   run an unbounded LIS, which is move-count minimal like vdom's.
+        //   `span <= 2 * queuedLength` here, so this stays O(queued).
+        // - sparse (a couple of rows moved across an otherwise untouched
+        //   list, e.g. a far swap): keep the in-place matches pinned, which
+        //   costs nothing but bounds each segment's LIS by its stationary
+        //   neighbours. Not minimal in general, but it never walks the
+        //   untouched majority.
         let sequence: number[] | undefined
         let sequenceInput: number[] | undefined
         if (mountCounter !== queuedLength) {
+          const span = queuedIndices[queuedLength - 1] - queuedIndices[0] + 1
+          if (stationaryIndices && queuedLength * 2 >= span) {
+            // dense: merge the stationaries inside the span into the plan,
+            // keeping both parallel arrays in ascending index order
+            const firstIndex = queuedIndices[0]
+            const lastIndex = queuedIndices[queuedLength - 1]
+            for (let i = 0; i < stationaryIndices.length; i++) {
+              const index = stationaryIndices[i]
+              if (index > firstIndex && index < lastIndex) {
+                queuedIndices.push(index)
+                // a prefix stationary sits at the same index in both lists
+                queuedOldIndex.push(index)
+              }
+            }
+            if (queuedIndices.length !== queuedLength) {
+              sortQueueByIndex(queuedIndices, queuedOldIndex)
+              queuedLength = queuedIndices.length
+            }
+          }
+
           // `getSequence` input: the old position (+1, so 0 stays free as its
-          // "skip" marker) of every block that is allowed to stay put, and 0
-          // for the rest. Because a segment's eligible old indices all lie
-          // between its two bounding stationaries, and those bounds never
-          // overlap between segments, every value in one segment is smaller
-          // than every value in the next — so one whole-array LIS yields the
-          // same answer as running it per segment.
+          // "skip" marker) of every block allowed to stay put, 0 for the rest.
           sequenceInput = new Array(queuedLength)
           let eligible = 0
-          let seg = 0
-          while (seg < queuedLength) {
-            let segEnd = seg
-            while (
-              segEnd + 1 < queuedLength &&
-              queuedIndices[segEnd + 1] === queuedIndices[segEnd] + 1
-            ) {
-              segEnd++
-            }
-            // prefix stationaries sit at their own index in both lists; the
-            // first suffix stationary (index e3) sits at old index e2. With
-            // no bounding stationary the bounds are -1 / e2 == oldLength.
-            const lowerBound = queuedIndices[seg] - 1
-            const nextIndex = queuedIndices[segEnd] + 1
-            const upperBound = nextIndex < e3 ? nextIndex : e2
-            for (let q = seg; q <= segEnd; q++) {
+          if (queuedLength * 2 >= span) {
+            // dense: no bounds, every reuse competes for the LIS
+            for (let q = 0; q < queuedLength; q++) {
               const oldIndex = queuedOldIndex[q]
-              if (
-                oldIndex < 0 ||
-                oldIndex <= lowerBound ||
-                oldIndex >= upperBound
-              ) {
+              if (oldIndex < 0) {
                 sequenceInput[q] = 0
               } else {
                 sequenceInput[q] = oldIndex + 1
                 eligible++
               }
             }
-            seg = segEnd + 1
+          } else {
+            // sparse: in-place matches partition the queued indices into
+            // segments of consecutive positions, and bound each segment's
+            // eligible old indices. Because those bounds never overlap
+            // between segments, one whole-array LIS still yields the same
+            // answer as running it per segment.
+            let seg = 0
+            while (seg < queuedLength) {
+              let segEnd = seg
+              while (
+                segEnd + 1 < queuedLength &&
+                queuedIndices[segEnd + 1] === queuedIndices[segEnd] + 1
+              ) {
+                segEnd++
+              }
+              // prefix stationaries sit at their own index in both lists; the
+              // first suffix stationary (index e3) sits at old index e2. With
+              // no bounding stationary the bounds are -1 / e2 == oldLength.
+              const lowerBound = queuedIndices[seg] - 1
+              const nextIndex = queuedIndices[segEnd] + 1
+              const upperBound = nextIndex < e3 ? nextIndex : e2
+              for (let q = seg; q <= segEnd; q++) {
+                const oldIndex = queuedOldIndex[q]
+                if (
+                  oldIndex < 0 ||
+                  oldIndex <= lowerBound ||
+                  oldIndex >= upperBound
+                ) {
+                  sequenceInput[q] = 0
+                } else {
+                  sequenceInput[q] = oldIndex + 1
+                  eligible++
+                }
+              }
+              seg = segEnd + 1
+            }
           }
 
           if (eligible) sequence = getSequence(sequenceInput)
@@ -426,7 +466,10 @@ export const createFor = (
           let anchorNode: Node | undefined
           for (let i = index + 1; i < scanFrom; i++) {
             const node = getBlockFirstNode(newBlocks[i].nodes)
-            if (node && node.parentNode) {
+            // must be attached to *this* list's parent: a node that is still
+            // connected elsewhere (teleport target, suspense pending
+            // container, keep-alive storage) would make insertBefore throw
+            if (node && node.parentNode === parent) {
               anchorNode = node
               break
             }
@@ -448,7 +491,7 @@ export const createFor = (
                   const oldBlock = oldBlocks[i]
                   if (!oldKeyIndexMap.has(oldBlock.key)) break
                   const first = getBlockFirstNode(oldBlock.nodes)
-                  if (first && first.parentNode) cachedAnchor = first
+                  if (first && first.parentNode === parent) cachedAnchor = first
                 }
               }
             }
@@ -828,6 +871,24 @@ export function createSelector(source: () => any): ForSelector {
     generation++
   }
   return register
+}
+
+// Restores ascending index order after the dense planner appended the
+// stationaries; both arrays move together. The appended tail is itself sorted
+// and usually short, so insertion sort runs near-linearly here.
+function sortQueueByIndex(indices: number[], oldIndices: number[]): void {
+  for (let i = 1; i < indices.length; i++) {
+    const index = indices[i]
+    const oldIndex = oldIndices[i]
+    let j = i - 1
+    while (j >= 0 && indices[j] > index) {
+      indices[j + 1] = indices[j]
+      oldIndices[j + 1] = oldIndices[j]
+      j--
+    }
+    indices[j + 1] = index
+    oldIndices[j + 1] = oldIndex
+  }
 }
 
 function stopBlockScopes(blocks: ForBlock[]): void {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -270,12 +270,8 @@ export const createFor = (
         const e2 = oldLength - endOffset
         const e3 = newLength - endOffset
 
-        // parallel arrays holding blocks that need a mount or a move, in
-        // ascending index order (built packed, so a small change in a large
-        // list only allocates for the actual churn). After the reuse pass
-        // `queuedOldIndex[q]` distinguishes them: the block's old position
-        // for a reuse (its ForBlock is already in `newBlocks`), or -1 for a
-        // fresh mount.
+        // new indices needing a mount or a move, ascending (built packed, so a
+        // small change in a large list only allocates for the actual churn)
         const queuedIndices: number[] = []
         const oldKeyIndexMap = new Map<any, number>()
 
@@ -303,14 +299,19 @@ export const createFor = (
         }
 
         let queuedLength = queuedIndices.length
-        const queuedOldIndex: number[] = new Array(queuedLength)
+        // `getSequence` input, doubling as the old-position record: the
+        // block's old index + 1 (0 stays free as the "skip" marker, and also
+        // marks a fresh mount). The bounds filter below zeroes reuses that may
+        // not stay put; the apply pass tells move from mount by
+        // `newBlocks[index]`, which the reuse pass has already filled in.
+        const sources: number[] = new Array(queuedLength)
         let mountCounter = 0
 
         if (oldKeyIndexMap.size === 0) {
           // pure append/replace: nothing to pair up. Plain loop over fill():
           // the inlined monomorphic store beats the generic builtin on a
           // freshly allocated (holey) array.
-          for (let q = 0; q < queuedLength; q++) queuedOldIndex[q] = -1
+          for (let q = 0; q < queuedLength; q++) sources[q] = 0
           mountCounter = queuedLength
         } else {
           for (let q = queuedLength - 1; q >= 0; q--) {
@@ -321,9 +322,9 @@ export const createFor = (
               oldKeyIndexMap.delete(key)
               const reusedBlock = (newBlocks[index] = oldBlocks[oldIndex])
               updateAt(reusedBlock, source, index)
-              queuedOldIndex[q] = oldIndex
+              sources[q] = oldIndex + 1
             } else {
-              queuedOldIndex[q] = -1
+              sources[q] = 0
               mountCounter++
             }
           }
@@ -364,7 +365,7 @@ export const createFor = (
         //   neighbours. Not minimal in general, but it never walks the
         //   untouched majority.
         let sequence: number[] | undefined
-        let sequenceInput: number[] | undefined
+        let allKept = false
         if (mountCounter !== queuedLength) {
           const span = queuedIndices[queuedLength - 1] - queuedIndices[0] + 1
           if (stationaryIndices && queuedLength * 2 >= span) {
@@ -377,28 +378,28 @@ export const createFor = (
               if (index > firstIndex && index < lastIndex) {
                 queuedIndices.push(index)
                 // a prefix stationary sits at the same index in both lists
-                queuedOldIndex.push(index)
+                sources.push(index + 1)
               }
             }
             if (queuedIndices.length !== queuedLength) {
-              sortQueueByIndex(queuedIndices, queuedOldIndex)
+              sortQueueByIndex(queuedIndices, sources)
               queuedLength = queuedIndices.length
             }
           }
 
-          // `getSequence` input: the old position (+1, so 0 stays free as its
-          // "skip" marker) of every block allowed to stay put, 0 for the rest.
-          sequenceInput = new Array(queuedLength)
           let eligible = 0
+          // if the eligible old positions already ascend, they are all in
+          // relative order and every one of them stays put — no LIS needed
+          let moved = false
+          let maxSource = 0
           if (queuedLength * 2 >= span) {
             // dense: no bounds, every reuse competes for the LIS
             for (let q = 0; q < queuedLength; q++) {
-              const oldIndex = queuedOldIndex[q]
-              if (oldIndex < 0) {
-                sequenceInput[q] = 0
-              } else {
-                sequenceInput[q] = oldIndex + 1
+              const value = sources[q]
+              if (value !== 0) {
                 eligible++
+                if (value < maxSource) moved = true
+                else maxSource = value
               }
             }
           } else {
@@ -423,23 +424,26 @@ export const createFor = (
               const nextIndex = queuedIndices[segEnd] + 1
               const upperBound = nextIndex < e3 ? nextIndex : e2
               for (let q = seg; q <= segEnd; q++) {
-                const oldIndex = queuedOldIndex[q]
+                const value = sources[q]
+                const oldIndex = value - 1
                 if (
                   oldIndex < 0 ||
                   oldIndex <= lowerBound ||
                   oldIndex >= upperBound
                 ) {
-                  sequenceInput[q] = 0
+                  sources[q] = 0
                 } else {
-                  sequenceInput[q] = oldIndex + 1
                   eligible++
+                  if (value < maxSource) moved = true
+                  else maxSource = value
                 }
               }
               seg = segEnd + 1
             }
           }
 
-          if (eligible) sequence = getSequence(sequenceInput)
+          if (eligible && moved) sequence = getSequence(sources)
+          else if (eligible) allKept = true
         }
 
         // apply back-to-front so every block can anchor on the finalized
@@ -453,12 +457,12 @@ export const createFor = (
         let cachedAnchor: Node | undefined
         for (let q = queuedLength - 1; q >= 0; q--) {
           const index = queuedIndices[q]
-          let isKept = false
+          let isKept = allKept && sources[q] !== 0
           if (sequenceEnd >= 0 && sequence![sequenceEnd] === q) {
             sequenceEnd--
             // `getSequence` seeds its result with index 0, so it can report
             // a leading entry that was never selected; skip that marker
-            isKept = sequenceInput![q] !== 0
+            isKept = sources[q] !== 0
           }
 
           // A block that renders nothing has no first node, so look past it
@@ -501,7 +505,7 @@ export const createFor = (
           cachedAnchor = anchorNode
 
           if (isKept) continue
-          if (queuedOldIndex[q] >= 0) {
+          if (newBlocks[index] !== undefined) {
             insertForBlock(newBlocks[index], anchorNode)
           } else {
             mount(source, index, anchorNode)

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -13,7 +13,7 @@ import {
   toReadonly,
   watch,
 } from '@vue/reactivity'
-import { isArray, isObject, isString } from '@vue/shared'
+import { getSequence, isArray, isObject, isString } from '@vue/shared'
 import { createComment, createTextNode } from './dom/node'
 import {
   type Block,
@@ -27,7 +27,7 @@ import {
   removeNode,
 } from './block'
 import { queuePostFlushCb, warn } from '@vue/runtime-dom'
-import { currentInstance, isVaporComponent } from './component'
+import { currentInstance } from './component'
 import {
   type DynamicSlot,
   type VaporSlot,
@@ -71,7 +71,6 @@ import {
   resetInsertionState,
 } from './insertionState'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
-import { isTeleportEnabled, isTeleportFragment } from './teleport'
 import { setBlockKey } from './helpers/setKey'
 import { currentSlotBoundary, setCurrentSlotBoundary } from './slotBoundary'
 
@@ -231,7 +230,7 @@ export const createFor = (
           updateAt((newBlocks[i] = oldBlocks[i]), source, i)
         }
         for (let i = oldLength; i < newLength; i++) {
-          mountAt(source, i)
+          mount(source, i, parentAnchor)
         }
         for (let i = newLength; i < oldLength; i++) {
           unmount(oldBlocks[i])
@@ -256,7 +255,6 @@ export const createFor = (
 
         const commonLength = Math.min(oldLength, newLength)
         let endOffset = 0
-        let queuedLength = 0
 
         while (endOffset < commonLength) {
           const index = newLength - endOffset - 1
@@ -273,13 +271,12 @@ export const createFor = (
         const e3 = newLength - endOffset
 
         // parallel arrays holding blocks that need a mount or a move, in
-        // ascending index order; the suffix scan above already excluded
-        // everything from e3 on. After the reuse pass `queuedOldIndex[q]`
-        // distinguishes them: the block's old position for a reuse (its
-        // ForBlock is already in `newBlocks`), or -1 for a fresh mount.
-        const queuedIndices: number[] = new Array(e3)
-        const queuedOldIndex: number[] = new Array(e3)
-
+        // ascending index order (built packed, so a small change in a large
+        // list only allocates for the actual churn). After the reuse pass
+        // `queuedOldIndex[q]` distinguishes them: the block's old position
+        // for a reuse (its ForBlock is already in `newBlocks`), or -1 for a
+        // fresh mount.
+        const queuedIndices: number[] = []
         const oldKeyIndexMap = new Map<any, number>()
 
         for (let i = 0; i < e1; i++) {
@@ -288,7 +285,7 @@ export const createFor = (
           if (oldBlock.key === currentKey) {
             updateAt((newBlocks[i] = oldBlock), source, i)
           } else {
-            queuedIndices[queuedLength++] = i
+            queuedIndices.push(i)
             oldKeyIndexMap.set(oldBlock.key, i)
           }
         }
@@ -298,23 +295,33 @@ export const createFor = (
         }
 
         for (let i = e1; i < e3; i++) {
-          queuedIndices[queuedLength++] = i
+          queuedIndices.push(i)
         }
 
+        const queuedLength = queuedIndices.length
+        const queuedOldIndex: number[] = new Array(queuedLength)
         let mountCounter = 0
 
-        for (let q = queuedLength - 1; q >= 0; q--) {
-          const index = queuedIndices[q]
-          const key = newKeys![index]
-          const oldIndex = oldKeyIndexMap.get(key)
-          if (oldIndex !== undefined) {
-            oldKeyIndexMap.delete(key)
-            const reusedBlock = (newBlocks[index] = oldBlocks[oldIndex])
-            updateAt(reusedBlock, source, index)
-            queuedOldIndex[q] = oldIndex
-          } else {
-            queuedOldIndex[q] = -1
-            mountCounter++
+        if (oldKeyIndexMap.size === 0) {
+          // pure append/replace: nothing to pair up. Plain loop over fill():
+          // the inlined monomorphic store beats the generic builtin on a
+          // freshly allocated (holey) array.
+          for (let q = 0; q < queuedLength; q++) queuedOldIndex[q] = -1
+          mountCounter = queuedLength
+        } else {
+          for (let q = queuedLength - 1; q >= 0; q--) {
+            const index = queuedIndices[q]
+            const key = newKeys![index]
+            const oldIndex = oldKeyIndexMap.get(key)
+            if (oldIndex !== undefined) {
+              oldKeyIndexMap.delete(key)
+              const reusedBlock = (newBlocks[index] = oldBlocks[oldIndex])
+              updateAt(reusedBlock, source, index)
+              queuedOldIndex[q] = oldIndex
+            } else {
+              queuedOldIndex[q] = -1
+              mountCounter++
+            }
           }
         }
 
@@ -349,12 +356,18 @@ export const createFor = (
         // no work here — but a coincidental in-place match inside an
         // otherwise heavily shuffled range splits a segment and can cost
         // more moves than vdom's unpinned whole-range LIS.
-        let keep: boolean[] | undefined
+        let sequence: number[] | undefined
+        let sequenceInput: number[] | undefined
         if (mountCounter !== queuedLength) {
-          keep = new Array(queuedLength)
-          const tailValues: number[] = []
-          const tailPositions: number[] = []
-          const lisParent: number[] = new Array(queuedLength)
+          // `getSequence` input: the old position (+1, so 0 stays free as its
+          // "skip" marker) of every block that is allowed to stay put, and 0
+          // for the rest. Because a segment's eligible old indices all lie
+          // between its two bounding stationaries, and those bounds never
+          // overlap between segments, every value in one segment is smaller
+          // than every value in the next — so one whole-array LIS yields the
+          // same answer as running it per segment.
+          sequenceInput = new Array(queuedLength)
+          let eligible = 0
           let seg = 0
           while (seg < queuedLength) {
             let segEnd = seg
@@ -370,107 +383,85 @@ export const createFor = (
             const lowerBound = queuedIndices[seg] - 1
             const nextIndex = queuedIndices[segEnd] + 1
             const upperBound = nextIndex < e3 ? nextIndex : e2
-            tailValues.length = tailPositions.length = 0
             for (let q = seg; q <= segEnd; q++) {
-              keep[q] = false
               const oldIndex = queuedOldIndex[q]
               if (
+                oldIndex < 0 ||
                 oldIndex <= lowerBound ||
-                oldIndex >= upperBound ||
-                oldIndex < 0
+                oldIndex >= upperBound
               ) {
-                continue
+                sequenceInput[q] = 0
+              } else {
+                sequenceInput[q] = oldIndex + 1
+                eligible++
               }
-              let lo = 0
-              let hi = tailValues.length
-              while (lo < hi) {
-                const mid = (lo + hi) >> 1
-                if (tailValues[mid] < oldIndex) lo = mid + 1
-                else hi = mid
-              }
-              tailValues[lo] = oldIndex
-              lisParent[q] = lo > 0 ? tailPositions[lo - 1] : -1
-              tailPositions[lo] = q
-            }
-            for (
-              let q = tailValues.length
-                ? tailPositions[tailValues.length - 1]
-                : -1;
-              q !== -1;
-              q = lisParent[q]
-            ) {
-              keep[q] = true
             }
             seg = segEnd + 1
           }
-        }
 
-        // Rows removed under a leave transition stay in the DOM until the
-        // animation ends. Only the tail needs special handling: a row landing
-        // at the end would otherwise be inserted at `parentAnchor`, i.e.
-        // *after* those still-animating rows, which reorders them relative to
-        // a surviving neighbor they used to follow. Mid-list insertions anchor
-        // on the next live row, matching vdom (which never steps over leaving
-        // elements either), so ghosts keep their place there.
-        // Only a row landing at the tail while a leave transition is running
-        // needs the ghost set, so it is built on first use rather than per
-        // patch (lists without <TransitionGroup> never build it at all).
-        const hasGhosts = isTransitionEnabled && !!frag.$transition
-        let tailGhostNodes: Set<Node> | undefined
+          if (eligible) sequence = getSequence(sequenceInput)
+        }
 
         // apply back-to-front so every block can anchor on the finalized
         // block after it (kept blocks count as finalized: relative order
         // among all unmoved blocks is already correct)
+        let sequenceEnd = sequence ? sequence.length - 1 : -1
+        // nearest attached node at positions >= scanFrom; positions past it
+        // are already scanned, keeping the whole pass O(newLength) even
+        // across runs of blocks that render nothing
+        let scanFrom = newLength
+        let cachedAnchor: Node | undefined
         for (let q = queuedLength - 1; q >= 0; q--) {
-          const isReuse = queuedOldIndex[q] >= 0
-          if (isReuse && keep![q]) continue
           const index = queuedIndices[q]
+          let isKept = false
+          if (sequenceEnd >= 0 && sequence![sequenceEnd] === q) {
+            sequenceEnd--
+            // `getSequence` seeds its result with index 0, so it can report
+            // a leading entry that was never selected; skip that marker
+            isKept = sequenceInput![q] !== 0
+          }
 
           // A block that renders nothing has no first node, so look past it
           // for the next attached one.
           let anchorNode: Node | undefined
-          for (let i = index + 1; i < newLength; i++) {
+          for (let i = index + 1; i < scanFrom; i++) {
             const node = getBlockFirstNode(newBlocks[i].nodes)
             if (node && node.parentNode) {
               anchorNode = node
               break
             }
           }
-
           if (anchorNode === undefined) {
-            // landing at the tail: step in front of rows still leaving, which
-            // `parentAnchor` alone would place this row after
-            anchorNode = parentAnchor
-            if (hasGhosts) {
-              if (!tailGhostNodes) {
-                tailGhostNodes = new Set()
-                for (const leftoverIndex of oldKeyIndexMap.values()) {
-                  const nodes = oldBlocks[leftoverIndex].nodes
-                  if (isSingleNode) {
-                    tailGhostNodes.add(nodes as Node)
-                  } else {
-                    collectBlockNodes(nodes, tailGhostNodes)
-                  }
+            if (cachedAnchor === undefined) {
+              // Landing at the tail. Rows removed under a leave transition
+              // stay in the DOM until their animation ends, and
+              // `parentAnchor` alone would place this row after them,
+              // reordering them relative to a surviving neighbor they used
+              // to follow (mid-list insertions anchor on the next live row,
+              // matching vdom, so ghosts keep their place there). Ghosts
+              // never move, so the run adjacent to the anchor is exactly
+              // the trailing run of leftovers in old order — step in front
+              // of it.
+              cachedAnchor = parentAnchor
+              if (isTransitionEnabled && frag.$transition) {
+                for (let i = e2 - 1; i >= 0; i--) {
+                  const oldBlock = oldBlocks[i]
+                  if (!oldKeyIndexMap.has(oldBlock.key)) break
+                  const first = getBlockFirstNode(oldBlock.nodes)
+                  if (first && first.parentNode) cachedAnchor = first
                 }
               }
-              let prev = anchorNode.previousSibling
-              while (prev && tailGhostNodes.has(prev)) {
-                anchorNode = prev
-                prev = prev.previousSibling
-              }
             }
+            anchorNode = cachedAnchor
           }
+          scanFrom = index + 1
+          cachedAnchor = anchorNode
 
-          if (isReuse) {
+          if (isKept) continue
+          if (queuedOldIndex[q] >= 0) {
             insertForBlock(newBlocks[index], anchorNode)
           } else {
-            mount(
-              source,
-              index,
-              anchorNode,
-              getItemValue(source, index),
-              newKeys![index],
-            )
+            mount(source, index, anchorNode)
           }
         }
       }
@@ -508,11 +499,9 @@ export const createFor = (
     source: ResolvedSource,
     idx: number,
     anchor: Node | undefined,
-    item: any,
-    key2: any,
   ): ForBlock => {
     const keys = source.keys
-    const itemRef = shallowRef(item)
+    const itemRef = shallowRef(getItemValue(source, idx))
     // avoid creating refs if the render fn doesn't need it
     const keyRef = needKey ? shallowRef(keys ? keys[idx] : idx) : undefined
     const indexRef = needIndex ? shallowRef(keys ? idx : undefined) : undefined
@@ -520,16 +509,15 @@ export const createFor = (
     let nodes: Block
     const scope = new EffectScope(true)
     const prevScope = setCurrentScope(scope)
+    let ok = false
     try {
       nodes = renderItem(itemRef, keyRef as any, indexRef as any)
-    } catch (err) {
+      ok = true
+    } finally {
       // restore before stopping so scope cleanups never observe the dying
       // scope as current (matches the previous scope.run() ordering)
       setCurrentScope(prevScope)
-      scope.stop()
-      throw err
-    } finally {
-      setCurrentScope(prevScope)
+      if (!ok) scope.stop()
     }
 
     const block = (newBlocks[idx] = new ForBlock(
@@ -538,7 +526,7 @@ export const createFor = (
       itemRef,
       keyRef,
       indexRef,
-      key2,
+      newKeys ? newKeys[idx] : undefined,
     ))
 
     // apply transition for new nodes
@@ -554,18 +542,9 @@ export const createFor = (
     return block
   }
 
-  const mountAt = (source: ResolvedSource, idx: number): ForBlock =>
-    mount(
-      source,
-      idx,
-      parentAnchor,
-      getItemValue(source, idx),
-      newKeys ? newKeys[idx] : undefined,
-    )
-
   const mountAll = (source: ResolvedSource, newLength: number): void => {
     for (let i = 0; i < newLength; i++) {
-      mountAt(source, i)
+      mount(source, i, parentAnchor)
     }
   }
 
@@ -602,7 +581,7 @@ export const createFor = (
       if (emptyLocalRange && newLength) {
         reuseBoundaryClose(hydrationStart)
         for (let i = 0; i < newLength; i++) {
-          mountAt(source, i)
+          mount(source, i, parentAnchor)
         }
         setCurrentHydrationNode(parentAnchor)
       } else {
@@ -613,7 +592,7 @@ export const createFor = (
           } else {
             nextNode = nextLogicalSibling(currentHydrationNode!)
           }
-          mountAt(source, i)
+          mount(source, i, parentAnchor)
           if (nextNode) setCurrentHydrationNode(nextNode)
         }
 
@@ -849,30 +828,6 @@ export function createSelector(source: () => any): ForSelector {
     generation++
   }
   return register
-}
-
-// Collects a block's own nodes in the main view, so a sibling walk can tell
-// which nodes belong to a row that is still leaving.
-function collectBlockNodes(block: Block, set: Set<Node>): void {
-  if (!block) {
-    return
-  } else if (block instanceof Node) {
-    set.add(block)
-  } else if (isArray(block)) {
-    for (let i = 0; i < block.length; i++) {
-      collectBlockNodes(block[i], set)
-    }
-  } else if (isVaporComponent(block)) {
-    if (block.block) collectBlockNodes(block.block, set)
-  } else if (isTeleportEnabled && isTeleportFragment(block)) {
-    // teleported content lives in the target container; only the main-view
-    // markers can appear as siblings here
-    if (block.placeholder) set.add(block.placeholder)
-    if (block.anchor) set.add(block.anchor)
-  } else {
-    collectBlockNodes(block.nodes, set)
-    if (block.anchor) set.add(block.anchor)
-  }
 }
 
 function stopBlockScopes(blocks: ForBlock[]): void {

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -397,7 +397,12 @@ export function normalizeBlock(block: Block): Node[] {
   return nodes
 }
 
-export function getBlockFirstNode(block: Block): Node {
+/**
+ * First node of a block as it appears in its own container, or `undefined`
+ * when the block has no node there: an empty array of blocks, or a block
+ * whose content lives elsewhere (a teleport target) and has no marker left.
+ */
+export function getBlockFirstNode(block: Block): Node | undefined {
   if (block instanceof Node) {
     return block
   } else if (isArray(block)) {
@@ -405,7 +410,7 @@ export function getBlockFirstNode(block: Block): Node {
       const anchor = getBlockFirstNode(block[i])
       if (anchor) return anchor
     }
-    return undefined!
+    return undefined
   } else if (isVaporComponent(block)) {
     return getBlockFirstNode(getComponentPhysicalBlock(block))
   } else {

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -409,6 +409,11 @@ export function getBlockFirstNode(block: Block): Node {
   } else if (isVaporComponent(block)) {
     return getBlockFirstNode(getComponentPhysicalBlock(block))
   } else {
+    if (isTeleportEnabled && isTeleportFragment(block)) {
+      // teleported content lives in the target container; in the main view
+      // the fragment starts at its placeholder
+      return (block.placeholder || block.anchor)!
+    }
     const nodes = block.nodes
     // Empty fragments may keep their insertion anchor in `anchor` or in
     // `nodes` (ForFragment).

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -411,8 +411,10 @@ export function getBlockFirstNode(block: Block): Node {
   } else {
     if (isTeleportEnabled && isTeleportFragment(block)) {
       // teleported content lives in the target container; in the main view
-      // the fragment starts at its placeholder
-      return (block.placeholder || block.anchor)!
+      // the fragment starts at its placeholder. Both markers are absent while
+      // hydrating and after removal, so fall through to the generic path.
+      const marker = block.placeholder || block.anchor
+      if (marker) return marker
     }
     const nodes = block.nodes
     // Empty fragments may keep their insertion anchor in `anchor` or in

--- a/packages/runtime-vapor/src/directives/vModel.ts
+++ b/packages/runtime-vapor/src/directives/vModel.ts
@@ -11,7 +11,6 @@ import {
 } from '@vue/runtime-dom'
 import { renderEffect } from '../renderEffect'
 import { looseEqual } from '@vue/shared'
-import { addEventListener } from '../dom/event'
 import { traverse } from '@vue/reactivity'
 
 type VaporModelDirective<
@@ -72,7 +71,8 @@ export const applyRadioModel: VaporModelDirective<HTMLInputElement> = (
   get,
   set,
 ) => {
-  addEventListener(el, 'change', () => set(vModelGetValue(el)))
+  // static listener: lives and dies with the element, no disposer needed
+  el.addEventListener('change', () => set(vModelGetValue(el)))
   ensureMounted(() => {
     let value: any
     renderEffect(() => {

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -26,13 +26,14 @@ export function on(
   el: Element,
   event: string,
   handler: EventHandlerValue,
-  options: AddEventListenerOptions = {},
+  options?: AddEventListenerOptions,
 ): void {
   if (isArray(handler)) {
     handler.forEach(fn => on(el, event, fn, options))
   } else {
     if (!handler) return
-    addEventListener(el, event, createInvoker(handler), options)
+    // no cleanup closure: static listeners live and die with the element
+    el.addEventListener(event, createInvoker(handler), options)
   }
 }
 
@@ -40,7 +41,7 @@ export function onBinding(
   el: Element,
   event: string,
   handler: EventHandlerValue,
-  options: AddEventListenerOptions = {},
+  options?: AddEventListenerOptions,
 ): void {
   if (isArray(handler)) {
     handler.forEach(fn => onBinding(el, event, fn, options))

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -253,9 +253,6 @@ export class ForFragment extends VaporFragment<Block[]> {
 export class ForBlock extends VaporFragment {
   scope: EffectScope | undefined
   key: any
-  prev?: ForBlock
-  next?: ForBlock
-  prevAnchor?: ForBlock
 
   itemRef: ShallowRef<any>
   keyRef: ShallowRef<any> | undefined

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -58,6 +58,7 @@ export class RenderEffect extends ReactiveEffect {
     }
 
     this.i = instance
+    this.job = undefined
 
     // Allow self re-queue when render/hook logic mutates reactive state.
     // Safe in Vapor because updates are always async via queueJob(), and

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -78,14 +78,14 @@ export class RenderEffect extends ReactiveEffect {
           this.i.deferredKeepAliveUpdates
         if (deferred) {
           if (isDeferredKeepAliveStateLive(deferred)) {
-            deferred.effects.push(this.job!)
+            deferred.effects.push(job)
             return
           }
           // The pending root can no longer resolve through this state
           // (unmounted early or superseded suspense cycle) - drop the stale
           // state and replay its buffered updates together with this job in
           // scheduler order (this job re-enters with the state cleared).
-          settleDeferredKeepAliveUpdates(deferred, this.job!)
+          settleDeferredKeepAliveUpdates(deferred, job)
           return
         }
         this.run()

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -25,7 +25,8 @@ export class RenderEffect extends ReactiveEffect {
   i: VaporComponentInstance | null
   // Created lazily on first notify: most render effects are never
   // scheduled individually, so eagerly allocating the job closure at
-  // creation time is pure overhead in list-mount hot paths.
+  // creation time is pure overhead in list-mount hot paths. The constructor
+  // still primes the field to keep every instance on one hidden class.
   job?: SchedulerJob
   updateJob?: SchedulerJob
   render: () => void

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -23,7 +23,10 @@ import { isSuspenseEnabled } from './suspense'
 
 export class RenderEffect extends ReactiveEffect {
   i: VaporComponentInstance | null
-  job: SchedulerJob
+  // Created lazily on first notify: most render effects are never
+  // scheduled individually, so eagerly allocating the job closure at
+  // creation time is pure overhead in list-mount hot paths.
+  job?: SchedulerJob
   updateJob?: SchedulerJob
   render: () => void
   // Creation order within the owning component.
@@ -36,31 +39,6 @@ export class RenderEffect extends ReactiveEffect {
     this.order = instance ? instance.effectCount++ : 0
     if (__DEV__ && !__TEST__ && !this.subs && !isVaporComponent(instance)) {
       warn('renderEffect called without active EffectScope or Vapor instance.')
-    }
-
-    const job: SchedulerJob = () => {
-      // The job may already be queued when its owning scope is paused.
-      if (!(this.flags & EffectFlags.PAUSED) && this.dirty) {
-        // A pending KeepAlive async root defers updates along its root chain.
-        const deferred =
-          __FEATURE_SUSPENSE__ &&
-          isSuspenseEnabled &&
-          this.i &&
-          this.i.deferredKeepAliveUpdates
-        if (deferred) {
-          if (isDeferredKeepAliveStateLive(deferred)) {
-            deferred.effects.push(this.job)
-            return
-          }
-          // The pending root can no longer resolve through this state
-          // (unmounted early or superseded suspense cycle) - drop the stale
-          // state and replay its buffered updates together with this job in
-          // scheduler order (this job re-enters with the state cleared).
-          settleDeferredKeepAliveUpdates(deferred, this.job)
-          return
-        }
-        this.run()
-      }
     }
 
     if (instance) {
@@ -77,17 +55,44 @@ export class RenderEffect extends ReactiveEffect {
       if (__DEV__) {
         ;(instance.renderEffects ||= []).push(this)
       }
-      job.i = instance
     }
 
-    this.job = job
     this.i = instance
 
     // Allow self re-queue when render/hook logic mutates reactive state.
     // Safe in Vapor because updates are always async via queueJob(), and
     // isUpdating prevents duplicate bu/u hooks on re-entry.
     this.flags |= EffectFlags.ALLOW_RECURSE
-    this.job.flags! |= SchedulerJobFlags.ALLOW_RECURSE
+  }
+
+  createJob(): SchedulerJob {
+    const job: SchedulerJob = () => {
+      // The job may already be queued when its owning scope is paused.
+      if (!(this.flags & EffectFlags.PAUSED) && this.dirty) {
+        // A pending KeepAlive async root defers updates along its root chain.
+        const deferred =
+          __FEATURE_SUSPENSE__ &&
+          isSuspenseEnabled &&
+          this.i &&
+          this.i.deferredKeepAliveUpdates
+        if (deferred) {
+          if (isDeferredKeepAliveStateLive(deferred)) {
+            deferred.effects.push(this.job!)
+            return
+          }
+          // The pending root can no longer resolve through this state
+          // (unmounted early or superseded suspense cycle) - drop the stale
+          // state and replay its buffered updates together with this job in
+          // scheduler order (this job re-enters with the state cleared).
+          settleDeferredKeepAliveUpdates(deferred, this.job!)
+          return
+        }
+        this.run()
+      }
+    }
+    if (this.i) job.i = this.i
+    job.flags! |= SchedulerJobFlags.ALLOW_RECURSE
+    return (this.job = job)
   }
 
   fn(): void {
@@ -132,7 +137,12 @@ export class RenderEffect extends ReactiveEffect {
   notify(): void {
     const flags = this.flags
     if (!(flags & EffectFlags.PAUSED)) {
-      queueJob(this.job, this.i ? this.i.uid : undefined, false, this.order)
+      queueJob(
+        this.job || this.createJob(),
+        this.i ? this.i.uid : undefined,
+        false,
+        this.order,
+      )
     }
   }
 }


### PR DESCRIPTION
- avoid per-item [item, key, index] tuple allocations in createFor:
  getItemValue + positional args, parallel queued arrays instead of
  MountOper/MoveOper objects, direct-build key index map
- enter item scopes via setCurrentScope instead of a per-row
  scope.run() closure
- create RenderEffect scheduler jobs lazily on first notify
- drop the per-listener cleanup closure in the static on() path and
  the default options object in on()/onBinding()

## Benchmarks

In-repo harness (`packages-private/benchmark`), headless Chrome 151,
`page.emulateCPUThrottling(4)`, 5 warmup + 30 recorded rounds, medians in ms.

**Both sides use `@click.delegate` on the row handlers**, so the table isolates
the runtime change — event delegation contributes nothing to these deltas.

| op | `minor` | this branch | Δ |
| --- | --- | --- | --- |
| create 1,000 rows | 16.8 | **15.9** | −5% |
| append 1,000 rows | 18.5 | **17.3** | −6% |
| create 10,000 rows | 187.9 | **173.0** | −8% |
| **swap rows** | 1.7 | **1.1** | **−35%** |
| **remove row** | 1.0 | **0.6** | **−40%** |
| clear rows | 16.5 | 15.8 | −4% |
| partial update | 1.3 | 1.5 | noise |

`swap` and `remove` are unaffected by delegation either way, so those are
entirely this branch's.

### Cross-checked on js-framework-benchmark

Against a `vue-vapor` entry pinned to `3.6.0-rc.4` (this branch's merge base),
identical app, both delegating — 25 rounds, script duration:

| op | rc.4 | this branch | Δ |
| --- | --- | --- | --- |
| swap rows | 2.14 | **1.70** | −20% |
| remove row | 0.96 | **0.82** | −15% |
| replace 1k | 15.24 | **14.30** | −6% |
| clear rows | 20.76 | **19.82** | −5% |
| create 10k | 101.72 | **99.06** | −3% |
| geometric mean | 6.10 | **5.80** | **−5%** |

No benchmark regressed outside noise (all |t| < 2 except the wins above).

### Move planning (not covered by js-framework-benchmark)

The keyed-diff rewrite targets reorder patterns jsfb doesn't measure. Wall time
for reordering 1,000 laid-out rows, old chain heuristic vs the new planner:

| pattern | before | after | DOM moves |
| --- | --- | --- | --- |
| move last row to front | 22.6 | **1.7** (**13×**) | 999 → 1 |
| move middle row to front | — | — | 500 → 1 |
| shuffle | 27.8 | 24.4 (−12%) | 995 → 944 |
| reverse (control) | 21.0 | 20.2 (parity) | 999 → 999 |
| swap (jsfb gate) | 1.3 | 1.4 (parity) | 2 → 2 |

The old apply pass cascaded on backward moves — dragging one row toward the
front moved every row in between. `reverse` is the control: both algorithms
must move n−1 rows there and they tie, confirming the delta is move-count
driven, and `swap` confirms the jsfb-measured op does not regress.

Move counts are also no longer bounded away from the optimum by a coincidental
in-place match: `[0..8] → [5,6,7,8,4,0,1,2,3]` went from 8 moves to 5 (the
unbounded-LIS minimum), with the adversarial family `[0..2m] → [m+1..2m, m,
0..m-1]` previously approaching 2× the minimum.

### Caveat

Because the row handlers go through delegation, neither harness exercises this
PR's removal of the discarded cleanup closure in the static `on()` path — that
change's benefit is not visible in these numbers.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyed list reordering for more reliable DOM placement, including rows that render no elements.
  * Fixed teleport content positioning during keyed mid-list reordering.
  * Improved handling of transition placeholders and hydrated content during list updates.

* **Improvements**
  * Improved event listener handling and radio input updates.
  * Reduced unnecessary work during rendering and list reconciliation.
  * Improved benchmark control and row interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->