### PR TITLE
fix(runtime-vapor): reuse SSR v-if anchors in dynamic elements

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/component.spec.ts
@@ -816,6 +816,30 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test('dynamic native element with empty v-if child', async () => {
+      const { container, data, html } = await testHydration(
+        `<template>
+          <component :is="data ? 'section' : 'div'">
+            <span v-if="data" class="badge">named</span>
+          </component>
+        </template>`,
+        {},
+        ref(false),
+      )
+
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+      expect(html).toBe(`<div><!--v-if--></div>`)
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<div><!--v-if--></div><!--dynamic-component-->"`,
+      )
+
+      data.value = true
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<section><span class="badge">named</span><!--if--></section><!--dynamic-component-->"`,
+      )
+    })
+
     test('in ssr slot vnode fallback', async () => {
       const { container, data } = await testHydration(
         `<template>

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -370,8 +370,9 @@ function isReusableAnchorCandidate(
       isComment(node, ']') ||
       (__DEV__ &&
         frag !== undefined &&
-        frag.anchorLabel !== undefined &&
-        isComment(node, frag.anchorLabel)))
+        ((frag.__vf & IF && isComment(node, 'v-if')) ||
+          (frag.anchorLabel !== undefined &&
+            isComment(node, frag.anchorLabel)))))
   )
 }
 


### PR DESCRIPTION
close #15371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration for dynamic elements containing conditionally rendered content.
  * Prevented incorrect hydration mismatch warnings when empty conditional content is represented by a runtime marker.
  * Ensured dynamic elements update correctly after conditional content becomes visible.

* **Tests**
  * Added coverage for server-rendered hydration and subsequent dynamic element updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->