### PR TITLE
fix(runtime-vapor): preserve once listeners across effect updates

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -805,6 +805,28 @@ describe('patchProp', () => {
       scope.stop()
     })
 
+    test('should not re-register unchanged once listeners on effect updates', async () => {
+      const el = document.createElement('button')
+      const count = ref(0)
+      const handler = vi.fn(() => count.value++)
+      const scope = effectScope()
+      scope.run(() => {
+        renderEffect(() => {
+          setDynamicProps(el, [{ onClickOnce: handler }])
+          // Keep the dynamic props and an unrelated reactive binding in the
+          // same effect, as generated Vapor code does for this case.
+          el.title = String(count.value)
+        })
+      })
+
+      el.click()
+      await nextTick()
+      el.click()
+
+      expect(handler).toHaveBeenCalledTimes(1)
+      scope.stop()
+    })
+
     test('should restore fallthrough state when dynamic props throw', () => {
       const el = document.createElement('div')
       const attrs: Record<string, any> = {}

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -827,6 +827,44 @@ describe('patchProp', () => {
       scope.stop()
     })
 
+    test('should preserve once listeners through updates before first click', async () => {
+      const el = document.createElement('button')
+      const count = ref(0)
+      const handler = vi.fn()
+      const scope = effectScope()
+      scope.run(() => {
+        renderEffect(() => {
+          setDynamicProps(el, [{ onClickOnce: handler }])
+          el.title = String(count.value)
+        })
+      })
+      count.value++
+      await nextTick()
+      el.click()
+      el.click()
+      expect(handler).toHaveBeenCalledTimes(1)
+      scope.stop()
+    })
+
+    test('should preserve consumed once array listeners through effect updates', async () => {
+      const el = document.createElement('button')
+      const count = ref(0)
+      const handler = vi.fn()
+      const scope = effectScope()
+      scope.run(() => {
+        renderEffect(() => {
+          setDynamicProps(el, [{ onClickOnce: [handler] }])
+          el.title = String(count.value)
+        })
+      })
+      el.click()
+      count.value++
+      await nextTick()
+      el.click()
+      expect(handler).toHaveBeenCalledTimes(1)
+      scope.stop()
+    })
+
     test('should restore fallthrough state when dynamic props throw', () => {
       const el = document.createElement('div')
       const attrs: Record<string, any> = {}

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -12,6 +12,15 @@ type EventHandler = (...args: any[]) => any
 type EventHandlerValue = EventHandler | EventHandler[]
 type MaybeEventHandlerValue = EventHandlerValue | null | undefined
 
+type OnceState = { remaining: number }
+
+const onceStates = new WeakMap<Element, Map<string, OnceState>>()
+
+const countHandlers = (handler: EventHandlerValue): number =>
+  isArray(handler)
+    ? handler.reduce((count, fn) => count + countHandlers(fn), 0)
+    : 1
+
 export function addEventListener(
   el: Element,
   event: string,
@@ -42,14 +51,44 @@ export function onBinding(
   event: string,
   handler: EventHandlerValue,
   options?: AddEventListenerOptions,
+  onceKey?: string,
 ): void {
-  if (isArray(handler)) {
-    handler.forEach(fn => onBinding(el, event, fn, options))
-  } else {
-    if (!handler) return
-    const cleanup = addEventListener(el, event, createInvoker(handler), options)
-    onEffectCleanup(cleanup)
+  const stateKey = onceKey && options && options.once ? onceKey : undefined
+  if (!handler) {
+    if (stateKey) {
+      const states = onceStates.get(el)
+      if (states) states.delete(stateKey)
+    }
+    return
   }
+
+  const onceState = stateKey ? { remaining: countHandlers(handler) } : undefined
+  if (stateKey) {
+    let states = onceStates.get(el)
+    if (!states) onceStates.set(el, (states = new Map()))
+    states.set(stateKey, onceState!)
+  }
+
+  const bind = (value: EventHandlerValue): void => {
+    if (isArray(value)) {
+      value.forEach(bind)
+    } else {
+      const cleanup = addEventListener(
+        el,
+        event,
+        createInvoker(value, onceState && (() => onceState.remaining--)),
+        options,
+      )
+      onEffectCleanup(cleanup)
+    }
+  }
+  bind(handler)
+}
+
+export function isOnceListenerConsumed(el: Element, onceKey: string): boolean {
+  const states = onceStates.get(el)
+  const state = states && states.get(onceKey)
+  return !!state && state.remaining === 0
 }
 
 export function delegate(el: any, event: string, handler: EventHandler): void {
@@ -154,13 +193,18 @@ export function withVaporKeys<T extends (event: KeyboardEvent) => any>(
   ) as T
 }
 
-export function createInvoker(handler: MaybeEventHandlerValue): EventHandler {
+export function createInvoker(
+  handler: MaybeEventHandlerValue,
+  onInvoke?: () => void,
+): EventHandler {
   const i = currentInstance!
-  return (...args: any[]) =>
-    callWithAsyncErrorHandling(
+  return (...args: any[]) => {
+    if (onInvoke) onInvoke()
+    return callWithAsyncErrorHandling(
       handler as EventHandlerValue,
       i,
       ErrorCodes.NATIVE_EVENT_HANDLER,
       args,
     )
+  }
 }

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -16,7 +16,7 @@ import {
   stringifyStyle,
   toDisplayString,
 } from '@vue/shared'
-import { onBinding } from './event'
+import { isOnceListenerConsumed, onBinding } from './event'
 import {
   type GenericComponentInstance,
   MismatchTypes,
@@ -508,13 +508,27 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
     // reset its once state.
     const isEvent = isOn(key)
     const eventOptions = isEvent ? parseEventName(key)[1] : undefined
+    const isConsumedOnce =
+      isEvent &&
+      eventOptions &&
+      'once' in eventOptions &&
+      eventOptions.once &&
+      isOnceListenerConsumed(el, key)
+    const prevValue = prevProps && prevProps[key]
+    const sameValue =
+      Object.is(prevValue, value) ||
+      (isConsumedOnce &&
+        Array.isArray(prevValue) &&
+        Array.isArray(value) &&
+        prevValue.length === value.length &&
+        prevValue.every((v: any, i: number) => Object.is(v, value[i])))
     if (
       prevProps &&
       key in prevProps &&
-      (!isEvent ||
-        (eventOptions && 'once' in eventOptions && eventOptions.once)) &&
-      (value == null || typeof value !== 'object') &&
-      Object.is(prevProps[key], value)
+      ((!isEvent && (value == null || typeof value !== 'object')) ||
+        (isConsumedOnce &&
+          (typeof value === 'function' || Array.isArray(value)))) &&
+      sameValue
     ) {
       continue
     }
@@ -543,7 +557,7 @@ export function setDynamicProp(
       return
     }
     const [event, options] = parseEventName(key)
-    onBinding(el, event, value, options)
+    onBinding(el, event, value, options, key)
   } else if (
     // force hydrate v-bind with .prop modifiers
     (forceHydrate = key[0] === '.')

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -502,11 +502,17 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
     const value = props[key]
     nextProps[key] = value
     // Events and objects can have stable identity with mutable internals, so
-    // only skip unchanged primitive values.
+    // only skip unchanged primitive values. A native `.once` listener is
+    // consumed by the browser after the first dispatch; re-registering the
+    // same binding when an unrelated dependency updates would incorrectly
+    // reset its once state.
+    const isEvent = isOn(key)
+    const eventOptions = isEvent ? parseEventName(key)[1] : undefined
     if (
       prevProps &&
       key in prevProps &&
-      !isOn(key) &&
+      (!isEvent ||
+        (eventOptions && 'once' in eventOptions && eventOptions.once)) &&
       (value == null || typeof value !== 'object') &&
       Object.is(prevProps[key], value)
     ) {


### PR DESCRIPTION
## Summary

- preserve dynamic `.once` listeners when an unrelated reactive update reruns the effect before the first dispatch
- preserve consumed `.once` listeners without re-registering them, including array-valued handlers
- add regression coverage for both lifecycle cases

Fixes #15378

The branch is based on #15379 and contains the follow-up fix for the listener cleanup/re-registration edge cases.
