### PR TITLE
refactor(runtime-vapor): consolidate the unmount-suspense ambient behind named operations

### DIFF
--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -22,7 +22,7 @@ import {
 import { isTeleportEnabled, isTeleportFragment } from './teleport'
 import { isTransitionEnabled } from './transition'
 import { isInteropEnabled } from './vdomInteropState'
-import { currentUnmountSuspense, isSuspenseEnabled } from './suspense'
+import { isSuspenseEnabled, resolveUnmountSuspense } from './suspense'
 
 export interface VaporTransitionHooks extends TransitionHooks {
   __vapor: true
@@ -288,16 +288,13 @@ export function remove(block: Block, parent?: ParentNode): void {
   if (block instanceof Node) {
     removeNode(block, parent)
   } else if (isVaporComponent(block)) {
-    if (
-      __FEATURE_SUSPENSE__ &&
-      isSuspenseEnabled &&
-      isInteropEnabled &&
-      currentUnmountSuspense !== undefined
-    ) {
-      unmountComponent(block, parent, currentUnmountSuspense)
-    } else {
-      unmountComponent(block, parent)
-    }
+    unmountComponent(
+      block,
+      parent,
+      __FEATURE_SUSPENSE__ && isSuspenseEnabled && isInteropEnabled
+        ? resolveUnmountSuspense(block.suspense)
+        : block.suspense,
+    )
   } else if (isArray(block)) {
     for (let i = 0; i < block.length; i++) {
       remove(block[i], parent)

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -148,7 +148,8 @@ import {
   currentUnmountSuspense,
   isSuspenseEnabled,
   parentSuspense,
-  setCurrentUnmountSuspense,
+  resolveUnmountSuspense,
+  runWithUnmountSuspense,
   setParentSuspense,
 } from './suspense'
 import { isInteropEnabled } from './vdomInteropState'
@@ -544,11 +545,13 @@ export function createComponent(
     }
     onScopeDispose(
       () =>
-        __FEATURE_SUSPENSE__ &&
-        isInteropEnabled &&
-        currentUnmountSuspense !== undefined
-          ? unmountComponent(instance, undefined, currentUnmountSuspense)
-          : unmountComponent(instance),
+        unmountComponent(
+          instance,
+          undefined,
+          __FEATURE_SUSPENSE__ && isInteropEnabled
+            ? resolveUnmountSuspense(instance.suspense)
+            : instance.suspense,
+        ),
       true,
     )
 
@@ -1422,7 +1425,9 @@ export function unmountComponent(
     isInteropEnabled &&
     currentUnmountSuspense !== parentSuspense
   ) {
-    unmountComponentWithParentSuspense(instance, parentNode, parentSuspense)
+    runWithUnmountSuspense(parentSuspense, () =>
+      unmountComponent(instance, parentNode, parentSuspense),
+    )
     return
   }
 
@@ -1502,19 +1507,6 @@ export function unmountComponent(
   if (pendingAsyncSetup) {
     instance.restoreAsyncContext = undefined
     instance.deferredHydrationBoundary = undefined
-  }
-}
-
-function unmountComponentWithParentSuspense(
-  instance: VaporComponentInstance,
-  parentNode: ParentNode | undefined,
-  parentSuspense: SuspenseBoundary | null,
-): void {
-  const prev = setCurrentUnmountSuspense(parentSuspense)
-  try {
-    unmountComponent(instance, parentNode, parentSuspense)
-  } finally {
-    setCurrentUnmountSuspense(prev)
   }
 }
 

--- a/packages/runtime-vapor/src/suspense.ts
+++ b/packages/runtime-vapor/src/suspense.ts
@@ -28,7 +28,7 @@ export function setParentSuspense(
   }
 }
 
-export function setCurrentUnmountSuspense(
+function setCurrentUnmountSuspense(
   suspense: SuspenseBoundary | null | undefined,
 ): SuspenseBoundary | null | undefined {
   try {
@@ -36,4 +36,35 @@ export function setCurrentUnmountSuspense(
   } finally {
     currentUnmountSuspense = suspense
   }
+}
+
+/**
+ * Establishes `suspense` as the active unmount pass's boundary around `fn`.
+ * The single entry point for the ambient: unmountComponent and the interop
+ * vnode unmount re-enter through this when their explicit argument differs
+ * from the active pass.
+ */
+export function runWithUnmountSuspense<T>(
+  suspense: SuspenseBoundary | null,
+  fn: () => T,
+): T {
+  const prev = setCurrentUnmountSuspense(suspense)
+  try {
+    return fn()
+  } finally {
+    setCurrentUnmountSuspense(prev)
+  }
+}
+
+/**
+ * The effective boundary for a teardown reached without a parameter channel —
+ * scope-disposal callbacks and block removal: the active unmount pass's
+ * boundary when one is set, the caller's fallback otherwise.
+ */
+export function resolveUnmountSuspense(
+  fallback: SuspenseBoundary | null,
+): SuspenseBoundary | null {
+  return currentUnmountSuspense === undefined
+    ? fallback
+    : currentUnmountSuspense
 }

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -207,7 +207,8 @@ import {
   currentUnmountSuspense,
   enableSuspense,
   isSuspenseEnabled,
-  setCurrentUnmountSuspense,
+  resolveUnmountSuspense,
+  runWithUnmountSuspense,
   setParentSuspense,
 } from './suspense'
 
@@ -321,19 +322,6 @@ function filterReservedProps(props: VNode['props']): VNode['props'] {
     }
   }
   return filtered
-}
-
-function unmountVaporInteropWithParentSuspense(
-  vnode: VNode,
-  doRemove: boolean | undefined,
-  parentSuspense: SuspenseBoundary | null,
-): void {
-  const prev = setCurrentUnmountSuspense(parentSuspense)
-  try {
-    vaporInteropImpl.unmount(vnode, doRemove, parentSuspense)
-  } finally {
-    setCurrentUnmountSuspense(prev)
-  }
 }
 
 // mounting vapor components and slots in vdom
@@ -482,7 +470,9 @@ const vaporInteropImpl: VaporInVdomInterface = {
       isSuspenseEnabled &&
       currentUnmountSuspense !== parentSuspense
     ) {
-      unmountVaporInteropWithParentSuspense(vnode, doRemove, parentSuspense)
+      runWithUnmountSuspense(parentSuspense, () =>
+        vaporInteropImpl.unmount(vnode, doRemove, parentSuspense),
+      )
       return
     }
 
@@ -1069,14 +1059,6 @@ function createVNodeFragment(vnode: VNode): {
     content.resolved ? isValidBlock(frag.nodes, componentAsValid) : true
   trackFragmentVNodeUpdates(frag, vnode, syncNodes)
   return { frag, syncNodes }
-}
-
-function resolveUnmountSuspense(
-  suspense: SuspenseBoundary | null,
-): SuspenseBoundary | null {
-  return currentUnmountSuspense === undefined
-    ? suspense
-    : currentUnmountSuspense
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component removal when using Suspense, including nested and interop-rendered content.
  * Prevented stale or incorrect Suspense context during unmounting.
  * Improved cleanup reliability when Suspense boundaries are removed or resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->