### PR TITLE
fix(runtime-vapor): clear v-for index alias for non-object sources

### DIFF
--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -170,6 +170,30 @@ describe('createFor', () => {
     ])
   })
 
+  test('should clear index ref when source switches from object to array', async () => {
+    const source = ref<any>({ x: 'A' })
+
+    const { host } = define(() => {
+      return createFor(
+        () => source.value,
+        (item, key, index) => {
+          const div = document.createElement('div')
+          renderEffect(() => {
+            div.textContent = `${item.value}-${key.value}-${String(index.value)}`
+          })
+          return div
+        },
+      )
+    }).render()
+
+    expect(host.innerHTML).toBe('<div>A-x-0</div><!--for-->')
+
+    source.value = ['B']
+    await nextTick()
+
+    expect(host.innerHTML).toBe('<div>B-0-undefined</div><!--for-->')
+  })
+
   test('array source', async () => {
     const list = ref([{ name: '1' }, { name: '2' }, { name: '3' }])
     function reverse() {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -598,7 +598,7 @@ export const createFor = (
     if (keyRef && newKey !== undefined && newKey !== keyRef.value) {
       keyRef.value = newKey
     }
-    if (indexRef && newIndex !== undefined && newIndex !== indexRef.value) {
+    if (indexRef && newIndex !== indexRef.value) {
       indexRef.value = newIndex
     }
   }


### PR DESCRIPTION
## Vue version
3.6.0-rc.5

## Link to minimal reproduction
[play](https://play.vuejs.org/#eNp9U02L2zAQ/SuDLk4gaxfS9hCcpdmyh/bQLU3ppSrFq0xSJbZk9OF6Mf7vO5KdbHYJAYPm472ZNyO5Y6u6ThuPbMFyK4ysHVh0voamqLW55UpWdDrowOAWetgaXUFChIQrroRWlgjaG4GwDJBJB+0CklUC/TQgtl4JJ7UCb/HhcY/CrSN6MoWOKxi5aVOUPlR4YXNF32v+ypji6Sr9d3KX/InMPBumoQnIcVjVZeGQPIC8KqSKFtkb2YwmOY/eOWr1SZRSHJacvdHM2a2O7tg2zwbC1QJnoolfBO8yPc8GLZeEkQPNzVYbqjmRNM0MDvg0A6k22E7pGEtShyMHIOCWXRdP6HvIAicE6Bj8SA+RtTNS7SZjuZ72NzYeNb2282zcYJ6dLZbNmLP0ILZyl+6tVvSi4hVxJnRVyxLNQx1u0nK2GC4v5Iqy1P+/xpgzHmfHuPiH4nAhvrdtiHH23aBF09DIp5wrzA7dkL5ff8OW7FOy0htfEvpK8gdaXfqgcYDdebUh2We4qPZL/CNoXz/tfetQ2eNQQWhA9hHPGf0ln6+M/iJ3nr6PPHq5tMW/DZpQkxY4Tz+m726MSD+EuLO/ThmKp3PWPwPHNzuV)

## Steps to reproduce
Click the "array source" button.

## What is expected?
The index value is "undefined".

## What is actually happening?
The index value is "0".



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `createFor` so the index value is correctly cleared when switching from an object source to an array.
  * Updated rendered output to reflect an undefined index when no valid index is available.

* **Tests**
  * Added coverage for switching collection types and clearing the index reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->