### PR TITLE
fix(runtime-vapor): derive transition persisted deterministically and let the renderer own v-show enter

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -630,15 +630,42 @@ describe('Transition', () => {
     expect(onAppear).not.toHaveBeenCalled()
   })
 
-  test('dynamic slot branch swaps preserve persisted hooks for slot-root v-show', async () => {
-    const data = ref({
-      branch: true,
-      show: true,
-    })
+  // Runtime-derived persisted (slot-propagated roots): independent of
+  // `appear`/`mode`, structural when a v-if/v-for/dynamic-slot boundary sits
+  // between Transition and the v-show target.
+  test('slotted v-if root with v-show leaves on removal with appear', async () => {
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({ visible: true, onLeave })
+    const Child = compile(
+      `<template><div v-if="data.visible" v-show="true">foo</div></template>`,
+      data,
+    )
+    const App = compile(
+      `<template>
+        <Transition appear :css="false" @leave="data.onLeave">
+          <components.Child />
+        </Transition>
+      </template>`,
+      data,
+      { Child },
+    )
+    const { host } = define(App as any).render()
+    await nextTick()
+
+    data.value.visible = false
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')).toBeNull()
+  })
+
+  test('dynamic slot swap of v-show roots animates with appear', async () => {
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({ branch: true, show: true, onEnter, onLeave })
     const Child = compile(`<template><slot /></template>`, data)
     const App = compile(
       `<template>
-        <Transition appear>
+        <Transition appear :css="false" @enter="data.onEnter" @leave="data.onLeave">
           <template #default v-if="data.branch">
             <components.Child>
               <div v-show="data.show">foo</div>
@@ -654,22 +681,186 @@ describe('Transition', () => {
       data,
       { Child },
     )
-    const { host, instance } = define(App as any).render()
-    const transitionFragment = (instance!.block as any).block
-    const getTransitionOwner = () =>
-      transitionFragment.nodes?.$transition
-        ? transitionFragment.nodes
-        : transitionFragment.nodes?.block
-
+    const { host } = define(App as any).render()
     await nextTick()
-
-    expect(getTransitionOwner()?.$transition?.persisted).toBe(true)
+    onEnter.mockClear()
 
     data.value.branch = false
     await nextTick()
-
     expect(host.textContent).toContain('bar')
-    expect(getTransitionOwner()?.$transition?.persisted).toBe(true)
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(onEnter).toHaveBeenCalledOnce()
+    onEnter.mockClear()
+    onLeave.mockClear()
+
+    // the new root keeps v-show driven transitions
+    data.value.show = false
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')?.style.display).toBe('none')
+
+    data.value.show = true
+    await nextTick()
+    expect(onEnter).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')?.style.display).toBe('')
+  })
+
+  test('dynamic slot removal of a v-show root leaves with appear', async () => {
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({ branch: true, onLeave })
+    const Child = compile(`<template><slot /></template>`, data)
+    const App = compile(
+      `<template>
+        <Transition appear :css="false" @leave="data.onLeave">
+          <template #default v-if="data.branch">
+            <components.Child>
+              <div v-show="true">foo</div>
+            </components.Child>
+          </template>
+        </Transition>
+      </template>`,
+      data,
+      { Child },
+    )
+    const { host } = define(App as any).render()
+    await nextTick()
+
+    data.value.branch = false
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledOnce()
+    expect(host.querySelector('div')).toBeNull()
+  })
+
+  test.each([false, true])(
+    'slotted v-show component with dynamic root swaps branch as persisted (appear: %s)',
+    async appear => {
+      const onEnter = vi.fn((_el: Element, done: () => void) => done())
+      const onLeave = vi.fn((_el: Element, done: () => void) => done())
+      const data = ref({ ok: true, onEnter, onLeave })
+      const Child = compile(`<template><slot /></template>`, data)
+      const Inner = compile(
+        `<template><div v-if="data.ok">foo</div><span v-else>bar</span></template>`,
+        data,
+      )
+      const App = compile(
+        `<template>
+          <Transition :appear="${appear}" :css="false" @enter="data.onEnter" @leave="data.onLeave">
+            <components.Child>
+              <components.Inner v-show="true" />
+            </components.Child>
+          </Transition>
+        </template>`,
+        data,
+        { Child, Inner },
+      )
+      const { host } = define(App as any).render()
+      await nextTick()
+      onEnter.mockClear()
+
+      data.value.ok = false
+      await nextTick()
+      expect(host.querySelector('span')?.textContent).toBe('bar')
+      // same as a direct `<Inner v-show>` child: the new root enters, the
+      // old root is removed without a leave
+      expect(onEnter).toHaveBeenCalledOnce()
+      expect(onLeave).not.toHaveBeenCalled()
+    },
+  )
+
+  test.each(['direct', 'slotted'])(
+    'hidden v-show component with dynamic root swaps branch without hooks (%s)',
+    async placement => {
+      const onBeforeEnter = vi.fn()
+      const onBeforeLeave = vi.fn()
+      const data = ref({ ok: true, onBeforeEnter, onBeforeLeave })
+      const Child = compile(`<template><slot /></template>`, data)
+      const Inner = compile(
+        `<template><div v-if="data.ok">foo</div><span v-else>bar</span></template>`,
+        data,
+      )
+      const App = compile(
+        `<template>
+          <Transition :css="false" @before-enter="data.onBeforeEnter" @before-leave="data.onBeforeLeave">
+            ${
+              placement === 'slotted'
+                ? '<components.Child><components.Inner v-show="false" /></components.Child>'
+                : '<components.Inner v-show="false" />'
+            }
+          </Transition>
+        </template>`,
+        data,
+        { Child, Inner },
+      )
+      const { host } = define(App as any).render()
+      await nextTick()
+
+      data.value.ok = false
+      await nextTick()
+      expect(host.querySelector('span')?.style.display).toBe('none')
+      expect(onBeforeEnter).not.toHaveBeenCalled()
+      expect(onBeforeLeave).not.toHaveBeenCalled()
+    },
+  )
+
+  test('appear on a persisted root without v-show does not enter', async () => {
+    const onBeforeAppear = vi.fn()
+    const data = ref({ onBeforeAppear })
+    const App = compile(
+      `<template>
+        <Transition appear persisted :css="false" @before-appear="data.onBeforeAppear">
+          <div>foo</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    define(App as any).render()
+    await nextTick()
+    expect(onBeforeAppear).not.toHaveBeenCalled()
+  })
+
+  test('appear on a v-if root with v-show enters once', async () => {
+    const onBeforeAppear = vi.fn()
+    const onAppear = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({ visible: true, onBeforeAppear, onAppear })
+    const App = compile(
+      `<template>
+        <Transition appear :css="false" @before-appear="data.onBeforeAppear" @appear="data.onAppear">
+          <div v-if="data.visible" v-show="true">foo</div>
+        </Transition>
+      </template>`,
+      data,
+    )
+    define(App as any).render()
+    await nextTick()
+    expect(onBeforeAppear).toHaveBeenCalledOnce()
+    expect(onAppear).toHaveBeenCalledOnce()
+  })
+
+  test('out-in mode does not stall on a persisted root branch swap', async () => {
+    const data = ref({ ok: true })
+    const Inner = compile(
+      `<template><div v-if="data.ok">foo</div><span v-else>bar</span></template>`,
+      data,
+    )
+    const App = compile(
+      `<template>
+        <Transition mode="out-in" :css="false">
+          <components.Inner v-show="true" />
+        </Transition>
+      </template>`,
+      data,
+      { Inner },
+    )
+    const { host } = define(App as any).render()
+    await nextTick()
+
+    data.value.ok = false
+    await nextTick()
+    expect(host.querySelector('span')?.textContent).toBe('bar')
+
+    data.value.ok = true
+    await nextTick()
+    expect(host.querySelector('div')?.textContent).toBe('foo')
   })
 
   test('does not leak persisted from a v-show branch onto a non-v-show root', async () => {

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -11,8 +11,11 @@ import {
   type TransitionHooks,
   type TransitionProps,
   type TransitionState,
+  type VShowElement,
   performTransitionEnter,
   performTransitionLeave,
+  queuePostRenderEffect,
+  vShowHidden,
 } from '@vue/runtime-dom'
 import {
   type DynamicFragment,
@@ -24,9 +27,16 @@ import { isTransitionEnabled } from './transition'
 import { isInteropEnabled } from './vdomInteropState'
 import { isSuspenseEnabled, resolveUnmountSuspense } from './suspense'
 
+export interface VaporTransitionState extends TransitionState {
+  // Transition's own root block; persisted derivation walks from here on
+  // every apply, and hooks resolved afterwards fold the result in.
+  root?: Block
+  persisted?: boolean
+}
+
 export interface VaporTransitionHooks extends TransitionHooks {
   __vapor: true
-  state: TransitionState
+  state: VaporTransitionState
   props: TransitionProps
   instance: VaporComponentInstance
   // Temporarily skips enter/move during TransitionGroup FLIP measurement.
@@ -44,6 +54,8 @@ export interface VaporTransitionHooks extends TransitionHooks {
 export interface TransitionOptions {
   $key?: any
   $transition?: VaporTransitionHooks
+  // v-show is applied to this block (set by applyVShow after unwrapping)
+  $vshow?: true
 }
 
 export type TransitionBlock = (
@@ -138,18 +150,28 @@ export function insertNode(
 ): void {
   if (!isHydrating) {
     // only apply transition on Element nodes
-    if (
-      isTransitionEnabled &&
-      block instanceof Element &&
-      (block as TransitionBlock).$transition &&
-      !(block as TransitionBlock).$transition!.disabled
-    ) {
-      performTransitionEnter(
-        block,
-        (block as TransitionBlock).$transition as TransitionHooks,
-        () => parent.insertBefore(block, anchor as Node),
-        parentSuspense,
-      )
+    const transition =
+      isTransitionEnabled && block instanceof Element
+        ? (block as TransitionBlock).$transition
+        : undefined
+    if (transition && !transition.disabled) {
+      const insert = () => parent.insertBefore(block, anchor)
+      if (isVShowMountEnter(block as Element, transition)) {
+        transition.beforeEnter(block)
+        insert()
+        queuePostRenderEffect(
+          () => transition.enter(block),
+          undefined,
+          parentSuspense,
+        )
+      } else {
+        performTransitionEnter(
+          block,
+          transition as TransitionHooks,
+          insert,
+          parentSuspense,
+        )
+      }
     } else if (block !== anchor) {
       // `block === anchor` happens when a fragment's own anchor travels
       // inside its `nodes` (ForFragment, vdom interop fragments), when a
@@ -159,6 +181,22 @@ export function insertNode(
       parent.insertBefore(block, anchor)
     }
   }
+}
+
+// A persisted root is v-show-owned: vdom's directive enters it on mount when
+// shown (not suspense-gated; the queued enter waits for the boundary), but
+// vapor's v-show can't (hooks attach after render), so the renderer does it.
+// Elements touched only by vdom's directive carry no `$vshow`, so foreign
+// hooks keep the persisted skip.
+function isVShowMountEnter(
+  el: Element,
+  transition: VaporTransitionHooks,
+): boolean {
+  return (
+    transition.persisted &&
+    !!(el as TransitionBlock).$vshow &&
+    !(el as VShowElement)[vShowHidden]
+  )
 }
 
 export function insertFragment(

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -14,13 +14,11 @@ import {
   isAsyncWrapper,
   isTemplateNode,
   leaveCbKey,
-  onBeforeMount,
   queuePostRenderEffect,
   resolveTransitionProps,
   restoreCurrentInstance,
   setCurrentInstance,
   useTransitionState,
-  vShowOriginalDisplay,
   warn,
 } from '@vue/runtime-dom'
 import { computed } from '@vue/reactivity'
@@ -30,6 +28,7 @@ import {
   type TransitionBlock,
   type TransitionOptions,
   type VaporTransitionHooks,
+  type VaporTransitionState,
   isValidBlock,
   remove,
 } from '../block'
@@ -61,7 +60,6 @@ import {
   setCurrentHydrationNode,
 } from '../dom/hydration'
 import { updateLastLocatedLogicalChild } from '../dom/node'
-import { type PendingVShow, setCurrentPendingVShows } from '../directives/vShow'
 import { isInteropEnabled } from '../vdomInteropState'
 
 export type ResolvedTransitionBlock = (
@@ -149,7 +147,7 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
     const performAppear = isHydrating
       ? hydrateTransitionImpl(instance.suspense)
       : undefined
-    const state = useTransitionState()
+    const state: VaporTransitionState = useTransitionState()
     const { mode } = props
     __DEV__ && checkTransitionMode(mode)
 
@@ -160,12 +158,12 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
       },
     })
 
-    const shouldCaptureVShow = !isHydrating && !!props.appear
     const shouldPerformAppear = !!props.appear && !!performAppear
     // Dynamic slot sources can add/remove the default slot after setup, so
     // Transition needs a DynamicFragment to drive enter/leave on updates.
     if (instance.rawSlots.$) {
       const frag = new DynamicFragment(0, __DEV__ ? 'transition' : undefined)
+      state.root = frag
       let isMounted = false
       renderEffect(() => {
         if (!frag.$transition) {
@@ -180,32 +178,15 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
           // so keep it in sync when Transition mode changes reactively.
           frag.$transition.mode = resolvedProps.value.mode
         }
-        const [, pendingVShows] = capturePendingVShows(
-          shouldCaptureVShow && !isMounted,
-          () => frag.update(slots.default),
-        )
-        if (pendingVShows && pendingVShows.length) {
-          let hasStructuralRoot = false
-          const root = resolveTransitionBlock(frag.nodes, fragment => {
-            hasStructuralRoot ||= isStructuralTransitionFragment(fragment)
-          })
-          applyPendingVShows(
-            frag.$transition!,
-            root,
-            pendingVShows,
-            hasStructuralRoot,
-          )
-        }
+        frag.update(slots.default)
         if (!isMounted && shouldPerformAppear) performAppear(frag.$transition!)
         isMounted = true
       })
       return frag
     }
 
-    const [children, pendingVShows] = capturePendingVShows(
-      shouldCaptureVShow,
-      () => ((slots.default && slots.default()) || []) as any as Block,
-    )
+    const children = ((slots.default && slots.default()) || []) as any as Block
+    state.root = children
 
     let appliedHooks = {
       __vapor: true,
@@ -220,18 +201,13 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
     // props eagerly, so propsProxy alone can't keep an already-applied hooks
     // closure live; re-applying rebinds the root element's (and any inner
     // fragment's) $transition to fresh closures, mirroring VDOM's per-render
-    // re-resolve. Reusing appliedHooks preserves runtime state (persisted /
-    // delayedLeave) across re-resolves.
+    // re-resolve. Reusing appliedHooks preserves runtime state (delayedLeave)
+    // across re-resolves.
     renderEffect(() => {
-      const { hooks, root, hasStructuralRoot } = applyResolvedTransitionHooks(
-        children,
-        appliedHooks,
-      )
-      appliedHooks = hooks
+      appliedHooks = applyTransitionHooksImpl(children, appliedHooks)
       if (!isMounted) {
         isMounted = true
-        applyPendingVShows(hooks, root, pendingVShows, hasStructuralRoot)
-        if (shouldPerformAppear) performAppear(hooks)
+        if (shouldPerformAppear) performAppear(appliedHooks)
       }
     })
     return children
@@ -337,7 +313,7 @@ const getTransitionHooksContext = (
 export function resolveTransitionHooks(
   block: ResolvedTransitionBlock,
   props: TransitionProps,
-  state: TransitionState,
+  state: VaporTransitionState,
   instance: GenericComponentInstance,
   postClone?: (hooks: TransitionHooks) => void,
 ): VaporTransitionHooks {
@@ -355,6 +331,7 @@ export function resolveTransitionHooks(
     instance,
   ) as VaporTransitionHooks
   hooks.__vapor = true
+  hooks.persisted = hooks.persisted || !!state.persisted
   hooks.state = state
   hooks.props = props
   hooks.instance = instance as VaporComponentInstance
@@ -365,24 +342,13 @@ export function applyTransitionHooksImpl(
   block: Block,
   hooks: VaporTransitionHooks,
 ): VaporTransitionHooks {
-  return applyResolvedTransitionHooks(block, hooks).hooks
-}
-
-function applyResolvedTransitionHooks(
-  block: Block,
-  hooks: VaporTransitionHooks,
-): {
-  hooks: VaporTransitionHooks
-  root?: ResolvedTransitionBlock
-  hasStructuralRoot: boolean
-} {
   // filter out comment nodes
   if (isArray(block)) {
     block = block.filter(b => !(b instanceof Comment))
     if (block.length === 1) {
       block = block[0]
     } else if (block.length === 0) {
-      return { hooks, hasStructuralRoot: false }
+      return hooks
     }
   }
 
@@ -396,15 +362,13 @@ function applyResolvedTransitionHooks(
       (isVaporComponent(block) && isSlotFragment(block.block)))
   ) {
     hooks.applyGroup(block, hooks.props, hooks.state, hooks.instance)
-    return { hooks, hasStructuralRoot: false }
+    return hooks
   }
 
   const fragments: VaporFragment[] = []
-  let hasStructuralRoot = false
-  const child = resolveTransitionBlock(block, fragment => {
-    fragments.push(fragment)
-    hasStructuralRoot ||= isStructuralTransitionFragment(fragment)
-  })
+  const child = resolveTransitionBlock(block, fragment =>
+    fragments.push(fragment),
+  )
   if (!child) {
     // set transition hooks on fragments for later use
     fragments.forEach(f => (f.$transition = hooks))
@@ -412,10 +376,11 @@ function applyResolvedTransitionHooks(
     if (__DEV__ && fragments.length === 0) {
       warn('Transition component has no valid child element')
     }
-    return { hooks, hasStructuralRoot }
+    return hooks
   }
 
   const { props, instance, state, delayedLeave } = hooks
+  state.persisted = isPersistedRoot(state.root)
   let resolvedHooks = resolveTransitionHooks(
     child,
     props,
@@ -423,34 +388,39 @@ function applyResolvedTransitionHooks(
     instance,
     hooks => (resolvedHooks = hooks as VaporTransitionHooks),
   )
-  // Dynamic slot / branch swaps replace the active hook object. The previously
-  // derived persisted state (slot/component-root v-show, detected only at mount
-  // via applyPendingVShows) must carry forward when the new root is *also* a
-  // v-show root, but must NOT leak onto a structural root — otherwise that
-  // root's removal would wrongly skip its leave animation. Gating the
-  // carry-forward on both the current root's v-show marker and its ownership
-  // keeps the latch tied to the live root; mount/non-appear paths are untouched
-  // because they never have a latched `hooks.persisted` to carry.
-  resolvedHooks.persisted =
-    resolvedHooks.persisted ||
-    (!hasStructuralRoot && hooks.persisted && hasVShowMarker(child))
   resolvedHooks.delayedLeave = delayedLeave
   child.$transition = resolvedHooks
   fragments.forEach(f => (f.$transition = resolvedHooks))
-
-  return {
-    hooks: resolvedHooks,
-    root: child,
-    hasStructuralRoot,
-  }
+  return resolvedHooks
 }
 
-function isStructuralTransitionFragment(fragment: VaporFragment): boolean {
-  return !!(
-    isDynamicFragment(fragment) &&
-    !isSlotFragment(fragment) &&
-    fragment.inTransition
-  )
+// Runtime equivalent of the compiler's persisted rule for roots the compiler
+// can't see (slot content): the v-show target is reached from Transition's
+// root through components and slot outlets only; a v-if / v-for / dynamic
+// slot boundary before it makes the root structural. Walked from the root on
+// every apply so branch swaps can't latch a stale result.
+function isPersistedRoot(block: Block | undefined): boolean {
+  while (block) {
+    if ((block as TransitionOptions).$vshow) return true
+    if (isVaporComponent(block)) {
+      if (isVaporTransition(block.type)) return false
+      block =
+        isAsyncComponentEnabled && isAsyncWrapper(block)
+          ? getAsyncWrapperInner(block)
+          : block.block
+    } else if (isArray(block)) {
+      block = block.find(b => !(b instanceof Comment))
+    } else if (
+      isFragment(block) &&
+      (isSlotFragment(block) ||
+        !(isDynamicFragment(block) || isForFragment(block)))
+    ) {
+      block = block.nodes
+    } else {
+      return false
+    }
+  }
+  return false
 }
 
 export function applyTransitionLeaveHooksImpl(
@@ -551,6 +521,9 @@ function removeBranchWithLeaveImpl(
   const mode = transition.mode
   if (
     mode &&
+    // persisted roots are toggled in place; mode only sequences structural
+    // swaps, and a skipped persisted leave would never fire afterLeave.
+    !transition.persisted &&
     // in-out only works when there is an incoming branch to trigger
     // delayedLeave; otherwise the current branch should leave immediately.
     (mode !== 'in-out' || render) &&
@@ -745,79 +718,4 @@ export function getTransitionElement(
   if (isInteropEnabled && isFragment(block) && block.getTransitionElement) {
     return block.getTransitionElement()
   }
-}
-
-function capturePendingVShows<T>(
-  enabled: boolean,
-  render: () => T,
-): [block: T, pendingVShows: PendingVShow[] | undefined] {
-  if (!enabled) {
-    return [render(), undefined]
-  }
-
-  const pendingVShows: PendingVShow[] = []
-  const prev = setCurrentPendingVShows(pendingVShows)
-  try {
-    return [render(), pendingVShows]
-  } finally {
-    setCurrentPendingVShows(prev)
-  }
-}
-
-function applyPendingVShows(
-  hooks: VaporTransitionHooks,
-  root: ResolvedTransitionBlock | undefined,
-  pendingVShows: PendingVShow[] | undefined,
-  hasStructuralRoot: boolean,
-): void {
-  if (!pendingVShows) return
-
-  if (root) {
-    // Keep compiler-injected persisted for direct v-show children, and
-    // additionally treat slot/component roots as persisted when their
-    // deferred v-show target resolves to the same transition root.
-    hooks.persisted =
-      hooks.persisted ||
-      (!hasStructuralRoot &&
-        pendingVShows.some(
-          pending =>
-            pending.target === root ||
-            resolveTransitionBlock(pending.target) === root,
-        ))
-  }
-
-  onBeforeMount(() => {
-    // Flush the deferred initial v-show display writes before mount so hooks are
-    // ready, then run enter after DOM insertion but before mounted state flips.
-    let enterCbs: (() => void)[] | undefined
-    pendingVShows.forEach(pending => {
-      const enterCb = pending.apply()
-      if (enterCb) {
-        ;(enterCbs ||= []).push(enterCb)
-      }
-    })
-    pendingVShows.length = 0
-    if (enterCbs) {
-      const cbs = enterCbs
-      queuePostRenderEffect(
-        () => cbs.forEach(cb => cb()),
-        -1,
-        hooks.instance.suspense,
-      )
-    }
-  })
-}
-
-// Whether the resolved root is (still) a v-show-persisted element. v-show's
-// setDisplay tags the leaf element with `vShowOriginalDisplay` on its first
-// run, which on branch/slot updates happens during render (before hooks are
-// applied), so it doubles as a "this root is persisted" marker without
-// re-running the mount-only applyPendingVShows derivation.
-function hasVShowMarker(block: Block | undefined): boolean {
-  if (!block) return false
-  if (block instanceof Element) return vShowOriginalDisplay in block
-  if (isVaporComponent(block)) return hasVShowMarker(block.block)
-  if (isArray(block)) return block.length === 1 && hasVShowMarker(block[0])
-  if (isFragment(block)) return hasVShowMarker(block.nodes)
-  return false
 }

--- a/packages/runtime-vapor/src/directives/vShow.ts
+++ b/packages/runtime-vapor/src/directives/vShow.ts
@@ -16,23 +16,6 @@ import { isHydrating } from '../dom/hydration'
 import { isDynamicFragment, isFragment, isInteropFragment } from '../fragment'
 import { isInteropEnabled } from '../vdomInteropState'
 
-export interface PendingVShow {
-  target: Block
-  apply: () => (() => void) | undefined
-}
-
-export let currentPendingVShows: PendingVShow[] | null = null
-
-export function setCurrentPendingVShows(
-  pending: PendingVShow[] | null,
-): PendingVShow[] | null {
-  try {
-    return currentPendingVShows
-  } finally {
-    currentPendingVShows = pending
-  }
-}
-
 export function applyVShow(target: Block, source: () => any): void {
   if (isVaporComponent(target)) {
     return applyVShow(target.block, source)
@@ -42,13 +25,11 @@ export function applyVShow(target: Block, source: () => any): void {
     return applyVShow(target[0], source)
   }
 
+  ;(target as TransitionBlock).$vshow = true
+
   if (isDynamicFragment(target)) {
-    const update = target.update
-    target.update = (...args) => {
-      const res = update.call(target, ...args)
-      setDisplayUntracked(target, source)
-      return res
-    }
+    // write the display state onto a fresh branch before it is inserted
+    ;(target.bm ||= []).push(nodes => setDisplayUntracked(nodes, source))
   } else if (isFragment(target) && target.insert) {
     const insert = target.insert
     target.insert = (...args) => {
@@ -58,20 +39,7 @@ export function applyVShow(target: Block, source: () => any): void {
     }
   }
 
-  renderEffect(() => {
-    const value = source()
-    if (currentPendingVShows) {
-      // Inside Transition appear, target.$transition is not assigned yet.
-      // Defer the initial setDisplay until Transition beforeMount so it can
-      // enter through the transition-aware branch.
-      currentPendingVShows.push({
-        target,
-        apply: () => setDisplay(target, value, true),
-      })
-      return
-    }
-    setDisplay(target, value)
-  })
+  renderEffect(() => setDisplay(target, source()))
 }
 
 // Fragment operations may leave the caller's subscriber active. The source is
@@ -88,32 +56,37 @@ function setDisplayUntracked(target: Block, source: () => any): void {
 function setDisplay(
   target: Block,
   value: unknown,
-  deferEnter = false,
   transition: TransitionBlock['$transition'] = undefined,
-): (() => void) | undefined {
+): void {
   if (isVaporComponent(target)) {
-    return setDisplay(target.block, value, deferEnter, transition)
+    return setDisplay(target.block, value, transition)
   }
   if (isArray(target)) {
     if (target.length === 0) return
-    if (target.length === 1)
-      return setDisplay(target[0], value, deferEnter, transition)
+    if (target.length === 1) return setDisplay(target[0], value, transition)
   }
   if (isFragment(target)) {
     if (isInteropEnabled && isInteropFragment(target) && target.$transition) {
       transition = target.$transition
     }
-    return setDisplay(target.nodes, value, deferEnter, transition)
+    return setDisplay(target.nodes, value, transition)
   }
 
   if (target instanceof Element) {
     const el = target as VShowElement
+    const hidden = !value
     if (!(vShowOriginalDisplay in el)) {
+      // First touch, before insertion: only record the display state and
+      // mark the element as v-show-owned. The renderer owns enter on insert
+      // (vdom's directive beforeMount/mounted role), so no transition runs.
+      ;(target as TransitionBlock).$vshow = true
       el[vShowOriginalDisplay] =
         el.style.display === 'none' ? '' : el.style.display
+      el[vShowHidden] = hidden
+      writeDisplay(el, value)
+      return
     }
 
-    const hidden = !value
     if (el[vShowHidden] === hidden) return
     el[vShowHidden] = hidden
 
@@ -124,58 +97,46 @@ function setDisplay(
         if (value) {
           $transition.beforeEnter(target)
           el.style.display = el[vShowOriginalDisplay]!
-          if (deferEnter) {
-            return () => {
-              const prevSub = setActiveSub()
-              try {
-                $transition.enter(target)
-              } finally {
-                setActiveSub(prevSub)
-              }
-            }
-          }
           $transition.enter(target)
-        } else {
-          // during initial render, the element is not yet inserted into the
-          // DOM, and it is hidden, no need to trigger transition
-          if (target.isConnected) {
-            $transition.leave(target, () => {
-              el.style.display = 'none'
-            })
-          } else {
+        } else if (target.isConnected) {
+          $transition.leave(target, () => {
             el.style.display = 'none'
-          }
+          })
+        } else {
+          // detached (e.g. deactivated): nothing to animate
+          el.style.display = 'none'
         }
       } finally {
         setActiveSub(prevSub)
       }
     } else {
-      if (
-        (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
-        isHydrating
-      ) {
-        if (!value && el.style.display !== 'none') {
-          const hasMismatch = warnPropMismatch(
-            el,
-            'style',
-            MismatchTypes.STYLE,
-            `display: ${el.style.display}`,
-            'display: none',
-          )
-          if (hasMismatch) {
-            logMismatchError()
-            el.style.display = 'none'
-            el[vShowOriginalDisplay] = ''
-          }
-        }
-      } else {
-        el.style.display = value ? el[vShowOriginalDisplay]! : 'none'
-      }
+      writeDisplay(el, value)
     }
   } else if (__DEV__) {
     warn(
       `v-show used on component with non-single-element root node ` +
         `and will be ignored.`,
     )
+  }
+}
+
+function writeDisplay(el: VShowElement, value: unknown): void {
+  if ((__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) && isHydrating) {
+    if (!value && el.style.display !== 'none') {
+      const hasMismatch = warnPropMismatch(
+        el,
+        'style',
+        MismatchTypes.STYLE,
+        `display: ${el.style.display}`,
+        'display: none',
+      )
+      if (hasMismatch) {
+        logMismatchError()
+        el.style.display = 'none'
+        el[vShowOriginalDisplay] = ''
+      }
+    }
+  } else {
+    el.style.display = value ? el[vShowOriginalDisplay]! : 'none'
   }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -148,6 +148,8 @@ export class VaporFragment<
   /** @internal live transition element of the backing vnode's subtree */
   getTransitionElement?: (this: VaporFragment) => Element | undefined
 
+  /** beforeMount: a fresh branch is rendered but not inserted yet */
+  bm?: ((nodes: Block) => void)[]
   /** beforeUnmount */
   bum?: (() => void)[]
   /** beforeUpdate */
@@ -507,6 +509,12 @@ export class DynamicFragment extends RenderContextFragment {
             // on purpose: the enclosing application traverses into them and
             // owns their first application.
             if (parent && this.fallthrough) this.fallthrough(nodes)
+            const bm = this.bm
+            if (bm) {
+              for (let i = 0; i < bm.length; i++) {
+                bm[i](nodes)
+              }
+            }
             return nodes
           }, this.scope)
         } finally {


### PR DESCRIPTION
Slot-propagated v-show roots derived `persisted` only under `appear` and carried it across branch swaps via an element marker, so structural enter/leave flipped with `appear` and `mode`. v-show also drove enter/leave on its first touch of a fresh branch element, firing hooks on hidden nodes and double-entering in slots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transitions for `v-show` elements used within slots, dynamic branches, and components.
  * Fixed cases where `appear` transitions did not run or ran more than once.
  * Prevented `out-in` transitions from becoming stuck when persisted branches change.
  * Improved transition behavior when hidden elements swap branches or are removed dynamically.

* **Tests**
  * Expanded coverage for slot-based, dynamic, persisted, and `v-show` transition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->