### PR TITLE
fix(runtime-vapor): preserve dynamic once listeners

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -805,6 +805,28 @@ describe('patchProp', () => {
       scope.stop()
     })
 
+    test('should not re-register unchanged once listeners on effect updates', async () => {
+      const el = document.createElement('button')
+      const count = ref(0)
+      const handler = vi.fn(() => count.value++)
+      const scope = effectScope()
+      scope.run(() => {
+        renderEffect(() => {
+          setDynamicProps(el, [{ onClickOnce: handler }])
+          // Keep the dynamic props and an unrelated reactive binding in the
+          // same effect, as generated Vapor code does for this case.
+          el.title = String(count.value)
+        })
+      })
+
+      el.click()
+      await nextTick()
+      el.click()
+
+      expect(handler).toHaveBeenCalledTimes(1)
+      scope.stop()
+    })
+
     test('should restore fallthrough state when dynamic props throw', () => {
       const el = document.createElement('div')
       const attrs: Record<string, any> = {}

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -502,11 +502,17 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
     const value = props[key]
     nextProps[key] = value
     // Events and objects can have stable identity with mutable internals, so
-    // only skip unchanged primitive values.
+    // only skip unchanged primitive values. A native `.once` listener is
+    // consumed by the browser after the first dispatch; re-registering the
+    // same binding when an unrelated dependency updates would incorrectly
+    // reset its once state.
+    const isEvent = isOn(key)
+    const eventOptions = isEvent ? parseEventName(key)[1] : undefined
     if (
       prevProps &&
       key in prevProps &&
-      !isOn(key) &&
+      (!isEvent ||
+        (eventOptions && 'once' in eventOptions && eventOptions.once)) &&
       (value == null || typeof value !== 'object') &&
       Object.is(prevProps[key], value)
     ) {


### PR DESCRIPTION
## Summary

- preserve consumed `.once` listeners when dynamic props are re-applied by a rerender
- add a regression test covering an unrelated reactive update in the same effect

## Cause

Vapor compiles dynamic `v-bind` props into a render effect. `setDynamicProps()` intentionally re-applied event props on every effect run because event values may contain mutable internals. For `onClickOnce`, this re-added the native listener after the browser had already removed it following the first click, effectively resetting the `.once` state.

When the event key, handler identity, and `.once` option are unchanged, the listener must remain registered (or remain consumed) across the update.

Fixes #15378
