### PR TITLE
refactor(runtime-vapor): render native custom element slot outlets on the fast path

### DIFF
--- a/packages/runtime-vapor/__tests__/customElement.spec.ts
+++ b/packages/runtime-vapor/__tests__/customElement.spec.ts
@@ -1,5 +1,6 @@
 import type { MockedFunction } from 'vite-plus/test'
 import type { VaporElement } from '../src/apiDefineCustomElement'
+import { DynamicFragment, SlotFragment } from '../src/fragment'
 import { VaporSlotFlags } from '@vue/shared'
 import {
   type HMRRuntime,
@@ -917,6 +918,61 @@ describe('defineVaporCustomElement', () => {
       expect(e.shadowRoot!.innerHTML).toBe(
         `<div><slot class="bar"></slot><!--slot--></div>`,
       )
+    })
+
+    test('native outlet uses the fast-path fragment', () => {
+      let block: any
+      const E = defineVaporCustomElement({
+        setup() {
+          block = createSlot('default', null, () =>
+            template('<i>fallback</i>')(),
+          )
+          return block
+        },
+      })
+      customElements.define('my-el-native-slot-fast-path', E)
+      container.innerHTML = `<my-el-native-slot-fast-path></my-el-native-slot-fast-path>`
+      const e = container.childNodes[0] as VaporElement
+      expect(e.shadowRoot!.innerHTML).toBe(
+        `<slot><i>fallback</i></slot><!--slot-->`,
+      )
+      // the browser decides fallback visibility, so no SlotFragment is needed
+      expect(block).toBeInstanceOf(DynamicFragment)
+      expect(block).not.toBeInstanceOf(SlotFragment)
+    })
+
+    test('native outlet forwarded through a child slot', async () => {
+      const Child = defineVaporComponent({
+        setup() {
+          return createSlot('default', null, () =>
+            template('<i>child fallback</i>')(),
+          )
+        },
+      })
+      const E = defineVaporCustomElement({
+        setup() {
+          return createComponent(Child, null, {
+            default: () =>
+              createSlot('default', null, undefined, VaporSlotFlags.FORWARDED),
+          })
+        },
+      })
+      customElements.define('my-el-native-slot-forwarded', E)
+      container.innerHTML =
+        `<my-el-native-slot-forwarded>` +
+        `<span>content</span>` +
+        `</my-el-native-slot-forwarded>`
+      const e = container.childNodes[0] as VaporElement
+      // the native outlet is valid content for the child's boundary, so the
+      // child fallback stays hidden and the light DOM is projected
+      expect(e.shadowRoot!.innerHTML).toBe(
+        `<slot></slot><!--slot--><!--slot-->`,
+      )
+      expect(
+        (e.shadowRoot!.querySelector('slot') as HTMLSlotElement)
+          .assignedNodes()
+          .map(n => (n as Element).outerHTML),
+      ).toEqual([`<span>content</span>`])
     })
 
     test('dynamic slot name updates the native outlet in place', async () => {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -328,13 +328,11 @@ export function createSlot(
     // root the host hands its light DOM children over as static slots, so the
     // outlet resolves them like any other slot.
     isCustomElementSlot = !!(ce && ce._hasShadowRoot())
-    const needsSlotFragment = shouldUseSlotFragment(
-      rawSlots,
-      name,
-      fallback,
-      flags,
-      isCustomElementSlot,
-    )
+    // A native <slot> hands fallback to the browser, so there is nothing for
+    // a SlotFragment to arbitrate.
+    const needsSlotFragment =
+      !isCustomElementSlot &&
+      shouldUseSlotFragment(rawSlots, name, fallback, flags)
     const slotFragment = needsSlotFragment
       ? new SlotFragment(flags, _insertionAnchor)
       : undefined
@@ -387,10 +385,11 @@ export function createSlot(
         if (fallback) {
           const fallbackFn = fallback
           // The fallback renders outside the fragment's own render seam, so
-          // establish the outlet cell explicitly around it.
+          // establish the outlet cell explicitly around it. Like any fast-path
+          // outlet it must not render under an enclosing boundary.
           const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
           try {
-            withSlotBoundary(slotFragment!.slotBoundary, () => {
+            withSlotBoundary(null, () => {
               insert(fallbackFn(), el)
             })
           } finally {
@@ -478,11 +477,7 @@ function shouldUseSlotFragment(
   name: string | (() => string),
   fallback: VaporSlot | undefined,
   flags: number,
-  isCustomElementSlot: boolean,
 ): boolean {
-  // Native CE slots render a real <slot>, so SlotFragment owns fallback.
-  if (isCustomElementSlot) return true
-
   // Compiler-marked forwarded roots must preserve the enclosing boundary
   // chain. Everything below is boundary-independent: a non-forwarded outlet
   // never chains outward, so local fallback reachability follows the same


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom-element slot rendering when fallback content is present.
  * Fixed forwarded native slots so light DOM content displays correctly while child fallback content remains hidden.
  * Ensured native slot outlets use the appropriate rendering path for browser-managed fallback visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->