### PR TITLE
refactor(vapor): split NON_STABLE slot marker out of VaporSlotFlags

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -42,7 +42,7 @@ export function render(_ctx) {
       return n3
     }, null, 17 /* TRUE_SINGLE_ROOT, ONCE */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   _withVaporDirectives(n4, [[_directive_test]])
   return n4
 }"

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/TransformTransition.spec.ts.snap
@@ -87,7 +87,7 @@ export function render(_ctx) {
       return n15
     }, 645 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, SLOT_ROOT, KEYED_INDEX_1 */), 389 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, SLOT_ROOT, KEYED_INDEX_0 */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n17
 }"
 `;
@@ -136,7 +136,7 @@ export function render(_ctx) {
       return n2
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n3
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -151,7 +151,7 @@ export function render(_ctx) {
       return n3
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n1
-  }, { _: 8 /* NON_STABLE */ }))
+  }, { _: 1 /* NON_STABLE */ }))
   return [n0, n5]
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -156,7 +156,7 @@ export function render(_ctx) {
   const _component_Comp = _resolveComponent("Comp")
   const n2 = _createComponentWithFallback(_component_Comp, null, () => {
     const n1 = _createComponentWithFallback(_component_Comp, null, _extend(() => {
-      const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+      const n0 = _createSlot("default", null, null, 4 /* FORWARDED */)
       return n0
     }, { _: 1 /* NON_STABLE */ }))
     return n1
@@ -170,7 +170,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag only 1`] = `
 
 export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+    const n0 = _createSlot("default", null, null, 4 /* FORWARDED */)
     return n0
   }, { _: 1 /* NON_STABLE */ }), true)
   return n1
@@ -182,7 +182,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ template 1`]
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+    const n0 = _createSlot("default", null, null, 4 /* FORWARDED */)
     return n0
   }, { _: 1 /* NON_STABLE */ }), true)
   return n2
@@ -195,7 +195,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-for 1`] = 
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createFor(() => (_ctx.b), (_for_item0) => {
-      const n2 = _createSlot("default", null, null, 20 /* SLOT_ROOT, SHARED_FALLBACK */)
+      const n2 = _createSlot("default", null, null, 12 /* FORWARDED, SHARED_FALLBACK */)
       return n2
     }, undefined, 48 /* IS_FRAGMENT, SLOT_ROOT */)
     return n0
@@ -210,7 +210,7 @@ exports[`compiler: transform slot > forwarded slots > <slot> tag w/ v-if 1`] = `
 export function render(_ctx) {
   const n3 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createIf(() => (_ctx.ok), () => {
-      const n2 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+      const n2 = _createSlot("default", null, null, 4 /* FORWARDED */)
       return n2
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
@@ -403,7 +403,7 @@ export function render(_ctx) {
         return n4
       }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
       return n2
-    }, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+    }, 4 /* FORWARDED */)
     return n0
   }, { _: 1 /* NON_STABLE */ }), true)
   return n5
@@ -480,7 +480,7 @@ export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, {
     $: [
       _createForSlots(() => (_ctx.slots), (_for_item0, _for_key0) => () => {
-        const n0 = _createSlot(() => (_for_key0.value), null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+        const n0 = _createSlot(() => (_for_key0.value), null, null, 4 /* FORWARDED */)
         return n0
       }, (_, name) => (name))
     ]
@@ -649,7 +649,7 @@ exports[`compiler: transform slot > slot owner context > slot with slot outlet i
 
 export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
-    const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
+    const n0 = _createSlot("default", null, null, 4 /* FORWARDED */)
     return n0
   }, { _: 1 /* NON_STABLE */ }), true)
   return n2

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -158,7 +158,7 @@ export function render(_ctx) {
     const n1 = _createComponentWithFallback(_component_Comp, null, _extend(() => {
       const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
       return n0
-    }, { _: 8 /* NON_STABLE */ }))
+    }, { _: 1 /* NON_STABLE */ }))
     return n1
   }, true)
   return n2
@@ -172,7 +172,7 @@ export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n1
 }"
 `;
@@ -184,7 +184,7 @@ export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n2
 }"
 `;
@@ -199,7 +199,7 @@ export function render(_ctx) {
       return n2
     }, undefined, 48 /* IS_FRAGMENT, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -214,7 +214,7 @@ export function render(_ctx) {
       return n2
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -262,7 +262,7 @@ export function render(_ctx) {
   const n2 = _createAssetComponent("Foo", null, {
     "header": _extend(() => {
       return []
-    }, { _: 8 /* NON_STABLE */ }),
+    }, { _: 1 /* NON_STABLE */ }),
     "default": () => {
       const n1 = _createComponentWithFallback(_component_Bar)
       return n1
@@ -350,7 +350,7 @@ export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, {
     "nav-bar-title-before": _extend(() => {
       return []
-    }, { _: 8 /* NON_STABLE */ })
+    }, { _: 1 /* NON_STABLE */ })
   }, true)
   return n1
 }"
@@ -405,7 +405,7 @@ export function render(_ctx) {
       return n2
     }, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -440,7 +440,7 @@ export function render(_ctx) {
       return n2
     }, undefined, 40 /* IS_SINGLE_NODE, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -456,7 +456,7 @@ export function render(_ctx) {
       return n2
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n3
 }"
 `;
@@ -468,7 +468,7 @@ export function render(_ctx) {
   const n1 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 4 /* SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n1
 }"
 `;
@@ -503,7 +503,7 @@ export function render(_ctx) {
       return n3
     }, undefined, 40 /* IS_SINGLE_NODE, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -522,7 +522,7 @@ export function render(_ctx) {
       return n3
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -553,7 +553,7 @@ export function render(_ctx) {
       return n3
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n5
 }"
 `;
@@ -612,7 +612,7 @@ export function render(_ctx) {
       return n6
     }, null, 129 /* TRUE_SINGLE_ROOT, SLOT_ROOT */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n8
 }"
 `;
@@ -651,7 +651,7 @@ export function render(_ctx) {
   const n2 = _createAssetComponent("Comp", null, _extend(() => {
     const n0 = _createSlot("default", null, null, 36 /* SLOT_ROOT, INHERIT_FALLBACK */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n2
 }"
 `;
@@ -671,7 +671,7 @@ export function render(_ctx) {
     const x0 = _txt(n0)
     _renderEffect(() => _setText(x0, _toDisplayString(_ctx.item)))
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n4
 }"
 `;
@@ -691,7 +691,7 @@ export function render(_ctx) {
       return n4
     }, 389 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, SLOT_ROOT, KEYED_INDEX_0 */)
     return n0
-  }, { _: 8 /* NON_STABLE */ }), true)
+  }, { _: 1 /* NON_STABLE */ }), true)
   return n7
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -784,7 +784,10 @@ describe('compiler: transform slot', () => {
     test('v-once unique slot root inherits fallback without update tracking', () => {
       const { code } = compileVapor(`<Comp><slot v-once /></Comp>`)
 
+      // 'ONCE, FORWARDED' alone would also match the shared-mode emission
+      // 'ONCE, FORWARDED, SHARED_FALLBACK', so pin inherit mode explicitly.
       expect(code).toContain('ONCE, FORWARDED')
+      expect(code).not.toContain('SHARED_FALLBACK')
     })
 
     test.each([

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -24,9 +24,8 @@ import { makeCompile } from './_utils'
 
 const dynamicSlotRootFlag = `${VaporDynamicComponentFlags.SLOT_ROOT} /* SLOT_ROOT */`
 const slotNonStableFlag = `_: ${VaporSlotStability.NON_STABLE} /* NON_STABLE */`
-const slotRootFlag = `${VaporSlotFlags.SLOT_ROOT} /* SLOT_ROOT */`
-const inheritedFallbackSlotRootFlag = `${VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK} /* SLOT_ROOT, INHERIT_FALLBACK */`
-const sharedFallbackSlotRootFlag = `${VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.SHARED_FALLBACK} /* SLOT_ROOT, SHARED_FALLBACK */`
+const forwardedFlag = `${VaporSlotFlags.FORWARDED} /* FORWARDED */`
+const sharedFallbackFlag = `${VaporSlotFlags.FORWARDED | VaporSlotFlags.SHARED_FALLBACK} /* FORWARDED, SHARED_FALLBACK */`
 const keyedSlotRootCallRE =
   /const (n\d+) = _createKeyedFragment\([\s\S]*?\n\s*}, true\)\n\s*return \1/
 
@@ -745,7 +744,7 @@ describe('compiler: transform slot', () => {
       const { code } = compileWithSlots(`<Comp><slot/></Comp>`)
       expect(code).toContain(slotNonStableFlag)
       expect(code).toContain(
-        `_createSlot("default", null, null, ${inheritedFallbackSlotRootFlag})`,
+        `_createSlot("default", null, null, ${forwardedFlag})`,
       )
       expect(code).toMatchSnapshot()
     })
@@ -754,7 +753,7 @@ describe('compiler: transform slot', () => {
       const { code } = compileWithSlots(`<Comp><slot/><span/></Comp>`)
 
       expect(code).not.toContain('SLOT_ROOT')
-      expect(code).not.toContain('INHERIT_FALLBACK')
+      expect(code).not.toContain('FORWARDED')
       expect(code).not.toContain(slotNonStableFlag)
     })
 
@@ -764,13 +763,13 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code.match(/SHARED_FALLBACK/g)).toHaveLength(2)
-      expect(code).toContain(sharedFallbackSlotRootFlag)
+      expect(code).toContain(sharedFallbackFlag)
     })
 
     test('slot root shares fallback with a dynamic sibling', () => {
       const { code } = compileWithSlots(`<Comp><slot/><span v-if="ok"/></Comp>`)
 
-      expect(code).toContain(sharedFallbackSlotRootFlag)
+      expect(code).toContain(sharedFallbackFlag)
     })
 
     test('v-once slot root shares fallback without update tracking', () => {
@@ -779,15 +778,13 @@ describe('compiler: transform slot', () => {
       )
 
       expect(code.match(/SHARED_FALLBACK/g)).toHaveLength(2)
-      expect(code).toContain('ONCE, SHARED_FALLBACK')
-      expect(code).not.toContain('ONCE, SLOT_ROOT')
+      expect(code).toContain('ONCE, FORWARDED, SHARED_FALLBACK')
     })
 
     test('v-once unique slot root inherits fallback without update tracking', () => {
       const { code } = compileVapor(`<Comp><slot v-once /></Comp>`)
 
-      expect(code).toContain('ONCE, INHERIT_FALLBACK')
-      expect(code).not.toContain('ONCE, SLOT_ROOT')
+      expect(code).toContain('ONCE, FORWARDED')
     })
 
     test.each([
@@ -805,10 +802,7 @@ describe('compiler: transform slot', () => {
         const { code } = compileWithSlots(source)
 
         expect(code).toContain('SLOT_ROOT')
-        expect(code).not.toContain(
-          `_createSlot("default", null, null, ${slotRootFlag})`,
-        )
-        expect(code).not.toContain('INHERIT_FALLBACK')
+        expect(code).not.toContain('FORWARDED')
       },
     )
 
@@ -826,7 +820,7 @@ describe('compiler: transform slot', () => {
       })
 
       expect(code).toContain(
-        `_createSlot("default", null, null, ${inheritedFallbackSlotRootFlag})`,
+        `_createSlot("default", null, null, ${forwardedFlag})`,
       )
       expect(code).toMatch(keyedSlotRootCallRE)
     })

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -2,6 +2,7 @@ import { ErrorCodes, NodeTypes } from '@vue/compiler-dom'
 import {
   VaporDynamicComponentFlags,
   VaporSlotFlags,
+  VaporSlotStability,
   VaporVForFlags,
 } from '@vue/shared'
 import {
@@ -22,7 +23,7 @@ import {
 import { makeCompile } from './_utils'
 
 const dynamicSlotRootFlag = `${VaporDynamicComponentFlags.SLOT_ROOT} /* SLOT_ROOT */`
-const slotNonStableFlag = `_: ${VaporSlotFlags.NON_STABLE} /* NON_STABLE */`
+const slotNonStableFlag = `_: ${VaporSlotStability.NON_STABLE} /* NON_STABLE */`
 const slotRootFlag = `${VaporSlotFlags.SLOT_ROOT} /* SLOT_ROOT */`
 const inheritedFallbackSlotRootFlag = `${VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK} /* SLOT_ROOT, INHERIT_FALLBACK */`
 const sharedFallbackSlotRootFlag = `${VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.SHARED_FALLBACK} /* SLOT_ROOT, SHARED_FALLBACK */`

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -251,13 +251,9 @@ export function markSlotRootOperations(
     } else if (operation.type === IRNodeTypes.CREATE_COMPONENT_NODE) {
       markSlotRootComponent(operation)
     } else if (operation.type === IRNodeTypes.SLOT_OUTLET_NODE) {
-      if (!(operation.flags & VaporSlotFlags.ONCE)) {
-        operation.flags |= VaporSlotFlags.SLOT_ROOT
-      }
+      operation.flags |= VaporSlotFlags.FORWARDED
       if (sharedFallback) {
         operation.flags |= VaporSlotFlags.SHARED_FALLBACK
-      } else {
-        operation.flags |= VaporSlotFlags.INHERIT_FALLBACK
       }
     }
   }

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -1,6 +1,6 @@
 import {
   VaporDynamicComponentFlags,
-  VaporSlotFlags,
+  VaporSlotStability,
   camelize,
   extend,
   getModifierPropName,
@@ -831,30 +831,11 @@ function genSlotBlockWithProps(
   // Dynamic slot sources keep rawSlots.$, so runtime stays conservative.
   if (emitNonStableFlag && !hasStableRoot) {
     blockFn = genCall(context.helper('extend'), blockFn, [
-      `{ _: ${genSlotFlags(VaporSlotFlags.NON_STABLE)} }`,
+      `{ _: ${VaporSlotStability.NON_STABLE}${__DEV__ ? ` /* NON_STABLE */` : ``} }`,
     ])
   }
   exitSlotBlock()
   exitScope && exitScope()
 
   return blockFn
-}
-
-function genSlotFlags(flags: number): string {
-  const names: string[] = []
-
-  if (flags & VaporSlotFlags.NO_SLOTTED) {
-    names.push('NO_SLOTTED')
-  }
-  if (flags & VaporSlotFlags.ONCE) {
-    names.push('ONCE')
-  }
-  if (flags & VaporSlotFlags.SLOT_ROOT) {
-    names.push('SLOT_ROOT')
-  }
-  if (flags & VaporSlotFlags.NON_STABLE) {
-    names.push('NON_STABLE')
-  }
-
-  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
 }

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -32,6 +32,7 @@ import {
   INDENT_START,
   NEWLINE,
   genCall,
+  genFlags,
   genMulti,
 } from './utils'
 import { genExpression, genVarName } from './expression'
@@ -180,7 +181,7 @@ function genDynamicComponentFlags(
     return false
   }
 
-  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
+  return genFlags(flags, names)
 }
 
 function getUniqueHandlerName(context: CodegenContext, name: string): string {
@@ -831,7 +832,7 @@ function genSlotBlockWithProps(
   // Dynamic slot sources keep rawSlots.$, so runtime stays conservative.
   if (emitNonStableFlag && !hasStableRoot) {
     blockFn = genCall(context.helper('extend'), blockFn, [
-      `{ _: ${VaporSlotStability.NON_STABLE}${__DEV__ ? ` /* NON_STABLE */` : ``} }`,
+      `{ _: ${genFlags(VaporSlotStability.NON_STABLE, ['NON_STABLE'])} }`,
     ])
   }
   exitSlotBlock()

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -832,7 +832,11 @@ function genSlotBlockWithProps(
   // Dynamic slot sources keep rawSlots.$, so runtime stays conservative.
   if (emitNonStableFlag && !hasStableRoot) {
     blockFn = genCall(context.helper('extend'), blockFn, [
-      `{ _: ${genFlags(VaporSlotStability.NON_STABLE, ['NON_STABLE'])} }`,
+      `{ _: ${
+        __DEV__
+          ? genFlags(VaporSlotStability.NON_STABLE, ['NON_STABLE'])
+          : VaporSlotStability.NON_STABLE
+      } }`,
     ])
   }
   exitSlotBlock()

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -19,6 +19,7 @@ import {
   INDENT_START,
   NEWLINE,
   genCall,
+  genFlags,
   genMulti,
   getParserOptions,
 } from './utils'
@@ -237,7 +238,7 @@ function genForFlags(
     return undefined
   }
 
-  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
+  return genFlags(flags, names)
 }
 
 function isSingleNodeBlock(block: BlockIRNode): boolean {

--- a/packages/compiler-vapor/src/generators/if.ts
+++ b/packages/compiler-vapor/src/generators/if.ts
@@ -82,7 +82,9 @@ function genIfFlags(
     return false
   }
 
-  return genFlags(flags, genIfFlagNames(once, slotRoot, index, blockShape))
+  return __DEV__
+    ? genFlags(flags, genIfFlagNames(once, slotRoot, index, blockShape))
+    : String(flags)
 }
 
 function genIfFlagNames(

--- a/packages/compiler-vapor/src/generators/if.ts
+++ b/packages/compiler-vapor/src/generators/if.ts
@@ -3,7 +3,13 @@ import { IRNodeTypes, type IfIRNode } from '../ir'
 import { VaporBlockShape, VaporIfFlags } from '@vue/shared'
 import { genBlock } from './block'
 import { genExpression } from './expression'
-import { type CodeFragment, NEWLINE, buildCodeFragment, genCall } from './utils'
+import {
+  type CodeFragment,
+  NEWLINE,
+  buildCodeFragment,
+  genCall,
+  genFlags,
+} from './utils'
 
 export function genIf(
   oper: IfIRNode,
@@ -76,9 +82,7 @@ function genIfFlags(
     return false
   }
 
-  return __DEV__
-    ? `${flags} /* ${genIfFlagNames(once, slotRoot, index, blockShape)} */`
-    : String(flags)
+  return genFlags(flags, genIfFlagNames(once, slotRoot, index, blockShape))
 }
 
 function genIfFlagNames(
@@ -86,7 +90,7 @@ function genIfFlagNames(
   slotRoot: boolean | undefined,
   index: number | undefined,
   blockShape: number,
-): string {
+): string[] {
   const names = [`TRUE_${genBlockShapeName(blockShape)}`]
   const falseShape = blockShape >> 2
   const hasFalseBranch = (falseShape & 0b11) !== VaporBlockShape.EMPTY
@@ -112,7 +116,7 @@ function genIfFlagNames(
     names.push(`KEYED_INDEX_${index}`)
   }
 
-  return names.join(', ')
+  return names
 }
 
 function genBlockShapeName(flags: number): string {

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -63,14 +63,11 @@ function genSlotFlags(flags: number): string | undefined {
   if (flags & VaporSlotFlags.ONCE) {
     names.push('ONCE')
   }
-  if (flags & VaporSlotFlags.SLOT_ROOT) {
-    names.push('SLOT_ROOT')
+  if (flags & VaporSlotFlags.FORWARDED) {
+    names.push('FORWARDED')
   }
   if (flags & VaporSlotFlags.SHARED_FALLBACK) {
     names.push('SHARED_FALLBACK')
-  }
-  if (flags & VaporSlotFlags.INHERIT_FALLBACK) {
-    names.push('INHERIT_FALLBACK')
   }
 
   return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)

--- a/packages/compiler-vapor/src/generators/slotOutlet.ts
+++ b/packages/compiler-vapor/src/generators/slotOutlet.ts
@@ -3,7 +3,13 @@ import type { SlotOutletIRNode } from '../ir'
 import { VaporSlotFlags } from '@vue/shared'
 import { genBlock, markSlotRootOperations } from './block'
 import { genExpression } from './expression'
-import { type CodeFragment, NEWLINE, buildCodeFragment, genCall } from './utils'
+import {
+  type CodeFragment,
+  NEWLINE,
+  buildCodeFragment,
+  genCall,
+  genFlags,
+} from './utils'
 import { genRawProps } from './component'
 
 export function genSlotOutlet(
@@ -70,5 +76,5 @@ function genSlotFlags(flags: number): string | undefined {
     names.push('SHARED_FALLBACK')
   }
 
-  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
+  return genFlags(flags, names)
 }

--- a/packages/compiler-vapor/src/generators/utils.ts
+++ b/packages/compiler-vapor/src/generators/utils.ts
@@ -222,3 +222,8 @@ export function codeFragmentToString(
     })
   }
 }
+
+/** Formats a numeric flags argument with its dev-only name annotation. */
+export function genFlags(flags: number, names: string[]): string {
+  return __DEV__ ? `${flags} /* ${names.join(', ')} */` : String(flags)
+}

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -257,15 +257,13 @@ export interface VaporInVdomInterface {
 }
 
 /**
- * Options for rendering a VDOM slot inside vapor. The booleans describe the
- * outlet's position in the fallback chain; see renderVDOMSlot.
+ * Options for rendering a VDOM slot inside vapor. `flags` carries the
+ * outlet's VaporSlotFlags describing its position in the fallback chain;
+ * see renderVDOMSlot.
  */
 export interface VdomSlotOptions {
   fallback?: (...args: any[]) => any // VaporSlot
-  once?: boolean
-  slotRoot?: boolean
-  sharedFallback?: boolean
-  inheritFallback?: boolean
+  flags?: number
   adoptAnchor?: Node
 }
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -86,8 +86,7 @@ const slotRootIfShape = VaporBlockShape.SINGLE_ROOT | VaporIfFlags.SLOT_ROOT
 const keyedSlotRootIfShape = keyedIfShape | VaporIfFlags.SLOT_ROOT
 const slotRootForFlags = VaporVForFlags.SLOT_ROOT
 const nonStableSlot = { _: VaporSlotStability.NON_STABLE } as const
-const inheritedFallbackSlotRootFlags =
-  VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK
+const inheritedFallbackSlotRootFlags = VaporSlotFlags.FORWARDED
 const createInheritedSlotRoot = (name: string, fallback?: BlockFn) =>
   createSlot(name, null, fallback, inheritedFallbackSlotRootFlags)
 
@@ -266,7 +265,7 @@ describe('component: slots', () => {
       }
       const frag = withSlotBoundary(
         parentBoundary,
-        () => new SlotFragment(true),
+        () => new SlotFragment(VaporSlotFlags.FORWARDED),
       )
       const fallback = () => document.createTextNode('fallback')
 
@@ -307,7 +306,7 @@ describe('component: slots', () => {
       }
       const frag = withSlotBoundary(
         parentBoundary,
-        () => new SlotFragment(false, false, true),
+        () => new SlotFragment(VaporSlotFlags.FORWARDED),
       )
 
       frag.updateSlot(undefined, localFallback)
@@ -331,7 +330,10 @@ describe('component: slots', () => {
       }
       const frag = withSlotBoundary(
         parentBoundary,
-        () => new SlotFragment(true, true),
+        () =>
+          new SlotFragment(
+            VaporSlotFlags.FORWARDED | VaporSlotFlags.SHARED_FALLBACK,
+          ),
       )
 
       frag.updateSlot(undefined, localFallback)
@@ -350,7 +352,7 @@ describe('component: slots', () => {
       }
       const frag = withSlotBoundary(
         parentBoundary,
-        () => new SlotFragment(false, false, true),
+        () => new SlotFragment(VaporSlotFlags.FORWARDED),
       )
       let fallbackBoundary: any
 
@@ -376,7 +378,7 @@ describe('component: slots', () => {
       }
       const frag = withSlotBoundary(
         parentBoundary,
-        () => new SlotFragment(false, false, true),
+        () => new SlotFragment(VaporSlotFlags.FORWARDED),
       )
       const child = new DynamicFragment(IF, 'if', false, false)
       let initialized = false
@@ -1068,7 +1070,7 @@ describe('component: slots', () => {
       }
       const Child = defineVaporComponent(() =>
         withSlotBoundary(boundary, () =>
-          createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT),
+          createSlot('default', null, undefined, VaporSlotFlags.FORWARDED),
         ),
       )
 
@@ -1377,7 +1379,9 @@ describe('component: slots', () => {
         default: () => [h('div', text.value)],
       })
       const frag = withSlotBoundary(boundary, () =>
-        vdom.slot(slotsRef, 'default', {}, instance, { slotRoot: true }),
+        vdom.slot(slotsRef, 'default', {}, instance, {
+          flags: VaporSlotFlags.FORWARDED,
+        }),
       )
       const host = document.createElement('div')
 
@@ -1439,7 +1443,7 @@ describe('component: slots', () => {
       const frag = withSlotBoundary(boundary, () =>
         vdom.slot(slotsRef, 'default', {}, instance, {
           fallback: () => template('fallback')(),
-          slotRoot: true,
+          flags: VaporSlotFlags.FORWARDED,
         }),
       )
       const host = document.createElement('div')
@@ -1769,7 +1773,9 @@ describe('component: slots', () => {
         default: () => (show.value ? [h('div', 'content')] : []),
       })
       const frag = withSlotBoundary(boundary, () =>
-        vdom.slot(slotsRef, 'default', {}, instance, { slotRoot: true }),
+        vdom.slot(slotsRef, 'default', {}, instance, {
+          flags: VaporSlotFlags.FORWARDED,
+        }),
       )
       const host = document.createElement('div')
 
@@ -3844,7 +3850,7 @@ describe('component: slots', () => {
               'default',
               null,
               undefined,
-              VaporSlotFlags.SLOT_ROOT,
+              VaporSlotFlags.FORWARDED,
             ))
           })
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -28,6 +28,7 @@ import {
   h,
   nextTick,
   onScopeDispose,
+  reactive,
   ref,
   renderSlot,
   shallowRef,
@@ -86,9 +87,8 @@ const slotRootIfShape = VaporBlockShape.SINGLE_ROOT | VaporIfFlags.SLOT_ROOT
 const keyedSlotRootIfShape = keyedIfShape | VaporIfFlags.SLOT_ROOT
 const slotRootForFlags = VaporVForFlags.SLOT_ROOT
 const nonStableSlot = { _: VaporSlotStability.NON_STABLE } as const
-const inheritedFallbackSlotRootFlags = VaporSlotFlags.FORWARDED
 const createInheritedSlotRoot = (name: string, fallback?: BlockFn) =>
-  createSlot(name, null, fallback, inheritedFallbackSlotRootFlags)
+  createSlot(name, null, fallback, VaporSlotFlags.FORWARDED)
 
 function renderWithSlots(slots: any): any {
   let instance: any
@@ -3867,6 +3867,147 @@ describe('component: slots', () => {
           expect(slotBlock).not.toBeInstanceOf(SlotFragment)
           expect(isSlotFragment(slotBlock)).toBe(true)
           expect(observedBoundary).toBe(null)
+        })
+
+        test('unmarked outlet without fallback takes the fast path under an enclosing boundary', async () => {
+          let slotBlock!: Block
+          let observedBoundary: SlotBoundaryContext | null | undefined
+          const markDirty = vi.fn()
+          const boundary: SlotBoundaryContext = {
+            parent: null,
+            getFallback: () => undefined,
+            run: fn => fn(),
+            markDirty,
+          }
+          const show = ref(true)
+          const Comp = defineVaporComponent(() => {
+            return (slotBlock = withSlotBoundary(boundary, () =>
+              createSlot('default'),
+            ))
+          })
+
+          const { host } = define(() =>
+            createComponent(Comp, null, {
+              default: () => {
+                observedBoundary = currentSlotBoundary
+                return createIf(
+                  () => show.value,
+                  () => template('<span>content</span>')(),
+                  undefined,
+                  slotRootIfShape,
+                )
+              },
+            }),
+          ).render()
+
+          expect(slotBlock).toBeInstanceOf(DynamicFragment)
+          expect(slotBlock).not.toBeInstanceOf(SlotFragment)
+          // The fast-path fragment captures a null boundary, so content
+          // renders outside the enclosing resolution and its marked roots
+          // attach no dirty-tracking to it.
+          expect(observedBoundary).toBe(null)
+          expect(host.innerHTML).toBe(
+            '<span>content</span><!--if--><!--slot-->',
+          )
+
+          show.value = false
+          await nextTick()
+          expect(host.innerHTML).toBe('<!--if--><!--slot-->')
+
+          show.value = true
+          await nextTick()
+          expect(host.innerHTML).toBe(
+            '<span>content</span><!--if--><!--slot-->',
+          )
+          expect(markDirty).not.toHaveBeenCalled()
+        })
+
+        test('compiled component outlet inside slot content takes the fast path', async () => {
+          const data: any = reactive({ branch: true, show: true })
+          let cardBlock: Block | undefined
+          const Card = compile(`<template><slot /></template>`, data)
+          const CardSpy = extend({}, Card, {
+            setup(props: any, ctx: any) {
+              return (cardBlock = Card.setup(props, ctx))
+            },
+          })
+          const Receiver = compile(
+            `<template><slot><b>receiver fallback</b></slot></template>`,
+            data,
+          )
+          const App = compile(
+            `<template>
+              <components.Receiver>
+                <components.Card v-if="data.branch">
+                  <span v-if="data.show">content</span>
+                </components.Card>
+              </components.Receiver>
+            </template>`,
+            data,
+            { Receiver, Card: CardSpy },
+          )
+
+          const { host } = define(() => createComponent(App)).render()
+
+          // Card's own outlet is unmarked and has no fallback, so even under
+          // the receiver's boundary it takes the fast path.
+          expect(cardBlock).toBeInstanceOf(DynamicFragment)
+          expect(cardBlock).not.toBeInstanceOf(SlotFragment)
+          expect(host.textContent).toBe('content')
+
+          // The marked v-if at Card's consumer content root updates in place
+          // without disturbing the receiver's arbitration.
+          data.show = false
+          await nextTick()
+          expect(host.textContent).toBe('')
+
+          data.branch = false
+          await nextTick()
+          expect(host.textContent).toBe('receiver fallback')
+
+          data.branch = true
+          data.show = true
+          await nextTick()
+          expect(host.textContent).toBe('content')
+        })
+
+        // Coverage guard for the conservative branches of
+        // shouldUseSlotFragment; always green today, pins the split matrix.
+        // The FORWARDED-on-own-template-outlet pairing is synthetic (the
+        // compiler only marks forwarded roots inside slot blocks); the split
+        // decision reads flags and fallback alone, which is what this pins.
+        test('outlets participating in fallback arbitration keep the slot fragment under a boundary', () => {
+          let forwardedBlock!: Block
+          let fallbackBlock!: Block
+          const boundary: SlotBoundaryContext = {
+            parent: null,
+            getFallback: () => undefined,
+            run: fn => fn(),
+            markDirty: vi.fn(),
+          }
+          const Comp = defineVaporComponent(() =>
+            withSlotBoundary(boundary, () => [
+              (forwardedBlock = createSlot(
+                'a',
+                null,
+                undefined,
+                VaporSlotFlags.FORWARDED,
+              )),
+              (fallbackBlock = createSlot('b', null, () =>
+                template('fallback')(),
+              )),
+            ]),
+          )
+
+          define(() =>
+            createComponent(Comp, null, {
+              a: () => template('a')(),
+              b: () => template('b')(),
+            }),
+          ).render()
+
+          expect(forwardedBlock).toBeInstanceOf(SlotFragment)
+          expect(fallbackBlock).toBeInstanceOf(SlotFragment)
         })
 
         test('slot with fallback and explicit empty slots', () => {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1795,6 +1795,37 @@ describe('component: slots', () => {
       expect(boundary.markDirty).toHaveBeenCalledTimes(2)
     })
 
+    test('vdom slot without flags or fallback renders content outside the boundary chain', () => {
+      // Mirror of the vapor fast path: an outlet that joins no fallback
+      // arbitration must not interpose its own dead-end boundary, so nested
+      // outlets classify identically under both hosts. Hand-written: needs
+      // to observe the ambient boundary from inside the slot function.
+      let observedBoundary: SlotBoundaryContext | null | undefined
+      const instance = renderWithSlots({})
+      const app = createApp({ render: () => null })
+      app.use(vaporInteropPlugin)
+      const vdom = (app._context as any).vdom
+      const slotsRef = shallowRef({
+        default: () => {
+          observedBoundary = currentSlotBoundary
+          return [h('div', 'content')]
+        },
+      })
+      const frag = vdom.slot(slotsRef, 'default', {}, instance, {})
+      const host = document.createElement('div')
+      insert(frag, host)
+
+      expect(observedBoundary).toBe(null)
+      expect(host.innerHTML).toContain('<div>content</div>')
+
+      // An arbitrating outlet keeps its own boundary around content.
+      const fragWithFallback = vdom.slot(slotsRef, 'default', {}, instance, {
+        fallback: () => template('fallback')(),
+      })
+      insert(fragWithFallback, host)
+      expect(observedBoundary).not.toBe(null)
+    })
+
     test('compiled vdom slot propagates nested fallback validity changes', async () => {
       const show = ref(true)
       const Receiver = compile(

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -3979,6 +3979,7 @@ describe('component: slots', () => {
         test('outlets participating in fallback arbitration keep the slot fragment under a boundary', () => {
           let forwardedBlock!: Block
           let fallbackBlock!: Block
+          let loneSharedBlock!: Block
           const boundary: SlotBoundaryContext = {
             parent: null,
             getFallback: () => undefined,
@@ -3996,6 +3997,12 @@ describe('component: slots', () => {
               (fallbackBlock = createSlot('b', null, () =>
                 template('fallback')(),
               )),
+              (loneSharedBlock = createSlot(
+                'c',
+                null,
+                undefined,
+                VaporSlotFlags.SHARED_FALLBACK,
+              )),
             ]),
           )
 
@@ -4003,11 +4010,13 @@ describe('component: slots', () => {
             createComponent(Comp, null, {
               a: () => template('a')(),
               b: () => template('b')(),
+              c: () => template('c')(),
             }),
           ).render()
 
           expect(forwardedBlock).toBeInstanceOf(SlotFragment)
           expect(fallbackBlock).toBeInstanceOf(SlotFragment)
+          expect(loneSharedBlock).toBeInstanceOf(SlotFragment)
         })
 
         test('slot with fallback and explicit empty slots', () => {

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -38,6 +38,7 @@ import {
   VaporBlockShape,
   VaporIfFlags,
   VaporSlotFlags,
+  VaporSlotStability,
   VaporVForFlags,
   extend,
 } from '@vue/shared'
@@ -84,7 +85,7 @@ const keyedIfShape =
 const slotRootIfShape = VaporBlockShape.SINGLE_ROOT | VaporIfFlags.SLOT_ROOT
 const keyedSlotRootIfShape = keyedIfShape | VaporIfFlags.SLOT_ROOT
 const slotRootForFlags = VaporVForFlags.SLOT_ROOT
-const nonStableSlot = { _: VaporSlotFlags.NON_STABLE } as const
+const nonStableSlot = { _: VaporSlotStability.NON_STABLE } as const
 const inheritedFallbackSlotRootFlags =
   VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK
 const createInheritedSlotRoot = (name: string, fallback?: BlockFn) =>
@@ -3914,7 +3915,7 @@ describe('component: slots', () => {
         test('non-stable slot with fallback uses slot fragment', () => {
           let slotBlock!: Block
           const slot = (() => template('<p>A</p>')()) as BlockFn
-          ;(slot as any)._ = VaporSlotFlags.NON_STABLE
+          ;(slot as any)._ = VaporSlotStability.NON_STABLE
           const Comp = defineVaporComponent(() => {
             return (slotBlock = createSlot('default', null, () =>
               template('fallback')(),

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -1069,9 +1069,7 @@ describe('component: slots', () => {
         markDirty,
       }
       const Child = defineVaporComponent(() =>
-        withSlotBoundary(boundary, () =>
-          createSlot('default', null, undefined, VaporSlotFlags.FORWARDED),
-        ),
+        withSlotBoundary(boundary, () => createInheritedSlotRoot('default')),
       )
 
       define(() =>
@@ -3877,12 +3875,7 @@ describe('component: slots', () => {
           let slotBlock!: Block
           let observedBoundary: SlotBoundaryContext | null | undefined
           const Comp = defineVaporComponent(() => {
-            return (slotBlock = createSlot(
-              'default',
-              null,
-              undefined,
-              VaporSlotFlags.FORWARDED,
-            ))
+            return (slotBlock = createInheritedSlotRoot('default'))
           })
 
           define(() =>
@@ -4065,12 +4058,7 @@ describe('component: slots', () => {
           }
           const Comp = defineVaporComponent(() =>
             withSlotBoundary(boundary, () => [
-              (forwardedBlock = createSlot(
-                'a',
-                null,
-                undefined,
-                VaporSlotFlags.FORWARDED,
-              )),
+              (forwardedBlock = createInheritedSlotRoot('a')),
               (fallbackBlock = createSlot('b', null, () =>
                 template('fallback')(),
               )),

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -4002,15 +4002,61 @@ describe('component: slots', () => {
           expect(host.textContent).toBe('content')
         })
 
-        // Coverage guard for the conservative branches of
-        // shouldUseSlotFragment; always green today, pins the split matrix.
+        test('compiled outlet with fallback and stable content takes the fast path under a boundary', async () => {
+          const data: any = reactive({ branch: true })
+          let cardBlock: Block | undefined
+          const Card = compile(
+            `<template><slot><b>card fallback</b></slot></template>`,
+            data,
+          )
+          const CardSpy = extend({}, Card, {
+            setup(props: any, ctx: any) {
+              return (cardBlock = Card.setup(props, ctx))
+            },
+          })
+          const Receiver = compile(
+            `<template><slot><i>receiver fallback</i></slot></template>`,
+            data,
+          )
+          const App = compile(
+            `<template>
+              <components.Receiver>
+                <components.Card v-if="data.branch">
+                  <span>content</span>
+                </components.Card>
+              </components.Receiver>
+            </template>`,
+            data,
+            { Receiver, Card: CardSpy },
+          )
+
+          const { host } = define(() => createComponent(App)).render()
+
+          // Provided stable content keeps Card's local fallback unreachable,
+          // so the enclosing boundary does not force the slot fragment.
+          expect(cardBlock).not.toBeInstanceOf(SlotFragment)
+          expect(host.textContent).toBe('content')
+
+          data.branch = false
+          await nextTick()
+          expect(host.textContent).toBe('receiver fallback')
+
+          data.branch = true
+          await nextTick()
+          expect(host.textContent).toBe('content')
+        })
+
+        // Coverage guard for the split matrix of shouldUseSlotFragment.
         // The FORWARDED-on-own-template-outlet pairing is synthetic (the
         // compiler only marks forwarded roots inside slot blocks); the split
         // decision reads flags and fallback alone, which is what this pins.
         test('outlets participating in fallback arbitration keep the slot fragment under a boundary', () => {
           let forwardedBlock!: Block
           let fallbackBlock!: Block
+          let nonStableFallbackBlock!: Block
           let loneSharedBlock!: Block
+          const nonStableSlotFn = (() => template('d')()) as BlockFn
+          ;(nonStableSlotFn as any)._ = VaporSlotStability.NON_STABLE
           const boundary: SlotBoundaryContext = {
             parent: null,
             getFallback: () => undefined,
@@ -4028,6 +4074,11 @@ describe('component: slots', () => {
               (fallbackBlock = createSlot('b', null, () =>
                 template('fallback')(),
               )),
+              (nonStableFallbackBlock = createSlot('d', null, () =>
+                template('fallback')(),
+              )),
+              // Hand-written flags may carry the lone SHARED_FALLBACK bit;
+              // isForwardedSlot normalizes it as forwarded.
               (loneSharedBlock = createSlot(
                 'c',
                 null,
@@ -4042,11 +4093,16 @@ describe('component: slots', () => {
               a: () => template('a')(),
               b: () => template('b')(),
               c: () => template('c')(),
+              d: nonStableSlotFn,
             }),
           ).render()
 
           expect(forwardedBlock).toBeInstanceOf(SlotFragment)
-          expect(fallbackBlock).toBeInstanceOf(SlotFragment)
+          // Local fallback reachability is boundary-independent: a provided
+          // stable slot keeps the fallback unreachable, so the fast path
+          // applies; a non-stable slot keeps SlotFragment arbitration.
+          expect(fallbackBlock).not.toBeInstanceOf(SlotFragment)
+          expect(nonStableFallbackBlock).toBeInstanceOf(SlotFragment)
           expect(loneSharedBlock).toBeInstanceOf(SlotFragment)
         })
 

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -5196,6 +5196,42 @@ describe('component: slots', () => {
         expect(root.innerHTML).toBe('<p>alt fallback</p><!--slot-->')
       })
 
+      test('vdom fallback ownership ignores fast-path outlet fragments', async () => {
+        const text = ref('fallback')
+
+        const VdomSlotWithFallback = {
+          render(this: any) {
+            return renderSlot(this.$slots, 'foo', {}, () => [
+              h('div', text.value),
+            ])
+          },
+        }
+
+        const VaporParent = defineVaporComponent({
+          setup() {
+            return createComponent(
+              VdomSlotWithFallback,
+              null,
+              // Unmarked outlet without fallback: a fast-path DynamicFragment,
+              // which must not be mistaken for a SlotFragment that could own
+              // the vdom fallback decision. Hand-written on purpose: the
+              // compiler marks every root outlet FORWARDED, so this shape is
+              // only reachable through hand-written render functions.
+              { foo: () => createSlot('foo') },
+              true,
+            )
+          },
+        })
+
+        const root = document.createElement('div')
+        createVaporApp(VaporParent).use(vaporInteropPlugin).mount(root)
+        expect(root.textContent).toBe('fallback')
+
+        text.value = 'updated fallback'
+        await nextTick()
+        expect(root.textContent).toBe('updated fallback')
+      })
+
       test('vdom fallback for renderVaporSlot is evaluated once on initial mount', async () => {
         const fallbackText = ref('fallback')
         const fallbackSpy = vi.fn(() => [h('div', fallbackText.value)])

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'vue'
 import {
   VaporBlockShape,
-  VaporSlotFlags,
+  VaporSlotStability,
   VaporVForFlags,
   extend,
 } from '@vue/shared'
@@ -51,7 +51,7 @@ const define = makeRender()
 const timeout = (n: number = 0) => new Promise(r => setTimeout(r, n))
 const singleRootIfElse =
   VaporBlockShape.SINGLE_ROOT | (VaporBlockShape.SINGLE_ROOT << 2)
-const nonStableSlot = { _: VaporSlotFlags.NON_STABLE } as const
+const nonStableSlot = { _: VaporSlotStability.NON_STABLE } as const
 
 describe('VaporKeepAlive', () => {
   let one: VaporComponent

--- a/packages/runtime-vapor/__tests__/hydration/slotsForwarded.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/slotsForwarded.spec.ts
@@ -378,7 +378,21 @@ describe('Vapor Mode hydration', () => {
       data.branch = false
       await nextTick()
       expect(container.textContent).toBe('receiver fallback')
-      expect(container.innerHTML.match(/<!--slot-->/g)).toHaveLength(1)
+      // The receiver outlet claims its own SSR close marker as anchor
+      // instead of allocating a runtime <!--slot--> comment.
+      expect(container.innerHTML.match(/<!--slot-->/g)).toBeNull()
+
+      data.branch = true
+      await nextTick()
+      expect(container.querySelector('div')!.textContent).toBe('content')
+
+      data.show = false
+      await nextTick()
+      expect(container.querySelector('div')!.textContent).toBe('')
+
+      data.branch = false
+      await nextTick()
+      expect(container.textContent).toBe('receiver fallback')
     })
 
     test('nested fallbacks stay within a shared boundary during hydration', async () => {

--- a/packages/runtime-vapor/__tests__/scopeId.spec.ts
+++ b/packages/runtime-vapor/__tests__/scopeId.spec.ts
@@ -1665,7 +1665,7 @@ describe('vdom interop', () => {
                   'default',
                   null,
                   undefined,
-                  VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK,
+                  VaporSlotFlags.FORWARDED,
                 ),
             },
             true,
@@ -1695,7 +1695,7 @@ describe('vdom interop', () => {
           'default',
           null,
           () => template('<span>fallback</span>')(),
-          VaporSlotFlags.SLOT_ROOT,
+          VaporSlotFlags.FORWARDED,
         ) as any
       },
     })
@@ -1816,7 +1816,7 @@ describe('vdom interop', () => {
     const Receiver = defineVaporComponent({
       __scopeId: 'receiver',
       setup() {
-        return createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT)
+        return createSlot('default', null, undefined, VaporSlotFlags.FORWARDED)
       },
     })
     app = mountApp({
@@ -1843,7 +1843,7 @@ describe('vdom interop', () => {
     const Receiver = defineVaporComponent({
       __scopeId: 'receiver',
       setup() {
-        return createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT)
+        return createSlot('default', null, undefined, VaporSlotFlags.FORWARDED)
       },
     })
     const ScopedApp = {
@@ -1890,7 +1890,7 @@ describe('vdom interop', () => {
     const Receiver = defineVaporComponent({
       __scopeId: 'receiver',
       setup() {
-        return createSlot('default', null, undefined, VaporSlotFlags.SLOT_ROOT)
+        return createSlot('default', null, undefined, VaporSlotFlags.FORWARDED)
       },
     })
 

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -68,7 +68,6 @@ import {
 } from '../src'
 
 const define = makeInteropRender()
-const inheritedFallbackSlotRootFlags = VaporSlotFlags.FORWARDED
 
 describe('vdomInterop', () => {
   describe('key', () => {
@@ -1528,12 +1527,7 @@ describe('vdomInterop', () => {
             null,
             {
               bar: () =>
-                createSlot(
-                  'bar',
-                  null,
-                  undefined,
-                  inheritedFallbackSlotRootFlags,
-                ),
+                createSlot('bar', null, undefined, VaporSlotFlags.FORWARDED),
             },
             true,
           )
@@ -4421,7 +4415,7 @@ describe('vdomInterop', () => {
                           'default',
                           null,
                           undefined,
-                          inheritedFallbackSlotRootFlags,
+                          VaporSlotFlags.FORWARDED,
                         ),
                     },
                     true,

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -68,8 +68,7 @@ import {
 } from '../src'
 
 const define = makeInteropRender()
-const inheritedFallbackSlotRootFlags =
-  VaporSlotFlags.SLOT_ROOT | VaporSlotFlags.INHERIT_FALLBACK
+const inheritedFallbackSlotRootFlags = VaporSlotFlags.FORWARDED
 
 describe('vdomInterop', () => {
   describe('key', () => {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -481,12 +481,11 @@ function shouldUseSlotFragment(
   // Native CE slots render a real <slot>, so SlotFragment owns fallback.
   if (isCustomElementSlot) return true
 
-  // Under an enclosing boundary, only outlets that join fallback arbitration
-  // must preserve the chain: compiler-marked forwarded roots, or a local
-  // fallback feeding nested resolution.
-  if (currentSlotBoundary) {
-    return !!fallback || isForwardedSlot(flags)
-  }
+  // Compiler-marked forwarded roots must preserve the enclosing boundary
+  // chain. Everything below is boundary-independent: a non-forwarded outlet
+  // never chains outward, so local fallback reachability follows the same
+  // static analysis with or without an enclosing boundary.
+  if (currentSlotBoundary && isForwardedSlot(flags)) return true
 
   // Without fallback, there is no fallback branch to track.
   if (!fallback) return false

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -5,6 +5,7 @@ import {
   VaporSlotStability,
   hasOwn,
   isArray,
+  isForwardedSlot,
   isFunction,
 } from '@vue/shared'
 import { type Block, type BlockFn, insert } from './block'
@@ -484,7 +485,7 @@ function shouldUseSlotFragment(
   // must preserve the chain: compiler-marked forwarded roots, or a local
   // fallback feeding nested resolution.
   if (currentSlotBoundary) {
-    return !!(fallback || flags & VaporSlotFlags.FORWARDED)
+    return !!fallback || isForwardedSlot(flags)
   }
 
   // Without fallback, there is no fallback branch to track.

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -288,11 +288,6 @@ export function createSlot(
         rawPropsProxyHandlers,
       )
     : EMPTY_OBJ
-  if (once && fallback) {
-    const originalFallback = fallback
-    fallback = (...args: any[]) => withOnceSlot(() => originalFallback(...args))
-  }
-
   let fragment: VaporFragment
   let isCustomElementSlot = false
   const interopSlotsSource =
@@ -318,6 +313,13 @@ export function createSlot(
       setCurrentSlotScopeIds(prevSlotScopeIds)
     }
   } else {
+    // renderVDOMSlot wraps its fallback from flags itself, so only the
+    // non-interop paths wrap here.
+    if (once && fallback) {
+      const originalFallback = fallback
+      fallback = (...args: any[]) =>
+        withOnceSlot(() => originalFallback(...args))
+    }
     if (isHydrating) hydrationCursor = captureHydrationCursor()
     isCustomElementSlot = !!(
       (instance as GenericComponentInstance).ce ||
@@ -379,12 +381,13 @@ export function createSlot(
         if (once) setSlotProps()
         else renderEffect(setSlotProps)
         if (fallback) {
+          const fallbackFn = fallback
           // The fallback renders outside the fragment's own render seam, so
           // establish the outlet cell explicitly around it.
           const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
           try {
             withSlotBoundary(slotFragment!.slotBoundary, () => {
-              const fallbackBlock = fallback()
+              const fallbackBlock = fallbackFn()
               // Keep the live fallback block on the SlotFragment itself. The
               // native slot outlet is temporary and gets removed by CE slot
               // replacement, but the fragment remains Vapor's long-lived

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -326,6 +326,7 @@ export function createSlot(
       rawSlots,
       name,
       fallback,
+      flags,
       isCustomElementSlot,
     )
     const slotFragment = needsSlotFragment
@@ -346,6 +347,9 @@ export function createSlot(
         undefined,
         _insertionAnchor,
       )
+      // A fast-path outlet joins no fallback arbitration, so its content must
+      // not render under (or attach dirty-tracking to) an enclosing boundary.
+      dynamicFragment.slotBoundary = null
       fragment = dynamicFragment
     }
     // Replace the construction-time capture with the outlet cell so late
@@ -470,13 +474,18 @@ function shouldUseSlotFragment(
   rawSlots: RawSlots,
   name: string | (() => string),
   fallback: VaporSlot | undefined,
+  flags: number,
   isCustomElementSlot: boolean,
 ): boolean {
   // Native CE slots render a real <slot>, so SlotFragment owns fallback.
   if (isCustomElementSlot) return true
 
-  // Nested fallback resolution must preserve the boundary chain.
-  if (currentSlotBoundary) return true
+  // Under an enclosing boundary, only outlets that join fallback arbitration
+  // must preserve the chain: compiler-marked forwarded roots, or a local
+  // fallback feeding nested resolution.
+  if (currentSlotBoundary) {
+    return !!(fallback || flags & VaporSlotFlags.FORWARDED)
+  }
 
   // Without fallback, there is no fallback branch to track.
   if (!fallback) return false

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -499,10 +499,12 @@ function shouldUseSlotFragment(
   // Dynamic names and dynamic slot sources still need runtime resolution.
   if (isFunction(name) || rawSlots.$) return true
 
-  const slot = getSlot(rawSlots, name)
+  // Raw resolution only: the stability marker lives on the raw function, so
+  // the owner wrapper is left for renderSlot's single synchronous first run.
+  const slot = resolveSlot(rawSlots, name)
   // No matching static slot means fallback is the only possible branch.
   if (!slot) return false
 
   // Non-stable slot content can become invalid, making fallback reachable.
-  return slot._ === VaporSlotStability.NON_STABLE
+  return (isFunction(slot) ? slot : slot.fn)._ === VaporSlotStability.NON_STABLE
 }

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -281,9 +281,6 @@ export function createSlot(
       : [`${scopeId}-s`]
     : outerSlotScopeIds
   const once = !!(flags & VaporSlotFlags.ONCE)
-  const slotRoot = !!(flags & VaporSlotFlags.SLOT_ROOT)
-  const sharedFallback = !!(flags & VaporSlotFlags.SHARED_FALLBACK)
-  const inheritFallback = !!(flags & VaporSlotFlags.INHERIT_FALLBACK)
   const slotProps = rawProps
     ? new Proxy(
         once ? snapshotRawProps(rawProps as RawProps) : rawProps,
@@ -312,10 +309,7 @@ export function createSlot(
         instance,
         {
           fallback,
-          once,
-          slotRoot,
-          sharedFallback,
-          inheritFallback,
+          flags,
           adoptAnchor: _insertionAnchor,
         },
       )
@@ -335,12 +329,7 @@ export function createSlot(
       isCustomElementSlot,
     )
     const slotFragment = needsSlotFragment
-      ? new SlotFragment(
-          slotRoot,
-          sharedFallback,
-          inheritFallback,
-          _insertionAnchor,
-        )
+      ? new SlotFragment(flags, _insertionAnchor)
       : undefined
     let dynamicFragment: DynamicFragment | undefined
     if (slotFragment) {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -2,6 +2,7 @@ import {
   EMPTY_OBJ,
   NO,
   VaporSlotFlags,
+  VaporSlotStability,
   hasOwn,
   isArray,
   isFunction,
@@ -80,7 +81,7 @@ export type LooseRawSlots =
 export type StaticSlots = Record<string, VaporSlot>
 
 export type VaporSlot = BlockFn & {
-  _?: VaporSlotFlags.NON_STABLE
+  _?: VaporSlotStability.NON_STABLE
 }
 export type DynamicSlot = { name: string; fn: VaporSlot; key?: unknown }
 export type DynamicSlotFn = () => DynamicSlot | DynamicSlot[]
@@ -502,5 +503,5 @@ function shouldUseSlotFragment(
   if (!slot) return false
 
   // Non-stable slot content can become invalid, making fallback reachable.
-  return slot._ === VaporSlotFlags.NON_STABLE
+  return slot._ === VaporSlotStability.NON_STABLE
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1,4 +1,5 @@
 import { EffectScope, type ShallowRef, setActiveSub } from '@vue/reactivity'
+import { VaporSlotFlags } from '@vue/shared'
 import { createComment, createTextNode } from './dom/node'
 import {
   type Block,
@@ -576,13 +577,13 @@ export class SlotFragment
   private localFallback?: BlockFn
   private isUpdating = false
   private ownBoundary?: SlotBoundaryContext
-  // Slot-root outlets expose their content validity to the enclosing boundary.
-  constructor(
-    private readonly notifyParentBoundary: boolean = false,
-    private readonly sharedFallback: boolean = false,
-    private readonly inheritFallback: boolean = false,
-    adoptAnchor?: Node,
-  ) {
+  // Decoded from VaporSlotFlags: forwarded roots expose their content
+  // validity to the enclosing boundary (unless once, whose content never
+  // changes validity) and resolve fallback in shared or inherit mode.
+  private readonly notifyParentBoundary: boolean
+  private readonly sharedFallback: boolean
+  private readonly inheritFallback: boolean
+  constructor(flags: number = 0, adoptAnchor?: Node) {
     super(
       SLOT_FRAGMENT,
       __DEV__ ? 'slot' : undefined,
@@ -592,6 +593,15 @@ export class SlotFragment
       undefined,
       adoptAnchor,
     )
+    const forwarded = !!(
+      flags &
+      (VaporSlotFlags.FORWARDED | VaporSlotFlags.SHARED_FALLBACK)
+    )
+    const sharedFallback = (this.sharedFallback = !!(
+      flags & VaporSlotFlags.SHARED_FALLBACK
+    ))
+    this.inheritFallback = forwarded && !sharedFallback
+    this.notifyParentBoundary = forwarded && !(flags & VaporSlotFlags.ONCE)
     if (sharedFallback) {
       if (this.slotBoundary) {
         registerContentInvalid(

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -101,6 +101,7 @@ import {
   SLOT,
   SLOT_FRAGMENT,
   SLOT_OUTLET,
+  SLOT_RESOLVER,
   VDOM,
 } from './fragmentFlags'
 
@@ -591,7 +592,7 @@ export class SlotFragment
   private readonly inheritFallback: boolean
   constructor(flags: number = 0, adoptAnchor?: Node) {
     super(
-      SLOT_FRAGMENT,
+      SLOT_FRAGMENT | SLOT_RESOLVER,
       __DEV__ ? 'slot' : undefined,
       false,
       false,
@@ -968,4 +969,8 @@ export function isForBlock(val: unknown): val is ForBlock {
 
 export function isSlotFragment(val: unknown): val is SlotFragment {
   return !!(val && (val as any).__vf & SLOT)
+}
+
+export function isSlotResolver(val: unknown): val is SlotFragment {
+  return !!(val && (val as any).__vf & SLOT_RESOLVER)
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1,5 +1,9 @@
 import { EffectScope, type ShallowRef, setActiveSub } from '@vue/reactivity'
-import { VaporSlotFlags } from '@vue/shared'
+import {
+  VaporSlotFlags,
+  slotInheritsFallback,
+  slotNotifiesBoundary,
+} from '@vue/shared'
 import { createComment, createTextNode } from './dom/node'
 import {
   type Block,
@@ -170,7 +174,9 @@ export class RenderContextFragment<
   readonly renderInstance: GenericComponentInstance | null = currentInstance
   readonly slotOwner: VaporComponentInstance | null = currentSlotOwner
   readonly keepAliveCtx?: VaporKeepAliveContext | null
-  readonly slotBoundary: SlotBoundaryContext | null = currentSlotBoundary
+  // Captured by reference: fast-path slot outlets null this right after
+  // construction — they join no fallback arbitration (see createSlot).
+  slotBoundary: SlotBoundaryContext | null = currentSlotBoundary
   // The Suspense boundary this fragment renders *into*. Unlike
   // `renderInstance.suspense` (the boundary its owner was mounted in), slot
   // content can be declared outside a boundary and rendered inside one, so this
@@ -593,16 +599,10 @@ export class SlotFragment
       undefined,
       adoptAnchor,
     )
-    const forwarded = !!(
-      flags &
-      (VaporSlotFlags.FORWARDED | VaporSlotFlags.SHARED_FALLBACK)
-    )
-    const sharedFallback = (this.sharedFallback = !!(
-      flags & VaporSlotFlags.SHARED_FALLBACK
-    ))
-    this.inheritFallback = forwarded && !sharedFallback
-    this.notifyParentBoundary = forwarded && !(flags & VaporSlotFlags.ONCE)
-    if (sharedFallback) {
+    this.sharedFallback = !!(flags & VaporSlotFlags.SHARED_FALLBACK)
+    this.inheritFallback = slotInheritsFallback(flags)
+    this.notifyParentBoundary = slotNotifiesBoundary(flags)
+    if (this.sharedFallback) {
       if (this.slotBoundary) {
         registerContentInvalid(
           this.slotBoundary,

--- a/packages/runtime-vapor/src/fragmentFlags.ts
+++ b/packages/runtime-vapor/src/fragmentFlags.ts
@@ -14,5 +14,12 @@ export const IF: number = 1 << 8
  */
 export const NATIVE_CHILDREN: number = 1 << 9
 
+/**
+ * Set only by the SlotFragment class: the fragment runs the slot resolution
+ * state machine (SlotResolutionState). Fast-path outlet fragments carry SLOT
+ * but not this bit.
+ */
+export const SLOT_RESOLVER: number = 1 << 10
+
 // Subtype bits only — the DynamicFragment constructor adds DYNAMIC itself.
 export const SLOT_FRAGMENT: number = SLOT | SLOT_OUTLET

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -144,10 +144,11 @@ import {
 import {
   type DynamicFragment,
   RenderContextFragment,
-  SlotFragment,
+  type SlotFragment,
   type VaporFragment,
   createSlotBoundary,
   isFragment,
+  isSlotResolver,
   resolveFragmentAnchor,
   runWithFragmentCtxOnly,
 } from './fragment'
@@ -2860,9 +2861,9 @@ function renderVaporSlot(
       const finalizeResolvedContent = (
         resolvedContent: Block | undefined,
       ): Block | undefined => {
-        // Instance check, not the __vf bit test: fast-path outlet fragments
-        // carry the SLOT bit but own no fallback arbitration to delegate to.
-        if (hasInteropFallback && resolvedContent instanceof SlotFragment) {
+        // SLOT_RESOLVER, not the SLOT bit: fast-path outlet fragments
+        // carry SLOT but run no slot resolution to delegate to.
+        if (hasInteropFallback && isSlotResolver(resolvedContent)) {
           pending.finish(true)
           return resolvedContent
         }
@@ -2915,7 +2916,7 @@ function renderVaporSlot(
           onScopeDispose(() => dispose(), true)
         })
       }
-      if (hasInteropFallback && resolvedContent instanceof SlotFragment) {
+      if (hasInteropFallback && isSlotResolver(resolvedContent)) {
         ownedSlotFragment = resolvedContent
         trackInteropFallbackChanges(vnode.vs!.scope, slotState, () =>
           markInteropSlotResolutionDirty(),

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -110,6 +110,8 @@ import {
   isObject,
   isReservedProp,
   isString,
+  slotInheritsFallback,
+  slotNotifiesBoundary,
 } from '@vue/shared'
 import {
   type RawProps,
@@ -1757,20 +1759,15 @@ function renderVDOMSlot(
 ): VaporFragment {
   const { fallback, flags = 0, adoptAnchor } = options
   const once = !!(flags & VaporSlotFlags.ONCE)
-  const forwarded = !!(
-    flags &
-    (VaporSlotFlags.FORWARDED | VaporSlotFlags.SHARED_FALLBACK)
-  )
   const sharedFallback = !!(flags & VaporSlotFlags.SHARED_FALLBACK)
-  const inheritFallback = forwarded && !sharedFallback
-  // v-once content never changes validity, so there is nothing to notify.
-  const slotRoot = forwarded && !once
+  const inheritFallback = slotInheritsFallback(flags)
+  const slotRoot = slotNotifiesBoundary(flags)
   let suspense = currentParentSuspense || parentComponent.suspense
   // frag.slotScopeIds is the outlet's id cell (the ambient createSlot
   // establishes around this call) — the base patch context for content
   // patches.
   const frag = createInteropFragment(EMPTY_BLOCK, null, SLOT_OUTLET)
-  const isDirectSlotRoot = forwarded
+  const isDirectSlotRoot = !!(flags & VaporSlotFlags.FORWARDED)
   const slotBoundary = frag.slotBoundary
   const content = new InteropContentState()
   const scope = effectScope()

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -240,7 +240,7 @@ function getVaporInstance(vnode: VNode): VaporComponentInstance {
 function prepareInteropSlotTransition(
   frag: RenderContextFragment,
   vnode: VNode,
-  isDirectSlotRoot: boolean,
+  forwarded: boolean,
   previous: VNode | undefined,
   resumeAfterLeave: () => void,
   delayedLeaveSource?: TransitionHooks,
@@ -258,12 +258,12 @@ function prepareInteropSlotTransition(
   if (transition && transition.applyGroup) return
 
   // The slot can render before VaporTransition propagates its hooks, notably
-  // during hydration, but a direct slot root must already use
+  // during hydration, but a forwarded slot root must already use
   // BaseTransition's branch shape.
   if (
     !transition &&
     !(
-      isDirectSlotRoot &&
+      forwarded &&
       instance &&
       isVaporTransition(instance.type as VaporComponent)
     )
@@ -1760,14 +1760,14 @@ function renderVDOMSlot(
   const { fallback, flags = 0, adoptAnchor } = options
   const once = !!(flags & VaporSlotFlags.ONCE)
   const sharedFallback = !!(flags & VaporSlotFlags.SHARED_FALLBACK)
+  const forwarded = isForwardedSlot(flags)
   const inheritFallback = slotInheritsFallback(flags)
-  const slotRoot = slotNotifiesBoundary(flags)
+  const notifiesBoundary = slotNotifiesBoundary(flags)
   let suspense = currentParentSuspense || parentComponent.suspense
   // frag.slotScopeIds is the outlet's id cell (the ambient createSlot
   // establishes around this call) — the base patch context for content
   // patches.
   const frag = createInteropFragment(EMPTY_BLOCK, null, SLOT_OUTLET)
-  const isDirectSlotRoot = isForwardedSlot(flags)
   const slotBoundary = frag.slotBoundary
   const content = new InteropContentState()
   const scope = effectScope()
@@ -1809,7 +1809,7 @@ function renderVDOMSlot(
   // renders its content outside the boundary chain, so nested outlets
   // classify identically under both hosts and validity flips inside the
   // content never notify the dead-end own boundary.
-  const contentBoundary = isDirectSlotRoot || fallback ? boundary : null
+  const contentBoundary = forwarded || fallback ? boundary : null
   slotResolutionState = createSlotResolutionState(boundary, {
     getContent: () => content.nodes,
     getParentNode: () => currentParentNode,
@@ -1821,7 +1821,7 @@ function renderVDOMSlot(
       frag.nodes = resolveExposedSlotNodes(slotResolutionState)
     },
     notifyExposedValidityChange: () => {
-      if (slotRoot && !isContentUpdateRecheck && slotBoundary) {
+      if (notifiesBoundary && !isContentUpdateRecheck && slotBoundary) {
         slotBoundary.markDirty()
       }
     },
@@ -1830,7 +1830,7 @@ function renderVDOMSlot(
   if (sharedFallback && slotBoundary) {
     registerContentInvalid(slotBoundary, parkSharedContent, frag)
   }
-  if (slotRoot) {
+  if (notifiesBoundary) {
     trackSlotBoundaryDirtying(
       frag,
       sharedFallback ? undefined : cleanupInvalidContent,
@@ -2091,7 +2091,7 @@ function renderVDOMSlot(
           prepareInteropSlotTransition(
             frag,
             pendingContent,
-            isDirectSlotRoot,
+            forwarded,
             undefined,
             NOOP,
           ) || pendingContent
@@ -2249,7 +2249,7 @@ function renderVDOMSlot(
           prepareInteropSlotTransition(
             frag,
             slotContent,
-            isDirectSlotRoot,
+            forwarded,
             undefined,
             NOOP,
           ) || createCommentVNode()
@@ -2277,7 +2277,7 @@ function renderVDOMSlot(
     const transitionChild = prepareInteropSlotTransition(
       frag,
       slotContent,
-      isDirectSlotRoot,
+      forwarded,
       prevVNode || undefined,
       resumeOutIn,
       delayedLeaveSource,
@@ -2434,7 +2434,7 @@ function renderVDOMSlot(
       const transitionChild = prepareInteropSlotTransition(
         frag,
         hydratedContent,
-        isDirectSlotRoot,
+        forwarded,
         undefined,
         NOOP,
       )

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -106,6 +106,7 @@ import {
   VaporSlotFlags,
   extend,
   isArray,
+  isForwardedSlot,
   isFunction,
   isObject,
   isReservedProp,
@@ -1766,7 +1767,7 @@ function renderVDOMSlot(
   // establishes around this call) — the base patch context for content
   // patches.
   const frag = createInteropFragment(EMPTY_BLOCK, null, SLOT_OUTLET)
-  const isDirectSlotRoot = !!(flags & VaporSlotFlags.FORWARDED)
+  const isDirectSlotRoot = isForwardedSlot(flags)
   const slotBoundary = frag.slotBoundary
   const content = new InteropContentState()
   const scope = effectScope()

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -143,11 +143,10 @@ import {
 import {
   type DynamicFragment,
   RenderContextFragment,
-  type SlotFragment,
+  SlotFragment,
   type VaporFragment,
   createSlotBoundary,
   isFragment,
-  isSlotFragment,
   resolveFragmentAnchor,
   runWithFragmentCtxOnly,
 } from './fragment'
@@ -2855,7 +2854,9 @@ function renderVaporSlot(
       const finalizeResolvedContent = (
         resolvedContent: Block | undefined,
       ): Block | undefined => {
-        if (hasInteropFallback && isSlotFragment(resolvedContent)) {
+        // Instance check, not the __vf bit test: fast-path outlet fragments
+        // carry the SLOT bit but own no fallback arbitration to delegate to.
+        if (hasInteropFallback && resolvedContent instanceof SlotFragment) {
           pending.finish(true)
           return resolvedContent
         }
@@ -2908,7 +2909,7 @@ function renderVaporSlot(
           onScopeDispose(() => dispose(), true)
         })
       }
-      if (hasInteropFallback && isSlotFragment(resolvedContent)) {
+      if (hasInteropFallback && resolvedContent instanceof SlotFragment) {
         ownedSlotFragment = resolvedContent
         trackInteropFallbackChanges(vnode.vs!.scope, slotState, () =>
           markInteropSlotResolutionDirty(),

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1805,6 +1805,11 @@ function renderVDOMSlot(
     force => markSlotResolutionDirty(slotResolutionState, force),
     [cleanupInvalidContent],
   )
+  // Mirrors the vapor fast path: an outlet joining no fallback arbitration
+  // renders its content outside the boundary chain, so nested outlets
+  // classify identically under both hosts and validity flips inside the
+  // content never notify the dead-end own boundary.
+  const contentBoundary = isDirectSlotRoot || fallback ? boundary : null
   slotResolutionState = createSlotResolutionState(boundary, {
     getContent: () => content.nodes,
     getParentNode: () => currentParentNode,
@@ -2123,7 +2128,7 @@ function renderVDOMSlot(
   function renderContent(): void {
     notifyBeforeUpdate()
     runWithFragmentCtxOnly(frag, () =>
-      withSlotBoundary(boundary, () => {
+      withSlotBoundary(contentBoundary, () => {
         const { content: slotContent, valid: slotContentValid } =
           resolveSlotContent()
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -103,6 +103,7 @@ import {
   EMPTY_OBJ,
   NOOP,
   ShapeFlags,
+  VaporSlotFlags,
   extend,
   isArray,
   isFunction,
@@ -1754,20 +1755,22 @@ function renderVDOMSlot(
   parentComponent: VaporComponentInstance,
   options: VaporVdomSlotOptions = EMPTY_OBJ,
 ): VaporFragment {
-  const {
-    fallback,
-    once,
-    slotRoot,
-    sharedFallback,
-    inheritFallback,
-    adoptAnchor,
-  } = options
+  const { fallback, flags = 0, adoptAnchor } = options
+  const once = !!(flags & VaporSlotFlags.ONCE)
+  const forwarded = !!(
+    flags &
+    (VaporSlotFlags.FORWARDED | VaporSlotFlags.SHARED_FALLBACK)
+  )
+  const sharedFallback = !!(flags & VaporSlotFlags.SHARED_FALLBACK)
+  const inheritFallback = forwarded && !sharedFallback
+  // v-once content never changes validity, so there is nothing to notify.
+  const slotRoot = forwarded && !once
   let suspense = currentParentSuspense || parentComponent.suspense
   // frag.slotScopeIds is the outlet's id cell (the ambient createSlot
   // establishes around this call) — the base patch context for content
   // patches.
   const frag = createInteropFragment(EMPTY_BLOCK, null, SLOT_OUTLET)
-  const isDirectSlotRoot = !!(slotRoot || sharedFallback || inheritFallback)
+  const isDirectSlotRoot = forwarded
   const slotBoundary = frag.slotBoundary
   const content = new InteropContentState()
   const scope = effectScope()

--- a/packages/runtime-vapor/src/vdomInteropState.ts
+++ b/packages/runtime-vapor/src/vdomInteropState.ts
@@ -11,6 +11,7 @@ export const interopKey: unique symbol = Symbol(`interop`)
 /**
  * Carries the live VDOM slots ref on the raw-slots object handed to a vapor
  * component mounted from VDOM. Replaces the old overloaded `_` key, which
- * elsewhere means SlotFlags (vdom slots) or VaporSlotFlags (slot functions).
+ * elsewhere means SlotFlags (vdom slots) or VaporSlotStability (slot
+ * functions).
  */
 export const interopSlotsKey: unique symbol = Symbol(`interopSlots`)

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -105,15 +105,21 @@ export enum VaporSlotFlags {
   NO_SLOTTED = 1,
   ONCE = 1 << 1,
   SLOT_ROOT = 1 << 2,
-  // Per-slot function metadata. The slot root can start invalid or become
-  // invalid, so fallback may be reachable and needs SlotFragment tracking.
-  NON_STABLE = 1 << 3,
   // Multiple independently invalid roots share one enclosing fallback
   // decision instead of resolving that fallback from each root.
   SHARED_FALLBACK = 1 << 4,
   // The outlet is the only forwarded root, so it may resolve an enclosing
   // fallback after its own local fallback is exhausted.
   INHERIT_FALLBACK = 1 << 5,
+}
+
+/**
+ * Per-slot-function metadata attached by the compiler as `fn._`.
+ */
+export enum VaporSlotStability {
+  // The slot content root can start invalid or become invalid, so fallback
+  // may be reachable and needs SlotFragment tracking.
+  NON_STABLE = 1,
 }
 
 export enum VaporDynamicComponentFlags {

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -115,6 +115,18 @@ export enum VaporSlotFlags {
   SHARED_FALLBACK = 1 << 3,
 }
 
+export function slotInheritsFallback(flags: number): boolean {
+  return (
+    !!(flags & VaporSlotFlags.FORWARDED) &&
+    !(flags & VaporSlotFlags.SHARED_FALLBACK)
+  )
+}
+
+// v-once content never changes validity, so it has nothing to notify.
+export function slotNotifiesBoundary(flags: number): boolean {
+  return !!(flags & VaporSlotFlags.FORWARDED) && !(flags & VaporSlotFlags.ONCE)
+}
+
 /**
  * Per-slot-function metadata attached by the compiler as `fn._`.
  */

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -104,13 +104,15 @@ export enum TemplateFlags {
 export enum VaporSlotFlags {
   NO_SLOTTED = 1,
   ONCE = 1 << 1,
-  SLOT_ROOT = 1 << 2,
-  // Multiple independently invalid roots share one enclosing fallback
-  // decision instead of resolving that fallback from each root.
-  SHARED_FALLBACK = 1 << 4,
-  // The outlet is the only forwarded root, so it may resolve an enclosing
-  // fallback after its own local fallback is exhausted.
-  INHERIT_FALLBACK = 1 << 5,
+  // The outlet is a dynamic root on a forwarded slot chain. It exposes its
+  // content validity to the enclosing boundary (unless ONCE) and, without
+  // SHARED_FALLBACK, may resolve an enclosing fallback after its own local
+  // fallback is exhausted.
+  FORWARDED = 1 << 2,
+  // Implies FORWARDED: multiple independently invalid roots share one
+  // enclosing fallback decision instead of resolving that fallback from each
+  // root.
+  SHARED_FALLBACK = 1 << 3,
 }
 
 /**

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -115,16 +115,17 @@ export enum VaporSlotFlags {
   SHARED_FALLBACK = 1 << 3,
 }
 
+export function isForwardedSlot(flags: number): boolean {
+  return !!(flags & (VaporSlotFlags.FORWARDED | VaporSlotFlags.SHARED_FALLBACK))
+}
+
 export function slotInheritsFallback(flags: number): boolean {
-  return (
-    !!(flags & VaporSlotFlags.FORWARDED) &&
-    !(flags & VaporSlotFlags.SHARED_FALLBACK)
-  )
+  return isForwardedSlot(flags) && !(flags & VaporSlotFlags.SHARED_FALLBACK)
 }
 
 // v-once content never changes validity, so it has nothing to notify.
 export function slotNotifiesBoundary(flags: number): boolean {
-  return !!(flags & VaporSlotFlags.FORWARDED) && !(flags & VaporSlotFlags.ONCE)
+  return isForwardedSlot(flags) && !(flags & VaporSlotFlags.ONCE)
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved forwarded-slot handling across Vapor and VDOM interoperability.
  * Added faster rendering for eligible stable slot content.
  * Improved fallback ownership and boundary behavior for nested slots.

* **Bug Fixes**
  * Fixed hydration anchors and updates for nested forwarded slots.
  * Improved slot behavior with teleportation, cloned components, custom elements, and scope IDs.

* **Refactor**
  * Simplified slot configuration into unified flags, improving consistency across rendering paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->