### PR TITLE
fix(compiler-core): handle invalid static arg in same-name v-bind shorthand

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vBind.spec.ts
@@ -449,4 +449,12 @@ describe('compiler: transform v-bind', () => {
       },
     })
   })
+
+  test('error on invalid static argument for same-name shorthand', () => {
+    const onError = vi.fn()
+    expect(() => parseWithVBind(`<div :2xl />`, { onError })).not.toThrow()
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      code: ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
+    })
+  })
 })

--- a/packages/compiler-core/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vBind.spec.ts
@@ -435,6 +435,7 @@ describe('compiler: transform v-bind', () => {
   test('error on invalid argument for same-name shorthand', () => {
     const onError = vi.fn()
     parseWithVBind(`<div v-bind:[arg] />`, { onError })
+    expect(onError).toHaveBeenCalledTimes(1)
     expect(onError.mock.calls[0][0]).toMatchObject({
       code: ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
       loc: {
@@ -453,8 +454,25 @@ describe('compiler: transform v-bind', () => {
   test('error on invalid static argument for same-name shorthand', () => {
     const onError = vi.fn()
     expect(() => parseWithVBind(`<div :2xl />`, { onError })).not.toThrow()
+    expect(onError).toHaveBeenCalledTimes(1)
     expect(onError.mock.calls[0][0]).toMatchObject({
       code: ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
+      message:
+        "v-bind with same-name shorthand only allows static arguments that start with a valid identifier character or '-'.",
     })
+  })
+
+  test('error on invalid static argument in browser build', () => {
+    try {
+      __BROWSER__ = true
+      const onError = vi.fn()
+      expect(() => parseWithVBind(`<div :2xl />`, { onError })).not.toThrow()
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError.mock.calls[0][0]).toMatchObject({
+        code: ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
+      })
+    } finally {
+      __BROWSER__ = false
+    }
   })
 })

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -161,7 +161,9 @@ export const errorMessages: Record<ErrorCodes, string> = {
   [ErrorCodes.X_V_FOR_MALFORMED_EXPRESSION]: `v-for has invalid expression.`,
   [ErrorCodes.X_V_FOR_TEMPLATE_KEY_PLACEMENT]: `<template v-for> key should be placed on the <template> tag.`,
   [ErrorCodes.X_V_BIND_NO_EXPRESSION]: `v-bind is missing expression.`,
-  [ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT]: `v-bind with same-name shorthand only allows static argument.`,
+  [ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT]:
+    `v-bind with same-name shorthand only allows static arguments that ` +
+    `start with a valid identifier character or '-'.`,
   [ErrorCodes.X_V_ON_NO_EXPRESSION]: `v-on is missing expression.`,
   [ErrorCodes.X_V_SLOT_UNEXPECTED_DIRECTIVE_ON_SLOT_OUTLET]: `Unexpected custom directive on <slot> outlet.`,
   [ErrorCodes.X_V_SLOT_MIXED_SLOT_USAGE]:

--- a/packages/compiler-core/src/transforms/transformVBindShorthand.ts
+++ b/packages/compiler-core/src/transforms/transformVBindShorthand.ts
@@ -40,6 +40,14 @@ export const transformVBindShorthand: NodeTransform = (node, context) => {
             propName[0] === '-'
           ) {
             prop.exp = createSimpleExpression(propName, false, arg.loc)
+          } else {
+            context.onError(
+              createCompilerError(
+                ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
+                arg.loc,
+              ),
+            )
+            prop.exp = createSimpleExpression('', true, arg.loc)
           }
         }
       }

--- a/packages/compiler-core/src/transforms/transformVBindShorthand.ts
+++ b/packages/compiler-core/src/transforms/transformVBindShorthand.ts
@@ -31,7 +31,7 @@ export const transformVBindShorthand: NodeTransform = (node, context) => {
               arg.loc,
             ),
           )
-          prop.exp = createSimpleExpression('', true, arg.loc)
+          prop.exp = createSimpleExpression('undefined', false, arg.loc)
         } else {
           const propName = camelize((arg as SimpleExpressionNode).content)
           if (
@@ -47,7 +47,7 @@ export const transformVBindShorthand: NodeTransform = (node, context) => {
                 arg.loc,
               ),
             )
-            prop.exp = createSimpleExpression('', true, arg.loc)
+            prop.exp = createSimpleExpression('undefined', false, arg.loc)
           }
         }
       }


### PR DESCRIPTION
### What

A same-name `v-bind` shorthand whose static argument camelizes to a name with an invalid first identifier character (and is not a leading hyphen) — e.g. `<div :2xl />` — crashes the compiler with an uncaught `TypeError: Cannot read properties of undefined (reading 'type')`.

### Why

In `transformVBindShorthand`, the static-arg branch only assigns `prop.exp` when the camelized prop name starts with a valid identifier char or `-`. There was no `else`, so for an invalid first char `prop.exp` was left `undefined` on a `bind` directive that has an `arg`. Downstream, `transformBind` produces a property with `value === undefined`, and `analyzePatchFlag` in `transformElement` then dereferences `value.type`, throwing.

The sibling branch for a *dynamic* invalid same-name arg (`:[arg]`) already handles this gracefully by emitting `X_V_BIND_INVALID_SAME_NAME_ARGUMENT` and assigning a safe empty expression. The static branch was missing the equivalent handling.

### How

Add the matching `else` branch: emit `X_V_BIND_INVALID_SAME_NAME_ARGUMENT` and assign `prop.exp = createSimpleExpression('', true, arg.loc)`, guaranteeing `prop.exp` is always defined for a `bind` directive with an `arg`.

### Test

Added a regression test in `vBind.spec.ts` asserting `<div :2xl />` no longer throws and reports `X_V_BIND_INVALID_SAME_NAME_ARGUMENT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid same-name `v-bind` shorthand arguments, including numeric and dynamically invalid names.
  * Compilation now reports a clear validation error and safely produces an undefined value instead of incomplete output.
  * Clarified that shorthand arguments must begin with a valid identifier character or a hyphen.

* **Tests**
  * Added coverage for static and dynamic invalid arguments across standard and browser builds.
  * Confirmed compilation reports exactly one diagnostic without throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->