### PR TITLE
fix(suspense): don't treat the leaving branch as the fallback while its mount is pending

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -674,10 +674,14 @@ function createSuspenseBoundary(
         if (!suspense.isInFallback) {
           return
         }
+        // a parent update may have produced a newer fallback vnode while the
+        // mount was deferred (its patch is skipped during that window), so
+        // mount the latest one
+        const latestFallback = suspense.vnode.ssFallback!
         // mount the fallback tree
         patch(
           null,
-          fallbackVNode,
+          latestFallback,
           container,
           anchor,
           parentComponent,
@@ -686,7 +690,7 @@ function createSuspenseBoundary(
           slotScopeIds,
           optimized,
         )
-        setActiveBranch(suspense, fallbackVNode)
+        setActiveBranch(suspense, latestFallback)
       }
 
       const delayEnter =

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -266,7 +266,13 @@ function patchSuspense(
         // because we aren't actually showing a fallback content when
         // patchSuspense is called. In such case, patch of fallback content
         // should be no op
-        if (!isHydrating) {
+        // The same applies while the fallback mount is deferred to the leaving
+        // branch's afterLeave (out-in transition): activeBranch is still the
+        // leaving content, not the fallback. Patching it with the fallback here
+        // would hijack activeBranch, and resolve() would then attach the
+        // content move to an afterLeave that never fires, permanently dropping
+        // the resolved branch.
+        if (!isHydrating && !suspense.isFallbackMountPending) {
           patch(
             activeBranch,
             newFallback,
@@ -316,7 +322,9 @@ function patchSuspense(
         )
         if (suspense.deps <= 0) {
           suspense.resolve()
-        } else {
+        } else if (!suspense.isFallbackMountPending) {
+          // while the fallback mount is deferred to the leaving branch's
+          // afterLeave, activeBranch is still the leaving content — see above
           patch(
             activeBranch,
             newFallback,

--- a/packages/vue/__tests__/e2e/Transition.spec.ts
+++ b/packages/vue/__tests__/e2e/Transition.spec.ts
@@ -2242,6 +2242,83 @@ describe('e2e: Transition', () => {
       E2E_TIMEOUT,
     )
 
+    // a parent update that changes the fallback content while its mount is
+    // deferred must mount the latest fallback, not the stale one
+    test(
+      'fallback updated by parent while its mount is deferred',
+      async () => {
+        await page().evaluate(() => {
+          const { createApp, shallowRef, ref, h, defineAsyncComponent } = (
+            window as any
+          ).Vue
+          const One = {
+            setup() {
+              return () => h('div', { class: 'test' }, 'one')
+            },
+          }
+          const Two = {
+            async setup() {
+              return () => h('div', { class: 'test' }, 'two')
+            },
+          }
+          const AsyncTwo = defineAsyncComponent(
+            () =>
+              new Promise(res => {
+                ;(window as any).resolveTwo = () => res(Two as any)
+              }),
+          )
+          createApp({
+            template: `
+              <div id="container">
+                <transition mode="out-in" :duration="300">
+                  <Suspense :timeout="10">
+                    <component :is="view" :key="name" :data-tick="tick"/>
+                    <template #fallback><div class="fallback">loading {{ tick }}</div></template>
+                  </Suspense>
+                </transition>
+              </div>
+              <button id="toggleBtn" @click="click">button</button>
+              <button id="tickBtn" @click="tick++">tick</button>
+            `,
+            setup: () => {
+              const view = shallowRef(One)
+              const name = ref('one')
+              const tick = ref(0)
+              const click = () => {
+                view.value = AsyncTwo
+                name.value = 'two'
+              }
+              return { view, name, tick, click }
+            },
+          }).mount('#app')
+        })
+        await transitionFinish()
+        expect(await html('#container')).toBe(
+          '<div class="test" data-tick="0">one</div>',
+        )
+
+        // navigate to the cold async branch; the fallback mount is deferred
+        // to the old branch's afterLeave
+        await click('#toggleBtn')
+        await timeout(10 + buffer)
+        // parent update changes the fallback content while its mount is
+        // still deferred
+        await click('#tickBtn')
+        // let the leave finish so the (latest) fallback mounts
+        await transitionFinish(300)
+        await nextTick()
+        expect(await html('#container')).toContain('loading 1')
+        // the async branch resolves after the leave completed
+        await page().evaluate(() => (window as any).resolveTwo())
+        await transitionFinish(300)
+        await transitionFinish(300)
+        await nextTick()
+        expect(await html('#container')).toContain('two')
+        expect(await html('#container')).not.toContain('loading')
+      },
+      E2E_TIMEOUT,
+    )
+
     // #14640
     test(
       'switch suspense branches after teleport updates before pending mount finishes',

--- a/packages/vue/__tests__/e2e/Transition.spec.ts
+++ b/packages/vue/__tests__/e2e/Transition.spec.ts
@@ -2169,6 +2169,79 @@ describe('e2e: Transition', () => {
       E2E_TIMEOUT,
     )
 
+    // a parent update arriving while the timed-out fallback swap is waiting
+    // for the leaving branch's afterLeave must not drop the resolved branch
+    test(
+      'parent update during timed-out fallback swap with out-in transition',
+      async () => {
+        await page().evaluate(() => {
+          const { createApp, shallowRef, ref, h, defineAsyncComponent } = (
+            window as any
+          ).Vue
+          const One = {
+            setup() {
+              return () => h('div', { class: 'test' }, 'one')
+            },
+          }
+          const Two = {
+            async setup() {
+              return () => h('div', { class: 'test' }, 'two')
+            },
+          }
+          const AsyncTwo = defineAsyncComponent(
+            () =>
+              new Promise(res => {
+                ;(window as any).resolveTwo = () => res(Two as any)
+              }),
+          )
+          createApp({
+            template: `
+              <div id="container">
+                <transition mode="out-in" :duration="300">
+                  <Suspense :timeout="10">
+                    <component :is="view" :key="name" :data-tick="tick"/>
+                    <template #fallback><div class="fallback">loading</div></template>
+                  </Suspense>
+                </transition>
+              </div>
+              <button id="toggleBtn" @click="click">button</button>
+              <button id="tickBtn" @click="tick++">tick</button>
+            `,
+            setup: () => {
+              const view = shallowRef(One)
+              const name = ref('one')
+              const tick = ref(0)
+              const click = () => {
+                view.value = AsyncTwo
+                name.value = 'two'
+              }
+              return { view, name, tick, click }
+            },
+          }).mount('#app')
+        })
+        await transitionFinish()
+        expect(await html('#container')).toBe(
+          '<div class="test" data-tick="0">one</div>',
+        )
+
+        // navigate to the cold async branch; timeout=10 starts the fallback
+        // swap and the old branch's leave transition
+        await click('#toggleBtn')
+        await timeout(10 + buffer)
+        // unrelated parent re-render while the fallback mount is deferred to
+        // the leaving branch's afterLeave
+        await click('#tickBtn')
+        // the async branch resolves while the leave is still in progress
+        await page().evaluate(() => (window as any).resolveTwo())
+        await transitionFinish(300)
+        await transitionFinish(300)
+        await nextTick()
+        expect(await html('#container')).toContain('two')
+        expect(await html('#container')).not.toContain('loading')
+      },
+      E2E_TIMEOUT,
+    )
+
     // #14640
     test(
       'switch suspense branches after teleport updates before pending mount finishes',


### PR DESCRIPTION
close #15332

When `<Suspense timeout>` is wrapped in `<Transition mode="out-in">`, the fallback mount is deferred to the leaving branch's `afterLeave`. A parent update arriving in that window hit `patchSuspense`'s `isInFallback` paths, which patched `activeBranch` (still the leaving content) into the fallback and made it the active branch without clearing `isFallbackMountPending`. `resolve()` then skipped unmounting the active branch (the flag was still set) yet attached the content insertion to its `afterLeave` — which never fires for a branch that is never unmounted, so the resolved content was permanently dropped and the fallback stayed on screen.

This PR skips the fallback patch while `isFallbackMountPending` is true: the fallback is not the active branch yet, and `mountFallback` will bring it in on `afterLeave` as intended.

Regression introduced by 908c6ad05 (#9392), first released in v3.5.31; 3.5.30 is unaffected.

Verification:
- deterministic reproduction in #15332 (fails on the first run on 3.5.31+, passes on 3.5.30);
- added e2e regression test `parent update during timed-out fallback swap with out-in transition` — fails without the fix, passes with it;
- full Transition e2e suite passes (57/57, including the #9392 test, so #7966 is not reintroduced); Suspense + BaseTransition unit suites pass (97/97).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Suspense fallback transitions with out-in animations.
  * Prevented resolved content from being replaced prematurely during fallback swaps.
  * Ensured fallback content is removed correctly after the async branch resolves.
  * Updated deferred fallback rendering to reflect the latest parent content.

* **Tests**
  * Added regression coverage for parent updates during animated Suspense fallback transitions.
  * Added coverage for fallback updates before an asynchronous branch resolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->