### PR TITLE
refactor(runtime-vapor): replace vnode-hook hijacking with internal iu/ibu notification channel

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -873,6 +873,7 @@ function baseCreateRenderer(
     if ((vnodeHook = newProps.onVnodeBeforeUpdate)) {
       invokeVNodeHook(vnodeHook, parentComponent, n2, n1)
     }
+    if (n2.ibu) n2.ibu()
     if (dirs) {
       invokeDirectiveHook(n2, n1, parentComponent, 'beforeUpdate')
     }
@@ -986,10 +987,11 @@ function baseCreateRenderer(
       patchProps(el, oldProps, newProps, parentComponent, namespace)
     }
 
-    if ((vnodeHook = newProps.onVnodeUpdated) || dirs) {
+    if ((vnodeHook = newProps.onVnodeUpdated) || dirs || n2.iu) {
       queuePostRenderEffect(
         () => {
           vnodeHook && invokeVNodeHook(vnodeHook, parentComponent, n2, n1)
+          n2.iu && n2.iu()
           dirs && invokeDirectiveHook(n2, n1, parentComponent, 'updated')
         },
         undefined,
@@ -1269,15 +1271,17 @@ function baseCreateRenderer(
             if (vnodeBeforeUpdateHook) {
               invokeVNodeHook(vnodeBeforeUpdateHook, parentComponent, n2, n1)
             }
+            if (n2.ibu) n2.ibu()
           },
         )
         const vnodeUpdatedHook = n2.props && n2.props.onVnodeUpdated
-        if (shouldUpdate && (vnodeUpdatedHook || n2.dirs)) {
+        if (shouldUpdate && (vnodeUpdatedHook || n2.dirs || n2.iu)) {
           queuePostRenderEffect(
             () => {
               n2.dirs && invokeDirectiveHook(n2, n1, parentComponent, 'updated')
               vnodeUpdatedHook &&
                 invokeVNodeHook(vnodeUpdatedHook, parentComponent, n2, n1)
+              n2.iu && n2.iu()
             },
             undefined,
             parentSuspense,
@@ -1718,6 +1722,7 @@ function baseCreateRenderer(
         if ((vnodeHook = next.props && next.props.onVnodeBeforeUpdate)) {
           invokeVNodeHook(vnodeHook, parent, next, vnode)
         }
+        if (next.ibu) next.ibu()
         if (
           __COMPAT__ &&
           isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)
@@ -1766,9 +1771,12 @@ function baseCreateRenderer(
           queuePostRenderEffect(u, undefined, parentSuspense)
         }
         // onVnodeUpdated
-        if ((vnodeHook = next.props && next.props.onVnodeUpdated)) {
+        if ((vnodeHook = next.props && next.props.onVnodeUpdated) || next.iu) {
           queuePostRenderEffect(
-            () => invokeVNodeHook(vnodeHook!, parent, next!, vnode),
+            () => {
+              vnodeHook && invokeVNodeHook(vnodeHook, parent, next!, vnode)
+              next!.iu && next!.iu()
+            },
             undefined,
             parentSuspense,
           )

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -286,6 +286,19 @@ export interface VNode<
    * @internal Vapor slot Block
    */
   vb?: any
+  /**
+   * @internal vapor interop only — internal before-update notification, fired
+   * before this vnode is patched (alongside onVnodeBeforeUpdate). Single-owner:
+   * the interop layer assigns (never appends) so re-tracking replaces the
+   * previous callback.
+   */
+  ibu?: () => void
+  /**
+   * @internal vapor interop only — internal updated notification, fired after
+   * this vnode is patched (alongside onVnodeUpdated) so the interop layer can
+   * refresh its snapshot of the DOM range. Single-owner; see `ibu`.
+   */
+  iu?: () => void
 }
 
 // Since v-if and v-for are the two possible ways node structure can dynamically
@@ -783,6 +796,11 @@ export function cloneVNode<T, U>(
     vi: vnode.vi,
     vs: cloneVaporSlotMeta(vnode as VNode),
     vb: vnode.vb,
+    // interop range tracking must survive renderer-internal clones of mounted
+    // vnodes (cloneIfMounted / normalizeVNode), or nested updates would stop
+    // notifying after the first re-render of cached children.
+    ibu: vnode.ibu,
+    iu: vnode.iu,
   }
 
   // if the vnode will be replaced by the cloned one, it is necessary

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -779,6 +779,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
           [vnode, cached],
         )
       }
+      if (vnode.ibu) vnode.ibu()
       if (vnode.dirs) {
         invokeDirectiveHook(vnode, cached, parentComponent, 'beforeUpdate')
       }
@@ -802,6 +803,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
               [vnode, cached],
             )
           }
+          if (vnode.iu) vnode.iu()
         },
         undefined,
         parentSuspense,
@@ -983,43 +985,26 @@ function removeAttachedNodes(block: Block, parent: ParentNode): void {
   }
 }
 
-function appendVnodeHook(
-  vnode: VNode,
-  key: 'onVnodeBeforeUpdate' | 'onVnodeUpdated',
-  hook: () => void,
-): void {
-  let props = vnode.props
-  // The shared EMPTY_OBJ (frozen in dev only) and user-frozen props both need
-  // replacing with the vnode's own object.
-  if (!props || props === EMPTY_OBJ || !Object.isExtensible(props)) {
-    props = vnode.props = extend({}, props)
-  }
-  const existing = props[key]
-  props[key] = existing
-    ? isArray(existing)
-      ? [...existing, hook]
-      : [existing, hook]
-    : hook
-}
-
 function trackFragmentVNodeUpdates(
   frag: VaporFragment,
   vnode: VNode,
   syncNodes: () => void,
 ): void {
-  const beforeUpdate = () => {
+  // `ibu`/`iu` are the interop-internal notification channel the renderer
+  // fires alongside the public vnode hooks. Assignment (never append) keeps
+  // the channel single-owner: re-tracking replaces a stale callback instead
+  // of accumulating, and user props stay untouched.
+  vnode.ibu = () => {
     if (frag.onBeforeUpdate) {
       frag.onBeforeUpdate.forEach(bu => bu())
     }
   }
-  const updated = () => {
+  vnode.iu = () => {
     syncNodes()
     if (frag.onUpdated) {
       frag.onUpdated.forEach(u => u())
     }
   }
-  appendVnodeHook(vnode, 'onVnodeBeforeUpdate', beforeUpdate)
-  appendVnodeHook(vnode, 'onVnodeUpdated', updated)
 }
 
 function createVNodeFragment(vnode: VNode): {
@@ -1612,11 +1597,13 @@ function trackSlotVNodeUpdatesWithRefresh(
   refresh: () => void,
   beforeUpdate?: () => void,
 ): void {
-  const onUpdated = () => refresh()
-
+  // Fragment patches fire no notifications, so subscribe every top-level
+  // range participant (element/component children); a component child's
+  // self-update must still refresh the snapshot. cloneVNode carries the
+  // fields so renderer-internal clones of mounted children keep notifying.
   const track = (node: VNode) => {
-    if (beforeUpdate) appendVnodeHook(node, 'onVnodeBeforeUpdate', beforeUpdate)
-    appendVnodeHook(node, 'onVnodeUpdated', onUpdated)
+    if (beforeUpdate) node.ibu = beforeUpdate
+    node.iu = refresh
     if (node.type === Fragment && isArray(node.children)) {
       node.children.forEach(child => {
         if (isVNode(child)) track(child)
@@ -2963,6 +2950,7 @@ function ensureVNodeHookState(
           [state!.vnode, state!.vnode],
         )
       }
+      if (state!.vnode.ibu) state!.vnode.ibu()
     })
 
     // Sync the outer component vnode before running any updated hooks. Hooks
@@ -2983,6 +2971,7 @@ function ensureVNodeHookState(
           [state!.vnode, state!.vnode],
         )
       }
+      if (state!.vnode.iu) state!.vnode.iu()
     })
   } else {
     state.vnode = vnode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update notifications for components, fragments, slots, and elements.
  * Preserved update tracking across re-renders and cloned content.
  * Prevented duplicate or accumulated update handlers during VDOM/Vapor interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->