### PR TITLE
fix(runtime-vapor): do not skip the initial DOM prop set

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -467,7 +467,7 @@ describe('patchProp', () => {
 
       const img = document.createElement('img')
       setProp(img, 'width', 0)
-      expect(img.hasAttribute('width')).toBe(false) // skipped
+      expect(img.getAttribute('width')).toBe('0')
 
       setProp(img, 'width', null)
       expect(img.hasAttribute('width')).toBe(false)
@@ -478,6 +478,20 @@ describe('patchProp', () => {
       expect(img.hasAttribute('width')).toBe(false)
       setProp(img, 'width', 1)
       expect(img.hasAttribute('width')).toBe(true)
+    })
+
+    test('should set prop whose value matches the element default', () => {
+      const input = document.createElement('input')
+      setProp(input, 'type', 'text')
+      expect(input.getAttribute('type')).toBe('text')
+
+      const button = document.createElement('button')
+      setProp(button, 'type', 'submit')
+      expect(button.getAttribute('type')).toBe('submit')
+
+      const form = document.createElement('form')
+      setProp(form, 'method', 'get')
+      expect(form.getAttribute('method')).toBe('get')
     })
 
     test('should warn when set prop error', () => {

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -480,6 +480,7 @@ describe('patchProp', () => {
       expect(img.hasAttribute('width')).toBe(true)
     })
 
+    // #15339
     test('should set prop whose value matches the element default', () => {
       const input = document.createElement('input')
       setProp(input, 'type', 'text')

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -158,11 +158,14 @@ export function setDOMProp(
     }
   }
 
+  // the initial set must go through even when the value matches the property
+  // default, since reflected attributes only exist once assigned
+  const cacheKey = `$p$${key}`
   const prev = el[key]
-  if (value === prev && `$${key}` in el) {
+  if (value === prev && cacheKey in el) {
     return
   }
-  el[`$${key}`] = value
+  el[cacheKey] = value
 
   let needRemove = false
   if (value === '' || value == null) {

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -159,9 +159,10 @@ export function setDOMProp(
   }
 
   const prev = el[key]
-  if (value === prev) {
+  if (value === prev && `$${key}` in el) {
     return
   }
+  el[`$${key}`] = value
 
   let needRemove = false
   if (value === '' || value == null) {


### PR DESCRIPTION
`setDOMProp` compares the incoming value with the live DOM property, so a binding whose value happens to equal the element's default property value is never assigned. `type` is a reflected attribute that only comes into existence through that assignment, so `<input :type="'text'">` and `<button :type="'submit'">` render with no `type` attribute at all, while vdom writes it. Same for anything else that has a non-empty default, e.g. `<form :method="'get'">` or `<input :size="20">`.

Skipping now also requires that the prop was already set once on that element, so the initial set always goes through and repeated no-op updates stay skipped.

close #15339


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DOM properties so initial values are correctly written as attributes, even when they match the element’s default.
  * Ensured values such as image width `0`, input and button types, and form methods are reflected correctly in the DOM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->