### PR TITLE
fix(runtime-vapor): keep async wrapper hooks across deferred hydration

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration/asyncComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/asyncComponent.spec.ts
@@ -1028,5 +1028,58 @@ describe('Vapor Mode hydration', () => {
         '<!--[--><span>inner</span><!--async component--><span>inner</span><!--async component--><!--]-->',
       )
     })
+
+    test('async component without a strategy hydrates in place when created resolved', async () => {
+      const data = ref({ spy: vi.fn() })
+      const innerCode = `<button @click="data.spy">inner</button>`
+      const outerCode = `<div><components.Inner/></div>`
+      const appCode = `<components.Outer/><span>after</span>`
+
+      const SSRInner = defineAsyncComponent(() =>
+        Promise.resolve(
+          compileVaporComponent(innerCode, data, undefined, true),
+        ),
+      )
+      const SSROuter = defineAsyncComponent(() =>
+        Promise.resolve(
+          compileVaporComponent(outerCode, data, { Inner: SSRInner }, true),
+        ),
+      )
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(
+          compileVaporComponent(appCode, data, { Outer: SSROuter }, true),
+        ),
+      )
+
+      const InnerComp = compileVaporComponent(innerCode, data)
+      // no strategy: resolved before the deferred Outer creates it
+      const Inner = defineVaporAsyncComponent(() => Promise.resolve(InnerComp))
+      await (Inner as any).__asyncLoader()
+      let doHydrate: (() => void) | undefined
+      const Outer = defineVaporAsyncComponent({
+        loader: () =>
+          Promise.resolve(compileVaporComponent(outerCode, data, { Inner })),
+        hydrate(hydrate) {
+          doHydrate = hydrate
+        },
+      })
+      const App = compileVaporComponent(appCode, data, { Outer })
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      createVaporSSRApp(App).mount(container)
+      await new Promise(r => setTimeout(r))
+
+      triggerEvent('click', container.querySelector('button')!)
+      expect(data.value.spy).not.toHaveBeenCalled()
+
+      doHydrate!()
+      await new Promise(r => setTimeout(r))
+      triggerEvent('click', container.querySelector('button')!)
+      expect(data.value.spy).toHaveBeenCalledTimes(1)
+      expect(container.innerHTML).toBe(
+        '<!--[--><div><button>inner</button><!--async component--></div><!--async component--><span>after</span><!--]-->',
+      )
+    })
   })
 })

--- a/packages/runtime-vapor/__tests__/hydration/asyncComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/asyncComponent.spec.ts
@@ -929,5 +929,104 @@ describe('Vapor Mode hydration', () => {
       triggerEvent('click', container.querySelector('button')!)
       expect(data.value.spy).toHaveBeenCalledTimes(1)
     })
+
+    test('template ref on a lazily hydrated async component', async () => {
+      const data = ref({})
+      const compCode = `<span>inner</span>`
+      const appCode = `<components.AsyncComp ref="comp"/>`
+
+      const SSRAsync = defineAsyncComponent(() =>
+        Promise.resolve(compileVaporComponent(compCode, data, undefined, true)),
+      )
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(
+          compileVaporComponent(appCode, data, { AsyncComp: SSRAsync }, true),
+        ),
+      )
+
+      let resolve: any
+      let doHydrate: (() => void) | undefined
+      const Comp = compileVaporComponent(compCode, data)
+      const AsyncComp = defineVaporAsyncComponent({
+        loader: () =>
+          new Promise(r => {
+            resolve = r
+          }),
+        hydrate(hydrate) {
+          doHydrate = hydrate
+        },
+      })
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const app = createVaporSSRApp(App)
+      app.mount(container)
+      const refs = (app._instance as any).refs
+
+      expect(refs.comp).toBeFalsy()
+      resolve(Comp)
+      await new Promise(r => setTimeout(r))
+      // resolved, but hydration is still deferred by the strategy
+      expect(refs.comp).toBeFalsy()
+
+      doHydrate!()
+      await new Promise(r => setTimeout(r))
+      expect(refs.comp).toBeTruthy()
+      expect(refs.comp.type).toBe(Comp)
+    })
+
+    test('deferred async component stays unresolved for its consumers after a sibling resolved the loader', async () => {
+      const data = ref({})
+      const compCode = `<span>inner</span>`
+      const appCode = `<components.AsyncComp ref="a"/><components.AsyncComp ref="b"/>`
+
+      const SSRAsync = defineAsyncComponent(() =>
+        Promise.resolve(compileVaporComponent(compCode, data, undefined, true)),
+      )
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(
+          compileVaporComponent(appCode, data, { AsyncComp: SSRAsync }, true),
+        ),
+      )
+
+      let resolve: any
+      const hydrates: (() => void)[] = []
+      const Comp = compileVaporComponent(compCode, data)
+      const AsyncComp = defineVaporAsyncComponent({
+        loader: () =>
+          new Promise(r => {
+            resolve = r
+          }),
+        hydrate(hydrate) {
+          hydrates.push(hydrate)
+        },
+      })
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const app = createVaporSSRApp(App)
+      app.mount(container)
+      const refs = (app._instance as any).refs
+
+      resolve(Comp)
+      await new Promise(r => setTimeout(r))
+      expect(hydrates.length).toBe(2)
+
+      hydrates[0]()
+      await new Promise(r => setTimeout(r))
+      expect(refs.a.type).toBe(Comp)
+      // b's loader is resolved but its own hydration has not run: no ref yet,
+      // and never the raw SSR node
+      expect(refs.b == null).toBe(true)
+
+      hydrates[1]()
+      await new Promise(r => setTimeout(r))
+      expect(refs.b.type).toBe(Comp)
+      expect(container.innerHTML).toBe(
+        '<!--[--><span>inner</span><!--async component--><span>inner</span><!--async component--><!--]-->',
+      )
+    })
   })
 })

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -176,7 +176,7 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         // The loader settles outside any render context: render the branch
         // under the wrapper's scope so it owns it, and not at all once the
         // wrapper was unmounted while loading (Suspense discards the result).
-        const renderContent = (render: () => VaporComponentInstance) => {
+        const renderBranch = (render: () => VaporComponentInstance) => {
           if (!instance.isUnmounted) {
             instance.scope.run(() => frag.update(render))
           }
@@ -185,14 +185,14 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
           .then(() => {
             resolvedComp = getResolvedComp()
             if (resolvedComp) {
-              renderContent(() => createInnerComp(resolvedComp!, instance))
+              renderBranch(() => createInnerComp(resolvedComp!, instance))
             }
             return frag
           })
           .catch(err => {
             onError(err)
             if (errorComponent) {
-              renderContent(() =>
+              renderBranch(() =>
                 createErrorComp(errorComponent, instance, () => err),
               )
             }

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -73,16 +73,14 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
       // early return allows tree-shaking of hydration logic when not used
       if (!isHydrating) return
 
-      // Nothing to defer: hydrate in place like a plain component.
-      if (!hydrateStrategy && getResolvedComp()) return hydrate()
-
       // Placeholder for the deferred period: the wrapper's own fragment,
       // holding the adopted DOM. The wrapper can be moved or unmounted before
       // setup runs, and template refs / transitions register on the fragment
       // that setup will settle rather than on a stand-in.
+      const endAnchor = isComment(el, '[') ? locateEndAnchor(el)! : null
       let nodes: Block
-      if (isComment(el, '[')) {
-        const end = _next(locateEndAnchor(el)!)
+      if (endAnchor) {
+        const end = _next(endAnchor)
         const range = (nodes = [el as Node])
         let cur = el as Node
         while (true) {
@@ -115,9 +113,7 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
       instance.isMounted = true
 
       // Advance current hydration node to the nextSibling
-      setCurrentHydrationNode(
-        isComment(el, '[') ? locateEndAnchor(el)! : el.nextSibling,
-      )
+      setCurrentHydrationNode(endAnchor || el.nextSibling)
 
       performAsyncHydrate(
         el,
@@ -180,7 +176,7 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         // The loader settles outside any render context: render the branch
         // under the wrapper's scope so it owns it, and not at all once the
         // wrapper was unmounted while loading (Suspense discards the result).
-        const renderBranch = (render: () => VaporComponentInstance) => {
+        const renderContent = (render: () => VaporComponentInstance) => {
           if (!instance.isUnmounted) {
             instance.scope.run(() => frag.update(render))
           }
@@ -189,14 +185,14 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
           .then(() => {
             resolvedComp = getResolvedComp()
             if (resolvedComp) {
-              renderBranch(() => createInnerComp(resolvedComp!, instance))
+              renderContent(() => createInnerComp(resolvedComp!, instance))
             }
             return frag
           })
           .catch(err => {
             onError(err)
             if (errorComponent) {
-              renderBranch(() =>
+              renderContent(() =>
                 createErrorComp(errorComponent, instance, () => err),
               )
             }
@@ -253,6 +249,24 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
       return frag
     },
   }) as T
+}
+
+/**
+ * The block an async wrapper has settled on, or undefined while it is
+ * unresolved or (under deferred hydration) resolved but not set up yet.
+ * Consumers reading through the wrapper treat undefined as unresolved.
+ */
+export function getAsyncWrapperInner(
+  instance: VaporComponentInstance,
+): Block | undefined {
+  const frag = instance.block
+  if (
+    isDynamicFragment(frag) &&
+    frag.current !== undefined &&
+    instance.type.__asyncResolved
+  ) {
+    return frag.nodes
+  }
 }
 
 function createErrorComp(

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -19,16 +19,17 @@ import {
   enableAsyncComponent,
 } from './component'
 import { renderEffect } from './renderEffect'
-import { DynamicFragment } from './fragment'
+import { DynamicFragment, isDynamicFragment } from './fragment'
 import {
   hydrateNode,
   isComment,
   isHydrating,
   locateEndAnchor,
+  locateHydrationNode,
   setCurrentHydrationNode,
   withDeferredHydrationBoundary,
 } from './dom/hydration'
-import type { TransitionOptions } from './block'
+import { type Block, EMPTY_BLOCK, type TransitionOptions } from './block'
 import { _next } from './dom/node'
 import { isKeepAliveEnabled } from './keepAlive'
 
@@ -75,23 +76,38 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
       // Nothing to defer: hydrate in place like a plain component.
       if (!hydrateStrategy && getResolvedComp()) return hydrate()
 
-      // Create placeholder block that matches the adopted DOM.
-      // The async component may get unmounted before its inner component is loaded,
-      // so we need to give it a placeholder block.
+      // Placeholder for the deferred period: the wrapper's own fragment,
+      // holding the adopted DOM. The wrapper can be moved or unmounted before
+      // setup runs, and template refs / transitions register on the fragment
+      // that setup will settle rather than on a stand-in.
+      let nodes: Block
       if (isComment(el, '[')) {
         const end = _next(locateEndAnchor(el)!)
-        const block = (instance.block = [el as Node])
+        const range = (nodes = [el as Node])
         let cur = el as Node
         while (true) {
           let n = _next(cur)
           if (n && n !== end) {
-            block.push((cur = n))
+            range.push((cur = n))
           } else {
             break
           }
         }
       } else {
-        instance.block = el
+        nodes = el
+      }
+      const prev = setCurrentInstance(instance)
+      try {
+        const frag = new DynamicFragment(
+          0,
+          __DEV__ ? 'async component' : undefined,
+          false,
+          false,
+        )
+        frag.nodes = nodes
+        instance.block = frag
+      } finally {
+        restoreCurrentInstance(prev)
       }
 
       // Mark as mounted to ensure it can be unmounted before
@@ -122,10 +138,18 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         TransitionOptions
       markAsyncBoundary(instance)
 
-      const frag = new DynamicFragment(
-        0,
-        __DEV__ ? 'async component' : undefined,
-      )
+      // Deferred hydration hands over its placeholder (see __asyncHydrate)
+      // so hooks registered on it while setup was pending apply to the
+      // branch settled here.
+      const placeholder = instance.block
+      let frag: DynamicFragment
+      if (isHydrating && isDynamicFragment(placeholder)) {
+        frag = placeholder
+        frag.nodes = EMPTY_BLOCK
+        locateHydrationNode()
+      } else {
+        frag = new DynamicFragment(0, __DEV__ ? 'async component' : undefined)
+      }
 
       // already resolved: only reached where createComponent keeps the
       // wrapper (hydration, vdom interop inners); a resolved CSR mount is
@@ -133,6 +157,12 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
       let resolvedComp = getResolvedComp()
       if (resolvedComp) {
         frag.update(() => createInnerComp(resolvedComp!, instance))
+        if (frag === placeholder) {
+          // the first render settles the placeholder; renderBranch itself
+          // treats a first render as mount-time and stays silent
+          const u = frag.u
+          if (u) u.forEach(hook => hook(frag.nodes))
+        }
         return frag
       }
 

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -4,6 +4,7 @@ import {
   getExposed,
   isVaporComponent,
 } from './component'
+import { getAsyncWrapperInner } from './apiDefineAsyncComponent'
 import {
   ErrorCodes,
   type SchedulerJob,
@@ -393,17 +394,10 @@ function setRef(
 const getRefValue = (el: RefEl) => {
   if (isVaporComponent(el)) {
     if (isAsyncWrapper(el)) {
-      const frag = el.block as DynamicFragment
-      // unresolved, or resolved but this wrapper's own branch has not settled
-      // (deferred hydration): return null so the ref gets cleared
-      if (
-        !el.type.__asyncResolved ||
-        !isDynamicFragment(frag) ||
-        frag.current === undefined
-      ) {
-        return null
-      }
-      return getRefValue(frag.nodes as RefEl)
+      const inner = getAsyncWrapperInner(el)
+      // unsettled: return null so the ref gets cleared
+      if (inner === undefined) return null
+      return getRefValue(inner as RefEl)
     }
     return getExposed(el) || el
   } else if (isTeleportEnabled && isTeleportFragment(el)) {

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -393,9 +393,17 @@ function setRef(
 const getRefValue = (el: RefEl) => {
   if (isVaporComponent(el)) {
     if (isAsyncWrapper(el)) {
-      // unresolved async wrapper: return null so ref gets cleared
-      if (!el.type.__asyncResolved) return null
-      return getRefValue((el.block as DynamicFragment).nodes as RefEl)
+      const frag = el.block as DynamicFragment
+      // unresolved, or resolved but this wrapper's own branch has not settled
+      // (deferred hydration): return null so the ref gets cleared
+      if (
+        !el.type.__asyncResolved ||
+        !isDynamicFragment(frag) ||
+        frag.current === undefined
+      ) {
+        return null
+      }
+      return getRefValue(frag.nodes as RefEl)
     }
     return getExposed(el) || el
   } else if (isTeleportEnabled && isTeleportFragment(el)) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -271,7 +271,7 @@ export function enableAsyncComponent(): void {
 }
 
 // Not an explicit vapor component: mounted through vdom interop.
-function usesVdomInterop(
+function useVdomInterop(
   component: VaporComponent,
   appContext: GenericAppContext,
 ): boolean {
@@ -382,13 +382,13 @@ export function createComponent(
     let asyncBoundary = false
     if (isAsyncComponentEnabled && !isHydrating) {
       const resolved = component.__asyncResolved
-      if (resolved && !usesVdomInterop(resolved, appContext)) {
+      if (resolved && !useVdomInterop(resolved, appContext)) {
         component = resolved
         asyncBoundary = true
       }
     }
 
-    if (usesVdomInterop(component, appContext)) {
+    if (useVdomInterop(component, appContext)) {
       const frag = appContext.vdom!.mount(
         component as any,
         currentInstance as any,

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -270,6 +270,14 @@ export function enableAsyncComponent(): void {
   isAsyncComponentEnabled = true
 }
 
+// Not an explicit vapor component: mounted through vdom interop.
+function usesVdomInterop(
+  component: VaporComponent,
+  appContext: GenericAppContext,
+): boolean {
+  return isInteropEnabled && !!appContext.vdom && !component.__vapor
+}
+
 export function createComponent(
   component: VaporComponent,
   rawProps?: LooseRawProps | null,
@@ -372,20 +380,16 @@ export function createComponent(
     // so does an inner mounted through vdom interop, whose useId boundary is
     // the wrapper.
     let asyncBoundary = false
-    if (isAsyncComponentEnabled && component.__asyncLoader && !isHydrating) {
+    if (isAsyncComponentEnabled && !isHydrating) {
       const resolved = component.__asyncResolved
-      if (
-        resolved &&
-        !(isInteropEnabled && appContext.vdom && !resolved.__vapor)
-      ) {
+      if (resolved && !usesVdomInterop(resolved, appContext)) {
         component = resolved
         asyncBoundary = true
       }
     }
 
-    // vdom interop enabled and component is not an explicit vapor component
-    if (isInteropEnabled && appContext.vdom && !component.__vapor) {
-      const frag = appContext.vdom.mount(
+    if (usesVdomInterop(component, appContext)) {
+      const frag = appContext.vdom!.mount(
         component as any,
         currentInstance as any,
         rawProps,

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -43,6 +43,7 @@ import {
   type VaporComponentInstance,
   isVaporComponent,
 } from '../component'
+import { getAsyncWrapperInner } from '../apiDefineAsyncComponent'
 import { isArray } from '@vue/shared'
 import { renderEffect } from '../renderEffect'
 import {
@@ -629,16 +630,15 @@ function collectComponentTransitionBlocks(
   children: ResolvedTransitionBlock[],
 ): void {
   if (isAsyncWrapper(block)) {
-    const frag = block.block as DynamicFragment
-    // unresolved, or resolved but this wrapper's own branch has not settled
-    // (deferred hydration): set transition hooks on the fragment
-    if (!block.type.__asyncResolved || frag.current === undefined) {
-      if (onFragment && isFragment(frag)) onFragment(frag)
+    const inner = getAsyncWrapperInner(block)
+    if (inner === undefined) {
+      // unsettled: set transition hooks on the wrapper's fragment
+      if (onFragment && isFragment(block.block)) onFragment(block.block)
       return
     }
 
     const start = children.length
-    collectTransitionBlocks(frag.nodes, onFragment, children)
+    collectTransitionBlocks(inner, onFragment, children)
     inheritSingleComponentKey(children[start], block)
     return
   }

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -629,18 +629,16 @@ function collectComponentTransitionBlocks(
   children: ResolvedTransitionBlock[],
 ): void {
   if (isAsyncWrapper(block)) {
-    // for unresolved async wrapper, set transition hooks on inner fragment
-    if (!block.type.__asyncResolved) {
-      if (onFragment) onFragment(block.block! as DynamicFragment)
+    const frag = block.block as DynamicFragment
+    // unresolved, or resolved but this wrapper's own branch has not settled
+    // (deferred hydration): set transition hooks on the fragment
+    if (!block.type.__asyncResolved || frag.current === undefined) {
+      if (onFragment && isFragment(frag)) onFragment(frag)
       return
     }
 
     const start = children.length
-    collectTransitionBlocks(
-      (block.block! as DynamicFragment).nodes,
-      onFragment,
-      children,
-    )
+    collectTransitionBlocks(frag.nodes, onFragment, children)
     inheritSingleComponentKey(children[start], block)
     return
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred hydration for asynchronous components, ensuring template refs remain unset until hydration completes.
  * Fixed hydration behavior when multiple components share a resolved asynchronous loader.
  * Ensured already-resolved asynchronous components hydrate correctly within deferred parent components.
  * Improved transition handling and DOM tracking before and after deferred hydration.
  * Improved compatibility when asynchronous components interact with other component rendering modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->