### PR TITLE
types(runtime-vapor): export DefineVaporSetupFnComponent

### DIFF
--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -3,6 +3,7 @@ export { createVaporApp, createVaporSSRApp } from './apiCreateApp'
 export {
   defineVaporComponent,
   type DefineVaporComponent,
+  type DefineVaporSetupFnComponent,
   type VaporPublicProps,
   type VaporRenderResult,
 } from './apiDefineComponent'


### PR DESCRIPTION
Same export with runtime-core https://github.com/vuejs/core/commit/6c74fb07a78ebd9512f35c331baf42ca1a5b147f

For `h` function to infer DefineSetupFnComponent's props and slots types.

```tsx
import type { DefineVaporSetupFnComponent, EmitsToProps, EmitsOptions, Block, VaporSlot } from 'vue'
import { defineVaporComponent } from 'vue' 

declare function h<
  Props extends Record<string, any>,
  Emits extends EmitsOptions,
  Slots extends Record<string, VaporSlot>,
>(
  type: DefineVaporSetupFnComponent<Props, Emits, Slots>,
  props?: P & EmitsToProps<Emits> | null, // <- infered Props
  children?: Slots
): Block

const Comp = defineVaporComponent((props: { foo: 1 }) => [])
h(Comp, { foo: 1 })
```