### PR TITLE
fix(runtime-vapor): keep fallthrough live for custom element root instances

### DIFF
--- a/packages/runtime-vapor/__tests__/customElement.spec.ts
+++ b/packages/runtime-vapor/__tests__/customElement.spec.ts
@@ -639,6 +639,32 @@ describe('defineVaporCustomElement', () => {
       expect(e.shadowRoot!.innerHTML).toBe('<div foo="changed">changed</div>')
     })
 
+    test('attr added after mount falls through when none existed at mount', async () => {
+      const E = defineVaporCustomElement({
+        props: { msg: String },
+        setup(props: any) {
+          const n0 = template('<div> </div>', 1)() as any
+          const x0 = txt(n0) as any
+          renderEffect(() => setText(x0, toDisplayString(props.msg)))
+          return n0
+        },
+      })
+      customElements.define('my-el-late-attr', E)
+      container.innerHTML = `<my-el-late-attr></my-el-late-attr>`
+      const e = container.childNodes[0] as VaporElement
+      expect(e.shadowRoot!.innerHTML).toBe('<div></div>')
+
+      e.setAttribute('foo', 'bar')
+      await nextTick()
+      await nextTick()
+      expect(e.shadowRoot!.innerHTML).toBe('<div foo="bar"></div>')
+
+      e.removeAttribute('foo')
+      await nextTick()
+      await nextTick()
+      expect(e.shadowRoot!.innerHTML).toBe('<div></div>')
+    })
+
     test('non-declared properties should not show up in $attrs', () => {
       const e = new E()
       // @ts-expect-error

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -993,7 +993,9 @@ export class VaporComponentInstance<
       this.isOnce && rawProps
         ? snapshotRawProps(rawProps)
         : rawProps || EMPTY_OBJ
-    this.hasFallthrough = hasFallthroughAttrs(comp, this.rawProps)
+    // a custom element host mutates its props object after creation, so its
+    // attrs key set is never static
+    this.hasFallthrough = !!ce || hasFallthroughAttrs(comp, this.rawProps)
     if (rawProps || comp.props) {
       const [propsHandlers, attrsHandlers] = getPropsProxyHandlers(comp)
       this.attrs = new Proxy(this, attrsHandlers)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom elements now correctly pass through attributes added after mounting.
  * Removing a dynamically added attribute now removes it from the rendered content.
  * Improved handling of reactive custom-element attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->