### PR TITLE
refactor(runtime-core): make the lazy hydration "patched" guard opt-in

### DIFF
--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -77,6 +77,7 @@ export function defineAsyncComponent<
         getResolvedComp,
         load,
         hydrateStrategy,
+        true,
       )
     },
 
@@ -324,10 +325,16 @@ export function performAsyncHydrate(
   getResolvedComp: () => GenericComponent | undefined,
   load: () => Promise<GenericComponent>,
   hydrateStrategy: HydrationStrategy | undefined,
+  // vdom: a parent update before lazy hydration ran has already patched the
+  // subtree, so hydrating on top of it would mismatch. Vapor props flow
+  // reactively and need no such guard.
+  skipIfUpdated: boolean,
 ): void {
   const wasConnected = el.isConnected
   let patched = false
-  ;(instance.bu || (instance.bu = [])).push(() => (patched = true))
+  if (skipIfUpdated) {
+    ;(instance.bu || (instance.bu = [])).push(() => (patched = true))
+  }
   const performHydrate = () => {
     // skip hydration if the component has been patched
     if (patched) {

--- a/packages/runtime-vapor/__tests__/hydration/asyncComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/asyncComponent.spec.ts
@@ -974,6 +974,9 @@ describe('Vapor Mode hydration', () => {
       await new Promise(r => setTimeout(r))
       expect(refs.comp).toBeTruthy()
       expect(refs.comp.type).toBe(Comp)
+      // vapor props flow reactively, so the wrapper never needs the vdom-only
+      // "patched before lazy hydration" update hook
+      expect((app._instance as any).block.bu).toBeUndefined()
     })
 
     test('deferred async component stays unresolved for its consumers after a sibling resolved the loader', async () => {

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -122,6 +122,7 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         getResolvedComp,
         load,
         hydrateStrategy,
+        false,
       )
     },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lazy hydration for asynchronous components in Vapor applications.
  * Prevented unnecessary update guards during hydration, allowing component properties and template references to remain reactive.
  * Ensured resolved component references are available correctly after hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->