### PR TITLE
fix(runtime-vapor): update custom element slot outlet name in place

### DIFF
--- a/packages/runtime-vapor/__tests__/customElement.spec.ts
+++ b/packages/runtime-vapor/__tests__/customElement.spec.ts
@@ -919,6 +919,40 @@ describe('defineVaporCustomElement', () => {
       )
     })
 
+    test('dynamic slot name updates the native outlet in place', async () => {
+      const name = ref('a')
+      const fallback = vi.fn(() => template('<i>fallback</i>')())
+      const E = defineVaporCustomElement({
+        setup() {
+          return createSlot(() => name.value, null, fallback)
+        },
+      })
+      customElements.define('my-el-dynamic-slot-name', E)
+      container.innerHTML =
+        `<my-el-dynamic-slot-name>` +
+        `<div slot="b">b</div>` +
+        `</my-el-dynamic-slot-name>`
+      const e = container.childNodes[0] as VaporElement
+      expect(e.shadowRoot!.innerHTML).toBe(
+        `<slot name="a"><i>fallback</i></slot><!--slot-->`,
+      )
+      expect(fallback).toHaveBeenCalledTimes(1)
+
+      name.value = 'b'
+      await nextTick()
+      expect(e.shadowRoot!.innerHTML).toBe(
+        `<slot name="b"><i>fallback</i></slot><!--slot-->`,
+      )
+      // the outlet is updated in place, not re-created
+      expect(fallback).toHaveBeenCalledTimes(1)
+
+      name.value = 'default'
+      await nextTick()
+      expect(e.shadowRoot!.innerHTML).toBe(
+        `<slot><i>fallback</i></slot><!--slot-->`,
+      )
+    })
+
     test('applies v-once to slot props', async () => {
       const foo = ref('foo')
       const E = defineVaporCustomElement({

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -362,15 +362,16 @@ export function createSlot(
     const isDynamicName = isFunction(name)
 
     const renderSlot = () => {
-      const slotName = isFunction(name) ? name() : name
-
       // in custom element mode, render <slot/> as actual slot outlets
       // because in shadowRoot: false mode the slot element gets
-      // replaced by injected content
+      // replaced by injected content. The outlet is created once: a dynamic
+      // name is read inside the prop effect rather than re-running this
+      // function, which would pile up orphan outlets and fallbacks.
       if (isCustomElementSlot) {
         const el = createElement('slot')
         if (slotScopeIds) setElementScopeIds(el, slotScopeIds)
         const setSlotProps = () => {
+          const slotName = isFunction(name) ? name() : name
           setDynamicProps(el, [
             slotProps,
             slotName !== 'default' ? { name: slotName } : {},
@@ -403,6 +404,7 @@ export function createSlot(
         return
       }
 
+      const slotName = isFunction(name) ? name() : name
       const resolvedSlot = resolveSlot(rawSlots, slotName)
       const slot = resolvedSlot
         ? getOwnedSlot(
@@ -448,7 +450,7 @@ export function createSlot(
     }
 
     // dynamic slot name or has dynamicSlots
-    if (!once && (isDynamicName || rawSlots.$)) {
+    if (!once && !isCustomElementSlot && (isDynamicName || rawSlots.$)) {
       renderEffect(renderSlot)
     } else {
       renderSlot()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic slot names in custom elements so the native slot outlet updates in place when the name changes.
  * Prevented duplicate slot outlets and unnecessary fallback re-rendering during slot updates.

* **Tests**
  * Added coverage for switching dynamic slot names between named and default slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->