### PR TITLE
refactor(runtime-vapor): create resolved async components without a wrapper

### DIFF
--- a/packages-private/vapor-e2e-test/__tests__/transition.spec.ts
+++ b/packages-private/vapor-e2e-test/__tests__/transition.spec.ts
@@ -1310,18 +1310,16 @@ describe('vapor transition', () => {
       await nextTick()
       await nextFrame()
       expect(html(containerSelector)).toContain(
-        '<div class="v-enter-from v-enter-active">vapor compA</div><!--async component--><!--if-->',
+        '<div class="v-enter-from v-enter-active">vapor compA</div><!--if-->',
       )
       await nextFrame()
       expect(html(containerSelector)).toContain(
-        '<div class="v-enter-active v-enter-to">vapor compA</div><!--async component--><!--if-->',
+        '<div class="v-enter-active v-enter-to">vapor compA</div><!--if-->',
       )
       await transitionFinish()
       await expect
         .element(css(containerSelector))
-        .toContainHTML(
-          '<div class="">vapor compA</div><!--async component--><!--if-->',
-        )
+        .toContainHTML('<div class="">vapor compA</div><!--if-->')
     })
 
     test('apply transition to pre-resolved async component', async () => {
@@ -1341,18 +1339,16 @@ describe('vapor transition', () => {
       await nextTick()
       await nextFrame()
       expect(html(containerSelector)).toContain(
-        '<div class="v-enter-from v-enter-active">vapor compA</div><!--async component--><!--if-->',
+        '<div class="v-enter-from v-enter-active">vapor compA</div><!--if-->',
       )
       await nextFrame()
       expect(html(containerSelector)).toContain(
-        '<div class="v-enter-active v-enter-to">vapor compA</div><!--async component--><!--if-->',
+        '<div class="v-enter-active v-enter-to">vapor compA</div><!--if-->',
       )
       await transitionFinish()
       await expect
         .element(css(containerSelector))
-        .toContainHTML(
-          '<div class="">vapor compA</div><!--async component--><!--if-->',
-        )
+        .toContainHTML('<div class="">vapor compA</div><!--if-->')
 
       // leave
       click(btnSelector)
@@ -1373,18 +1369,16 @@ describe('vapor transition', () => {
       await nextTick()
       await nextFrame()
       expect(html(containerSelector)).toContain(
-        '<div class="v-enter-from v-enter-active">vapor compA</div><!--async component--><!--if-->',
+        '<div class="v-enter-from v-enter-active">vapor compA</div><!--if-->',
       )
       await nextFrame()
       expect(html(containerSelector)).toContain(
-        '<div class="v-enter-active v-enter-to">vapor compA</div><!--async component--><!--if-->',
+        '<div class="v-enter-active v-enter-to">vapor compA</div><!--if-->',
       )
       await transitionFinish()
       await expect
         .element(css(containerSelector))
-        .toContainHTML(
-          '<div class="">vapor compA</div><!--async component--><!--if-->',
-        )
+        .toContainHTML('<div class="">vapor compA</div><!--if-->')
     })
 
     test(

--- a/packages/runtime-vapor/__tests__/apiDefineAsyncComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiDefineAsyncComponent.spec.ts
@@ -1,5 +1,9 @@
-import { nextTick, onActivated, ref } from '@vue/runtime-dom'
-import { type VaporComponent, createComponent } from '../src/component'
+import { nextTick, onActivated, onMounted, ref, useId } from '@vue/runtime-dom'
+import {
+  type VaporComponent,
+  type VaporComponentInstance,
+  createComponent,
+} from '../src/component'
 import { defineVaporAsyncComponent } from '../src/apiDefineAsyncComponent'
 import { makeRender } from './_utils'
 import {
@@ -53,7 +57,7 @@ describe('api: defineAsyncComponent', () => {
     // already resolved component should update on nextTick
     toggle.value = true
     await nextTick()
-    expect(html()).toBe('resolved<!--async component--><!--if-->')
+    expect(html()).toBe('resolved<!--if-->')
   })
 
   test('with loading component', async () => {
@@ -98,7 +102,7 @@ describe('api: defineAsyncComponent', () => {
     // state
     toggle.value = true
     await nextTick()
-    expect(html()).toBe('resolved<!--async component--><!--if-->')
+    expect(html()).toBe('resolved<!--if-->')
   })
 
   test('with loading component + explicit delay (0)', async () => {
@@ -139,7 +143,7 @@ describe('api: defineAsyncComponent', () => {
     // state
     toggle.value = true
     await nextTick()
-    expect(html()).toBe('resolved<!--async component--><!--if-->')
+    expect(html()).toBe('resolved<!--if-->')
   })
 
   test('passes props and slots to loading component', async () => {
@@ -816,7 +820,7 @@ describe('api: defineAsyncComponent', () => {
     // already resolved component should update on nextTick
     toggle.value = true
     await nextTick()
-    expect(root.innerHTML).toBe('resolved<!--async component--><!--if-->')
+    expect(root.innerHTML).toBe('resolved<!--if-->')
     expect(fooRef.value.id).toBe('foo')
   })
 
@@ -1005,6 +1009,75 @@ describe('api: defineAsyncComponent', () => {
 
   test.todo('suspense with error handling', async () => {})
 
+  test('resolved async component is created as its resolved component', async () => {
+    let parent: VaporComponentInstance
+    let appInstance: VaporComponentInstance
+    const Inner = defineVaporComponent({
+      setup(_, instance) {
+        parent = (instance as unknown as VaporComponentInstance)
+          .parent as VaporComponentInstance
+        return template('resolved')()
+      },
+    })
+    const Foo = defineVaporAsyncComponent(() => Promise.resolve(Inner))
+
+    const toggle = ref(true)
+    const { html } = define({
+      setup(_, instance) {
+        appInstance = instance as unknown as VaporComponentInstance
+        return createIf(
+          () => toggle.value,
+          () => createComponent(Foo),
+        )
+      },
+    }).render()
+    expect(html()).toBe('<!--async component--><!--if-->')
+
+    await timeout()
+    expect(html()).toBe('resolved<!--async component--><!--if-->')
+    expect(parent!.type).toBe(Foo)
+
+    toggle.value = false
+    await nextTick()
+    toggle.value = true
+    await nextTick()
+    // no wrapper instance and no wrapper anchor once resolved
+    expect(html()).toBe('resolved<!--if-->')
+    expect(parent!).toBe(appInstance!)
+  })
+
+  test('useId is stable between pending and resolved mounts', async () => {
+    const ids: string[] = []
+    const Inner = defineVaporComponent({
+      setup() {
+        ids.push(useId())
+        return template('inner')()
+      },
+    })
+    const Sibling = defineVaporComponent({
+      setup() {
+        ids.push(useId())
+        return template('sibling')()
+      },
+    })
+    const Foo = defineVaporAsyncComponent(() => Promise.resolve(Inner))
+    const App = defineVaporComponent({
+      setup() {
+        return [createComponent(Foo), createComponent(Sibling)]
+      },
+    })
+
+    define(App).render({}, document.createElement('div'))
+    await timeout()
+    // the pending mount renders Inner after Sibling, so compare as sets
+    const pendingIds = ids.splice(0).sort()
+    expect(pendingIds).toHaveLength(2)
+
+    define(App).render({}, document.createElement('div'))
+    await timeout()
+    expect(ids.sort()).toEqual(pendingIds)
+  })
+
   test('with KeepAlive', async () => {
     const spy = vi.fn()
     let resolve: (comp: VaporComponent) => void
@@ -1060,6 +1133,61 @@ describe('api: defineAsyncComponent', () => {
     toggle.value = false
     await timeout()
     expect(html()).toBe('Bar<!--async component--><!--if-->')
+  })
+
+  test('with KeepAlive: reuses a resolved async component cached under its resolved component', async () => {
+    const mounted = vi.fn()
+    const activated = vi.fn()
+    const Inner = defineVaporComponent({
+      setup(_, { expose }) {
+        const count = ref(0)
+        expose({ inc: () => count.value++ })
+        onMounted(mounted)
+        onActivated(activated)
+        const n = template(' ')() as Text
+        renderEffect(() => setElementText(n, String(count.value)))
+        return n
+      },
+    })
+    const Foo = defineVaporAsyncComponent(() => Promise.resolve(Inner))
+    // resolve before the KeepAlive child is ever created
+    await (Foo as any).__asyncLoader()
+
+    const toggle = ref(true)
+    const fooRef = ref<any>(null)
+    const { html } = define({
+      setup() {
+        const setRef = createTemplateRefSetter()
+        return createComponent(VaporKeepAlive, null, {
+          default: () =>
+            createIf(
+              () => toggle.value,
+              () => {
+                const n0 = createComponent(Foo)
+                setRef(n0, fooRef)
+                return n0
+              },
+            ),
+        })
+      },
+    }).render()
+    expect(html()).toBe('0<!--if-->')
+    expect(mounted).toHaveBeenCalledTimes(1)
+    expect(activated).toHaveBeenCalledTimes(1)
+
+    fooRef.value.inc()
+    await nextTick()
+    expect(html()).toBe('1<!--if-->')
+
+    toggle.value = false
+    await nextTick()
+    expect(html()).toBe('<!--if-->')
+
+    toggle.value = true
+    await nextTick()
+    expect(html()).toBe('1<!--if-->')
+    expect(mounted).toHaveBeenCalledTimes(1)
+    expect(activated).toHaveBeenCalledTimes(2)
   })
 
   test('with KeepAlive + include', async () => {

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -2424,12 +2424,12 @@ describe('VaporKeepAlive', () => {
 
     toggle.value = true
     await nextTick()
-    expect(html()).toBe('<p>0</p><!--async component--><!--if-->')
+    expect(html()).toBe('<p>0</p><!--if-->')
     expect(loaderCallCount).toBe(2)
 
     instanceRef.value.inc()
     await nextTick()
-    expect(html()).toBe('<p>1</p><!--async component--><!--if-->')
+    expect(html()).toBe('<p>1</p><!--if-->')
 
     toggle.value = false
     await nextTick()
@@ -2437,7 +2437,7 @@ describe('VaporKeepAlive', () => {
 
     toggle.value = true
     await nextTick()
-    expect(html()).toBe('<p>1</p><!--async component--><!--if-->')
+    expect(html()).toBe('<p>1</p><!--if-->')
     expect(loaderCallCount).toBe(2)
   })
 
@@ -2561,7 +2561,7 @@ describe('VaporKeepAlive', () => {
 
     toggle.value = true
     await nextTick()
-    expect(html()).toBe('<p>0</p><!--async component--><!--if-->')
+    expect(html()).toBe('<p>0</p><!--if-->')
     expect(loader).toHaveBeenCalledTimes(1)
   })
 
@@ -2663,7 +2663,7 @@ describe('VaporKeepAlive', () => {
 
     toggle.value = true
     await nextTick()
-    expect(html()).toBe('<p>0</p><!--async component--><!--if-->')
+    expect(html()).toBe('<p>0</p><!--if-->')
     expect(loaderCallCount).toBe(2)
   })
 
@@ -2732,7 +2732,7 @@ describe('VaporKeepAlive', () => {
     // Toggle on - should remount, NOT activate from cache
     toggle.value = true
     await nextTick()
-    expect(html()).toBe(`<div>Bar</div><!--async component--><!--if-->`)
+    expect(html()).toBe(`<div>Bar</div><!--if-->`)
     expect(mounted).toHaveBeenCalledTimes(2) // Should be called again
     expect(activated).toHaveBeenCalledTimes(0)
   })

--- a/packages/runtime-vapor/__tests__/hmr.spec.ts
+++ b/packages/runtime-vapor/__tests__/hmr.spec.ts
@@ -1416,9 +1416,7 @@ describe('hot module replacement', () => {
 
     await timeout()
 
-    expect(root.innerHTML).toBe(
-      `<div>1</div><!--async component--><div>1</div><!--async component-->`,
-    )
+    expect(root.innerHTML).toBe(`<div>1</div><div>1</div>`)
   })
 
   test.todo('reload async child wrapped in Suspense + KeepAlive', async () => {

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -16,6 +16,7 @@ import {
   type VaporComponent,
   type VaporComponentInstance,
   createComponent,
+  enableAsyncComponent,
 } from './component'
 import { renderEffect } from './renderEffect'
 import { DynamicFragment } from './fragment'
@@ -41,6 +42,7 @@ const enum AsyncBranch {
 export function defineVaporAsyncComponent<T extends VaporComponent>(
   source: AsyncComponentLoader<T> | AsyncComponentOptions<T>,
 ): T {
+  enableAsyncComponent()
   const {
     load,
     getResolvedComp,

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -127,7 +127,9 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         __DEV__ ? 'async component' : undefined,
       )
 
-      // already resolved
+      // already resolved: only reached where createComponent keeps the
+      // wrapper (hydration, vdom interop inners); a resolved CSR mount is
+      // created as the resolved component and never enters this setup
       let resolvedComp = getResolvedComp()
       if (resolvedComp) {
         frag.update(() => createInnerComp(resolvedComp!, instance))

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -264,6 +264,12 @@ export type LooseRawProps = Record<string, unknown> & {
   $?: DynamicPropsSource[]
 }
 
+export let isAsyncComponentEnabled = false
+
+export function enableAsyncComponent(): void {
+  isAsyncComponentEnabled = true
+}
+
 export function createComponent(
   component: VaporComponent,
   rawProps?: LooseRawProps | null,
@@ -360,6 +366,23 @@ export function createComponent(
       if (cached) return cached
     }
 
+    // A resolved async component is created as its resolved component: with
+    // no diffing there is nothing for a wrapper to be the stable identity of.
+    // Hydration keeps the wrapper so the lazy path owns the adopted DOM, and
+    // so does an inner mounted through vdom interop, whose useId boundary is
+    // the wrapper.
+    let asyncBoundary = false
+    if (isAsyncComponentEnabled && component.__asyncLoader && !isHydrating) {
+      const resolved = component.__asyncResolved
+      if (
+        resolved &&
+        !(isInteropEnabled && appContext.vdom && !resolved.__vapor)
+      ) {
+        component = resolved
+        asyncBoundary = true
+      }
+    }
+
     // vdom interop enabled and component is not an explicit vapor component
     if (isInteropEnabled && appContext.vdom && !component.__vapor) {
       const frag = appContext.vdom.mount(
@@ -452,6 +475,7 @@ export function createComponent(
     if (inputScope) {
       instance.inputScope = inputScope
     }
+    if (asyncBoundary) markAsyncBoundary(instance)
 
     // Async wrappers are skipped here: their DynamicFragment resolves the outer
     // KeepAlive context from the wrapper's parent chain during setup.

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -360,13 +360,12 @@ const VaporKeepAliveImpl = defineVaporComponent({
           return cache.get(comp.key ?? currentCacheKey ?? comp.type)
         }
         const branchKey = key ?? currentCacheKey
-        if (branchKey != null) return cache.get(branchKey)
-        return (
-          cache.get(comp) ||
-          // An async component is cached as its wrapper when it entered
-          // pending, and as its resolved component when it was created resolved.
-          cache.get((comp as AsyncComponentInternalOptions).__asyncResolved)
-        )
+        return branchKey != null
+          ? cache.get(branchKey)
+          : cache.get(comp) ||
+              // An async component is cached as its wrapper when it entered
+              // pending, and as its resolved component when it was created resolved.
+              cache.get((comp as AsyncComponentInternalOptions).__asyncResolved)
       },
       activate: (instance, parentNode, anchor, parentSuspense) => {
         current = instance

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -359,7 +359,14 @@ const VaporKeepAliveImpl = defineVaporComponent({
         if (isInteropEnabled && isVNode(comp)) {
           return cache.get(comp.key ?? currentCacheKey ?? comp.type)
         }
-        return cache.get(key ?? currentCacheKey ?? comp)
+        const branchKey = key ?? currentCacheKey
+        if (branchKey != null) return cache.get(branchKey)
+        return (
+          cache.get(comp) ||
+          // An async component is cached as its wrapper when it entered
+          // pending, and as its resolved component when it was created resolved.
+          cache.get((comp as AsyncComponentInternalOptions).__asyncResolved)
+        )
       },
       activate: (instance, parentNode, anchor, parentSuspense) => {
         current = instance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added async component support to the Vapor runtime.
  - Resolved async components now render directly after remounting while preserving identity, state, lifecycle behavior, and stable IDs.
  - Improved KeepAlive reuse for async components resolved before creation.

- **Bug Fixes**
  - Removed obsolete async-component placeholder markers after resolution and reload.
  - Preserved correct async-component behavior during hydration, transitions, and dynamic toggling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->