### PR TITLE
fix(types): keep optional runtime props optional in function defineComponent

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1544,6 +1544,32 @@ describe('function syntax w/ runtime props', () => {
   // @ts-expect-error bar doesn't exist
   expectType<JSX.Element>(<Comp3 msg="1" bar="2" />)
 
+  // #13964 function syntax: optional runtime props must stay optional
+  const CompOptional = defineComponent(
+    props => {
+      expectType<string | undefined>(props.p1)
+      expectType<number | undefined>(props.p2)
+      expectType<boolean | undefined>(props.p3)
+      expectType<string>(props.p4)
+      return () => {}
+    },
+    {
+      props: {
+        p1: String,
+        p2: { type: Number },
+        p3: { type: Boolean, required: false },
+        p4: { type: String, required: true },
+      },
+    },
+  )
+
+  expectType<JSX.Element>(<CompOptional p4="ok" />)
+  expectType<JSX.Element>(<CompOptional p1="a" p2={1} p3={false} p4="ok" />)
+  // @ts-expect-error p4 is required
+  expectType<JSX.Element>(<CompOptional />)
+  // @ts-expect-error p4 type is incorrect
+  expectType<JSX.Element>(<CompOptional p4={1} />)
+
   // @ts-expect-error string prop names don't match
   defineComponent(
     (_props: { msg: string }) => {
@@ -1554,13 +1580,13 @@ describe('function syntax w/ runtime props', () => {
     },
   )
 
+  // @ts-expect-error prop type mismatch
   defineComponent(
     (_props: { msg: string }) => {
       return () => {}
     },
     {
       props: {
-        // @ts-expect-error prop type mismatch
         msg: Number,
       },
     },

--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1,5 +1,6 @@
 import {
   type Component,
+  type ComponentObjectPropsOptions,
   type ComponentOptions,
   type ComponentPublicInstance,
   type PropType,
@@ -1618,6 +1619,20 @@ describe('function syntax w/ runtime props', () => {
   )
   expectType<JSX.Element>(<CompExactOptional />)
   expectType<JSX.Element>(<CompExactOptional msg="ok" />)
+
+  const runtimeProps: ComponentObjectPropsOptions<{ msg: string }> = {
+    msg: { type: String, required: true },
+  }
+  const CompHoisted = defineComponent(
+    props => {
+      expectType<string>(props.msg)
+      return () => {}
+    },
+    { props: runtimeProps },
+  )
+  expectType<JSX.Element>(<CompHoisted msg="ok" />)
+  // @ts-expect-error msg is required
+  expectType<JSX.Element>(<CompHoisted />)
 
   // @ts-expect-error string prop names don't match
   defineComponent(

--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1597,6 +1597,28 @@ describe('function syntax w/ runtime props', () => {
   })
   expectType<JSX.Element>(<CompAnnotated />)
 
+  // annotation equal to resolved setup type: public contract is still ExtractPublicPropTypes
+  const CompExactBool = defineComponent(
+    (_: Readonly<{ flag: boolean }>) => () => {},
+    { props: { flag: Boolean } },
+  )
+  expectType<JSX.Element>(<CompExactBool />)
+  expectType<JSX.Element>(<CompExactBool flag={true} />)
+
+  const CompExactDefault = defineComponent(
+    (_: Readonly<{ foo: string }>) => () => {},
+    { props: { foo: { type: String, default: 'x' } } },
+  )
+  expectType<JSX.Element>(<CompExactDefault />)
+  expectType<JSX.Element>(<CompExactDefault foo="y" />)
+
+  const CompExactOptional = defineComponent(
+    (_: Readonly<{ msg: string | undefined }>) => () => {},
+    { props: { msg: String } },
+  )
+  expectType<JSX.Element>(<CompExactOptional />)
+  expectType<JSX.Element>(<CompExactOptional msg="ok" />)
+
   // @ts-expect-error string prop names don't match
   defineComponent(
     (_props: { msg: string }) => {

--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1551,6 +1551,8 @@ describe('function syntax w/ runtime props', () => {
       expectType<number | undefined>(props.p2)
       expectType<boolean | undefined>(props.p3)
       expectType<string>(props.p4)
+      // @ts-expect-error props should be readonly
+      props.p4 = 'value'
       return () => {}
     },
     {

--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1549,7 +1549,7 @@ describe('function syntax w/ runtime props', () => {
     props => {
       expectType<string | undefined>(props.p1)
       expectType<number | undefined>(props.p2)
-      expectType<boolean | undefined>(props.p3)
+      expectType<boolean>(props.p3)
       expectType<string>(props.p4)
       // @ts-expect-error props should be readonly
       props.p4 = 'value'
@@ -1571,6 +1571,31 @@ describe('function syntax w/ runtime props', () => {
   expectType<JSX.Element>(<CompOptional />)
   // @ts-expect-error p4 type is incorrect
   expectType<JSX.Element>(<CompOptional p4={1} />)
+
+  // resolved setup vs public contract: Boolean / default are present in setup
+  const CompResolved = defineComponent(
+    props => {
+      expectType<boolean>(props.flag)
+      expectType<string>(props.foo)
+      return () => {}
+    },
+    {
+      props: {
+        flag: Boolean,
+        foo: { type: String, default: 'x' },
+      },
+    },
+  )
+  expectType<JSX.Element>(<CompResolved />)
+  expectType<JSX.Element>(<CompResolved flag={true} foo="y" />)
+
+  // annotated setup must keep the existing object-props overload
+  const CompAnnotated = defineComponent((_: { msg?: string }) => () => {}, {
+    props: {
+      msg: { type: String, required: true },
+    },
+  })
+  expectType<JSX.Element>(<CompAnnotated />)
 
   // @ts-expect-error string prop names don't match
   defineComponent(

--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -3,6 +3,7 @@ import {
   type ComponentObjectPropsOptions,
   type ComponentOptions,
   type ComponentPublicInstance,
+  type DefineSetupFnComponent,
   type PropType,
   type SetupContext,
   type Slots,
@@ -1424,6 +1425,14 @@ describe('function syntax w/ emits', () => {
 })
 
 describe('function syntax w/ runtime props', () => {
+  type AnySetupInstance = InstanceType<DefineSetupFnComponent<any>>
+  expectType<IsAny<AnySetupInstance>>(true)
+
+  const CompAny = defineComponent((_props: any) => () => {}, {
+    props: { msg: String },
+  })
+  expectType<IsAny<InstanceType<typeof CompAny>>>(true)
+
   // with runtime props, the runtime props must match
   // manual type declaration
   const Comp1 = defineComponent(
@@ -1646,6 +1655,38 @@ describe('function syntax w/ runtime props', () => {
   expectType<JSX.Element>(<CompMixed msg="ok" />)
   // @ts-expect-error msg is required
   expectType<JSX.Element>(<CompMixed />)
+
+  const narrowedRuntimeProps: Record<'msg', PropType<string> | null> = {
+    msg: String,
+  }
+  const CompNarrowed = defineComponent(
+    props => {
+      expectType<string>(props.msg)
+      return () => {}
+    },
+    { props: narrowedRuntimeProps },
+  )
+  expectType<JSX.Element>(<CompNarrowed msg="ok" />)
+  // @ts-expect-error msg is required
+  expectType<JSX.Element>(<CompNarrowed />)
+  // @ts-expect-error msg must use the inferred string payload
+  expectType<JSX.Element>(<CompNarrowed msg={1} />)
+
+  const neverRuntimeProps: ComponentObjectPropsOptions<{ value: never }> = {
+    value: { type: null, required: true },
+  }
+  const CompNever = defineComponent(
+    props => {
+      expectType<never>(props.value)
+      return () => {}
+    },
+    { props: neverRuntimeProps },
+  )
+  expectType<JSX.Element>(<CompNever value={undefined as never} />)
+  // @ts-expect-error value remains required
+  expectType<JSX.Element>(<CompNever />)
+  // @ts-expect-error value retains the never payload
+  expectType<JSX.Element>(<CompNever value="nope" />)
 
   const resolvedVm = {} as InstanceType<typeof CompResolved>
   expectType<boolean>(resolvedVm.flag)

--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1634,6 +1634,23 @@ describe('function syntax w/ runtime props', () => {
   // @ts-expect-error msg is required
   expectType<JSX.Element>(<CompHoisted />)
 
+  const mixedProps = { ...runtimeProps, count: Number }
+  const CompMixed = defineComponent(
+    props => {
+      expectType<string>(props.msg)
+      expectType<number | undefined>(props.count)
+      return () => {}
+    },
+    { props: mixedProps },
+  )
+  expectType<JSX.Element>(<CompMixed msg="ok" />)
+  // @ts-expect-error msg is required
+  expectType<JSX.Element>(<CompMixed />)
+
+  const resolvedVm = {} as InstanceType<typeof CompResolved>
+  expectType<boolean>(resolvedVm.flag)
+  expectType<string>(resolvedVm.foo)
+
   // @ts-expect-error string prop names don't match
   defineComponent(
     (_props: { msg: string }) => {

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -125,23 +125,27 @@ export type DefineSetupFnComponent<
   S extends SlotsType = SlotsType,
   Props = P & EmitsToProps<E>,
   PP = PublicProps,
-> = new (
-  props: Props & PP,
-) => CreateComponentPublicInstanceWithMixins<
-  Props,
-  {},
-  {},
-  {},
-  {},
-  ComponentOptionsMixin,
-  ComponentOptionsMixin,
-  E,
-  PP,
-  {},
-  false,
-  {},
-  S
->
+  InstanceProps = Props,
+> = new (props: Props & PP) => Omit<
+  CreateComponentPublicInstanceWithMixins<
+    InstanceProps,
+    {},
+    {},
+    {},
+    {},
+    ComponentOptionsMixin,
+    ComponentOptionsMixin,
+    E,
+    PP,
+    {},
+    false,
+    {},
+    S
+  >,
+  '$props'
+> & {
+  $props: Props & PP
+}
 
 type ToResolvedProps<Props, Emits extends EmitsOptions> = Readonly<Props> &
   Readonly<EmitsToProps<Emits>>
@@ -154,27 +158,28 @@ type PropValueType<V> = [Exclude<V, undefined>] extends [Prop<infer T> | null]
     : never
   : never
 
+type PreTypedKeys<O> = {
+  [K in keyof O]-?: [PropValueType<O[K]>] extends [never] ? never : K
+}[keyof O]
+
+type LiteralRuntimePropKeys<O> = Exclude<keyof O, PreTypedKeys<O>>
+
 type PreTypedProps<O> = {
-  [K in keyof O]: PropValueType<O[K]>
+  [K in keyof Pick<O, PreTypedKeys<O>>]: PropValueType<O[K]>
 }
 
-type IsPreTypedRuntimeProps<O> = [keyof O] extends [never]
-  ? false
-  : false extends {
-        [K in keyof O]-?: [PropValueType<O[K]>] extends [never] ? false : true
-      }[keyof O]
-    ? false
-    : true
+type LiteralRuntimePropsOptions<O> = {
+  [K in keyof Pick<O, LiteralRuntimePropKeys<O>>]: O[K]
+}
 
 type PublicRuntimeProps<O extends ComponentObjectPropsOptions> =
-  IsPreTypedRuntimeProps<O> extends true
-    ? { [K in keyof PreTypedProps<O>]: PreTypedProps<O>[K] }
-    : { [K in keyof ExtractPublicPropTypes<O>]: ExtractPublicPropTypes<O>[K] }
+  PreTypedProps<O> & ExtractPublicPropTypes<LiteralRuntimePropsOptions<O>>
 
-type ResolvedRuntimeProps<O extends ComponentObjectPropsOptions> =
-  IsPreTypedRuntimeProps<O> extends true
-    ? Readonly<LooseRequired<Readonly<PreTypedProps<O>>>>
-    : Readonly<LooseRequired<Readonly<ExtractPropTypes<O>>>>
+type ResolvedRuntimeProps<O extends ComponentObjectPropsOptions> = Readonly<
+  LooseRequired<
+    Readonly<PreTypedProps<O> & ExtractPropTypes<LiteralRuntimePropsOptions<O>>>
+  >
+>
 
 type IsEqual<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
@@ -226,7 +231,14 @@ export function defineComponent<
     emits?: E | EE[]
     slots?: S
   },
-): DefineSetupFnComponent<PublicRuntimeProps<RuntimePropsOptions>, E, S>
+): DefineSetupFnComponent<
+  PublicRuntimeProps<RuntimePropsOptions>,
+  E,
+  S,
+  PublicRuntimeProps<RuntimePropsOptions> & EmitsToProps<E>,
+  PublicProps,
+  ToResolvedProps<ResolvedRuntimeProps<RuntimePropsOptions>, E>
+>
 // function syntax + object runtime props, annotated setup
 export function defineComponent<
   Props extends Record<string, any>,

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -21,6 +21,7 @@ import type {
   ComponentPropsOptions,
   ExtractDefaultPropTypes,
   ExtractPropTypes,
+  ExtractPublicPropTypes,
 } from './componentProps'
 import type {
   EmitsOptions,
@@ -139,6 +140,10 @@ export type DefineSetupFnComponent<
 type ToResolvedProps<Props, Emits extends EmitsOptions> = Readonly<Props> &
   Readonly<EmitsToProps<Emits>>
 
+type PublicRuntimeProps<O extends ComponentObjectPropsOptions> = {
+  [K in keyof ExtractPublicPropTypes<O>]: ExtractPublicPropTypes<O>[K]
+}
+
 // defineComponent is a utility that is primarily used for type inference
 // when declaring components. Type inference is provided in the component
 // options (provided as the argument). The returned value has artificial types
@@ -162,6 +167,25 @@ export function defineComponent<
     slots?: S
   },
 ): DefineSetupFnComponent<Props, E, S>
+// function syntax + object runtime props, unannotated setup:
+// infer public/setup props from ExtractPublicPropTypes (#13964)
+export function defineComponent<
+  RuntimePropsOptions extends ComponentObjectPropsOptions,
+  E extends EmitsOptions = {},
+  EE extends string = string,
+  S extends SlotsType = {},
+>(
+  setup: (
+    props: PublicRuntimeProps<RuntimePropsOptions>,
+    ctx: SetupContext<E, S>,
+  ) => RenderFunction | Promise<RenderFunction>,
+  options: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
+    props: RuntimePropsOptions
+    emits?: E | EE[]
+    slots?: S
+  },
+): DefineSetupFnComponent<PublicRuntimeProps<RuntimePropsOptions>, E, S>
+// function syntax + object runtime props, annotated setup
 export function defineComponent<
   Props extends Record<string, any>,
   E extends EmitsOptions = {},

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -176,7 +176,7 @@ export function defineComponent<
   S extends SlotsType = {},
 >(
   setup: (
-    props: PublicRuntimeProps<RuntimePropsOptions>,
+    props: Readonly<PublicRuntimeProps<RuntimePropsOptions>>,
     ctx: SetupContext<E, S>,
   ) => RenderFunction | Promise<RenderFunction>,
   options: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -22,6 +22,7 @@ import type {
   ExtractDefaultPropTypes,
   ExtractPropTypes,
   ExtractPublicPropTypes,
+  Prop,
 } from './componentProps'
 import type {
   EmitsOptions,
@@ -145,13 +146,35 @@ export type DefineSetupFnComponent<
 type ToResolvedProps<Props, Emits extends EmitsOptions> = Readonly<Props> &
   Readonly<EmitsToProps<Emits>>
 
-type PublicRuntimeProps<O extends ComponentObjectPropsOptions> = {
-  [K in keyof ExtractPublicPropTypes<O>]: ExtractPublicPropTypes<O>[K]
+// ComponentObjectPropsOptions<P> widens values to `Prop<P[K]> | null`.
+// Detect that mapped form so we don't run Extract* on it again.
+type PropValueType<V> = [Exclude<V, undefined>] extends [Prop<infer T> | null]
+  ? [Prop<T> | null] extends [Exclude<V, undefined>]
+    ? T
+    : never
+  : never
+
+type PreTypedProps<O> = {
+  [K in keyof O]: PropValueType<O[K]>
 }
 
-type ResolvedRuntimeProps<O extends ComponentObjectPropsOptions> = Readonly<
-  LooseRequired<Readonly<ExtractPropTypes<O>>>
->
+type IsPreTypedRuntimeProps<O> = [keyof O] extends [never]
+  ? false
+  : false extends {
+        [K in keyof O]-?: [PropValueType<O[K]>] extends [never] ? false : true
+      }[keyof O]
+    ? false
+    : true
+
+type PublicRuntimeProps<O extends ComponentObjectPropsOptions> =
+  IsPreTypedRuntimeProps<O> extends true
+    ? { [K in keyof PreTypedProps<O>]: PreTypedProps<O>[K] }
+    : { [K in keyof ExtractPublicPropTypes<O>]: ExtractPublicPropTypes<O>[K] }
+
+type ResolvedRuntimeProps<O extends ComponentObjectPropsOptions> =
+  IsPreTypedRuntimeProps<O> extends true
+    ? Readonly<LooseRequired<Readonly<PreTypedProps<O>>>>
+    : Readonly<LooseRequired<Readonly<ExtractPropTypes<O>>>>
 
 type IsEqual<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -23,6 +23,7 @@ import type {
   ExtractPropTypes,
   ExtractPublicPropTypes,
   Prop,
+  PropType,
 } from './componentProps'
 import type {
   EmitsOptions,
@@ -125,6 +126,30 @@ export type DefineSetupFnComponent<
   S extends SlotsType = SlotsType,
   Props = P & EmitsToProps<E>,
   PP = PublicProps,
+> = new (
+  props: Props & PP,
+) => CreateComponentPublicInstanceWithMixins<
+  Props,
+  {},
+  {},
+  {},
+  {},
+  ComponentOptionsMixin,
+  ComponentOptionsMixin,
+  E,
+  PP,
+  {},
+  false,
+  {},
+  S
+>
+
+type DefineSetupFnComponentWithInstanceProps<
+  P extends Record<string, any>,
+  E extends EmitsOptions,
+  S extends SlotsType,
+  Props,
+  PP = PublicProps,
   InstanceProps = Props,
 > = new (props: Props & PP) => Omit<
   CreateComponentPublicInstanceWithMixins<
@@ -150,16 +175,28 @@ export type DefineSetupFnComponent<
 type ToResolvedProps<Props, Emits extends EmitsOptions> = Readonly<Props> &
   Readonly<EmitsToProps<Emits>>
 
-// ComponentObjectPropsOptions<P> widens values to `Prop<P[K]> | null`.
-// Detect that mapped form so we don't run Extract* on it again.
-type PropValueType<V> = [Exclude<V, undefined>] extends [Prop<infer T> | null]
+// Detect both ComponentObjectPropsOptions<P> and its PropType-only narrowed
+// form. Keep match state separate because `never` is a valid inferred payload.
+type PropValueMatch<V> = [Exclude<V, undefined>] extends [Prop<infer T> | null]
   ? [Prop<T> | null] extends [Exclude<V, undefined>]
+    ? { matched: true; value: T }
+    : [Exclude<V, undefined>] extends [PropType<infer U> | null]
+      ? [PropType<U> | null] extends [Exclude<V, undefined>]
+        ? { matched: true; value: U }
+        : { matched: false }
+      : { matched: false }
+  : { matched: false }
+
+type PropValueType<V> =
+  PropValueMatch<V> extends {
+    matched: true
+    value: infer T
+  }
     ? T
     : never
-  : never
 
 type PreTypedKeys<O> = {
-  [K in keyof O]-?: [PropValueType<O[K]>] extends [never] ? never : K
+  [K in keyof O]-?: PropValueMatch<O[K]> extends { matched: true } ? K : never
 }[keyof O]
 
 type LiteralRuntimePropKeys<O> = Exclude<keyof O, PreTypedKeys<O>>
@@ -231,7 +268,7 @@ export function defineComponent<
     emits?: E | EE[]
     slots?: S
   },
-): DefineSetupFnComponent<
+): DefineSetupFnComponentWithInstanceProps<
   PublicRuntimeProps<RuntimePropsOptions>,
   E,
   S,

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -182,7 +182,9 @@ export function defineComponent<
   },
 ): DefineSetupFnComponent<Props, E, S>
 // function syntax + object runtime props, unannotated setup:
-// setup gets resolved/internal props; public contract stays ExtractPublicPropTypes (#13964)
+// setup gets resolved/internal props; public contract stays ExtractPublicPropTypes (#13964).
+// An explicit annotation that is exactly the resolved setup type cannot be
+// distinguished from unannotated inference, so it also uses the public contract.
 export function defineComponent<
   RuntimePropsOptions extends ComponentObjectPropsOptions,
   E extends EmitsOptions = {},

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -28,7 +28,12 @@ import type {
   EmitsToProps,
   TypeEmitsToOptions,
 } from './componentEmits'
-import { type IsKeyValues, extend, isFunction } from '@vue/shared'
+import {
+  type IsKeyValues,
+  type LooseRequired,
+  extend,
+  isFunction,
+} from '@vue/shared'
 import type { VNodeProps } from './vnode'
 import type {
   ComponentPublicInstanceConstructor,
@@ -144,6 +149,15 @@ type PublicRuntimeProps<O extends ComponentObjectPropsOptions> = {
   [K in keyof ExtractPublicPropTypes<O>]: ExtractPublicPropTypes<O>[K]
 }
 
+type ResolvedRuntimeProps<O extends ComponentObjectPropsOptions> = Readonly<
+  LooseRequired<Readonly<ExtractPropTypes<O>>>
+>
+
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false
+
 // defineComponent is a utility that is primarily used for type inference
 // when declaring components. Type inference is provided in the component
 // options (provided as the argument). The returned value has artificial types
@@ -168,17 +182,20 @@ export function defineComponent<
   },
 ): DefineSetupFnComponent<Props, E, S>
 // function syntax + object runtime props, unannotated setup:
-// infer public/setup props from ExtractPublicPropTypes (#13964)
+// setup gets resolved/internal props; public contract stays ExtractPublicPropTypes (#13964)
 export function defineComponent<
   RuntimePropsOptions extends ComponentObjectPropsOptions,
   E extends EmitsOptions = {},
   EE extends string = string,
   S extends SlotsType = {},
+  P = ResolvedRuntimeProps<RuntimePropsOptions>,
 >(
-  setup: (
-    props: Readonly<PublicRuntimeProps<RuntimePropsOptions>>,
-    ctx: SetupContext<E, S>,
-  ) => RenderFunction | Promise<RenderFunction>,
+  setup: IsEqual<P, ResolvedRuntimeProps<RuntimePropsOptions>> extends true
+    ? (
+        props: P,
+        ctx: SetupContext<E, S>,
+      ) => RenderFunction | Promise<RenderFunction>
+    : never,
   options: Pick<ComponentOptions, 'name' | 'inheritAttrs'> & {
     props: RuntimePropsOptions
     emits?: E | EE[]


### PR DESCRIPTION
close #13964

## Summary

Function-syntax `defineComponent(setup, { props })` reverse-inferred `Props` from the runtime props object, so every declared key became required (`p1: String`, `{ type: Number }`, `{ required: false }`). Options syntax already uses `ExtractPublicPropTypes` and stayed correct.

This adds a setup overload that infers unannotated `setup` props from `ExtractPublicPropTypes`. Annotated setup (including generic Comp3) still uses the existing object-props overload.

## Test plan

- [x] `pnpm run build-dts && pnpm run test-dts-only`
- [x] dts coverage for #13964: optional `p1`/`p2`/`p3`, required `p4`, JSX
- [x] existing `function syntax w/ runtime props` Comp1–Comp3 still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript support for function-based components with runtime prop definitions.
  * Setup functions now receive accurately resolved prop types, including Boolean props, default values, and optional props.
  * Public component prop types continue to reflect correct optional and required contracts.
  * Preserved support for compatible annotated setup functions, with clearer errors for mismatched prop types.
  * Added support for typed object-based runtime props and kept component props readonly for safer type usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->