### PR TITLE
fix(compiler-vapor): drop comment children of Transition/TransitionGroup

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/TransformTransition.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/TransformTransition.spec.ts
@@ -278,6 +278,32 @@ describe('compiler: transition', () => {
     expect(code).not.toContain('persisted')
   })
 
+  // #15372
+  test('should drop comment children to match vdom runtime and SSR behavior', () => {
+    // vdom runtime filters comment children of Transition/TransitionGroup and
+    // SSR omits them (#5351, #11961) - vapor drops them at compile time
+    const { code } = compile(
+      `<transition>
+        <!-- comment -->
+        <div>foo</div>
+      </transition>`,
+      { prefixIdentifiers: true },
+    )
+    expect(code).not.toContain('comment')
+    expect(code).toMatchSnapshot()
+
+    const { code: groupCode } = compile(
+      `<transition-group tag="ul">
+        <!-- comment -->
+        <li key="a">a</li>
+        <li key="b">b</li>
+      </transition-group>`,
+      { prefixIdentifiers: true },
+    )
+    expect(groupCode).not.toContain('comment')
+    expect(groupCode).toMatchSnapshot()
+  })
+
   test('the v-if/else-if/else branches in Transition should ignore comments', () => {
     const { code } = compile(
       `

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
@@ -28,6 +28,36 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: transition > should drop comment children to match vdom runtime and SSR behavior 1`] = `
+"import { VaporTransition as _VaporTransition, createComponent as _createComponent, template as _template } from 'vue';
+const t0 = _template("<div>foo", 3)
+
+export function render(_ctx) {
+  const n2 = _createComponent(_VaporTransition, null, () => {
+    const n1 = t0()
+    return n1
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transition > should drop comment children to match vdom runtime and SSR behavior 2`] = `
+"import { VaporTransitionGroup as _VaporTransitionGroup, setBlockKey as _setBlockKey, createComponent as _createComponent, template as _template } from 'vue';
+const t0 = _template("<li>a</li>")
+const t1 = _template("<li>b")
+
+export function render(_ctx) {
+  const n3 = _createComponent(_VaporTransitionGroup, { tag: "ul" }, () => {
+    const n1 = t0()
+    const n2 = t1()
+    _setBlockKey(n1, "a")
+    _setBlockKey(n2, "b")
+    return [n1, n2]
+  }, true)
+  return n3
+}"
+`;
+
 exports[`compiler: transition > the v-if/else-if/else branches in Transition should ignore comments 1`] = `
 "import { VaporTransition as _VaporTransition, setInsertionState as _setInsertionState, createIf as _createIf, extend as _extend, createComponent as _createComponent, template as _template } from 'vue';
 const t0 = _template("<div>hey", 3)

--- a/packages/compiler-vapor/src/transforms/vSlot.ts
+++ b/packages/compiler-vapor/src/transforms/vSlot.ts
@@ -26,6 +26,8 @@ import {
 import {
   findDir,
   findProp,
+  isTransitionGroupNode,
+  isTransitionNode,
   propToExpression,
   resolveExpression,
 } from '../utils'
@@ -74,6 +76,10 @@ function transformComponentSlot(
   const { children } = node
   const arg = dir && dir.arg
   const hasTemplateSlots = children.some(isSlotTemplateChild)
+  // Transition/TransitionGroup filter out comment children at runtime in
+  // vdom mode and SSR omits them (#5351, #11961), so drop them here to keep
+  // client render and hydration in sync with the server output (#15372)
+  const isTransitionHost = isTransitionNode(node) || isTransitionGroupNode(node)
 
   // whitespace: 'preserve'
   const emptyTextNodes: TemplateChildNode[] = []
@@ -81,7 +87,10 @@ function transformComponentSlot(
     if (isSlotTemplateChild(n)) {
       return false
     }
-    if (n.type === NodeTypes.COMMENT && hasTemplateSlots) {
+    if (
+      n.type === NodeTypes.COMMENT &&
+      (hasTemplateSlots || isTransitionHost)
+    ) {
       ignoreComment(n, context)
       return false
     }

--- a/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
@@ -473,6 +473,43 @@ describe('Vapor Mode hydration', () => {
       ).not.toHaveBeenWarned()
     })
 
+    // #15372
+    test('should drop comment children to stay in sync with SSR output', async () => {
+      const data = ref({
+        items: ['a', 'b', 'c'],
+      })
+      const code = `
+        <TransitionGroup :css="false" tag="ul">
+          <!-- comment -->
+          <li v-for="item in data.items" :key="item">{{ item }}</li>
+        </TransitionGroup>
+      `
+      const SSRComp = compileVaporComponent(code, data, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+      // SSR deliberately omits comment children of TransitionGroup (#11961)
+      expect(html).not.toContain('comment')
+
+      const { container } = await mountWithHydration(html, code, data)
+      const ul = container.querySelector('ul')!
+
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>a</li><li>b</li><li>c</li><!--for-->"`,
+      )
+      expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+
+      data.value.items.push('d')
+      await nextTick()
+      expect(formatHtml(ul.innerHTML)).toMatchInlineSnapshot(
+        `"<li>a</li><li>b</li><li>c</li><li>d</li><!--for-->"`,
+      )
+    })
+
     test('with tag should hydrate empty claimed container for flattened v-for children', async () => {
       const data = ref({
         items: [] as number[],


### PR DESCRIPTION
close #15372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transition and transition-group rendering so comment-only children are omitted from generated and server-rendered output.
  * Improved hydration consistency for transition groups containing comments, preventing mismatch warnings and keeping the DOM synchronized after list updates.

* **Tests**
  * Added coverage for compilation, server-side rendering, hydration, and subsequent transition-group updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->