### PR TITLE
fix(runtime-vapor): keep deferred teleport mounts on their suspense boundary and scope children re-runs

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -763,6 +763,59 @@ describe('effects in pending branches', () => {
     target.remove()
   })
 
+  test('teleport revealed by a branch update inside a pending boundary waits for resolve', async () => {
+    const asyncSetup = deferred()
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const showTeleport = ref(false)
+
+    const VaporChild = defineVaporComponent({
+      setup() {
+        return createIf(
+          () => showTeleport.value,
+          () =>
+            createComponent(
+              VaporTeleport,
+              { to: () => target },
+              { default: () => template('<div>teleported</div>')() },
+            ),
+        )
+      },
+    })
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(target.textContent).toBe('')
+
+    // reveal the teleport while the boundary is still pending: the deferred
+    // target mount must buffer on the boundary, not the global queue
+    showTeleport.value = true
+    await nextTick()
+    expect(target.textContent).toBe('')
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(target.textContent).toBe('teleported')
+    app.unmount()
+    target.remove()
+  })
+
   test('unmounted hook waits when a child is removed from the pending branch', async () => {
     const asyncSetup = deferred()
     const show = ref(true)

--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -767,21 +767,16 @@ describe('effects in pending branches', () => {
     const asyncSetup = deferred()
     const target = document.createElement('div')
     document.body.appendChild(target)
-    const showTeleport = ref(false)
+    const data = ref({ show: false, target })
 
-    const VaporChild = defineVaporComponent({
-      setup() {
-        return createIf(
-          () => showTeleport.value,
-          () =>
-            createComponent(
-              VaporTeleport,
-              { to: () => target },
-              { default: () => template('<div>teleported</div>')() },
-            ),
-        )
-      },
-    })
+    const VaporChild = compile(
+      `<template>
+        <Teleport v-if="data.show" :to="data.target">
+          <div>teleported</div>
+        </Teleport>
+      </template>`,
+      data,
+    )
     const AsyncSibling = defineComponent({
       async setup() {
         await asyncSetup.promise
@@ -805,7 +800,7 @@ describe('effects in pending branches', () => {
 
     // reveal the teleport while the boundary is still pending: the deferred
     // target mount must buffer on the boundary, not the global queue
-    showTeleport.value = true
+    data.value.show = true
     await nextTick()
     expect(target.textContent).toBe('')
 

--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -2012,6 +2012,59 @@ test('should delay child setup until teleport target becomes available', async (
   expect(targetEl.innerHTML).toBe('<div>three</div>')
 })
 
+test('should stop effects of the previous children render when the slot re-runs', async () => {
+  const target = document.createElement('div')
+  const flag = ref(true)
+  const msg = ref('one')
+  const unmounted = vi.fn()
+  let effectRuns = 0
+
+  const Inner = defineVaporComponent({
+    setup() {
+      onUnmounted(unmounted)
+      return template('<span>inner</span>')()
+    },
+  })
+
+  const makeContent = (label: string) => {
+    const n0 = template('<div> </div>')() as any
+    const x0 = child(n0) as any
+    renderEffect(() => {
+      effectRuns++
+      setText(x0, `${label}:${msg.value}`)
+    })
+    return [n0, createComp(Inner)]
+  }
+
+  define({
+    setup() {
+      return createComp(
+        VaporTeleport,
+        { to: () => target },
+        // the slot reads flag.value synchronously, so the children effect
+        // re-runs the whole slot on toggle
+        { default: () => (flag.value ? makeContent('a') : makeContent('b')) },
+      )
+    },
+  }).render()
+
+  expect(target.innerHTML).toBe('<div>a:one</div><span>inner</span>')
+
+  flag.value = false
+  await nextTick()
+  expect(target.innerHTML).toBe('<div>b:one</div><span>inner</span>')
+  // the replaced component unmounted exactly once
+  expect(unmounted).toHaveBeenCalledTimes(1)
+
+  // the previous run's render effect must be stopped: a dependency write
+  // may only run the live effect, and must not touch detached nodes
+  effectRuns = 0
+  msg.value = 'two'
+  await nextTick()
+  expect(target.innerHTML).toBe('<div>b:two</div><span>inner</span>')
+  expect(effectRuns).toBe(1)
+})
+
 test('should cache delayed teleported child under KeepAlive once target becomes available', async () => {
   const show = ref(true)
   const target = ref<any>('#missing-teleport-target-keepalive')

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -1,4 +1,9 @@
-import { getCurrentScope, pauseTracking, resetTracking } from '@vue/reactivity'
+import {
+  EffectScope,
+  getCurrentScope,
+  pauseTracking,
+  resetTracking,
+} from '@vue/reactivity'
 import {
   type GenericComponentInstance,
   MismatchTypes,
@@ -50,6 +55,7 @@ import type { RawSlots } from '../componentSlots'
 import { applyTransitionHooks, isTransitionEnabled } from '../transition'
 import { enableTeleport } from '../teleport'
 import { TELEPORT } from '../fragmentFlags'
+import { isSuspenseEnabled } from '../suspense'
 
 const VaporTeleportImpl = {
   name: 'VaporTeleport',
@@ -88,6 +94,9 @@ export class TeleportFragment extends RenderContextFragment {
   isDisabled?: boolean
   private childrenInitialized = false
   private readonly childrenScope = getCurrentScope()
+  // One scope per slot run, so a re-run can stop the previous run's effects
+  // (the DynamicFragment branch-scope discipline, and the same field name).
+  private scope?: EffectScope
 
   target?: ParentNode | null
   targetAnchor?: Node | null
@@ -156,13 +165,20 @@ export class TeleportFragment extends RenderContextFragment {
       // init and slot re-runs, where new nodes capture the ambient context.
       // The equality fast path keeps the synchronous first run free.
       renderEffect(() =>
-        runWithFragmentCtxOnly(this, () =>
+        runWithFragmentCtxOnly(this, () => {
+          // Stop the previous run's effects before tearing down its nodes;
+          // components unmount here, handleChildrenUpdate detaches the DOM.
+          const prevScope = this.scope
+          if (prevScope) prevScope.stop()
+          const scope = (this.scope = new EffectScope())
           this.handleChildrenUpdate(
-            this.rawSlots && this.rawSlots.default
-              ? (this.rawSlots.default as BlockFn)()
-              : [],
-          ),
-        ),
+            scope.run(() =>
+              this.rawSlots && this.rawSlots.default
+                ? (this.rawSlots.default as BlockFn)()
+                : [],
+            ) || [],
+          )
+        }),
       )
       this.bindChildren(this.nodes)
     } finally {
@@ -304,7 +320,10 @@ export class TeleportFragment extends RenderContextFragment {
     queuePostRenderEffect(
       this.mountToTargetJob,
       undefined,
-      this.parentSuspense || null,
+      this.parentSuspense !== undefined
+        ? this.parentSuspense
+        : (__FEATURE_SUSPENSE__ && isSuspenseEnabled && this.renderSuspense) ||
+            null,
     )
   }
 
@@ -313,6 +332,7 @@ export class TeleportFragment extends RenderContextFragment {
     if (target) {
       this.ensureChildrenInitialized()
       this.mount(target, this.targetAnchor!, TeleportMountLocation.Target)
+      this.cancelMountToTarget()
     } else {
       if (__DEV__) {
         warn(
@@ -365,7 +385,9 @@ export class TeleportFragment extends RenderContextFragment {
   ): void => {
     if (isHydrating) return
 
-    this.parentSuspense = parentSuspense
+    // Re-inserts without an explicit boundary (branch renders, v-for
+    // reorders, KeepAlive moves) must not clear a previously known one.
+    if (parentSuspense !== undefined) this.parentSuspense = parentSuspense
 
     const wasMountedInTarget =
       this.mountState.location === TeleportMountLocation.Target
@@ -432,6 +454,13 @@ export class TeleportFragment extends RenderContextFragment {
   }
 
   dispose = (): void => {
+    // Block removal may run without the owning scope stopping; the run scope
+    // must not outlive the children it rendered.
+    const scope = this.scope
+    if (scope) {
+      this.scope = undefined
+      scope.stop()
+    }
     const mountState = this.mountState
     if (this.nodes && mountState.location === TeleportMountLocation.Main) {
       remove(this.nodes, mountState.container)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed teleported content revealed inside a pending Suspense boundary so it now appears only after the boundary resolves.
  * Fixed stale effects from replaced teleported content, preventing updates from affecting detached elements.
  * Improved teleport mounting behavior to avoid duplicate or outdated pending mounts.
  * Ensured teleported content updates and unmounts cleanly when its conditional rendering changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->