### PR TITLE
fix(runtime-dom): support !important on CSS custom properties in style binding

### DIFF
--- a/packages/runtime-dom/__tests__/patchStyle.spec.ts
+++ b/packages/runtime-dom/__tests__/patchStyle.spec.ts
@@ -161,6 +161,13 @@ describe(`runtime-dom: style patching`, () => {
     expect(el.style.getPropertyValue('--theme')).toBe('red')
   })
 
+  it('CSS custom properties with !important', () => {
+    const setProperty = vi.fn()
+    const el = { style: { setProperty } }
+    patchProp(el as any, 'style', {}, { '--theme': 'red !important' } as any)
+    expect(setProperty).toHaveBeenCalledWith('--theme', 'red', 'important')
+  })
+
   it('auto vendor prefixing', () => {
     const el = mockElementWithStyle()
     patchProp(el as any, 'style', {}, { transition: 'all 1s' })

--- a/packages/runtime-dom/src/modules/style.ts
+++ b/packages/runtime-dom/src/modules/style.ts
@@ -99,7 +99,12 @@ function setStyle(
     }
     if (name.startsWith('--')) {
       // custom property definition
-      style.setProperty(name, val)
+      if (importantRE.test(val)) {
+        // !important
+        style.setProperty(name, val.replace(importantRE, ''), 'important')
+      } else {
+        style.setProperty(name, val)
+      }
     } else {
       const prefixed = autoPrefix(style, name)
       if (importantRE.test(val)) {


### PR DESCRIPTION
### What

An `!important` flag on a CSS custom property (CSS variable) style binding, e.g. `:style="{ '--theme': 'red !important' }"`, was not applied. The important priority was never set, and because a custom-property value containing a top-level `!` is an invalid `<declaration-value>`, spec-compliant browsers drop the declaration entirely — so the variable ends up not being set at all.

### Why

In `setStyle`, the custom-property branch (`name.startsWith('--')`) called `style.setProperty(name, val)` with the raw value. Unlike the normal-property branch, it did not detect a trailing `!important`, strip it from the value, and pass `'important'` as the third (priority) argument of `setProperty`. So `--theme` was set to the literal string `red !important`, which is not a valid custom-property value.

### How

Apply the same `importantRE` handling used for normal properties to the custom-property branch: when the value ends with `!important`, strip it and call `style.setProperty(name, strippedVal, 'important')`.

### Test

Added a regression test in `patchStyle.spec.ts` (using a `setProperty` spy, since jsdom does not round-trip custom properties) asserting `patchProp(el, 'style', {}, { '--theme': 'red !important' })` calls `setProperty('--theme', 'red', 'important')`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of CSS custom properties marked `!important`, ensuring the priority is applied correctly.
  - Preserved existing behavior for other custom-property styles.

- **Tests**
  - Added coverage to verify correct application of `!important` custom-property values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->