### PR TITLE
fix(runtime-vapor): avoid re-registering fired once listeners

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/event.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/event.spec.ts
@@ -441,4 +441,31 @@ describe('dom event', () => {
 
     expect(hits.value).toBe(1)
   })
+
+  test('does not rebind a once handler in a v-on object after firing', async () => {
+    const hits = ref(0)
+    const onOnce = () => hits.value++
+    const Comp = defineVaporComponent({
+      setup() {
+        return { hits, onOnce }
+      },
+      render: compileToVaporRender(
+        `<button v-on="{ clickOnce: onOnce }">v-on object once listener</button><p>{{ hits }}</p>`,
+        {
+          bindingMetadata: {
+            hits: BindingTypes.SETUP_REF,
+            onOnce: BindingTypes.SETUP_CONST,
+          },
+        },
+      ),
+    })
+    const { host } = define(Comp).render()
+    const button = host.querySelector('button')!
+
+    button.click()
+    await nextTick()
+    button.click()
+
+    expect(hits.value).toBe(1)
+  })
 })

--- a/packages/runtime-vapor/src/dom/event.ts
+++ b/packages/runtime-vapor/src/dom/event.ts
@@ -4,6 +4,7 @@ import {
   ErrorCodes,
   callWithAsyncErrorHandling,
   currentInstance,
+  parseEventName,
   withKeys as withDomKeys,
   withModifiers as withDomModifiers,
 } from '@vue/runtime-dom'
@@ -45,11 +46,21 @@ export function onBinding(
 ): void {
   if (isArray(handler)) {
     handler.forEach(fn => onBinding(el, event, fn, options))
-  } else {
-    if (!handler) return
-    const cleanup = addEventListener(el, event, createInvoker(handler), options)
-    onEffectCleanup(cleanup)
+    return
   }
+  if (!handler) return
+  if (options && options.once) {
+    // #15378 avoid re-registering invoked once listeners on effect re-runs
+    const firedKey = `$evtonce_${options.capture ? 1 : 0}_${event}`
+    if ((el as any)[firedKey]) return
+    const invoker = handler
+    handler = (...args: any[]) => {
+      ;(el as any)[firedKey] = true
+      return invoker(...args)
+    }
+  }
+  const cleanup = addEventListener(el, event, createInvoker(handler), options)
+  onEffectCleanup(cleanup)
 }
 
 export function delegate(el: any, event: string, handler: EventHandler): void {
@@ -126,7 +137,8 @@ export function setDynamicEvents(
   events: Record<string, EventHandlerValue>,
 ): void {
   for (const name in events) {
-    onBinding(el, name, events[name])
+    const [event, options] = parseEventName(`on:${name}`)
+    onBinding(el, event, events[name], options)
   }
 }
 

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -501,15 +501,12 @@ export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
   for (const key of Object.keys(props)) {
     const value = props[key]
     nextProps[key] = value
-    if (isOn(key)) {
-      setEvent(el, key, value, nextProps, prevProps)
-      continue
-    }
-    // Objects can have stable identity with mutable internals, so only skip
-    // unchanged primitive values.
+    // Events and objects can have stable identity with mutable internals, so
+    // only skip unchanged primitive values.
     if (
       prevProps &&
       key in prevProps &&
+      !isOn(key) &&
       (value == null || typeof value !== 'object') &&
       Object.is(prevProps[key], value)
     ) {
@@ -536,7 +533,11 @@ export function setDynamicProp(
   } else if (key === 'style') {
     setStyle(el, value)
   } else if (isOn(key)) {
-    setEvent(el, key, value)
+    if (shouldSkipFallthroughKey(el, key)) {
+      return
+    }
+    const [event, options] = parseEventName(key)
+    onBinding(el, event, value, options)
   } else if (
     // force hydrate v-bind with .prop modifiers
     (forceHydrate = key[0] === '.')
@@ -733,34 +734,4 @@ function shouldForceHydrate(el: Element, key: string): boolean {
     // force hydrate custom element dynamic props
     tagName.includes('-')
   )
-}
-
-function setEvent(
-  el: TargetElement,
-  key: string,
-  value: any,
-  propCache?: Record<string, any>,
-  prevProps?: Record<string, any>,
-): void {
-  if (shouldSkipFallthroughKey(el, key)) {
-    return
-  }
-  const [event, options] = parseEventName(key)
-  const eventOptions = options as AddEventListenerOptions | undefined
-  if (eventOptions && eventOptions.once && propCache) {
-    propCache[key] = !!prevProps && prevProps[key] === true
-    // #15378 avoid binding the same event twice when the once binding is already fired
-    if (!propCache[key] && value) {
-      onBinding(
-        el,
-        event,
-        // mark the once binding as fired
-        () => (propCache[key] = true),
-        eventOptions,
-      )
-      onBinding(el, event, value, eventOptions)
-    }
-  } else {
-    onBinding(el, event, value, eventOptions)
-  }
 }


### PR DESCRIPTION
Revert #15383 and re-fix #15378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed one-time event handlers configured through dynamic `v-on` bindings so they execute only once, even when the component updates.
  - Improved dynamic event handling for array-based and empty handlers.
  - Ensured event options such as `.once` are consistently recognized across dynamic bindings.
- **Tests**
  - Added coverage confirming a one-time click handler is not registered again after firing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->