### PR TITLE
fix(runtime-vapor): align DOM prop updates with VDOM

### DIFF
--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -958,6 +958,20 @@ describe('component', () => {
     expect(ownerAfterThrow).toBe(owner)
     expect(suspenseAfterThrow).toBe(previousSuspense)
   })
+
+  it('should write reflected prop when normalized value is unchanged', async () => {
+    const type = ref('invalid')
+    const Comp = compile(`<template><input :type="data" /></template>`, type)
+    const { host } = define(Comp).render()
+    const input = host.firstChild as HTMLInputElement
+
+    expect(input.type).toBe('text')
+    expect(input.getAttribute('type')).toBe('invalid')
+
+    type.value = 'text'
+    await nextTick()
+    expect(input.getAttribute('type')).toBe('text')
+  })
 })
 
 function getEffectsCount(scope: EffectScope): number {

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -485,7 +485,7 @@ describe('patchProp', () => {
       expect(el.hasAttribute('id')).toBe(false)
 
       setProp(el, 'id', '')
-      expect(el.hasAttribute('id')).toBe(false)
+      expect(el.hasAttribute('id')).toBe(true)
 
       const img = document.createElement('img')
       setProp(img, 'width', 0)
@@ -493,13 +493,15 @@ describe('patchProp', () => {
 
       setProp(img, 'width', null)
       expect(img.hasAttribute('width')).toBe(false)
+      setProp(img, 'width', 0)
+      expect(img.getAttribute('width')).toBe('0')
       setProp(img, 'width', 1)
       expect(img.hasAttribute('width')).toBe(true)
 
       setProp(img, 'width', undefined)
       expect(img.hasAttribute('width')).toBe(false)
-      setProp(img, 'width', 1)
-      expect(img.hasAttribute('width')).toBe(true)
+      setProp(img, 'width', 0)
+      expect(img.getAttribute('width')).toBe('0')
     })
 
     // #15339

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -158,18 +158,17 @@ export function setDOMProp(
     }
   }
 
-  // the initial set must go through even when the value matches the property
-  // default, since reflected attributes only exist once assigned
+  // DOM properties may normalize values differently from reflected attributes,
+  // so compare against the previous binding and always perform the initial set.
   const cacheKey = `$p$${key}`
-  const prev = el[key]
-  if (value === prev && cacheKey in el) {
+  if (value === el[cacheKey] && cacheKey in el) {
     return
   }
   el[cacheKey] = value
 
   let needRemove = false
   if (value === '' || value == null) {
-    const type = typeof prev
+    const type = typeof el[key]
     if (type === 'boolean') {
       value = includeBooleanAttr(value)
     } else if (value == null && type === 'string') {


### PR DESCRIPTION
Compare DOM prop updates against the previous raw binding value instead of the browser-normalized live property.

This ensures changed bindings are written even when the DOM property already normalizes to the same value, while preserving initial writes and same-binding skips. Add regressions for reflected string and numeric properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOM property updates when browser normalization changes a value.
  * Preserved empty-string attributes where appropriate.
  * Ensured numeric values such as `0` are correctly written to DOM attributes.
  * Updated reflected attributes when a normalized property value becomes explicitly matched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->