### PR TITLE
fix(runtime-core): keep .trim result when combined with .number v-model modifier

### DIFF
--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -481,6 +481,29 @@ describe('component: emit', () => {
     expect(fn2).toHaveBeenCalledWith(1)
   })
 
+  test('.trim and .number modifiers should keep trim for non-numeric values', () => {
+    const Foo = defineComponent({
+      render() {},
+      created() {
+        this.$emit('update:modelValue', '  hello  ')
+      },
+    })
+
+    const fn = vi.fn()
+
+    const Comp = () =>
+      h(Foo, {
+        modelValue: null,
+        modelModifiers: { trim: true, number: true },
+        'onUpdate:modelValue': fn,
+      })
+
+    render(h(Comp), nodeOps.createElement('div'))
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith('hello')
+  })
+
   test('only trim string parameter when work with v-model on component', () => {
     const Foo = defineComponent({
       render() {},

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -166,7 +166,7 @@ export function emit(
       args = rawArgs.map(a => (isString(a) ? a.trim() : a))
     }
     if (modifiers.number) {
-      args = rawArgs.map(looseToNumber)
+      args = args.map(looseToNumber)
     }
   }
 


### PR DESCRIPTION
### What

When a component `v-model` uses both the `.trim` and `.number` modifiers, the `.trim` result was being discarded for non-numeric values.

### Why

In the `emit` path (`componentEmits.ts`), modifiers are applied sequentially. The `.trim` step correctly maps over `rawArgs` and stores the result in `args`. However, the subsequent `.number` step re-mapped over the original `rawArgs` instead of the already-trimmed `args`, throwing away the trim result.

For numeric inputs this was masked because `looseToNumber` parses the untrimmed string anyway, but for non-numeric values (where `looseToNumber` returns the original string) the emitted value kept its surrounding whitespace. This differs from the native element behavior in `runtime-dom`, where `castValue` chains trim then number on the same value.

```js
// before: '  hello  ' with { trim: true, number: true } emits '  hello  '
// after:  emits 'hello'
```

### How

Chain the `.number` map onto `args` (the possibly-trimmed value) rather than `rawArgs`, matching the runtime-dom `castValue` chaining order.

### Test

Added a regression test in `componentEmits.spec.ts` that emits a non-numeric whitespace-padded string with `{ trim: true, number: true }` and asserts the handler receives the trimmed string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed combined `.trim` and `.number` `v-model` modifiers so non-numeric values are trimmed correctly without being incorrectly converted to numbers.

- **Tests**
  - Added regression coverage to verify the corrected modifier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->