### PR TITLE
fix(runtime-vapor): stop resuming an out-in branch after unmount

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -863,6 +863,38 @@ describe('Transition', () => {
     expect(host.querySelector('div')?.textContent).toBe('foo')
   })
 
+  test('unmount during an out-in leave does not resume the pending branch', async () => {
+    let leaveDone: (() => void) | undefined
+    const data = ref<any>({
+      b: 1,
+      onLeave: (_el: Element, done: () => void) => {
+        leaveDone = done
+      },
+    })
+    const App = compile(
+      `<template>
+        <Transition mode="out-in" :css="false" @leave="data.onLeave">
+          <div v-if="data.b === 1">one</div>
+          <span v-else>two</span>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { host, app } = define(App as any).render()
+    await nextTick()
+
+    data.value.b = 2
+    await nextTick()
+    expect(host.innerHTML).toBe('<div>one</div><!--if-->')
+
+    app.unmount()
+    expect(host.innerHTML).toBe('')
+
+    // the pending leave callback from the interrupted leave
+    expect(() => leaveDone!()).not.toThrow()
+    expect(host.innerHTML).toBe('')
+  })
+
   test('does not leak persisted from a v-show branch onto a non-v-show root', async () => {
     let leaveCalls = 0
     let leaveDone: (() => void) | undefined

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -379,7 +379,8 @@ export function removeNode(block: Node, parent?: ParentNode): void {
     performTransitionLeave(
       block,
       (block as TransitionBlock).$transition as TransitionHooks,
-      () => parent && parent.removeChild(block),
+      // deferred: an unmount may have removed the node meanwhile
+      () => parent && block.parentNode === parent && parent.removeChild(block),
     )
   } else {
     parent && parent.removeChild(block)

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -533,6 +533,9 @@ function removeBranchWithLeaveImpl(
   ) {
     const instance = currentInstance
     applyTransitionLeaveHooksImpl(frag.nodes, transition, () => {
+      // Unmounting cuts the leave short and runs afterLeave synchronously;
+      // the pending branch must not be rendered into the torn-down tree.
+      if (transition.state.isUnmounting) return
       // By the time this deferred out-in branch runs, the renderEffect
       // has finished and currentInstance may have changed, so restore
       // the captured instance.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where content could reappear after an application was unmounted during an out-in transition.
  - Prevented transition cleanup from attempting to remove elements that had already been detached.
- **Tests**
  - Added coverage for unmounting during a pending leave transition, confirming the host remains empty and no errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->