### PR TITLE
Revert "fix(compiler-core): handle invalid static arg in same-name v-bind shorthand"

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vBind.spec.ts
@@ -435,7 +435,6 @@ describe('compiler: transform v-bind', () => {
   test('error on invalid argument for same-name shorthand', () => {
     const onError = vi.fn()
     parseWithVBind(`<div v-bind:[arg] />`, { onError })
-    expect(onError).toHaveBeenCalledTimes(1)
     expect(onError.mock.calls[0][0]).toMatchObject({
       code: ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
       loc: {
@@ -449,30 +448,5 @@ describe('compiler: transform v-bind', () => {
         },
       },
     })
-  })
-
-  test('error on invalid static argument for same-name shorthand', () => {
-    const onError = vi.fn()
-    expect(() => parseWithVBind(`<div :2xl />`, { onError })).not.toThrow()
-    expect(onError).toHaveBeenCalledTimes(1)
-    expect(onError.mock.calls[0][0]).toMatchObject({
-      code: ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
-      message:
-        "v-bind with same-name shorthand only allows static arguments that start with a valid identifier character or '-'.",
-    })
-  })
-
-  test('error on invalid static argument in browser build', () => {
-    try {
-      __BROWSER__ = true
-      const onError = vi.fn()
-      expect(() => parseWithVBind(`<div :2xl />`, { onError })).not.toThrow()
-      expect(onError).toHaveBeenCalledTimes(1)
-      expect(onError.mock.calls[0][0]).toMatchObject({
-        code: ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
-      })
-    } finally {
-      __BROWSER__ = false
-    }
   })
 })

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -161,9 +161,7 @@ export const errorMessages: Record<ErrorCodes, string> = {
   [ErrorCodes.X_V_FOR_MALFORMED_EXPRESSION]: `v-for has invalid expression.`,
   [ErrorCodes.X_V_FOR_TEMPLATE_KEY_PLACEMENT]: `<template v-for> key should be placed on the <template> tag.`,
   [ErrorCodes.X_V_BIND_NO_EXPRESSION]: `v-bind is missing expression.`,
-  [ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT]:
-    `v-bind with same-name shorthand only allows static arguments that ` +
-    `start with a valid identifier character or '-'.`,
+  [ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT]: `v-bind with same-name shorthand only allows static argument.`,
   [ErrorCodes.X_V_ON_NO_EXPRESSION]: `v-on is missing expression.`,
   [ErrorCodes.X_V_SLOT_UNEXPECTED_DIRECTIVE_ON_SLOT_OUTLET]: `Unexpected custom directive on <slot> outlet.`,
   [ErrorCodes.X_V_SLOT_MIXED_SLOT_USAGE]:

--- a/packages/compiler-core/src/transforms/transformVBindShorthand.ts
+++ b/packages/compiler-core/src/transforms/transformVBindShorthand.ts
@@ -31,7 +31,7 @@ export const transformVBindShorthand: NodeTransform = (node, context) => {
               arg.loc,
             ),
           )
-          prop.exp = createSimpleExpression('undefined', false, arg.loc)
+          prop.exp = createSimpleExpression('', true, arg.loc)
         } else {
           const propName = camelize((arg as SimpleExpressionNode).content)
           if (
@@ -40,14 +40,6 @@ export const transformVBindShorthand: NodeTransform = (node, context) => {
             propName[0] === '-'
           ) {
             prop.exp = createSimpleExpression(propName, false, arg.loc)
-          } else {
-            context.onError(
-              createCompilerError(
-                ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT,
-                arg.loc,
-              ),
-            )
-            prop.exp = createSimpleExpression('undefined', false, arg.loc)
           }
         }
       }


### PR DESCRIPTION
Reverts vuejs/core#15347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of same-name `v-bind` shorthand with invalid or dynamic arguments.
  * Updated the related compiler error message for clearer, more concise guidance.
  * Prevented invalid shorthand arguments from producing unexpected compiler behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->