### PR TITLE
refactor(runtime-vapor): type the interop seam

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -261,7 +261,7 @@ export interface VaporInVdomInterface {
  * outlet's position in the fallback chain; see renderVDOMSlot.
  */
 export interface VdomSlotOptions {
-  fallback?: any // VaporSlot
+  fallback?: (...args: any[]) => any // VaporSlot
   once?: boolean
   slotRoot?: boolean
   sharedFallback?: boolean

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -17,7 +17,13 @@ import type {
   ComponentPublicInstance,
 } from './componentPublicInstance'
 import { type Directive, validateDirectiveName } from './directives'
-import type { ElementNamespace, MoveType, RootRenderFunction } from './renderer'
+import type {
+  ElementNamespace,
+  MoveType,
+  RendererElement,
+  RendererNode,
+  RootRenderFunction,
+} from './renderer'
 import type { InjectionKey } from './apiInject'
 import { warn } from './warning'
 import type { VNode } from './vnode'
@@ -180,8 +186,8 @@ export interface AppConfig extends GenericAppConfig {
 export interface VaporInVdomInterface {
   mount(
     vnode: VNode,
-    container: any,
-    anchor: any,
+    container: RendererElement,
+    anchor: RendererNode | null,
     parentComponent: ComponentInternalInstance | null,
     parentSuspense: SuspenseBoundary | null,
     onBeforeMount?: () => void,
@@ -201,53 +207,66 @@ export interface VaporInVdomInterface {
   ): void
   move(
     vnode: VNode,
-    container: any,
-    anchor: any,
+    container: RendererElement,
+    anchor: RendererNode | null,
     moveType: MoveType,
     parentSuspense: SuspenseBoundary | null,
   ): void
   slot(
     n1: VNode | null,
     n2: VNode,
-    container: any,
-    anchor: any,
+    container: RendererElement,
+    anchor: RendererNode | null,
     parentComponent: ComponentInternalInstance | null,
     parentSuspense: SuspenseBoundary | null,
     slotScopeIds: string[] | null,
   ): void
   hydrate(
     vnode: VNode,
-    node: any,
-    container: any,
-    anchor: any,
+    node: Node,
+    container: RendererElement,
+    anchor: RendererNode | null,
     parentComponent: ComponentInternalInstance | null,
     parentSuspense: SuspenseBoundary | null,
     onBeforeMount?: () => void,
     onVnodeBeforeMount?: () => void,
-  ): Node
+  ): Node | null
   hydrateSlot(
     vnode: VNode,
-    node: any,
+    node: Node,
     parentComponent: ComponentInternalInstance | null,
     parentSuspense: SuspenseBoundary | null,
     slotScopeIds: string[] | null,
-  ): Node
+  ): Node | null
   activate(
     vnode: VNode,
-    container: any,
-    anchor: any,
+    container: RendererElement,
+    anchor: RendererNode | null,
     parentComponent: ComponentInternalInstance,
     parentSuspense: SuspenseBoundary | null,
   ): void
   deactivate(
     vnode: VNode,
-    container: any,
+    container: RendererElement,
     parentSuspense: SuspenseBoundary | null,
   ): void
   setTransitionHooks(
     component: ComponentInternalInstance,
     transition: TransitionHooks,
   ): void
+}
+
+/**
+ * Options for rendering a VDOM slot inside vapor. The booleans describe the
+ * outlet's position in the fallback chain; see renderVDOMSlot.
+ */
+export interface VdomSlotOptions {
+  fallback?: any // VaporSlot
+  once?: boolean
+  slotRoot?: boolean
+  sharedFallback?: boolean
+  inheritFallback?: boolean
+  adoptAnchor?: Node
 }
 
 /**
@@ -266,12 +285,7 @@ export interface VdomInVaporInterface {
     name: string | (() => string),
     props: Record<string, any>,
     parentComponent: any, // VaporComponentInstance
-    fallback?: any, // VaporSlot
-    once?: boolean,
-    slotRoot?: boolean,
-    sharedFallback?: boolean,
-    inheritFallback?: boolean,
-    adoptAnchor?: Node,
+    options?: VdomSlotOptions,
   ) => any
   mountVNode: (
     vnode: VNode,

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -524,6 +524,7 @@ export { type NormalizedPropsOptions } from './componentProps'
 export {
   type VaporInVdomInterface,
   type VdomInVaporInterface,
+  type VdomSlotOptions,
 } from './apiCreateApp'
 /**
  * @internal

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1376,7 +1376,7 @@ describe('component: slots', () => {
         default: () => [h('div', text.value)],
       })
       const frag = withSlotBoundary(boundary, () =>
-        vdom.slot(slotsRef, 'default', {}, instance, undefined, false, true),
+        vdom.slot(slotsRef, 'default', {}, instance, { slotRoot: true }),
       )
       const host = document.createElement('div')
 
@@ -1436,15 +1436,10 @@ describe('component: slots', () => {
         default: () => (show.value ? [h('div', 'content')] : []),
       })
       const frag = withSlotBoundary(boundary, () =>
-        vdom.slot(
-          slotsRef,
-          'default',
-          {},
-          instance,
-          () => template('fallback')(),
-          false,
-          true,
-        ),
+        vdom.slot(slotsRef, 'default', {}, instance, {
+          fallback: () => template('fallback')(),
+          slotRoot: true,
+        }),
       )
       const host = document.createElement('div')
 
@@ -1773,7 +1768,7 @@ describe('component: slots', () => {
         default: () => (show.value ? [h('div', 'content')] : []),
       })
       const frag = withSlotBoundary(boundary, () =>
-        vdom.slot(slotsRef, 'default', {}, instance, undefined, false, true),
+        vdom.slot(slotsRef, 'default', {}, instance, { slotRoot: true }),
       )
       const host = document.createElement('div')
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -309,12 +309,14 @@ export function createSlot(
         name,
         slotProps,
         instance,
-        fallback,
-        once,
-        slotRoot,
-        sharedFallback,
-        inheritFallback,
-        _insertionAnchor,
+        {
+          fallback,
+          once,
+          slotRoot,
+          sharedFallback,
+          inheritFallback,
+          adoptAnchor: _insertionAnchor,
+        },
       )
     } finally {
       setCurrentSlotScopeIds(prevSlotScopeIds)

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -24,6 +24,7 @@ import {
   type VaporInVdomInterface,
   VaporSlot as VaporSlotVNode,
   type VdomInVaporInterface,
+  type VdomSlotOptions,
   callWithAsyncErrorHandling,
   cloneVNode,
   createCommentVNode,
@@ -226,6 +227,13 @@ function isVaporTransitionHooks(
   return !!hooks && (hooks as VaporTransitionHooks).__vapor === true
 }
 
+// runtime-core types `vnode.component` as its own instance; on a vapor vnode
+// it holds the vapor instance, and that union is not nameable cross-package.
+// The one cast, named.
+function getVaporInstance(vnode: VNode): VaporComponentInstance {
+  return vnode.component as any
+}
+
 function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
@@ -328,8 +336,8 @@ function filterReservedProps(props: VNode['props']): VNode['props'] {
 const vaporInteropImpl: VaporInVdomInterface = {
   mount(
     vnode,
-    container,
-    anchor,
+    container: ParentNode,
+    anchor: Node | null,
     parentComponent,
     parentSuspense,
     onBeforeMount,
@@ -427,7 +435,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
     n2.el = n1.el
     n2.anchor = n1.anchor
 
-    const instance = n2.component as any as VaporComponentInstance
+    const instance = getVaporInstance(n2)
     const vnodeHookState = ensureVNodeHookState(instance, n2)
 
     if (shouldUpdate) {
@@ -477,7 +485,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
     }
 
     const container = doRemove ? vnode.anchor!.parentNode : undefined
-    const instance = vnode.component as any as VaporComponentInstance
+    const instance = getVaporInstance(vnode)
     let slotStartAnchor: Node | null = null
     if (instance) {
       const anchor = vnode.anchor as Node | null
@@ -543,8 +551,8 @@ const vaporInteropImpl: VaporInVdomInterface = {
   slot(
     n1: VNode,
     n2: VNode,
-    container,
-    anchor,
+    container: ParentNode,
+    anchor: Node | null,
     parentComponent,
     parentSuspense,
     slotScopeIds,
@@ -620,7 +628,13 @@ const vaporInteropImpl: VaporInVdomInterface = {
     }
   },
 
-  move(vnode, container, anchor, moveType, parentSuspense) {
+  move(
+    vnode,
+    container: ParentNode,
+    anchor: Node | null,
+    moveType,
+    parentSuspense,
+  ) {
     const block = vnode.vb || (vnode.component as any)
     // Resolved Vapor blocks exclude the VDOM-owned opening marker, but a
     // pending hydration range includes it. Avoid moving `vnode.el` twice.
@@ -654,9 +668,9 @@ const vaporInteropImpl: VaporInVdomInterface = {
 
   hydrate(
     vnode,
-    node,
-    container,
-    anchor,
+    node: Node,
+    container: ParentNode,
+    anchor: Node | null,
     parentComponent,
     parentSuspense,
     onBeforeMount,
@@ -691,7 +705,13 @@ const vaporInteropImpl: VaporInVdomInterface = {
     return anchor
   },
 
-  hydrateSlot(vnode, node, parentComponent, parentSuspense, slotScopeIds) {
+  hydrateSlot(
+    vnode,
+    node: Node,
+    parentComponent,
+    parentSuspense,
+    slotScopeIds,
+  ) {
     if (!isHydrating && !isVdomHydrating && !isVdomHydratingEnabled) {
       return node
     }
@@ -747,14 +767,20 @@ const vaporInteropImpl: VaporInVdomInterface = {
     setVaporTransitionHooks(component as any, hooks as VaporTransitionHooks)
   },
 
-  activate(vnode, container, anchor, parentComponent, parentSuspense) {
+  activate(
+    vnode,
+    container: ParentNode,
+    anchor: Node | null,
+    parentComponent,
+    parentSuspense,
+  ) {
     const cached = (parentComponent.ctx as KeepAliveContext).getCachedComponent(
       vnode,
     )
     vnode.el = cached.el
     vnode.component = cached.component
     vnode.anchor = cached.anchor
-    const instance = vnode.component as any as VaporComponentInstance
+    const instance = getVaporInstance(vnode)
     const vnodeHookState = ensureVNodeHookState(instance, vnode)
     const rootEl = getRootElement(instance)
     if (rootEl) {
@@ -836,8 +862,8 @@ const vaporInteropImpl: VaporInVdomInterface = {
     }
   },
 
-  deactivate(vnode, container, parentSuspense) {
-    const instance = vnode.component as any as VaporComponentInstance
+  deactivate(vnode, container: ParentNode, parentSuspense) {
+    const instance = getVaporInstance(vnode)
     deactivate(instance, container, parentSuspense)
     insert(vnode.anchor as any, container)
     queuePostRenderEffect(
@@ -1716,19 +1742,26 @@ interface PendingOutIn {
  * - `hydrateContent` — the one-shot SSR range claimer
  * - fallback plumbing through slotFragment's SlotResolutionState protocol
  */
+interface VaporVdomSlotOptions extends VdomSlotOptions {
+  fallback?: VaporSlot
+}
+
 function renderVDOMSlot(
   internals: RendererInternals,
   slotsRef: ShallowRef<Slots>,
   name: string | (() => string),
   props: Record<string, any>,
   parentComponent: VaporComponentInstance,
-  fallback?: VaporSlot,
-  once?: boolean,
-  slotRoot?: boolean,
-  sharedFallback?: boolean,
-  inheritFallback?: boolean,
-  adoptAnchor?: Node,
+  options: VaporVdomSlotOptions = EMPTY_OBJ,
 ): VaporFragment {
+  const {
+    fallback,
+    once,
+    slotRoot,
+    sharedFallback,
+    inheritFallback,
+    adoptAnchor,
+  } = options
   let suspense = currentParentSuspense || parentComponent.suspense
   // frag.slotScopeIds is the outlet's id cell (the ambient createSlot
   // establishes around this call) — the base patch context for content

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -549,7 +549,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
    * vapor slot in vdom
    */
   slot(
-    n1: VNode,
+    n1: VNode | null,
     n2: VNode,
     container: ParentNode,
     anchor: Node | null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved type safety across rendering, hydration, activation, and interoperability APIs.
  * Updated slot configuration to use a clearer options object.
  * Added support for configuring slot fallbacks and rendering behavior in one place.
  * Hydration APIs now accurately indicate when no node is returned.
  * Improved interoperability between VDOM and Vapor rendering modes while preserving existing slot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->