### PR TITLE
refactor(runtime-vapor): replace string slot interop markers with symbol keys

### DIFF
--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -21,9 +21,25 @@ import { warn } from '../warning'
 import { isAsyncWrapper } from '../apiAsyncComponent'
 import type { Data } from '../component'
 
+/**
+ * Links a slot function to its raw vapor slot: a raw vapor slot carries
+ * itself, and the wrapper the interop slots proxy hands out carries the raw
+ * slot it wraps — one lookup answers both "is this a vapor slot" and
+ * "which one".
+ * @internal vapor interop only
+ */
+export const rawVaporSlotKey: unique symbol = Symbol(`rawVaporSlot`)
+
+/**
+ * Marks a compiler-generated slot fallback as VDOM-rendered so the vapor
+ * interop fallback chain renders it through the VDOM renderer.
+ * @internal vapor interop only
+ */
+export const vdomSlotFallbackKey: unique symbol = Symbol(`vdomSlotFallback`)
+
 type SlotFallback = {
   (): VNodeArrayChildren
-  __vdom?: boolean
+  [vdomSlotFallbackKey]?: boolean
 }
 
 /**
@@ -49,13 +65,10 @@ export function renderSlot(
   if (props == null) props = {}
 
   let slot = slots[name]
-  if (fallback) fallback.__vdom = true
+  if (fallback) fallback[vdomSlotFallbackKey] = true
 
   // vapor slots rendered in vdom
-  // __vs: original vapor slot stored on a wrapper from vaporSlotsProxyHandler
-  // __vapor: marker indicating the slot itself is an original vapor slot
-  const vaporSlot =
-    slot && ((slot as any).__vs || ((slot as any).__vapor ? slot : null))
+  const vaporSlot = slot && (slot as any)[rawVaporSlotKey]
   if (vaporSlot) {
     const ret = (openBlock(), createBlock(VaporSlot, props))
     ret.vs = { slot: vaporSlot, fallback }

--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -25,15 +25,14 @@ import type { Data } from '../component'
  * Links a slot function to its raw vapor slot: a raw vapor slot carries
  * itself, and the wrapper the interop slots proxy hands out carries the raw
  * slot it wraps — one lookup answers both "is this a vapor slot" and
- * "which one".
- * @internal vapor interop only
+ * "which one". Internal to vapor interop.
  */
 export const rawVaporSlotKey: unique symbol = Symbol(`rawVaporSlot`)
 
 /**
  * Marks a compiler-generated slot fallback as VDOM-rendered so the vapor
- * interop fallback chain renders it through the VDOM renderer.
- * @internal vapor interop only
+ * interop fallback chain renders it through the VDOM renderer. Internal to
+ * vapor interop.
  */
 export const vdomSlotFallbackKey: unique symbol = Symbol(`vdomSlotFallback`)
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -380,11 +380,7 @@ export {
 } from './componentRenderContext'
 export { renderList } from './helpers/renderList'
 export { toHandlers } from './helpers/toHandlers'
-export {
-  renderSlot,
-  rawVaporSlotKey,
-  vdomSlotFallbackKey,
-} from './helpers/renderSlot'
+export { renderSlot } from './helpers/renderSlot'
 export { createSlots } from './helpers/createSlots'
 export { withMemo, isMemoSame } from './helpers/withMemo'
 export {
@@ -627,7 +623,12 @@ export {
 /**
  * @internal
  */
-export { ensureValidVNode, ensureVaporSlotFallback } from './helpers/renderSlot'
+export {
+  ensureValidVNode,
+  ensureVaporSlotFallback,
+  rawVaporSlotKey,
+  vdomSlotFallbackKey,
+} from './helpers/renderSlot'
 /**
  * @internal
  */

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -380,7 +380,11 @@ export {
 } from './componentRenderContext'
 export { renderList } from './helpers/renderList'
 export { toHandlers } from './helpers/toHandlers'
-export { renderSlot } from './helpers/renderSlot'
+export {
+  renderSlot,
+  rawVaporSlotKey,
+  vdomSlotFallbackKey,
+} from './helpers/renderSlot'
 export { createSlots } from './helpers/createSlots'
 export { withMemo, isMemoSame } from './helpers/withMemo'
 export {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -17,7 +17,6 @@ import {
   type GenericComponentInstance,
   currentInstance,
   isAsyncWrapper,
-  isRef,
 } from '@vue/runtime-dom'
 import type { LooseRawProps, VaporComponentInstance } from './component'
 import { renderEffect } from './renderEffect'
@@ -43,7 +42,7 @@ import { SLOT_FRAGMENT } from './fragmentFlags'
 import { currentSlotBoundary, withSlotBoundary } from './slotBoundary'
 import { createElement } from './dom/node'
 import { setDynamicProps } from './dom/prop'
-import { isInteropEnabled } from './vdomInteropState'
+import { interopSlotsKey, isInteropEnabled } from './vdomInteropState'
 import {
   currentSlotScopeIds,
   renderWithSlotScopeIds,
@@ -297,14 +296,16 @@ export function createSlot(
 
   let fragment: VaporFragment
   let isCustomElementSlot = false
-  if (isRef(rawSlots._) && isInteropEnabled) {
+  const interopSlotsSource =
+    isInteropEnabled && (rawSlots as any)[interopSlotsKey]
+  if (interopSlotsSource) {
     if (isHydrating) hydrationCursor = enterHydrationCursor()
     // Establish the outlet cell as the creation ambient; the interop slot
     // captures it as the base patch context for the vdom-rendered content.
     const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
     try {
       fragment = instance.appContext.vdom!.slot(
-        rawSlots._,
+        interopSlotsSource,
         name,
         slotProps,
         instance,

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -51,6 +51,7 @@ import {
   prepareTransitionSwitch,
   queuePostFlushCb,
   queuePostRenderEffect,
+  rawVaporSlotKey,
   renderSlot,
   resolveTransitionChild,
   restoreCurrentInstance,
@@ -63,6 +64,7 @@ import {
   activate as vdomActivate,
   deactivate as vdomDeactivate,
   setRef as vdomSetRef,
+  vdomSlotFallbackKey,
   warn,
   withCtx,
 } from '@vue/runtime-dom'
@@ -185,7 +187,11 @@ import {
   setTransitionHooks as setVaporTransitionHooks,
 } from './components/Transition'
 import { isVaporTransition, registerTransitionInterop } from './transition'
-import { interopKey, setInteropEnabled } from './vdomInteropState'
+import {
+  interopKey,
+  interopSlotsKey,
+  setInteropEnabled,
+} from './vdomInteropState'
 import {
   type KeepAliveInstance,
   activate,
@@ -898,7 +904,7 @@ const vaporSlotsProxyHandler: ProxyHandler<any> = {
         ? getSlot(target, key)
         : target[key]
     if (isFunction(slot)) {
-      slot.__vapor = true
+      ;(slot as any)[rawVaporSlotKey] = slot
       let wrappers = vaporSlotWrappersCache.get(target)
       if (!wrappers) vaporSlotWrappersCache.set(target, (wrappers = new Map()))
       const cached = wrappers.get(key)
@@ -911,7 +917,7 @@ const vaporSlotsProxyHandler: ProxyHandler<any> = {
       const wrapped = (props?: Record<string, any>) => [
         renderSlot({ [key]: slot }, key as string, props),
       ]
-      ;(wrapped as any).__vs = slot
+      ;(wrapped as any)[rawVaporSlotKey] = slot
       wrappers.set(key, { slot, wrapped })
       return wrapped
     }
@@ -2629,7 +2635,7 @@ const renderEmptyVNodes = (): VNodeArrayChildren => EMPTY_VNODES
 
 type InteropSlotFallback = {
   (): any
-  __vdom?: boolean
+  [vdomSlotFallbackKey]?: boolean
 }
 
 interface InteropVaporSlotState {
@@ -2821,14 +2827,14 @@ function renderVaporSlot(
         parentComponent,
         () =>
           !!slotState.localFallback.value &&
-          !!slotState.localFallback.value.__vdom,
+          !!slotState.localFallback.value[vdomSlotFallbackKey],
       )
       outletFallback = createFallback(
         () => (slotState.outletFallback.value || renderEmptyVNodes)(),
         parentComponent,
         () =>
           !!slotState.outletFallback.value &&
-          !!slotState.outletFallback.value.__vdom,
+          !!slotState.outletFallback.value[vdomSlotFallbackKey],
       )
       const hasInteropFallback =
         !!slotState.localFallback.value || !!slotState.outletFallback.value
@@ -3330,7 +3336,7 @@ function normalizeInteropSlots(rawSlots: any): any {
       // Already-normalized VDOM slots and Vapor slots carry their own runtime
       // protocol markers, so keep them intact.
       normalized[key] =
-        (slot as any).__vapor || (slot as any).__vs || (slot as any)._n
+        (slot as any)[rawVaporSlotKey] || (slot as any)._n
           ? slot
           : normalizeInteropSlot(slot, rawSlots._ctx)
     } else if (slot != null) {
@@ -3434,16 +3440,14 @@ const interopSlotsSourceHandlers: ProxyHandler<ShallowRef<Slots>> = {
 }
 
 function createInteropRawSlots(slotsRef: ShallowRef<Slots>): RawSlots {
-  // `_` keeps direct <slot> outlets on the VDOM slot path; `$` exposes live
-  // slot keys to Vapor useSlots() / dynamic forwarding.
-  const rawSlots = {
+  // `interopSlotsKey` keeps direct <slot> outlets on the VDOM slot path
+  // (createSlot reads it); `$` exposes live slot keys to Vapor useSlots() /
+  // dynamic forwarding. The symbol key is invisible to string-keyed slot
+  // enumeration, so no defineProperty hiding is needed.
+  return {
     $: [new Proxy(slotsRef, interopSlotsSourceHandlers)],
-  } as any
-  Object.defineProperty(rawSlots, '_', {
-    value: slotsRef, // pass the slots ref
-    configurable: true,
-  })
-  return rawSlots as RawSlots
+    [interopSlotsKey]: slotsRef,
+  } as any as RawSlots
 }
 
 // vnode.el of an interop-mounted vapor component must follow its dynamic

--- a/packages/runtime-vapor/src/vdomInteropState.ts
+++ b/packages/runtime-vapor/src/vdomInteropState.ts
@@ -7,3 +7,10 @@ export function setInteropEnabled(): void {
 }
 
 export const interopKey: unique symbol = Symbol(`interop`)
+
+/**
+ * Carries the live VDOM slots ref on the raw-slots object handed to a vapor
+ * component mounted from VDOM. Replaces the old overloaded `_` key, which
+ * elsewhere means SlotFlags (vdom slots) or VaporSlotFlags (slot functions).
+ */
+export const interopSlotsKey: unique symbol = Symbol(`interopSlots`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved slot interoperability between Vapor and VDOM components.
  - Replaced ambiguous internal slot markers with dedicated identifiers, improving reliability when rendering slots and fallbacks.
  - Improved detection and handling of fallback content during cross-renderer slot rendering.
  - Preserved live slot updates when slots are passed between Vapor and VDOM components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->