### PR TITLE
types(runtime-vapor): infer exposed type from options setup

### DIFF
--- a/packages-private/dts-test/vapor/defineVaporComponent.test-d.tsx
+++ b/packages-private/dts-test/vapor/defineVaporComponent.test-d.tsx
@@ -801,7 +801,7 @@ describe('function syntax w/ expose', () => {
       expose({
         msg: props.msg,
       })
-      return []
+      return <div></div>
     },
   )
   const foo = new Foo()
@@ -1138,6 +1138,23 @@ describe('expose typing', () => {
 
   expectType<number>(bar.exposeProxy!.a)
   expectType<string>(bar.exposeProxy!.b)
+
+  // typed expose in options
+  const Baz = defineVaporComponent({
+    setup(
+      props: { msg: string },
+      { expose }: { expose: (exposed: { a: number; b: string }) => void },
+    ) {
+      expose({ a: 1, b: '' })
+      return <div></div>
+    },
+  })
+  const baz = new Baz()
+  // internal should still be exposed
+  baz.props
+
+  expectType<number>(foo.exposeProxy!.a)
+  expectType<string>(foo.exposeProxy!.b)
 })
 
 describe('Custom options', () => {

--- a/packages/runtime-vapor/src/apiDefineComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineComponent.ts
@@ -210,7 +210,7 @@ export function defineVaporComponent<
   ResolvedEmits,
   RuntimeEmitsKeys,
   Slots,
-  Block extends Exposed ? Record<string, any> : Exposed,
+  Exposed extends VaporRenderResult ? Record<string, any> : Exposed,
   TypeBlock,
   TypeRefs,
   // MakeDefaultsOptional - if TypeProps is provided, set to false to use

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -220,11 +220,11 @@ export interface VaporComponentOptions<
       emit: EmitFn<Emits>
       slots: Slots
       attrs: Record<string, any>
-      expose: <T extends Record<string, any> = Exposed>(exposed: T) => void
+      expose: (exposed: Exposed) => void
     },
-  ) => TypeBlock | Exposed | Promise<Exposed> | void
+  ) => VaporRenderResult<TypeBlock> | Exposed | Promise<Exposed> | void
   render?(
-    ctx: Block extends Exposed
+    ctx: Exposed extends VaporRenderResult
       ? Record<string, any>
       : ShallowUnwrapRef<Exposed>,
     props: Readonly<InferredProps>,
@@ -910,7 +910,7 @@ export class VaporComponentInstance<
   effectCount = 0
 
   // dev only
-  setupState?: Block extends Exposed
+  setupState?: Exposed extends VaporRenderResult
     ? Record<string, any>
     : ShallowUnwrapRef<Exposed>
   devtoolsRawSetupState?: any


### PR DESCRIPTION
Supports infer exposed type from options setup:
```tsx
const Baz = defineVaporComponent({
  setup(
    props: { msg: string },
    { expose }: { expose: (exposed: { foo: number }) => void },
  ) {
    expose({ a: 1 })
    return <div></div>
  },
})

const baz = new Baz()
expectType<number>(foo.exposeProxy!.foo)
```