### PR TITLE
fix(hmr): cover vapor fast-path reload with the hmr updating flag and reset it on failed updates

### DIFF
--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -58,6 +58,27 @@ if (__DEV__) {
   } as HMRRuntime
 }
 
+// Run one HMR update pass with `isHmrUpdating` set. On success the flag is
+// kept through the tick so queued follow-up work (forced child updates,
+// interop re-renders) is still covered; a failed pass has no follow-up work,
+// so reset immediately rather than leaving the flag permanently set.
+function runWithHmrUpdating(fn: () => void): void {
+  isHmrUpdating = true
+  let done = false
+  try {
+    fn()
+    done = true
+  } finally {
+    if (done) {
+      nextTick(() => {
+        isHmrUpdating = false
+      })
+    } else {
+      isHmrUpdating = false
+    }
+  }
+}
+
 const map: Map<
   string,
   {
@@ -128,19 +149,17 @@ function rerender(id: string, newRender?: Function): void {
       normalizeClassComponent(instance.type as HMRComponent).render = newRender
     }
     // this flag forces child components with slot content to update
-    isHmrUpdating = true
-    if (instance.vapor) {
-      if (!instance.isUnmounted) instance.hmrRerender!()
-    } else {
-      const i = instance as ComponentInternalInstance
-      // #13771 don't update if the job is already disposed
-      if (!(i.effect.flags! & EffectFlags.STOP)) {
-        i.renderCache = []
-        i.effect.run()
+    runWithHmrUpdating(() => {
+      if (instance.vapor) {
+        if (!instance.isUnmounted) instance.hmrRerender!()
+      } else {
+        const i = instance as ComponentInternalInstance
+        // #13771 don't update if the job is already disposed
+        if (!(i.effect.flags! & EffectFlags.STOP)) {
+          i.renderCache = []
+          i.effect.run()
+        }
       }
-    }
-    nextTick(() => {
-      isHmrUpdating = false
     })
   })
 }
@@ -175,22 +194,27 @@ function reload(id: string, newComp: HMRComponent): void {
     }
     const dirtyInstances = new Set(instances)
     const rerenderedParents = new Set<GenericComponentInstance>()
-    for (const instance of instances) {
-      const parent = instance.parent
-      if (parent) {
-        // A dirty ancestor will recreate this child. Otherwise, each parent
-        // only needs one rerender for this HMR record.
-        if (
-          !hasDirtyAncestor(instance, dirtyInstances) &&
-          !rerenderedParents.has(parent)
-        ) {
-          rerenderedParents.add(parent)
-          parent.hmrRerender!()
+    // parent rerenders re-run the setup/render of mounted instances, which is
+    // only exempt from mounted-state dev checks (e.g. provide()) while the
+    // hmr flag is set - same as the other update paths
+    runWithHmrUpdating(() => {
+      for (const instance of instances) {
+        const parent = instance.parent
+        if (parent) {
+          // A dirty ancestor will recreate this child. Otherwise, each parent
+          // only needs one rerender for this HMR record.
+          if (
+            !hasDirtyAncestor(instance, dirtyInstances) &&
+            !rerenderedParents.has(parent)
+          ) {
+            rerenderedParents.add(parent)
+            parent.hmrRerender!()
+          }
+        } else {
+          instance.hmrReload!(newComp)
         }
-      } else {
-        instance.hmrReload!(newComp)
       }
-    }
+    })
   } else {
     const parentUpdates = new Map<
       GenericComponentInstance,
@@ -255,23 +279,24 @@ function reload(id: string, newComp: HMRComponent): void {
     }
     parentUpdates.forEach((updates, parent) => {
       queueJob(() => {
-        isHmrUpdating = true
-        if (parent.vapor) {
-          parent.hmrRerender!()
-        } else {
-          const i = parent as ComponentInternalInstance
-          if (!(i.effect.flags! & EffectFlags.STOP)) {
-            i.renderCache = []
-            i.effect.run()
-          }
+        try {
+          runWithHmrUpdating(() => {
+            if (parent.vapor) {
+              parent.hmrRerender!()
+            } else {
+              const i = parent as ComponentInternalInstance
+              if (!(i.effect.flags! & EffectFlags.STOP)) {
+                i.renderCache = []
+                i.effect.run()
+              }
+            }
+          })
+        } finally {
+          // #6930, #11248 avoid infinite recursion
+          updates.forEach(([instance, dirtyInstances]) => {
+            dirtyInstances.delete(instance)
+          })
         }
-        nextTick(() => {
-          isHmrUpdating = false
-        })
-        // #6930, #11248 avoid infinite recursion
-        updates.forEach(([instance, dirtyInstances]) => {
-          dirtyInstances.delete(instance)
-        })
       })
     })
   }

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -3170,7 +3170,7 @@ describe('VaporKeepAlive', () => {
 
     const toggle = ref(true)
     const { instance } = define({
-      setup() {
+      render() {
         return createComponent(VaporKeepAlive, null, {
           default: () =>
             createIf(
@@ -3194,9 +3194,13 @@ describe('VaporKeepAlive', () => {
     keepAliveInstance.hmrRerender!()
     await nextTick()
 
-    expect(cache.size).toBe(1)
-    const keyA2 = Array.from(cache.keys())[0]
-    const cachedA2 = cache.get(keyA2)
+    // the rerender goes through the parent, replacing the KeepAlive instance
+    const newKeepAliveInstance = instance!.block as any
+    expect(newKeepAliveInstance).not.toBe(keepAliveInstance)
+    const newCache = newKeepAliveInstance.__v_cache as Map<any, any>
+    expect(newCache.size).toBe(1)
+    const keyA2 = Array.from(newCache.keys())[0]
+    const cachedA2 = newCache.get(keyA2)
     expect(keyA2).toBe(keyA1)
     expect(cachedA2).not.toBe(cachedA1)
   })

--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -1453,19 +1453,20 @@ describe('api: template ref', () => {
 
     expect(fn1).toHaveBeenCalledTimes(1)
     expect(fn2).toHaveBeenCalledTimes(0)
-    expect(app._instance!.scope.cleanups.length).toBe(1)
+    const { cleanups } = (app._instance as any).renderScope
+    expect(cleanups.length).toBe(1)
 
     toggle.value = false
     await nextTick()
     expect(fn1).toHaveBeenCalledTimes(1)
     expect(fn2).toHaveBeenCalledTimes(1)
-    expect(app._instance!.scope.cleanups.length).toBe(1)
+    expect(cleanups.length).toBe(1)
 
     toggle.value = true
     await nextTick()
     expect(fn1).toHaveBeenCalledTimes(2)
     expect(fn2).toHaveBeenCalledTimes(1)
-    expect(app._instance!.scope.cleanups.length).toBe(1)
+    expect(cleanups.length).toBe(1)
 
     app.unmount()
     await nextTick()
@@ -1496,13 +1497,14 @@ describe('api: template ref', () => {
 
     expect(el1.value).toBe(host.children[0])
     expect(el2.value).toBe(null)
-    expect(app._instance!.scope.cleanups.length).toBe(1)
+    const { cleanups } = (app._instance as any).renderScope
+    expect(cleanups.length).toBe(1)
 
     toggle.value = false
     await nextTick()
     expect(el1.value).toBe(null)
     expect(el2.value).toBe(host.children[0])
-    expect(app._instance!.scope.cleanups.length).toBe(1)
+    expect(cleanups.length).toBe(1)
 
     app.unmount()
     await nextTick()

--- a/packages/runtime-vapor/__tests__/hmr.spec.ts
+++ b/packages/runtime-vapor/__tests__/hmr.spec.ts
@@ -27,6 +27,7 @@ import {
   defineVaporAsyncComponent,
   defineVaporComponent,
   delegateEvents,
+  insert,
   renderEffect,
   setText,
   template,
@@ -368,6 +369,140 @@ describe('hot module replacement', () => {
       '[HMR] Something went wrong during Vue component hot-reload.',
     ).toHaveBeenWarned()
     expect(leakedInstance).toBe(null)
+  })
+
+  test('rerender should preserve fallthrough attrs', () => {
+    const root = document.createElement('div')
+    const childId = 'test-rerender-fallthrough-child'
+
+    const Child = defineVaporComponent({
+      __hmrId: childId,
+      render: compileToFunction(`<div>child</div>`),
+    })
+    createRecord(childId, Child as any)
+
+    const Parent = defineVaporComponent({
+      components: { Child },
+      render: compileToFunction(`<Child class="test" />`),
+    })
+
+    define(Parent).create().mount(root)
+    expect(root.innerHTML).toBe(`<div class="test">child</div>`)
+
+    rerender(childId, compileToFunction(`<div>child2</div>`))
+    expect(root.innerHTML).toBe(`<div class="test">child2</div>`)
+  })
+
+  test('reload child under setup-only parent should preserve parent fallthrough attrs', async () => {
+    const root = document.createElement('div')
+    const childId = 'test-reload-setup-only-fallthrough-child'
+
+    const Child = defineVaporComponent({
+      __hmrId: childId,
+      render: compileToFunction(`<span>old</span>`),
+    })
+    createRecord(childId, Child as any)
+
+    const Parent = defineVaporComponent({
+      setup() {
+        const el = template('<b></b>')() as ParentNode
+        insert(createComponent(Child), el)
+        return el
+      },
+    })
+
+    const GrandParent = defineVaporComponent({
+      components: { Parent: Parent as any },
+      render: compileToFunction(`<Parent class="test" />`),
+    })
+
+    define(GrandParent).create().mount(root)
+    expect(root.innerHTML).toBe(`<b class="test"><span>old</span></b>`)
+
+    reload(childId, {
+      __vapor: true,
+      __hmrId: childId,
+      render: compileToFunction(`<span>new</span>`),
+    })
+    await nextTick()
+    expect(root.innerHTML).toBe(`<b class="test"><span>new</span></b>`)
+  })
+
+  test('rerender should tear down element-nested child components', async () => {
+    const root = document.createElement('div')
+    const parentId = 'test-rerender-nested-teardown-parent'
+    const external = ref(0)
+    const effectSpy = vi.fn()
+    const mountSpy = vi.fn()
+    const unmountSpy = vi.fn()
+
+    const Child = defineVaporComponent({
+      setup() {
+        watchEffect(() => effectSpy(external.value))
+        onMounted(mountSpy)
+        onUnmounted(unmountSpy)
+      },
+      render: () => template('<i>c</i>')(),
+    })
+
+    const Parent = defineVaporComponent({
+      __hmrId: parentId,
+      components: { Child },
+      // element-nested child: not part of the parent's logical block graph
+      render: compileToFunction(`<div>x<Child/></div>`),
+    })
+    createRecord(parentId, Parent as any)
+
+    const { app } = define(Parent).create().mount(root)
+    await nextTick()
+    expect(effectSpy).toHaveBeenCalledTimes(1)
+    expect(mountSpy).toHaveBeenCalledTimes(1)
+
+    rerender(parentId, compileToFunction(`<div>y<Child/></div>`))
+    await nextTick()
+    expect(root.innerHTML).toBe(`<div>y<i>c</i></div>`)
+    expect(unmountSpy).toHaveBeenCalledTimes(1)
+    expect(mountSpy).toHaveBeenCalledTimes(2)
+    expect(effectSpy).toHaveBeenCalledTimes(2)
+    external.value++
+    await nextTick()
+    expect(effectSpy).toHaveBeenCalledTimes(3)
+
+    app.unmount()
+    await nextTick()
+    expect(unmountSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('rerender should unregister replaced child instances from hmr records', () => {
+    const root = document.createElement('div')
+    const parentId = 'test-rerender-unregister-parent'
+    const childId = 'test-rerender-unregister-child'
+    const renderSpy = vi.fn()
+
+    const Child = defineVaporComponent({
+      __hmrId: childId,
+      render: compileToFunction(`<span>v1</span>`),
+    })
+    createRecord(childId, Child as any)
+
+    const Parent = defineVaporComponent({
+      __hmrId: parentId,
+      components: { Child },
+      render: compileToFunction(`<div>x<Child/></div>`),
+    })
+    createRecord(parentId, Parent as any)
+
+    define(Parent).create().mount(root)
+    rerender(parentId, compileToFunction(`<div>y<Child/></div>`))
+    expect(root.innerHTML).toBe(`<div>y<span>v1</span></div>`)
+
+    // a leaked old instance would invoke the new render a second time
+    rerender(childId, () => {
+      renderSpy()
+      return template('<span>v2</span>')()
+    })
+    expect(root.innerHTML).toBe(`<div>y<span>v2</span></div>`)
+    expect(renderSpy).toHaveBeenCalledTimes(1)
   })
 
   // the vapor fast path rerenders parents synchronously; re-running a mounted
@@ -717,19 +852,27 @@ describe('hot module replacement', () => {
     expect(activeSpy).toHaveBeenCalledTimes(1)
     expect(deactivatedSpy).toHaveBeenCalledTimes(0)
 
-    // should not unmount when toggling
+    // should not unmount when toggling; the recreated content keeps its
+    // transition hooks
     triggerEvent('click', root.children[0] as Element)
     await nextTick()
+    expect(root.innerHTML).toBe(
+      `<button></button><div class="v-leave-from v-leave-active">1</div><!--if-->`,
+    )
+    await timeout()
     expect(root.innerHTML).toBe(`<button></button><!--if-->`)
     expect(unmountSpy).toHaveBeenCalledTimes(1)
     expect(mountSpy).toHaveBeenCalledTimes(1)
     expect(activeSpy).toHaveBeenCalledTimes(1)
     expect(deactivatedSpy).toHaveBeenCalledTimes(1)
 
-    // should not mount when toggling
+    // should not mount when toggling; enter classes stay in place - jsdom
+    // never fires transitionend
     triggerEvent('click', root.children[0] as Element)
     await nextTick()
-    expect(root.innerHTML).toBe(`<button></button><div>1</div><!--if-->`)
+    expect(root.innerHTML).toBe(
+      `<button></button><div class="v-enter-from v-enter-active">1</div><!--if-->`,
+    )
     expect(unmountSpy).toHaveBeenCalledTimes(1)
     expect(mountSpy).toHaveBeenCalledTimes(1)
     expect(activeSpy).toHaveBeenCalledTimes(2)
@@ -809,10 +952,13 @@ describe('hot module replacement', () => {
     expect(activeSpy).toHaveBeenCalledTimes(1)
     expect(deactivatedSpy).toHaveBeenCalledTimes(1)
 
-    // should not mount when toggling
+    // should not mount when toggling; enter classes stay in place - jsdom
+    // never fires transitionend
     triggerEvent('click', root.children[0] as Element)
     await nextTick()
-    expect(root.innerHTML).toBe(`<button></button><div>1</div><!--if-->`)
+    expect(root.innerHTML).toBe(
+      `<button></button><div class="v-enter-from v-enter-active">1</div><!--if-->`,
+    )
     expect(unmountSpy).toHaveBeenCalledTimes(1)
     expect(mountSpy).toHaveBeenCalledTimes(1)
     expect(activeSpy).toHaveBeenCalledTimes(2)

--- a/packages/runtime-vapor/__tests__/hmr.spec.ts
+++ b/packages/runtime-vapor/__tests__/hmr.spec.ts
@@ -370,6 +370,123 @@ describe('hot module replacement', () => {
     expect(leakedInstance).toBe(null)
   })
 
+  // the vapor fast path rerenders parents synchronously; re-running a mounted
+  // parent's setup (e.g. its provide() calls) is only exempt from misuse
+  // warnings while the hmr updating flag is set
+  test('reload with vapor fast path should set hmr updating state', async () => {
+    const childId = 'test-fast-path-reload-hmr-flag'
+    const Child = defineVaporComponent({
+      __hmrId: childId,
+      render: compileToFunction(`<div>foo</div>`),
+    })
+    createRecord(childId, Child as any)
+
+    const Parent = defineVaporComponent({
+      setup() {
+        provide('foo', 'bar')
+        return createComponent(Child)
+      },
+    })
+
+    const { html } = define({
+      setup() {
+        return createComponent(Parent)
+      },
+    }).render()
+
+    expect(html()).toBe('<div>foo</div>')
+
+    // __vapor is present on real plugin payloads and selects the fast path
+    reload(childId, {
+      __vapor: true,
+      __hmrId: childId,
+      render: compileToFunction(`<div>bar</div>`),
+    })
+
+    await nextTick()
+    expect(html()).toBe('<div>bar</div>')
+    expect('provide() can only be used inside setup()').not.toHaveBeenWarned()
+  })
+
+  test('failed rerender should still reset hmr updating state', async () => {
+    const root = document.createElement('div')
+    const id = 'test-failed-rerender-hmr-flag'
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const Comp = defineVaporComponent({
+      __hmrId: id,
+      render: () => template('ok')(),
+    })
+    createRecord(id, Comp as any)
+
+    const app = createVaporApp(Comp)
+    app.mount(root)
+
+    rerender(id, () => {
+      throw new Error('hmr rerender error')
+    })
+    errorSpy.mockRestore()
+    expect(
+      'Unhandled error during execution of render function',
+    ).toHaveBeenWarned()
+    expect(
+      '[HMR] Something went wrong during Vue component hot-reload.',
+    ).toHaveBeenWarned()
+    await nextTick()
+
+    // the flag must not leak past the failed update: provide() misuse on a
+    // mounted instance is only exempt from the warning while it is set
+    setCurrentInstance((app as any)._instance)
+    provide('foo', 'bar')
+    setCurrentInstance(null, undefined)
+    expect('provide() can only be used inside setup()').toHaveBeenWarned()
+  })
+
+  test('failed queued reload should still reset hmr updating state', async () => {
+    const root = document.createElement('div')
+    const childId = 'test-failed-queued-reload-hmr-flag'
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const Child = defineVaporComponent({
+      __hmrId: childId,
+      render: () => template('old')(),
+    })
+    createRecord(childId, Child as any)
+
+    const Parent = defineVaporComponent({
+      render: () => createComponent(Child),
+    })
+
+    const app = createVaporApp(Parent)
+    app.mount(root)
+
+    // no __vapor on the payload -> fallback path -> queued parent update
+    reload(childId, {
+      __hmrId: childId,
+      setup() {
+        throw new Error('hmr reload error')
+      },
+      render: () => template('new')(),
+    })
+    // the queued parent rerender rethrows the setup error in tests
+    await nextTick().catch(() => {})
+    errorSpy.mockRestore()
+    expect(
+      'Unhandled error during execution of setup function',
+    ).toHaveBeenWarned()
+    expect(
+      'Unhandled error during execution of render function',
+    ).toHaveBeenWarned()
+    expect(
+      'Unhandled error during execution of scheduler flush',
+    ).toHaveBeenWarned()
+
+    setCurrentInstance((app as any)._instance)
+    provide('foo', 'bar')
+    setCurrentInstance(null, undefined)
+    expect('provide() can only be used inside setup()').toHaveBeenWarned()
+  })
+
   test('reload KeepAlive slot', async () => {
     const root = document.createElement('div')
     document.body.appendChild(root)

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1,5 +1,6 @@
 import {
   type AsyncComponentInternalOptions,
+  type ComponentCustomElementInterface,
   type ComponentInternalInstance,
   type ComponentInternalOptions,
   type ComponentObjectPropsOptions,
@@ -79,7 +80,7 @@ import {
   setupPropsValidation,
   snapshotRawProps,
 } from './componentProps'
-import { type RenderEffect, renderEffect } from './renderEffect'
+import { renderEffect } from './renderEffect'
 import { emit, normalizeEmitsOptions } from './componentEmits'
 import { setDynamicProps } from './dom/prop'
 import {
@@ -753,8 +754,23 @@ function callRender(
 
 /**
  * dev only
+ * Runs devRender with everything it creates owned by a fresh per-render
+ * scope, so HMR rerender can tear down one generation by stopping the
+ * scope - including components nested inside elements, which the block
+ * graph cannot reach.
  */
-export function devRender(instance: VaporComponentInstance): void {
+export function runDevRender(instance: VaporComponentInstance): void {
+  // reset per-render dev state, preserving the optional-props marker
+  // (attrs === props installs no tracking proxy)
+  instance.accessedAttrs = instance.props === instance.attrs
+  const scope = (instance.renderScope = new EffectScope())
+  scope.run(() => devRender(instance))
+}
+
+/**
+ * dev only
+ */
+function devRender(instance: VaporComponentInstance): void {
   const prev = setCurrentRenderingInstance(
     instance as unknown as ComponentInternalInstance,
   )
@@ -862,6 +878,8 @@ export class VaporComponentInstance<
   // chain so A(pending) -> B -> A renders only the final branch, matching VDOM.
   deferredKeepAliveUpdates?: DeferredKeepAliveUpdates
 
+  ce?: ComponentCustomElementInterface
+
   // for v-once: caches props/attrs values to ensure they remain frozen
   // even when the component re-renders due to local state changes
   oncePropsCache?: Record<string | symbol, any>
@@ -902,7 +920,7 @@ export class VaporComponentInstance<
   emitsOptions?: ObjectEmitsOptions | null
   isSingleRoot?: boolean
   // for HMR rerender
-  renderEffects?: RenderEffect[]
+  renderScope?: EffectScope
 
   /**
    * dev only flag to track whether $attrs was used during render.
@@ -1676,7 +1694,7 @@ function handleSetupResult(
       }
       if (__DEV__) {
         instance.setupState = createDevSetupStateProxy(proxyRefs(setupResult))
-        devRender(instance)
+        runDevRender(instance)
       } else {
         // component has a render function but no setup function
         // (typically components with only a template and no state)
@@ -1688,17 +1706,27 @@ function handleSetupResult(
     instance.block = setupResult as Block
   }
 
-  // single root, inherit attrs. Gate on fallthrough *potential* only:
-  // attrs may be empty now and gain keys later, so emptiness is handled
-  // reactively inside the render effect.
-  if (instance.hasFallthrough && component.inheritAttrs !== false) {
-    // attach attrs to the root element, or to root dynamic fragments so they
-    // can be (re-)applied during each branch update
-    applyFallthroughAttrs(instance.block, instance)
-  }
+  applyComponentFallthrough(instance)
 
   if (__DEV__) {
     popWarningContext()
+  }
+}
+
+// single root, inherit attrs. Gate on fallthrough *potential* only:
+// attrs may be empty now and gain keys later, so emptiness is handled
+// reactively inside the render effect.
+export function applyComponentFallthrough(
+  instance: VaporComponentInstance,
+): void {
+  if (instance.hasFallthrough && instance.type.inheritAttrs !== false) {
+    // attach attrs to the root element, or to root dynamic fragments so they
+    // can be (re-)applied during each branch update
+    applyFallthroughAttrs(
+      instance.block,
+      instance,
+      __DEV__ ? instance.renderScope : undefined,
+    )
   }
 }
 

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -134,31 +134,6 @@ const VaporKeepAliveImpl = defineVaporComponent({
       ;(keepAliveInstance as any).__v_keptAliveScopes = keptAliveScopes
     }
 
-    // Clear cache and shapeFlags before HMR rerender so cached components
-    // can be properly unmounted
-    if (__DEV__) {
-      const rerender = keepAliveInstance.hmrRerender
-      keepAliveInstance.hmrRerender = () => {
-        keepAliveInstance.exposed = null
-        cache.forEach(cached => {
-          unsetShapeFlag(cached)
-          if (cached !== current) {
-            // Cached blocks may contain interop children whose VDOM teardown
-            // is owned by remove(), not scope.stop().
-            const parentNode = findBlockBoundary(cached).parentNode
-            if (parentNode) remove(cached, parentNode as ParentNode)
-          }
-        })
-        cache.clear()
-        keys.clear()
-        keptAliveScopes.forEach(scope => scope.stop())
-        keptAliveScopes.clear()
-        storageContainer.innerHTML = ''
-        current = undefined
-        rerender!()
-      }
-    }
-
     const addCacheKey = (key: CacheKey): void => {
       const { max } = props
 

--- a/packages/runtime-vapor/src/hmr.ts
+++ b/packages/runtime-vapor/src/hmr.ts
@@ -8,19 +8,29 @@ import { findBlockBoundary, insert, remove } from './block'
 import {
   type VaporComponent,
   type VaporComponentInstance,
+  applyComponentFallthrough,
   createComponent,
-  devRender,
   mountComponent,
+  runDevRender,
   unmountComponent,
 } from './component'
 import { applyComponentScopeIds, setCurrentSlotScopeIds } from './scopeId'
 
 export function hmrRerender(instance: VaporComponentInstance): void {
+  // A component without a separate render function (built-ins like
+  // KeepAlive, reached via reload delegation) cannot re-run its template
+  // alone - degrade to reload semantics through the nearest vapor parent.
+  // Terminal cases (custom element root, vdom parent) fall through to an
+  // in-place setup re-run.
+  if (!instance.type.render) {
+    const parent = instance.parent
+    if (parent && parent.vapor) return parent.hmrRerender!()
+    if (!parent && !instance.ce) return instance.hmrReload!(instance.type)
+  }
   const { parentNode, nextNode: anchor } = findBlockBoundary(instance.block)
   const parent = parentNode as ParentNode
-  if (instance.renderEffects) {
-    instance.renderEffects.forEach(e => e.stop())
-    instance.renderEffects.length = 0
+  if (instance.renderScope) {
+    instance.renderScope.stop()
   }
   remove(instance.block, parent)
   const prev = setCurrentInstance(instance)
@@ -29,7 +39,8 @@ export function hmrRerender(instance: VaporComponentInstance): void {
   // scope ids never apply; root-only ids are re-applied below.
   const prevSlotScopeIds = setCurrentSlotScopeIds(null)
   try {
-    devRender(instance)
+    runDevRender(instance)
+    applyComponentFallthrough(instance)
   } finally {
     setCurrentSlotScopeIds(prevSlotScopeIds)
     popWarningContext()

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -42,20 +42,13 @@ export class RenderEffect extends ReactiveEffect {
       warn('renderEffect called without active EffectScope or Vapor instance.')
     }
 
-    if (instance) {
-      if (__DEV__ && !noLifecycle) {
-        this.onTrack = instance.rtc
-          ? e => invokeArrayFns(instance.rtc!, e)
-          : void 0
-        this.onTrigger = instance.rtg
-          ? e => invokeArrayFns(instance.rtg!, e)
-          : void 0
-      }
-
-      // register effect for HMR rerender cleanup
-      if (__DEV__) {
-        ;(instance.renderEffects ||= []).push(this)
-      }
+    if (__DEV__ && instance && !noLifecycle) {
+      this.onTrack = instance.rtc
+        ? e => invokeArrayFns(instance.rtc!, e)
+        : void 0
+      this.onTrigger = instance.rtg
+        ? e => invokeArrayFns(instance.rtg!, e)
+        : void 0
     }
 
     this.i = instance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hot Module Replacement (HMR) rerender and reload behavior for Vapor components.
  - Preserved fallthrough attributes during HMR updates.
  - Correctly handles components without dedicated render functions.
  - Ensured failed HMR updates reset their updating state cleanly.
  - Improved KeepAlive cache replacement and nested component cleanup during HMR.

- **Tests**
  - Added coverage for HMR state handling, attribute preservation, transitions, cache updates, and component teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->