### PR TITLE
fix(runtime-vapor): scope each teleport children render so slot re-runs stop stale effects

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Teleport.spec.ts
@@ -2012,6 +2012,59 @@ test('should delay child setup until teleport target becomes available', async (
   expect(targetEl.innerHTML).toBe('<div>three</div>')
 })
 
+test('should stop effects of the previous children render when the slot re-runs', async () => {
+  const target = document.createElement('div')
+  const flag = ref(true)
+  const msg = ref('one')
+  const unmounted = vi.fn()
+  let effectRuns = 0
+
+  const Inner = defineVaporComponent({
+    setup() {
+      onUnmounted(unmounted)
+      return template('<span>inner</span>')()
+    },
+  })
+
+  const makeContent = (label: string) => {
+    const n0 = template('<div> </div>')() as any
+    const x0 = child(n0) as any
+    renderEffect(() => {
+      effectRuns++
+      setText(x0, `${label}:${msg.value}`)
+    })
+    return [n0, createComp(Inner)]
+  }
+
+  define({
+    setup() {
+      return createComp(
+        VaporTeleport,
+        { to: () => target },
+        // the slot reads flag.value synchronously, so the children effect
+        // re-runs the whole slot on toggle
+        { default: () => (flag.value ? makeContent('a') : makeContent('b')) },
+      )
+    },
+  }).render()
+
+  expect(target.innerHTML).toBe('<div>a:one</div><span>inner</span>')
+
+  flag.value = false
+  await nextTick()
+  expect(target.innerHTML).toBe('<div>b:one</div><span>inner</span>')
+  // the replaced component unmounted exactly once
+  expect(unmounted).toHaveBeenCalledTimes(1)
+
+  // the previous run's render effect must be stopped: a dependency write
+  // may only run the live effect, and must not touch detached nodes
+  effectRuns = 0
+  msg.value = 'two'
+  await nextTick()
+  expect(target.innerHTML).toBe('<div>b:two</div><span>inner</span>')
+  expect(effectRuns).toBe(1)
+})
+
 test('should cache delayed teleported child under KeepAlive once target becomes available', async () => {
   const show = ref(true)
   const target = ref<any>('#missing-teleport-target-keepalive')

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -1,4 +1,9 @@
-import { getCurrentScope, pauseTracking, resetTracking } from '@vue/reactivity'
+import {
+  EffectScope,
+  getCurrentScope,
+  pauseTracking,
+  resetTracking,
+} from '@vue/reactivity'
 import {
   type GenericComponentInstance,
   MismatchTypes,
@@ -89,6 +94,9 @@ export class TeleportFragment extends RenderContextFragment {
   isDisabled?: boolean
   private childrenInitialized = false
   private readonly childrenScope = getCurrentScope()
+  // One scope per slot run, so a re-run can stop the previous run's effects
+  // (the DynamicFragment branch-scope discipline, and the same field name).
+  private scope?: EffectScope
 
   target?: ParentNode | null
   targetAnchor?: Node | null
@@ -157,13 +165,20 @@ export class TeleportFragment extends RenderContextFragment {
       // init and slot re-runs, where new nodes capture the ambient context.
       // The equality fast path keeps the synchronous first run free.
       renderEffect(() =>
-        runWithFragmentCtxOnly(this, () =>
+        runWithFragmentCtxOnly(this, () => {
+          // Stop the previous run's effects before tearing down its nodes;
+          // components unmount here, handleChildrenUpdate detaches the DOM.
+          const prevScope = this.scope
+          if (prevScope) prevScope.stop()
+          const scope = (this.scope = new EffectScope())
           this.handleChildrenUpdate(
-            this.rawSlots && this.rawSlots.default
-              ? (this.rawSlots.default as BlockFn)()
-              : [],
-          ),
-        ),
+            scope.run(() =>
+              this.rawSlots && this.rawSlots.default
+                ? (this.rawSlots.default as BlockFn)()
+                : [],
+            ) || [],
+          )
+        }),
       )
       this.bindChildren(this.nodes)
     } finally {
@@ -437,6 +452,13 @@ export class TeleportFragment extends RenderContextFragment {
   }
 
   dispose = (): void => {
+    // Block removal may run without the owning scope stopping; the run scope
+    // must not outlive the children it rendered.
+    const scope = this.scope
+    if (scope) {
+      this.scope = undefined
+      scope.stop()
+    }
     const mountState = this.mountState
     if (this.nodes && mountState.location === TeleportMountLocation.Main) {
       remove(this.nodes, mountState.container)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Teleport content updates so replaced children are properly unmounted.
  * Prevented stale reactive effects from running after Teleport content is replaced or disposed.
  * Ensured subsequent updates affect only the currently active content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->