### PR TITLE
fix(runtime-vapor): de-structured rest does not include inherited properties

### DIFF
--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -836,6 +836,24 @@ describe('createFor', () => {
     expect(host.innerHTML).toBe('<!--for-->')
   })
 
+  test('de-structured rest does not include inherited properties', () => {
+    const item = Object.create({ inherited: 'prototype' })
+    item.id = 1
+    item.name = 'own'
+    const data = ref({ items: [item] })
+    const { id, ...rest } = item
+    expect(id).toBe(1)
+    expect(rest).toEqual({ name: 'own' })
+    const App = compile(
+      `<template><div v-for="({ id, ...rest }) in data.items">{{ rest.inherited || 'none' }}:{{ rest.name }}</div></template>`,
+      data,
+    )
+
+    const { host } = define(App).render()
+
+    expect(host.textContent).toBe('none:own')
+  })
+
   test('de-structured value (default value)', async () => {
     const list = ref<any[]>([{ name: '1' }, { name: '2' }, { name: '3' }])
     const getDefault = vi.fn(() => '0')

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -1103,7 +1103,7 @@ function getItem(
 // runtime helper for rest element destructure
 export function getRestElement(val: any, keys: string[]): any {
   const res: any = {}
-  for (const key in val) {
+  for (const key of Object.keys(val)) {
     if (!keys.includes(key)) res[key] = val[key]
   }
   return res


### PR DESCRIPTION
## Vue version
3.6.0-rc.6

## Link to minimal reproduction
[Playground](https://play.vuejs.org/#eNp9ks1O6zAQhV9l5E1AKu69KmJRFSRALGABCBAbjFBIpsUlsS17EoqC351x0haEECt7zpmfbyx34tg52TYopmIWCq8dQUBqHLS5s/5IGV3zSdCBxzlEmHtbQ8YFmTLKFNYEAk1YwyFcPS+xIFl4zAl3OtDmBT175RQy5y1ZeneYQdzlplwhdclF/9eByWvkMLNv5kfnwDLP3nlIwSMXz8YDKMNxwKKreCBHALM616a/8b3ULbR7c+sPlUg45QiklB65b9xluqG7Eut8gC4tGUhuweHjAzJjTaKO043do8a4njLmMcPs8Xr4bPyNSYwEBV5mrhdyGazhd+5SthKFrZ2u0F850rysElPoneTlVWXfLnqNfIOjjV68YPH6i74Mq6Qpcc2E6FtUYutR7hdIg312e4krvm/N2pZNxdl/mDcYbNUkxiHtpDElY3/L62nP+3+izeIunK0ITdgslUBTZuzzleC/c/rH6l+4E7nf1ykT+RWfWvSpJz/gRB7If3u+kAdJp3C/dViXExE/AYmo7uM=)

## What is expected?
Display "none:own"

## What is actually happening?
Display "prototype:own"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rest destructuring in `v-for` so inherited properties are excluded.
  * Rest values now include only an object’s own enumerable properties.

* **Tests**
  * Added coverage confirming correct behavior for objects with inherited properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->