### PR TITLE
fix(runtime-vapor): set value as attribute so form reset restores it

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -418,6 +418,12 @@ describe('patchProp', () => {
       expect(el.value).toBe(obj.toString())
       expect((el as any)._value).toBe(obj)
 
+      const div = document.createElement('div')
+      const symbol = Symbol('foo')
+      setValue(div, symbol)
+      expect((div as any).value).toBe(symbol)
+      expect(div.getAttribute('value')).toBe(symbol.toString())
+
       const option = document.createElement('option')
       setElementText(option, 'foo')
       expect(option.value).toBe('foo')

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -428,6 +428,22 @@ describe('patchProp', () => {
       expect(option.value).toBe('bar')
       expect(option.getAttribute('value')).toBe('bar')
     })
+
+    test('should set value as attribute so form reset works', () => {
+      const form = document.createElement('form')
+      const el = document.createElement('input')
+      el.type = 'range'
+      el.min = '0'
+      el.max = '100'
+      form.appendChild(el)
+
+      setValue(el, 30)
+      expect(el.getAttribute('value')).toBe('30')
+
+      el.value = '80'
+      form.reset()
+      expect(el.value).toBe('30')
+    })
   })
 
   describe('setDOMProp', () => {

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -400,8 +400,12 @@ export function setValue(
   if (oldValue !== newValue) {
     el.value = newValue
   }
+  // #6007 also set form state as attributes so they work with
+  // <input type="reset"> or libs / extensions that expect attributes
   if (value == null) {
     el.removeAttribute('value')
+  } else {
+    el.setAttribute('value', newValue)
   }
 }
 

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -405,7 +405,7 @@ export function setValue(
   if (value == null) {
     el.removeAttribute('value')
   } else {
-    el.setAttribute('value', newValue)
+    el.setAttribute('value', isSymbol(newValue) ? String(newValue) : newValue)
   }
 }
 

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -400,7 +400,7 @@ export function setValue(
   if (oldValue !== newValue) {
     el.value = newValue
   }
-  // #6007 also set form state as attributes so they work with
+  // #6007 also set value as an attribute so it works with
   // <input type="reset"> or libs / extensions that expect attributes
   if (value == null) {
     el.removeAttribute('value')


### PR DESCRIPTION
`value` on an `<input>` is not a reflected attribute, so writing the property leaves the content attribute absent. `form.reset()` restores from that attribute, so a vapor-rendered control with a bound `:value` resets to the browser fallback instead of its initial value.

`setValue` now mirrors the property write onto the attribute, the same way vdom's `patchProp` has since #6007.

close #15338


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization between element values and their `value` attributes.
  - Symbol values are now correctly converted to text.
  - Resetting range inputs now properly removes the associated value attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->