### PR TITLE
fix(compiler-ssr): compile v-html/v-text on components into props

### DIFF
--- a/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
@@ -76,6 +76,16 @@ describe('ssr: components', () => {
           }, _attrs), null), _parent)
         }"
       `)
+
+    expect(compile(`<component :is="foo" v-html="html" />`).code)
+      .toMatchInlineSnapshot(`
+        "const { resolveDynamicComponent: _resolveDynamicComponent, mergeProps: _mergeProps, createVNode: _createVNode } = require("vue")
+        const { ssrRenderVNode: _ssrRenderVNode } = require("vue/server-renderer")
+
+        return function ssrRender(_ctx, _push, _parent, _attrs) {
+          _ssrRenderVNode(_push, _createVNode(_resolveDynamicComponent(_ctx.foo), _mergeProps({ innerHTML: _ctx.html }, _attrs), null), _parent)
+        }"
+      `)
   })
 
   describe('slots', () => {

--- a/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
@@ -53,6 +53,31 @@ describe('ssr: components', () => {
       `)
   })
 
+  test('v-html/v-text on component', () => {
+    expect(compile(`<foo v-html="html" />`).code).toMatchInlineSnapshot(`
+      "const { resolveComponent: _resolveComponent, mergeProps: _mergeProps } = require("vue")
+      const { ssrRenderComponent: _ssrRenderComponent } = require("vue/server-renderer")
+
+      return function ssrRender(_ctx, _push, _parent, _attrs) {
+        const _component_foo = _resolveComponent("foo")
+
+        _push(_ssrRenderComponent(_component_foo, _mergeProps({ innerHTML: _ctx.html }, _attrs), null, _parent))
+      }"
+    `)
+
+    expect(compile(`<component :is="foo" v-text="text" />`).code)
+      .toMatchInlineSnapshot(`
+        "const { resolveDynamicComponent: _resolveDynamicComponent, toDisplayString: _toDisplayString, mergeProps: _mergeProps, createVNode: _createVNode } = require("vue")
+        const { ssrRenderVNode: _ssrRenderVNode } = require("vue/server-renderer")
+
+        return function ssrRender(_ctx, _push, _parent, _attrs) {
+          _ssrRenderVNode(_push, _createVNode(_resolveDynamicComponent(_ctx.foo), _mergeProps({
+            textContent: _toDisplayString(_ctx.text)
+          }, _attrs), null), _parent)
+        }"
+      `)
+  })
+
   describe('slots', () => {
     test('implicit default slot', () => {
       expect(compile(`<foo>hello<div/></foo>`).code).toMatchInlineSnapshot(`

--- a/packages/compiler-ssr/src/index.ts
+++ b/packages/compiler-ssr/src/index.ts
@@ -26,6 +26,8 @@ import { ssrTransformIf } from './transforms/ssrVIf'
 import { ssrTransformFor } from './transforms/ssrVFor'
 import { ssrTransformModel } from './transforms/ssrVModel'
 import { ssrTransformShow } from './transforms/ssrVShow'
+import { ssrTransformHtml } from './transforms/ssrVHtml'
+import { ssrTransformText } from './transforms/ssrVText'
 import { ssrInjectFallthroughAttrs } from './transforms/ssrInjectFallthroughAttrs'
 import { ssrInjectCssVars } from './transforms/ssrInjectCssVars'
 
@@ -77,6 +79,9 @@ export function compile(
       // model and show have dedicated SSR handling
       model: ssrTransformModel,
       show: ssrTransformShow,
+      // html and text only need handling on components
+      html: ssrTransformHtml,
+      text: ssrTransformText,
       // the following are ignored during SSR
       // on: noopDirectiveTransform,
       cloak: noopDirectiveTransform,

--- a/packages/compiler-ssr/src/transforms/ssrVHtml.ts
+++ b/packages/compiler-ssr/src/transforms/ssrVHtml.ts
@@ -1,0 +1,11 @@
+import {
+  DOMDirectiveTransforms,
+  type DirectiveTransform,
+  ElementTypes,
+} from '@vue/compiler-dom'
+
+// on plain elements ssrTransformElement renders v-html as the children
+export const ssrTransformHtml: DirectiveTransform = (dir, node, context) =>
+  node.tagType === ElementTypes.ELEMENT
+    ? { props: [] }
+    : DOMDirectiveTransforms.html(dir, node, context)

--- a/packages/compiler-ssr/src/transforms/ssrVText.ts
+++ b/packages/compiler-ssr/src/transforms/ssrVText.ts
@@ -1,0 +1,11 @@
+import {
+  DOMDirectiveTransforms,
+  type DirectiveTransform,
+  ElementTypes,
+} from '@vue/compiler-dom'
+
+// on plain elements ssrTransformElement renders v-text as the children
+export const ssrTransformText: DirectiveTransform = (dir, node, context) =>
+  node.tagType === ElementTypes.ELEMENT
+    ? { props: [] }
+    : DOMDirectiveTransforms.text(dir, node, context)

--- a/packages/server-renderer/__tests__/ssrDirectives.spec.ts
+++ b/packages/server-renderer/__tests__/ssrDirectives.spec.ts
@@ -296,6 +296,28 @@ describe('ssr: directives', () => {
         ),
       ).toBe(`<textarea>hello</textarea>`)
     })
+
+    test('dynamic component with v-html', async () => {
+      expect(
+        await renderToString(
+          createApp({
+            data: () => ({ tag: 'span', foo: '<b>hello</b>' }),
+            template: `<component :is="tag" v-html="foo"/>`,
+          }),
+        ),
+      ).toBe(`<span><b>hello</b></span>`)
+    })
+
+    test('dynamic component with v-text', async () => {
+      expect(
+        await renderToString(
+          createApp({
+            data: () => ({ tag: 'span', foo: '<b>hello</b>' }),
+            template: `<component :is="tag" v-text="foo"/>`,
+          }),
+        ),
+      ).toBe(`<span>&lt;b&gt;hello&lt;/b&gt;</span>`)
+    })
   })
 
   describe('vnode v-show', () => {


### PR DESCRIPTION
close #15365, partially addresses #6435

The SSR compiler registers no `html`/`text` directive transform, so `v-html` and `v-text` were only handled inside `ssrTransformElement`. On a component node `buildProps` drops them as built-in directives with no transform, which is why `<component :is="tag" v-html="html"/>` rendered nothing while `:innerHTML="html"` worked.

They now compile into `innerHTML`/`textContent` props on components, the same way the DOM compiler does, so a `<component :is>` resolving to a native tag renders the same on the server and on the client. Plain element codegen is unchanged. The remaining half of #6435, where the prop falls through onto a template-compiled component's root element and `ssrRenderAttrs` skips it, is not covered here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering support for `v-html` and `v-text` on elements and components.
  * `v-html` now correctly renders bound content as raw HTML in static and dynamic components.
  * `v-text` now correctly renders bound content with HTML escaping in static and dynamic components.
  * Improved handling of these directives when rendering dynamic component tags during server-side generation.
  * Added coverage to verify correct HTML insertion and text escaping across supported component scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->