### PR TITLE
fix(compiler-vapor): preserve empty text nodes in component slots

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -210,6 +210,20 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > empty literal component slot as text 1`] = `
+"import { setText as _setText, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template(" ")
+
+export function render(_ctx) {
+  const n1 = _createAssetComponent("Comp", null, () => {
+    const n0 = t0()
+    _setText(n0, '')
+    return n0
+  }, true)
+  return n1
+}"
+`;
+
 exports[`compile > execution order > basic 1`] = `
 "import { txt as _txt, setProp as _setProp, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div> ", 1)

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -46,6 +46,11 @@ describe('compile', () => {
     expect(code).matchSnapshot()
   })
 
+  test('empty literal component slot as text', () => {
+    const code = compile(`<Comp>{{ '' }}</Comp>`)
+    expect(code).toMatchSnapshot()
+  })
+
   test('bindings', () => {
     const code = compile(`<div>count is {{ count }}.</div>`, {
       bindingMetadata: {

--- a/packages/compiler-vapor/src/transforms/transformText.ts
+++ b/packages/compiler-vapor/src/transforms/transformText.ts
@@ -129,8 +129,15 @@ function processInterpolation(context: TransformContext<InterpolationNode>) {
 
   const literalValues = values.map(v => getLiteralExpressionValue(v))
   const allLiteral = literalValues.every(v => v != null)
-  if (allLiteral && parentNode.type !== NodeTypes.ROOT) {
-    const text = literalValues.join('')
+  const text = allLiteral ? literalValues.join('') : null
+  const isElementChild =
+    parentNode.type === NodeTypes.ELEMENT &&
+    parentNode.tagType === ElementTypes.ELEMENT
+  if (
+    text !== null &&
+    parentNode.type !== NodeTypes.ROOT &&
+    (isElementChild || text !== '')
+  ) {
     if (
       parentNode.type === NodeTypes.ELEMENT &&
       shouldUseCreateElement(
@@ -145,9 +152,6 @@ function processInterpolation(context: TransformContext<InterpolationNode>) {
       )
       return
     }
-    const isElementChild =
-      parentNode.type === NodeTypes.ELEMENT &&
-      parentNode.tagType === ElementTypes.ELEMENT
     context.template += isElementChild ? escapeHtml(text) : text
     return
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty text interpolations in compiled components.
  * Prevented empty literal content from being incorrectly merged or emitted in generated output.

* **Tests**
  * Added coverage for components containing empty literal string interpolations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->