### PR TITLE
fix(runtime-vapor): should preserve style merging order from static and v-bind props

### DIFF
--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -2174,4 +2174,20 @@ describe('attribute fallthrough', () => {
     await nextTick()
     expect(host.querySelector('span')!.className).toBe('')
   })
+
+  it('should preserve style merging order from static and v-bind props', () => {
+    const Child = defineVaporComponent({
+      setup() {
+        return template('<div></div>')()
+      },
+    })
+    const Parent = compile(
+      '<template><components.Child style="color:red" v-bind="data.attrs" /></template>',
+      { attrs: { style: { color: 'blue' } } } as any,
+      { Child },
+    )
+
+    const { html } = define(Parent).render()
+    expect(html()).toBe('<div style="color: blue;"></div>')
+  })
 })

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -540,7 +540,7 @@ export function getAttrFromRawProps(rawProps: RawProps, key: string): unknown {
       if (source && hasOwn(source, key)) {
         const value = isDynamic ? source[key] : resolveSource(source[key])
         if (merged) {
-          merged.unshift(value)
+          merged.push(value)
         } else {
           return value
         }
@@ -550,13 +550,13 @@ export function getAttrFromRawProps(rawProps: RawProps, key: string): unknown {
   if (hasOwn(rawProps, key)) {
     const value = resolveSource(rawProps[key])
     if (merged) {
-      merged.unshift(value)
+      merged.push(value)
     } else {
       return value
     }
   }
   if (merged && merged.length) {
-    return merged
+    return merged.reverse()
   }
 }
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -540,7 +540,7 @@ export function getAttrFromRawProps(rawProps: RawProps, key: string): unknown {
       if (source && hasOwn(source, key)) {
         const value = isDynamic ? source[key] : resolveSource(source[key])
         if (merged) {
-          merged.push(value)
+          merged.unshift(value)
         } else {
           return value
         }
@@ -550,7 +550,7 @@ export function getAttrFromRawProps(rawProps: RawProps, key: string): unknown {
   if (hasOwn(rawProps, key)) {
     const value = resolveSource(rawProps[key])
     if (merged) {
-      merged.push(value)
+      merged.unshift(value)
     } else {
       return value
     }


### PR DESCRIPTION
## Vue version
3.6.0-rc.6

## Link to minimal reproduction
[Playground](https://play.vuejs.org/#eNp9Uk1PwkAQ/SubvXCB1gTDAQuJEg56UKPG0yamtAMubHc3u9OKIfx3Z7dSSBQu7Xy+eTNvd/zW2qSpgY955gsnLTIPWFvW5Na4qdCyoj+ymaksWzpTsV6SBic09YQWujDaI8sRnWcTthOaMY/fCsatzdgiLzYrZ2pdzowybsx6C0W9/ZDd03cvdJa2s2keOQiVVTkCeYxlVS51tMiOLCL6RPAj7qBogR2UN4KzZrCQuqSKSIoCaYuU/kJl6ckE3ufoaYelXCVrbzQdIvIWvKBhUoF7sihpR8G7jQhZKfP1EGPoaoi7xJ5PKDb/xNd+G2KCPzvw4BoQvMth7laAbXr++ghbsrtkZcpaUfWF5At4o+rAsS27o4sQ7ZO6yPY+Cin16s3PtwjaH5YKRA9ahGoSNtz53OpHusPkOvaRhHTFw6M485IuSVzKZhraszRYfwX6aMAFugQ9TEbJ1cAVySjE0b93GYonQ77/AUL8708=)

## What is expected?
Display a blue background

## What is actually happening?
Display a red background

## Any additional comments?
`After adjustment, it maintains consistency with the behavior of the vdom mode`