### PR TITLE
fix(runtime-vapor): key async component branches by state

### DIFF
--- a/packages/runtime-vapor/__tests__/apiDefineAsyncComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiDefineAsyncComponent.spec.ts
@@ -538,6 +538,91 @@ describe('api: defineAsyncComponent', () => {
     expect(root.innerHTML).toBe('resolved<!--async component-->')
   })
 
+  test('timeout without error component keeps the loading component mounted', async () => {
+    let resolve: (comp: VaporComponent) => void
+    const loadingSetup = vi.fn()
+    const Loading = defineVaporComponent({
+      setup() {
+        loadingSetup()
+        return template('loading')()
+      },
+    })
+    const Foo = defineVaporAsyncComponent({
+      loader: () =>
+        new Promise(_resolve => {
+          resolve = _resolve as any
+        }),
+      delay: 1,
+      timeout: 16,
+      loadingComponent: Loading,
+    })
+
+    const root = document.createElement('div')
+    const { app, mount } = define({
+      setup() {
+        return createComponent(Foo)
+      },
+    }).create()
+    app.config.errorHandler = vi.fn()
+    mount(root)
+    await timeout(1)
+    expect(root.innerHTML).toBe('loading<!--async component-->')
+    expect(loadingSetup).toHaveBeenCalledTimes(1)
+
+    await timeout(16)
+    expect(root.innerHTML).toBe('loading<!--async component-->')
+    // the branch did not change, so the loading component must not be
+    // torn down and recreated
+    expect(loadingSetup).toHaveBeenCalledTimes(1)
+
+    resolve!(() => template('resolved')())
+    await timeout()
+    expect(root.innerHTML).toBe('resolved<!--async component-->')
+  })
+
+  test('error component receives a later error in place', async () => {
+    let reject: (e: Error) => void
+    const errorSetup = vi.fn()
+    const ErrorComp = defineVaporComponent({
+      props: { error: Object },
+      setup(props: { error: Error }) {
+        errorSetup()
+        const n = template(' ')() as Text
+        renderEffect(() => setElementText(n, props.error.message))
+        return n
+      },
+    })
+    const Foo = defineVaporAsyncComponent({
+      loader: () =>
+        new Promise((_resolve, _reject) => {
+          reject = _reject
+        }),
+      timeout: 1,
+      errorComponent: ErrorComp,
+    })
+
+    const root = document.createElement('div')
+    const { app, mount } = define({
+      setup() {
+        return createComponent(Foo)
+      },
+    }).create()
+    app.config.errorHandler = vi.fn()
+    mount(root)
+
+    await timeout(1)
+    expect(root.innerHTML).toBe(
+      'Async component timed out after 1ms.<!--async component-->',
+    )
+    expect(errorSetup).toHaveBeenCalledTimes(1)
+
+    // the pending loader rejects after the timeout: same branch, new error
+    reject!(new Error('loader failed'))
+    await timeout()
+    expect(root.innerHTML).toBe('loader failed<!--async component-->')
+    expect(errorSetup).toHaveBeenCalledTimes(1)
+  })
+
   test('retry (success)', async () => {
     let loaderCallCount = 0
     let resolve: (comp: VaporComponent) => void

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -31,6 +31,12 @@ import type { TransitionOptions } from './block'
 import { _next } from './dom/node'
 import { isKeepAliveEnabled } from './keepAlive'
 
+const enum AsyncBranch {
+  RESOLVED = 1,
+  ERROR,
+  LOADING,
+}
+
 /*@ __NO_SIDE_EFFECTS__ */
 export function defineVaporAsyncComponent<T extends VaporComponent>(
   source: AsyncComponentLoader<T> | AsyncComponentOptions<T>,
@@ -145,7 +151,9 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
           .catch(err => {
             onError(err)
             if (errorComponent) {
-              frag.update(() => createErrorComp(errorComponent, instance, err))
+              frag.update(() =>
+                createErrorComp(errorComponent, instance, () => err),
+              )
             }
             return frag
           })
@@ -175,16 +183,22 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
       renderEffect(() => {
         resolvedComp = getResolvedComp()
         let render
+        let key
         if (loaded.value && resolvedComp) {
           render = () => createInnerComp(resolvedComp!, instance)
+          key = AsyncBranch.RESOLVED
         } else if (error.value && errorComponent) {
-          const err = error.value
-          render = () => createErrorComp(errorComponent, instance, err)
+          render = () =>
+            createErrorComp(errorComponent, instance, () => error.value!)
+          key = AsyncBranch.ERROR
         } else if (loadingComponent && !delayed.value) {
           render = () => createInnerComp(loadingComponent, instance)
+          key = AsyncBranch.LOADING
         }
 
-        frag.update(render)
+        // Keyed by branch so a state change that lands on the same branch
+        // updates in place instead of recreating it.
+        frag.update(render, key)
         // Manually trigger cacheBlock for KeepAlive
         if (isKeepAliveEnabled && frag.keepAliveCtx) {
           frag.keepAliveCtx.cacheBlock()
@@ -199,12 +213,12 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
 function createErrorComp(
   comp: VaporComponent,
   parent: VaporComponentInstance & TransitionOptions,
-  error: Error,
+  getError: () => Error,
 ): VaporComponentInstance {
   return createInnerComp(
     comp,
     parent,
-    { error: () => error },
+    { error: getError },
     // Avoid wrapper slot fallthrough
     {},
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved async component transitions so loading and error views remain mounted when their state changes.
  - Prevented unnecessary recreation of loading and error components during delayed resolution or failure.
  - Ensured error views update correctly when an asynchronous loader rejects after a timeout.
  - Confirmed that resolved components render correctly after a loading timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->