### PR TITLE
chore: fix typos in comments

### DIFF
--- a/packages/vue/__tests__/e2e/Transition.spec.ts
+++ b/packages/vue/__tests__/e2e/Transition.spec.ts
@@ -3712,7 +3712,7 @@ describe('e2e: Transition', () => {
       }).mount('#app')
     })
 
-    // if transition starts while there's v-leave-active added along with v-leave-from, its bad, it has to start when it doesnt have the v-leave-from
+    // if transition starts while there's v-leave-active added along with v-leave-from, it's bad, it has to start when it doesn't have the v-leave-from
 
     // enter
     await classWhenTransitionStart()

--- a/packages/vue/jsx.d.ts
+++ b/packages/vue/jsx.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // global JSX namespace registration
-// somehow we have to copy=pase the jsx-runtime types here to make TypeScript happy
+// somehow we have to copy-paste the jsx-runtime types here to make TypeScript happy
 import type { NativeElements, ReservedProps, VNode } from '@vue/runtime-dom'
 
 declare global {


### PR DESCRIPTION
Fixes two typos found while reviewing the codebase:

- `packages/vue/jsx.d.ts`: `copy=pase` → `copy-paste`
- `packages/vue/__tests__/e2e/Transition.spec.ts`: grammar fix in a test comment (`its`/`doesnt` → `it's`/`doesn't`)

No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar and punctuation in an end-to-end test comment.
  * Fixed a typo in a JSX declaration file comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->