### PR TITLE
chore: enable pnpm trustPolicy: no-downgrade (supply-chain defense-in-depth)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,3 +31,5 @@ peerDependencyRules:
     '@typescript-eslint/utils>eslint': '^9.0.0'
 
 minimumReleaseAge: 1440
+
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

Enable pnpm's `trustPolicy: no-downgrade` in `pnpm-workspace.yaml` as an **optional supply-chain defense-in-depth** measure.

```diff
 minimumReleaseAge: 1440
+
+trustPolicy: no-downgrade
```

This is the focused follow-up that a maintainer invited when closing #15326:

> A focused proposal for `trustPolicy` may be considered separately with an appropriate rationale and clean, frozen-lockfile installation validation.

## Framing

This is **not** a vulnerability fix — it is optional defense-in-depth. I've dropped the two unrelated changes from #15326 that were rightly rejected (see "Scope" below).

## Rationale

[`trustPolicy`](https://pnpm.io/settings/dependency-resolution#trustpolicy) was added in pnpm **v10.21.0**; this repo pins `pnpm@11.13.0`, so it's supported. Its default is `off`.

With `no-downgrade`, pnpm fails an install when a dependency's *publishing trust level regresses* relative to an earlier release — e.g. a package that was previously published by a trusted publisher now arrives with only provenance or no trust evidence. The check is based on publish date rather than semver, so a version can't be installed if an earlier-published version had stronger trust evidence.

This is an independent signal that **complements** the existing `minimumReleaseAge`: where `minimumReleaseAge` buys time for the ecosystem to catch and pull malicious releases, `trustPolicy` catches a sudden drop in publishing trust evidence — a distinct compromise indicator.

## Scope (deliberately narrow)

Compared to #15326, this PR **excludes**:
- **`minimumReleaseAge` bump (1440 → 10080)** — kept at `1440` to stay consistent with `.github/renovate.json5`'s `minimumReleaseAge: '24 hours'`.
- **`blockExoticSubdeps: true`** — already the default in pnpm 11, so it's redundant.

Net change: `+2 -0`, one file.

## Validation — clean frozen-lockfile install

```
$ pnpm --version
11.13.0

$ pnpm install --frozen-lockfile
...
Done in 54s using pnpm v11.13.0

$ git diff --exit-code pnpm-lock.yaml && echo "lockfile unchanged ✓"
lockfile unchanged ✓
```

`pnpm install --frozen-lockfile` succeeds with no trust/lockfile errors, and `pnpm-lock.yaml` is byte-identical — enabling `trustPolicy` did not force any resolution changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a workspace package policy that prevents dependency versions from being downgraded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->