### PR TITLE
fix(runtime-vapor): avoid rebinding fired once handlers in dynamic props

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/event.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/event.spec.ts
@@ -414,4 +414,31 @@ describe('dom event', () => {
 
     expect(calls).toEqual(['child', 'parent'])
   })
+
+  test('does not rebind a once handler in dynamic props after firing', async () => {
+    const hits = ref(0)
+    const onOnce = () => hits.value++
+    const Comp = defineVaporComponent({
+      setup() {
+        return { hits, onOnce }
+      },
+      render: compileToVaporRender(
+        `<button v-bind="{ onClickOnce: onOnce }" /><p>{{ hits }}</p>`,
+        {
+          bindingMetadata: {
+            hits: BindingTypes.SETUP_REF,
+            onOnce: BindingTypes.SETUP_CONST,
+          },
+        },
+      ),
+    })
+    const { host } = define(Comp).render()
+    const button = host.querySelector('button')!
+
+    button.click()
+    await nextTick()
+    button.click()
+
+    expect(hits.value).toBe(1)
+  })
 })

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -501,12 +501,15 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
   for (const key of Object.keys(props)) {
     const value = props[key]
     nextProps[key] = value
-    // Events and objects can have stable identity with mutable internals, so
-    // only skip unchanged primitive values.
+    if (isOn(key)) {
+      setEvent(el, key, value, nextProps, prevProps)
+      continue
+    }
+    // Objects can have stable identity with mutable internals, so only skip
+    // unchanged primitive values.
     if (
       prevProps &&
       key in prevProps &&
-      !isOn(key) &&
       (value == null || typeof value !== 'object') &&
       Object.is(prevProps[key], value)
     ) {
@@ -533,11 +536,7 @@ export function setDynamicProp(
   } else if (key === 'style') {
     setStyle(el, value)
   } else if (isOn(key)) {
-    if (shouldSkipFallthroughKey(el, key)) {
-      return
-    }
-    const [event, options] = parseEventName(key)
-    onBinding(el, event, value, options)
+    setEvent(el, key, value)
   } else if (
     // force hydrate v-bind with .prop modifiers
     (forceHydrate = key[0] === '.')
@@ -734,4 +733,34 @@ function shouldForceHydrate(el: Element, key: string): boolean {
     // force hydrate custom element dynamic props
     tagName.includes('-')
   )
+}
+
+function setEvent(
+  el: TargetElement,
+  key: string,
+  value: any,
+  propCache?: Record<string, any>,
+  prevProps?: Record<string, any>,
+): void {
+  if (shouldSkipFallthroughKey(el, key)) {
+    return
+  }
+  const [event, options] = parseEventName(key)
+  const eventOptions = options as AddEventListenerOptions | undefined
+  if (eventOptions && eventOptions.once && propCache) {
+    propCache[key] = !!prevProps && prevProps[key] === true
+    // #15378 avoid binding the same event twice when the once binding is already fired
+    if (!propCache[key] && value) {
+      onBinding(
+        el,
+        event,
+        // mark the once binding as fired
+        () => (propCache[key] = true),
+        eventOptions,
+      )
+      onBinding(el, event, value, eventOptions)
+    }
+  } else {
+    onBinding(el, event, value, eventOptions)
+  }
 }


### PR DESCRIPTION
fix #15378

close #15379 
close #15382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed one-time event handlers configured through dynamic properties so they execute only once.
  * Prevented duplicate event bindings when dynamic properties are updated after the handler fires.
* **Tests**
  * Added coverage confirming that a one-time click handler runs once, even when the button is clicked repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->