### PR TITLE
fix(runtime-core): relocate persisted transition roots on forced leave

### DIFF
--- a/packages-private/vapor-e2e-test/__tests__/transition.spec.ts
+++ b/packages-private/vapor-e2e-test/__tests__/transition.spec.ts
@@ -1165,16 +1165,12 @@ describe('vapor transition', () => {
             `<h2>This is page1</h2>` +
             `<button id="changeShowBtn">false</button><!--dynamic-component-->`,
         )
-        await nextFrame()
-        expect(html(containerSelector)).toContain(
-          `<div class="test-leave-active test-leave-to"><h2>I shouldn't show </h2></div>` +
-            `<h2>This is page1</h2>` +
-            `<button id="changeShowBtn">false</button><!--dynamic-component-->`,
-        )
 
-        // switch to page2, before leave finishes
-        // expect v-show element's display to be none
-        await css(btnToggle).click()
+        // switch to page2 while the leave is still in flight (#13153): the
+        // pending leave is cancelled (display: none) and restarted for the
+        // move. Once a leave has finished, a persisted root only relocates
+        // (#14031), so switch right away instead of waiting another frame.
+        click(btnToggle)
         await nextTick()
         await expect
           .element(css(containerSelector))

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2345,38 +2345,19 @@ function baseCreateRenderer(
           true,
         )
       } else {
-        const { leave, delayLeave, afterLeave } = transition!
-        const remove = () => {
-          if (vnode.ctx!.isUnmounted) {
-            hostRemove(el!)
-          } else {
-            hostInsert(el!, container, anchor)
-          }
-        }
-        const performLeave = () => {
-          // #13153 move kept-alive node before v-show transition leave finishes
-          // it needs to call the leaving callback to ensure element's `display`
-          // is `none`
-          const wasLeaving = el!._isLeaving || !!el![leaveCbKey]
-          if (el!._isLeaving) {
-            el![leaveCbKey](true /* cancelled */)
-          }
-          // #14031 without a pending leave, persisted transitions should skip
-          // directive-owned leave hooks and just relocate.
-          if (transition!.persisted && !wasLeaving) {
-            remove()
-          } else {
-            leave(el!, () => {
-              remove()
-              afterLeave && afterLeave()
-            })
-          }
-        }
-        if (delayLeave) {
-          delayLeave(el!, remove, performLeave)
-        } else {
-          performLeave()
-        }
+        performTransitionLeave(
+          el!,
+          transition!,
+          () => {
+            if (vnode.ctx!.isUnmounted) {
+              hostRemove(el!)
+            } else {
+              hostInsert(el!, container, anchor)
+            }
+          },
+          true,
+          true,
+        )
       }
     } else {
       hostInsert(el!, container, anchor)
@@ -2954,7 +2935,11 @@ export function performTransitionLeave(
 ): void {
   const performRemove = () => {
     remove()
-    if (transition && !transition.persisted && transition.afterLeave) {
+    if (
+      transition &&
+      (force || !transition.persisted) &&
+      transition.afterLeave
+    ) {
       transition.afterLeave()
     }
   }
@@ -2965,10 +2950,17 @@ export function performTransitionLeave(
       // #13153 move kept-alive node before v-show transition leave finishes
       // it needs to call the leaving callback to ensure element's `display`
       // is `none`
+      const wasLeaving = el!._isLeaving || !!el![leaveCbKey]
       if (el!._isLeaving && force) {
         el![leaveCbKey](true /* cancelled */)
       }
-      leave(el, performRemove)
+      // #14031 without a pending leave, persisted transitions should skip
+      // directive-owned leave hooks and just relocate.
+      if (force && transition.persisted && !wasLeaving) {
+        remove()
+      } else {
+        leave(el, performRemove)
+      }
     }
     if (delayLeave) {
       delayLeave(el, performRemove, performLeave)

--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -1506,6 +1506,57 @@ describe('VaporKeepAlive', () => {
       await nextTick()
       expect(host.innerHTML).toBe('')
     })
+    // #14031
+    test('relocates a persisted transition root on deactivate/activate', async () => {
+      const onBeforeLeave = vi.fn()
+      const onLeave = vi.fn((_el: Element, done: () => void) => done())
+      const onBeforeEnter = vi.fn()
+      const onEnter = vi.fn((_el: Element, done: () => void) => done())
+      const CompA = compile(
+        `<template><div v-show="true">A</div></template>`,
+        ref(),
+      )
+      const CompB = compile(`<template><span>B</span></template>`, ref())
+      const data = shallowRef({
+        current: CompA,
+        onBeforeLeave,
+        onLeave,
+        onBeforeEnter,
+        onEnter,
+      })
+      const App = compile(
+        `<template>
+          <Transition
+            persisted
+            :css="false"
+            @before-leave="data.onBeforeLeave"
+            @leave="data.onLeave"
+            @before-enter="data.onBeforeEnter"
+            @enter="data.onEnter"
+          >
+            <KeepAlive>
+              <component :is="data.current" />
+            </KeepAlive>
+          </Transition>
+        </template>`,
+        data,
+      )
+      const { host } = define(App as any).render()
+      await nextTick()
+
+      data.value = { ...data.value, current: CompB }
+      await nextTick()
+      expect(host.innerHTML).toBe('<span>B</span><!--dynamic-component-->')
+      expect(onBeforeLeave).not.toHaveBeenCalled()
+      expect(onLeave).not.toHaveBeenCalled()
+
+      data.value = { ...data.value, current: CompA }
+      await nextTick()
+      expect(host.innerHTML).toBe('<div>A</div><!--dynamic-component-->')
+      expect(onBeforeEnter).not.toHaveBeenCalled()
+      expect(onEnter).not.toHaveBeenCalled()
+    })
+
     test('unmounts an incoming branch superseded during mount', async () => {
       const deactivatedB = vi.fn()
       const unmountedB = vi.fn()

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -264,7 +264,7 @@ export function move(
               parent.insertBefore(block, anchor as Node)
             }
           },
-          parentSuspense,
+          true,
           true,
         )
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed transition behavior when switching between kept-alive components during an in-progress leave transition.
  - Ensured persisted transition roots relocate correctly when returning to previously displayed components.
  - Prevented unintended leave and enter hooks from running during forced persisted transitions.

- **Tests**
  - Added regression coverage for transitions wrapping kept-alive components.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->