### PR TITLE
perf(runtime-vapor): gate async wrapper branches for tree-shaking

### DIFF
--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -16,8 +16,8 @@ import {
   type VaporComponent,
   type VaporComponentInstance,
   createComponent,
-  enableAsyncComponent,
 } from './component'
+import { enableAsyncComponent } from './asyncComponentState'
 import { renderEffect } from './renderEffect'
 import { DynamicFragment, isDynamicFragment } from './fragment'
 import {

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -5,6 +5,7 @@ import {
   isVaporComponent,
 } from './component'
 import { getAsyncWrapperInner } from './apiDefineAsyncComponent'
+import { isAsyncComponentEnabled } from './asyncComponentState'
 import {
   ErrorCodes,
   type SchedulerJob,
@@ -73,7 +74,7 @@ interface TemplateRefState {
 
 function getTemplateRefUpdateFragment(el: RefEl): DynamicFragment | undefined {
   if (isDynamicFragment(el)) return el
-  if (isVaporComponent(el) && isAsyncWrapper(el)) {
+  if (isAsyncComponentEnabled && isVaporComponent(el) && isAsyncWrapper(el)) {
     return el.block as DynamicFragment
   }
 }
@@ -393,7 +394,7 @@ function setRef(
 
 const getRefValue = (el: RefEl) => {
   if (isVaporComponent(el)) {
-    if (isAsyncWrapper(el)) {
+    if (isAsyncComponentEnabled && isAsyncWrapper(el)) {
       const inner = getAsyncWrapperInner(el)
       // unsettled: return null so the ref gets cleared
       if (inner === undefined) return null

--- a/packages/runtime-vapor/src/asyncComponentState.ts
+++ b/packages/runtime-vapor/src/asyncComponentState.ts
@@ -1,0 +1,7 @@
+// Set by defineVaporAsyncComponent. Applications without async components
+// leave it false, so the wrapper-aware branches tree-shake out.
+export let isAsyncComponentEnabled = false
+
+export function enableAsyncComponent(): void {
+  isAsyncComponentEnabled = true
+}

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -124,6 +124,7 @@ import {
   getKeepAliveContext,
   isKeepAliveEnabled,
 } from './keepAlive'
+import { isAsyncComponentEnabled } from './asyncComponentState'
 import {
   insertionAnchor,
   insertionParent,
@@ -262,12 +263,6 @@ interface SharedInternalOptions {
 // wider types to make `createComponent` ergonomic in tests and internal call sites.
 export type LooseRawProps = Record<string, unknown> & {
   $?: DynamicPropsSource[]
-}
-
-export let isAsyncComponentEnabled = false
-
-export function enableAsyncComponent(): void {
-  isAsyncComponentEnabled = true
 }
 
 // Not an explicit vapor component: mounted through vdom interop.
@@ -483,7 +478,10 @@ export function createComponent(
 
     // Async wrappers are skipped here: their DynamicFragment resolves the outer
     // KeepAlive context from the wrapper's parent chain during setup.
-    if (isKeepAliveEnabled && !isAsyncWrapper(instance)) {
+    if (
+      isKeepAliveEnabled &&
+      !(isAsyncComponentEnabled && isAsyncWrapper(instance))
+    ) {
       keepAliveCtx ||= getKeepAliveContext(currentInstance)
       if (keepAliveCtx) keepAliveCtx.processShapeFlag(instance)
     }
@@ -514,7 +512,12 @@ export function createComponent(
       }
 
       // hydrating async component
-      if (isHydrating && isAsyncWrapper(instance) && component.__asyncHydrate) {
+      if (
+        isHydrating &&
+        isAsyncComponentEnabled &&
+        isAsyncWrapper(instance) &&
+        component.__asyncHydrate
+      ) {
         const setup = () => setupComponent(instance, component)
         component.__asyncHydrate(
           currentHydrationNode as Element,
@@ -643,7 +646,10 @@ export function setupComponent(
 
   const isAsyncSetup = isPromise(setupResult)
 
-  if ((isAsyncSetup || instance.sp) && !isAsyncWrapper(instance)) {
+  if (
+    (isAsyncSetup || instance.sp) &&
+    !(isAsyncComponentEnabled && isAsyncWrapper(instance))
+  ) {
     // async setup / serverPrefetch, mark as async boundary for useId()
     markAsyncBoundary(instance)
   }

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -45,6 +45,7 @@ import { currentSlotBoundary, withSlotBoundary } from './slotBoundary'
 import { createElement } from './dom/node'
 import { setDynamicProps } from './dom/prop'
 import { interopSlotsKey, isInteropEnabled } from './vdomInteropState'
+import { isAsyncComponentEnabled } from './asyncComponentState'
 import {
   currentSlotScopeIds,
   renderWithSlotScopeIds,
@@ -321,9 +322,14 @@ export function createSlot(
         withOnceSlot(() => originalFallback(...args))
     }
     if (isHydrating) hydrationCursor = captureHydrationCursor()
+    // A definition that resolves to another async wrapper mounts that wrapper
+    // with the custom element callback, so its inner reads `ce` from it.
     const ce =
       (instance as GenericComponentInstance).ce ||
-      (instance.parent && isAsyncWrapper(instance.parent) && instance.parent.ce)
+      (isAsyncComponentEnabled &&
+        instance.parent &&
+        isAsyncWrapper(instance.parent) &&
+        instance.parent.ce)
     // Only shadow DOM needs a native <slot> for projection. Without a shadow
     // root the host hands its light DOM children over as static slots, so the
     // outlet resolves them like any other slot.

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -27,6 +27,7 @@ import {
   type VaporComponentInstance,
   isVaporComponent,
 } from '../component'
+import { isAsyncComponentEnabled } from '../asyncComponentState'
 import { isolatePropSources, resolveFunctionSource } from '../componentProps'
 import type { DynamicSlotFn, RawSlots } from '../componentSlots'
 import {
@@ -537,7 +538,7 @@ const unsetShapeFlag = (cached: VaporComponentInstance | VaporFragment) => {
     resetShapeFlag(cached)
     // for async components, also reset the inner resolved component's
     // shapeFlag.
-    if (isAsyncWrapper(cached)) {
+    if (isAsyncComponentEnabled && isAsyncWrapper(cached)) {
       const [inner] = getInnerBlock(cached.block)
       if (inner && isVaporComponent(inner)) {
         resetShapeFlag(inner)

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -44,6 +44,7 @@ import {
   isVaporComponent,
 } from '../component'
 import { getAsyncWrapperInner } from '../apiDefineAsyncComponent'
+import { isAsyncComponentEnabled } from '../asyncComponentState'
 import { isArray } from '@vue/shared'
 import { renderEffect } from '../renderEffect'
 import {
@@ -629,7 +630,7 @@ function collectComponentTransitionBlocks(
   onFragment: ((frag: VaporFragment) => void) | undefined,
   children: ResolvedTransitionBlock[],
 ): void {
-  if (isAsyncWrapper(block)) {
+  if (isAsyncComponentEnabled && isAsyncWrapper(block)) {
     const inner = getAsyncWrapperInner(block)
     if (inner === undefined) {
       // unsettled: set transition hooks on the wrapper's fragment

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -16,6 +16,7 @@ import {
   getRootElement,
   isVaporComponent,
 } from '../component'
+import { isAsyncComponentEnabled } from '../asyncComponentState'
 import { type VaporFragment, isFragment, isInteropFragment } from '../fragment'
 import { isInteropEnabled } from '../vdomInteropState'
 
@@ -128,6 +129,7 @@ export function withVaporDirectives(
 
       // Async wrappers keep an empty fragment until a renderable branch is available
       return (
+        isAsyncComponentEnabled &&
         isAsyncWrapper(block) &&
         isFragment(innerBlock) &&
         innerBlock.nodes === EMPTY_BLOCK

--- a/packages/runtime-vapor/src/keepAlive.ts
+++ b/packages/runtime-vapor/src/keepAlive.ts
@@ -29,6 +29,8 @@ export interface VaporKeepAliveContext {
   getStorageContainer(): ParentNode
 }
 
+import { isAsyncComponentEnabled } from './asyncComponentState'
+
 export let isKeepAliveEnabled = false
 export let currentCacheKey: any | undefined
 
@@ -47,7 +49,12 @@ export function getKeepAliveContext(
   let owner = instance
   // Async wrappers are transparent for KeepAlive context lookup: their setup
   // and resolved renders still belong to the outer KeepAlive owner.
-  while (owner && owner.vapor && isAsyncWrapper(owner)) {
+  while (
+    isAsyncComponentEnabled &&
+    owner &&
+    owner.vapor &&
+    isAsyncWrapper(owner)
+  ) {
     owner = owner.parent
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of async components when async-component support is enabled.
  - Ensured template refs, hydration, transitions, KeepAlive behavior, and directive updates correctly account for async component wrappers.
  - Preserved standard component behavior when async-component support is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->