### PR TITLE
fix(types): allow narrower element types in refs

### DIFF
--- a/packages-private/dts-test/h.test-d.ts
+++ b/packages-private/dts-test/h.test-d.ts
@@ -25,6 +25,9 @@ describe('h inference w/ element', () => {
   h('div', { ref: 'foo' })
   h('div', { ref: ref(null) })
   h('div', { ref: _el => {} })
+  h('form', { ref: (_el: HTMLFormElement | null) => {} })
+  // @ts-expect-error ref callback parameter must still be element-compatible
+  h('form', { ref: (_el: number | null) => {} })
   //  @ts-expect-error
   h('div', { ref: [] })
   //  @ts-expect-error

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -87,10 +87,13 @@ export type VNodeTypes =
 export type VNodeRef =
   | string
   | Ref
-  | ((
-      ref: Element | ComponentPublicInstance | null,
-      refs: Record<string, any>,
-    ) => void)
+  | {
+      // allow callbacks to use a more specific element type
+      bivarianceHack(
+        ref: Element | ComponentPublicInstance | null,
+        refs: Record<string, any>,
+      ): void
+    }['bivarianceHack']
 
 export type VNodeNormalizedRefAtom = {
   /**


### PR DESCRIPTION
## Summary

Allow function refs to declare a more specific DOM element type, such as
`HTMLFormElement`, while keeping unrelated parameter types rejected.

## Problem

`VNodeRef` currently uses a regular function type whose first parameter is
`Element | ComponentPublicInstance | null`. Under `strictFunctionTypes`, this
rejects callbacks accepting a narrower element type.

```ts
h('form', {
  ref: (el: HTMLFormElement | null) => {},
})

## Solution
Use a bivariant callback type so function refs can accept a compatible, more specific DOM element type while unrelated parameter types remain rejected.

close #13969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type checking for element ref callbacks.
  - Form refs now correctly accept form elements or `null`.
  - Invalid callback parameter types are rejected more reliably.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->