### PR TITLE
refactor(runtime-vapor): render custom element light DOM slots in place

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -265,12 +265,6 @@ export abstract class VueElementBase<
   protected abstract _mount(def: Def): void
   protected abstract _update(): void
   protected abstract _unmount(): void
-  // `usedFallback` preserves whether the outlet rendered native slotted
-  // content or its own fallback DOM so implementations can keep the right
-  // ownership model when syncing their block trees.
-  protected abstract _updateSlotNodes(
-    slot: Map<Node, { nodes: Node[]; usedFallback: boolean }>,
-  ): void
 
   constructor(
     /**
@@ -707,21 +701,11 @@ export abstract class VueElementBase<
   protected _renderSlots(): void {
     const outlets = this._getSlots()
     const scopeId = this._instance!.type.__scopeId
-    // Record both the final DOM nodes and whether they came from fallback.
-    // The nodes alone are not enough for runtimes that need to distinguish a
-    // plain DOM replacement from a live fallback owner.
-    const slotReplacements: Map<
-      Node,
-      { nodes: Node[]; usedFallback: boolean }
-    > = new Map()
-
     for (let i = 0; i < outlets.length; i++) {
       const o = outlets[i] as HTMLSlotElement
       const slotName = o.getAttribute('name') || 'default'
       const content = this._slots![slotName]
       const parent = o.parentNode!
-      const replacementNodes: Node[] = []
-
       if (content) {
         for (const n of content) {
           // for :slotted css
@@ -735,23 +719,12 @@ export abstract class VueElementBase<
             }
           }
           parent.insertBefore(n, o)
-          replacementNodes.push(n)
         }
       } else {
-        while (o.firstChild) {
-          const child = o.firstChild
-          parent.insertBefore(child, o)
-          replacementNodes.push(child)
-        }
+        while (o.firstChild) parent.insertBefore(o.firstChild, o)
       }
       parent.removeChild(o)
-      slotReplacements.set(o, {
-        nodes: replacementNodes,
-        usedFallback: !content,
-      })
     }
-
-    this._updateSlotNodes(slotReplacements)
   }
 
   /**
@@ -884,15 +857,6 @@ export class VueElement extends VueElementBase<
       this._instance.ce = undefined
     }
     this._app = this._instance = null
-  }
-
-  /**
-   * Only called when shadowRoot is false
-   */
-  protected _updateSlotNodes(
-    replacements: Map<Node, { nodes: Node[]; usedFallback: boolean }>,
-  ): void {
-    // do nothing
   }
 
   private _createVNode(): VNode<any, any> {

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -779,7 +779,10 @@ export abstract class VueElementBase<
    * @internal
    */
   _hasShadowRoot(): boolean {
-    return this._def.shadowRoot !== false
+    // `_def` is replaced by the resolved async component, which does not
+    // carry the host's shadowRoot option, so consult the root actually
+    // created for this host.
+    return this._root !== this
   }
 
   /**

--- a/packages/runtime-vapor/__tests__/customElement.spec.ts
+++ b/packages/runtime-vapor/__tests__/customElement.spec.ts
@@ -1728,6 +1728,34 @@ describe('defineVaporCustomElement', () => {
           `</div>`,
       )
     })
+
+    test('with slots and shadowRoot: false', async () => {
+      const E = defineVaporCustomElement(
+        defineVaporAsyncComponent(() =>
+          Promise.resolve(
+            defineVaporComponent({
+              setup() {
+                return createSlot('default')
+              },
+            }),
+          ),
+        ),
+        { shadowRoot: false },
+      )
+      customElements.define('my-el-async-light-dom-slots', E)
+      container.innerHTML =
+        `<my-el-async-light-dom-slots>` +
+        `<span>content</span>` +
+        `</my-el-async-light-dom-slots>`
+
+      await new Promise(r => setTimeout(r))
+
+      // the resolved def replaces `_def`, so the shadow root decision must
+      // come from the root actually created for the host
+      const e = container.childNodes[0] as VaporElement
+      expect(e.shadowRoot).toBe(null)
+      expect(e.innerHTML).toBe(`<span>content</span><!--slot-->`)
+    })
   })
 
   describe('shadowRoot: false', () => {

--- a/packages/runtime-vapor/__tests__/customElement.spec.ts
+++ b/packages/runtime-vapor/__tests__/customElement.spec.ts
@@ -1988,13 +1988,99 @@ describe('defineVaporCustomElement', () => {
       expect(e.innerHTML).toBe(
         `<my-child data-v-app=""><span>default</span><!--slot--></my-child><!--slot-->`,
       )
+      // light DOM content renders in place as part of the parent's mount, so
+      // the nested element connects and mounts before the parent's own
+      // mounted hook, like a regular child component
       expect(calls).toEqual([
         'parent rendering',
-        'parent mounted',
         'child rendering',
         'child mounted',
+        'parent mounted',
       ])
       app.unmount()
+    })
+
+    test('dynamic slot name re-projects light DOM content', async () => {
+      const name = ref('a')
+      const E = defineVaporCustomElement(
+        { setup: () => createSlot(() => name.value) },
+        { shadowRoot: false },
+      )
+      customElements.define('my-el-shadowroot-false-dynamic-name', E)
+      container.innerHTML =
+        `<my-el-shadowroot-false-dynamic-name>` +
+        `<div slot="a">A</div><div slot="b">B</div>` +
+        `</my-el-shadowroot-false-dynamic-name>`
+      const e = container.childNodes[0] as VaporElement
+      expect(e.innerHTML).toBe(`<div slot="a">A</div><!--slot-->`)
+
+      name.value = 'b'
+      await nextTick()
+      expect(e.innerHTML).toBe(`<div slot="b">B</div><!--slot-->`)
+
+      name.value = 'a'
+      await nextTick()
+      expect(e.innerHTML).toBe(`<div slot="a">A</div><!--slot-->`)
+    })
+
+    test('forwarded slot revealed by a child update renders light DOM content', async () => {
+      const show = ref(false)
+      const Child = defineVaporComponent({
+        setup() {
+          return createIf(
+            () => show.value,
+            () => createSlot('default'),
+          )
+        },
+      })
+      const E = defineVaporCustomElement(
+        {
+          setup() {
+            return createComponent(Child, null, {
+              default: () => createSlot('default'),
+            })
+          },
+        },
+        { shadowRoot: false },
+      )
+      customElements.define('my-el-shadowroot-false-forwarded', E)
+      container.innerHTML =
+        `<my-el-shadowroot-false-forwarded>` +
+        `<b>hi</b>` +
+        `</my-el-shadowroot-false-forwarded>`
+      const e = container.childNodes[0] as VaporElement
+      expect(e.innerHTML).toBe(`<!--if-->`)
+
+      show.value = true
+      await nextTick()
+      expect(e.innerHTML).toBe(`<b>hi</b><!--slot--><!--slot--><!--if-->`)
+
+      show.value = false
+      await nextTick()
+      expect(e.innerHTML).toBe(`<!--if-->`)
+
+      show.value = true
+      await nextTick()
+      expect(e.innerHTML).toBe(`<b>hi</b><!--slot--><!--slot--><!--if-->`)
+    })
+
+    test('exposes light DOM slots to setup', () => {
+      let keys: string[] = []
+      const E = defineVaporCustomElement(
+        {
+          setup(_: any, { slots }: any) {
+            keys = Object.keys(slots)
+            return createSlot('default')
+          },
+        },
+        { shadowRoot: false },
+      )
+      customElements.define('my-el-shadowroot-false-slot-keys', E)
+      container.innerHTML =
+        `<my-el-shadowroot-false-slot-keys>` +
+        `text<div slot="named"></div>` +
+        `</my-el-shadowroot-false-slot-keys>`
+      expect(keys).toEqual(['default', 'named'])
     })
 
     test('render nested Teleport w/ shadowRoot false', async () => {

--- a/packages/runtime-vapor/src/apiDefineCustomElement.ts
+++ b/packages/runtime-vapor/src/apiDefineCustomElement.ts
@@ -18,7 +18,6 @@ import {
   type VaporComponentOptions,
   createComponent,
 } from './component'
-import type { Block } from './block'
 import { withHydration } from './dom/hydration'
 import type {
   DefineVaporComponent,
@@ -26,7 +25,6 @@ import type {
   VaporRenderResult,
 } from './apiDefineComponent'
 import type { StaticSlots } from './componentSlots'
-import { isFragment, isSlotFragment } from './fragment'
 
 export type VaporElementConstructor<P = {}> = {
   new (initialProps?: Record<string, any>): VaporElement & P
@@ -238,12 +236,6 @@ export class VaporElement extends VueElementBase<
     }
 
     this._app!.mount(this._root)
-
-    // Render slots immediately after mount for shadowRoot: false
-    // This ensures correct lifecycle order for nested custom elements
-    if (!this.shadowRoot) {
-      this._renderSlots()
-    }
   }
 
   protected _update(): void {
@@ -264,78 +256,53 @@ export class VaporElement extends VueElementBase<
     this._app = this._instance = null
   }
 
-  /**
-   * Only called when shadowRoot is false
-   */
-  protected _updateSlotNodes(
-    replacements: Map<Node, { nodes: Node[]; usedFallback: boolean }>,
-  ): void {
-    this._updateFragmentNodes(
-      (this._instance! as VaporComponentInstance).block,
-      replacements,
-    )
-  }
-
-  /**
-   * Replace slot nodes with their replace content
-   * @internal
-   */
-  private _updateFragmentNodes(
-    block: Block,
-    replacements: Map<Node, { nodes: Node[]; usedFallback: boolean }>,
-  ): void {
-    if (Array.isArray(block)) {
-      block.forEach(item => this._updateFragmentNodes(item, replacements))
-      return
-    }
-
-    if (!isFragment(block)) return
-    const { nodes } = block
-    if (nodes instanceof HTMLSlotElement) {
-      const replacement = replacements.get(nodes)
-      if (!replacement) return
-
-      // Slotted content can be represented as plain nodes, but fallback must
-      // stay as its live block so nested updates and unmounting keep using the
-      // current owner rather than a stale DOM snapshot.
-      if (
-        replacement.usedFallback &&
-        isSlotFragment(block) &&
-        block.customElementFallback
-      ) {
-        this._updateFragmentNodes(block.customElementFallback, replacements)
-        block.nodes = block.customElementFallback
-      } else {
-        block.nodes = replacement.nodes
-      }
-    } else if (Array.isArray(nodes)) {
-      nodes.forEach(item => this._updateFragmentNodes(item, replacements))
-    } else {
-      this._updateFragmentNodes(nodes, replacements)
-    }
-  }
-
   private _createComponent() {
     const ce = (instance: VaporComponentInstance) => {
       this._app!._ceComponent = this._instance = instance
-      // For shadowRoot: false, _renderSlots is called synchronously after mount
-      // in _mount() to ensure correct lifecycle order
-      if (!this.shadowRoot) {
-        // Still set updated hooks for subsequent updates
-        this._instance!.u = [this._renderSlots.bind(this)]
-      }
       this._processInstance()
     }
 
     createComponent(
       this._def,
       this._props,
-      undefined,
+      this.shadowRoot ? undefined : this._createSlots(),
       undefined,
       undefined,
       this._app!._context,
       false,
       ce,
     )
+  }
+
+  /**
+   * Only called when shadowRoot is false. The light DOM children parsed on
+   * connect become static slots, so `<slot/>` outlets render them in place
+   * through the normal slot pipeline instead of a native outlet that has to
+   * be replaced after mount.
+   */
+  private _createSlots(): StaticSlots | undefined {
+    const parsed = this._slots
+    if (!parsed) return
+    const scopeId = this._def.__scopeId
+    let slots: StaticSlots | undefined
+    for (const name in parsed) {
+      const nodes = parsed[name]
+      // for :slotted css
+      if (scopeId) {
+        const id = scopeId + '-s'
+        for (const n of nodes) {
+          if (n.nodeType === 1) {
+            ;(n as Element).setAttribute(id, '')
+            const walker = document.createTreeWalker(n, 1)
+            let child
+            while ((child = walker.nextNode())) {
+              ;(child as Element).setAttribute(id, '')
+            }
+          }
+        }
+      }
+      ;(slots || (slots = {}))[name] = () => nodes
+    }
+    return slots
   }
 }

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -321,10 +321,13 @@ export function createSlot(
         withOnceSlot(() => originalFallback(...args))
     }
     if (isHydrating) hydrationCursor = captureHydrationCursor()
-    isCustomElementSlot = !!(
+    const ce =
       (instance as GenericComponentInstance).ce ||
       (instance.parent && isAsyncWrapper(instance.parent) && instance.parent.ce)
-    )
+    // Only shadow DOM needs a native <slot> for projection. Without a shadow
+    // root the host hands its light DOM children over as static slots, so the
+    // outlet resolves them like any other slot.
+    isCustomElementSlot = !!(ce && ce._hasShadowRoot())
     const needsSlotFragment = shouldUseSlotFragment(
       rawSlots,
       name,
@@ -362,11 +365,11 @@ export function createSlot(
     const isDynamicName = isFunction(name)
 
     const renderSlot = () => {
-      // in custom element mode, render <slot/> as actual slot outlets
-      // because in shadowRoot: false mode the slot element gets
-      // replaced by injected content. The outlet is created once: a dynamic
-      // name is read inside the prop effect rather than re-running this
-      // function, which would pile up orphan outlets and fallbacks.
+      // in custom element mode, render <slot/> as an actual slot outlet so
+      // the shadow root projects light DOM content natively. The outlet is
+      // created once: a dynamic name is read inside the prop effect rather
+      // than re-running this function, which would pile up orphan outlets
+      // and fallbacks.
       if (isCustomElementSlot) {
         const el = createElement('slot')
         if (slotScopeIds) setElementScopeIds(el, slotScopeIds)
@@ -388,13 +391,7 @@ export function createSlot(
           const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
           try {
             withSlotBoundary(slotFragment!.slotBoundary, () => {
-              const fallbackBlock = fallbackFn()
-              // Keep the live fallback block on the SlotFragment itself. The
-              // native slot outlet is temporary and gets removed by CE slot
-              // replacement, but the fragment remains Vapor's long-lived
-              // owner.
-              slotFragment!.customElementFallback = fallbackBlock
-              insert(fallbackBlock, el)
+              insert(fallbackFn(), el)
             })
           } finally {
             setCurrentSlotScopeIds(prevSlotScopeIds)

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -281,15 +281,6 @@ export class TeleportFragment extends RenderContextFragment {
     ))
     if (target) {
       this.prepareTargetAnchors(target)
-
-      // track CE teleport targets
-      const scopeOwner = this.scopeOwner
-      if (scopeOwner && scopeOwner.isCE) {
-        ;(
-          scopeOwner.ce!._teleportTargets ||
-          (scopeOwner.ce!._teleportTargets = new Set())
-        ).add(target)
-      }
     }
     return target
   }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -568,10 +568,6 @@ export class SlotFragment
   implements SlotResolutionState
 {
   private disposed = false
-  // Custom elements with `shadowRoot: false` replace their native slot outlet
-  // after mount. Keep the live fallback block on the fragment so CE slot sync
-  // can preserve block ownership after the outlet node is gone.
-  customElementFallback?: Block
   activeFallback: Block | null = null
   fallbackInserted = false
   fallbackScope?: EffectScope


### PR DESCRIPTION
For shadowRoot: false, the host parsed its light DOM children and the component still rendered native <slot> outlets that were swapped for the parsed nodes after mount, then the block tree was patched to point at the moved DOM. That replacement only ran on the root instance's updated hook, so an outlet revealed by a child component update was never replaced and the light DOM content was lost. Dynamic slot names had the same blind spot.

Hand the parsed nodes to the component as static slots instead. Outlets resolve them through the regular slot pipeline, which removes the post-mount replacement, the block tree fixup, the customElementFallback field and the per-flush outlet rescan. Native <slot> outlets are now only rendered for hosts with a shadow root.

Nested shadowRoot: false elements now mount before the parent's mounted hook, like a regular child component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom element slot rendering and light DOM content projection.
  * Fixed nested custom element mounting order when `shadowRoot` is disabled.
  * Fixed dynamic and forwarded slots so content appears correctly after updates.
  * Corrected slot exposure during component setup.
  * Improved fallback content handling and teleport behavior for custom elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->