### PR TITLE
fix(runtime-vapor): buffer deferred teleport target mounts on the suspense boundary

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -763,6 +763,54 @@ describe('effects in pending branches', () => {
     target.remove()
   })
 
+  test('teleport revealed by a branch update inside a pending boundary waits for resolve', async () => {
+    const asyncSetup = deferred()
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    const data = ref({ show: false, target })
+
+    const VaporChild = compile(
+      `<template>
+        <Teleport v-if="data.show" :to="data.target">
+          <div>teleported</div>
+        </Teleport>
+      </template>`,
+      data,
+    )
+    const AsyncSibling = defineComponent({
+      async setup() {
+        await asyncSetup.promise
+        return () => h('span', 'async')
+      },
+    })
+    const Root = defineComponent({
+      setup: () => () =>
+        h(Suspense, null, {
+          default: () => h('div', [h(VaporChild as any), h(AsyncSibling)]),
+          fallback: () => h('span', 'loading'),
+        }),
+    })
+    const host = document.createElement('div')
+    const app = createApp(Root)
+    app.use(vaporInteropPlugin)
+    app.mount(host)
+
+    await nextTick()
+    expect(target.textContent).toBe('')
+
+    // reveal the teleport while the boundary is still pending: the deferred
+    // target mount must buffer on the boundary, not the global queue
+    data.value.show = true
+    await nextTick()
+    expect(target.textContent).toBe('')
+
+    asyncSetup.resolve()
+    await flushResolution(asyncSetup.promise)
+    expect(target.textContent).toBe('teleported')
+    app.unmount()
+    target.remove()
+  })
+
   test('unmounted hook waits when a child is removed from the pending branch', async () => {
     const asyncSetup = deferred()
     const show = ref(true)

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -50,6 +50,7 @@ import type { RawSlots } from '../componentSlots'
 import { applyTransitionHooks, isTransitionEnabled } from '../transition'
 import { enableTeleport } from '../teleport'
 import { TELEPORT } from '../fragmentFlags'
+import { isSuspenseEnabled } from '../suspense'
 
 const VaporTeleportImpl = {
   name: 'VaporTeleport',
@@ -304,7 +305,10 @@ export class TeleportFragment extends RenderContextFragment {
     queuePostRenderEffect(
       this.mountToTargetJob,
       undefined,
-      this.parentSuspense || null,
+      this.parentSuspense !== undefined
+        ? this.parentSuspense
+        : (__FEATURE_SUSPENSE__ && isSuspenseEnabled && this.renderSuspense) ||
+            null,
     )
   }
 
@@ -313,6 +317,7 @@ export class TeleportFragment extends RenderContextFragment {
     if (target) {
       this.ensureChildrenInitialized()
       this.mount(target, this.targetAnchor!, TeleportMountLocation.Target)
+      this.cancelMountToTarget()
     } else {
       if (__DEV__) {
         warn(
@@ -365,7 +370,7 @@ export class TeleportFragment extends RenderContextFragment {
   ): void => {
     if (isHydrating) return
 
-    this.parentSuspense = parentSuspense
+    if (parentSuspense !== undefined) this.parentSuspense = parentSuspense
 
     const wasMountedInTarget =
       this.mountState.location === TeleportMountLocation.Target


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Teleport behavior within pending Suspense boundaries.
  * Teleported content now waits to mount in its target until the relevant Suspense boundary resolves.
  * Prevented premature target updates when content is revealed during a pending asynchronous render.

* **Tests**
  * Added coverage for Teleport behavior when revealed by a branch update inside Suspense.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->