### PR TITLE
fix(runtime-vapor): relocate v-for rows as reorders instead of enters

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -1321,7 +1321,6 @@ describe('effects in pending branches', () => {
   test('transition-group move processing waits for the branch to resolve', async () => {
     const asyncSetup = deferred()
     const items = ref([1, 2])
-    let first!: any
     const VaporChild = defineVaporComponent({
       setup() {
         const list = createFor(
@@ -1333,7 +1332,6 @@ describe('effects in pending branches', () => {
           },
           item => item,
         )
-        first = (list.nodes as any)[0][0].nodes
         return createComponent(VaporTransitionGroup, null, {
           default: () => list,
         })
@@ -1358,13 +1356,22 @@ describe('effects in pending branches', () => {
     app.mount(host)
 
     await nextTick()
+    // The position snapshot stays pending until the deferred flush runs, so a
+    // second update while the boundary is pending must not measure again.
+    const measure = vi.spyOn(Element.prototype, 'getBoundingClientRect')
     items.value = [2, 1]
     await nextTick()
-    expect(first.$transition.disabled).toBe(true)
+    expect(measure).toHaveBeenCalledTimes(2)
+    items.value = [1, 2]
+    await nextTick()
+    expect(measure).toHaveBeenCalledTimes(2)
 
     asyncSetup.resolve()
     await flushResolution(asyncSetup.promise)
-    expect(first.$transition.disabled).toBe(false)
+    items.value = [2, 1]
+    await nextTick()
+    expect(measure).toHaveBeenCalledTimes(4)
+    measure.mockRestore()
     app.unmount()
   })
 

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -203,34 +203,29 @@ describe('TransitionGroup', () => {
     expect(nodes[1].$transition).toBeDefined()
   })
 
-  test('restores disabled transition hooks when no move transform is available', async () => {
-    const items = ref([1, 2])
-    let list: any
-
-    define({
-      setup() {
-        list = createFor(
-          () => items.value,
-          item => {
-            const el = template(`<div></div>`)()
-            el.textContent = String(item.value)
-            return el
-          },
-          item => item,
-        )
-        return createComponent(VaporTransitionGroup, null, {
-          default: () => list,
-        })
-      },
-    }).render()
-
-    const first = list.nodes[0][0].nodes
-
-    items.value = [2, 1]
-    await nextTick()
+  test('keyed reorder does not run enter hooks on relocated rows', async () => {
+    const onBeforeEnter = vi.fn()
+    const data = ref<any>({ items: ['a', 'b', 'c'], onBeforeEnter })
+    const App = compile(
+      `<template>
+        <TransitionGroup tag="div" :css="false" @before-enter="data.onBeforeEnter">
+          <div v-for="i in data.items" :key="i">{{ i }}</div>
+        </TransitionGroup>
+      </template>`,
+      data,
+    )
+    const { host } = define(App as any).render()
     await nextTick()
 
-    expect(first.$transition.disabled).toBe(false)
+    data.value.items = ['c', 'a', 'b']
+    await nextTick()
+    expect(host.querySelector('div')!.textContent).toBe('cab')
+    expect(onBeforeEnter).not.toHaveBeenCalled()
+
+    // a new row still enters
+    data.value.items = ['c', 'a', 'b', 'd']
+    await nextTick()
+    expect(onBeforeEnter).toHaveBeenCalledOnce()
   })
 
   test('skips group hook and owner bookkeeping on ForBlock wrappers', () => {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -28,11 +28,12 @@ import {
   insertFragment,
   insertNode,
   isValidSlot,
+  move,
   remove,
   removeFragment,
   removeNode,
 } from './block'
-import { queuePostFlushCb, warn } from '@vue/runtime-dom'
+import { MoveType, queuePostFlushCb, warn } from '@vue/runtime-dom'
 import { currentInstance } from './component'
 import {
   type DynamicSlot,
@@ -427,7 +428,8 @@ export const createFor = (
 
           const block = newBlocks[index]
           if (block !== undefined) {
-            insertForBlock(block, anchorNode)
+            // relocating an existing row is not a structural enter
+            move(block.nodes, parent!, anchorNode, MoveType.REORDER)
           } else {
             mount(source, index, anchorNode)
           }

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -39,9 +39,6 @@ export interface VaporTransitionHooks extends TransitionHooks {
   state: VaporTransitionState
   props: TransitionProps
   instance: VaporComponentInstance
-  // Temporarily skips enter/move during TransitionGroup FLIP measurement.
-  // Leave transitions intentionally ignore this flag.
-  disabled?: boolean
   // TransitionGroup sets this to handle applying hooks to list children
   applyGroup?: (
     block: Block,
@@ -154,7 +151,7 @@ export function insertNode(
       isTransitionEnabled && block instanceof Element
         ? (block as TransitionBlock).$transition
         : undefined
-    if (transition && !transition.disabled) {
+    if (transition) {
       const insert = () => parent.insertBefore(block, anchor)
       if (isVShowMountEnter(block as Element, transition)) {
         transition.beforeEnter(block)
@@ -236,7 +233,6 @@ export function move(
       isTransitionEnabled &&
       block instanceof Element &&
       (block as TransitionBlock).$transition &&
-      !(block as TransitionBlock).$transition!.disabled &&
       moveType !== MoveType.REORDER
     ) {
       if (moveType === MoveType.ENTER) {

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -187,9 +187,6 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
           !(el as VShowElement)[vShowHidden]
         ) {
           prevChildren.push(child)
-          // Skip enter/move while children are placed for FLIP measurement.
-          // Leave still needs to run for removed children.
-          child.$transition!.disabled = true
           positionMap.set(child, el.getBoundingClientRect())
         }
       }
@@ -211,19 +208,17 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
           moveClass,
         )
       )
-      prevChildren.forEach(child => {
-        child.$transition!.disabled = false
-        if (hasMove) {
-          // pending enter/move cbs live on the element, which for interop
-          // children is not the block itself
-          const el = getTransitionElement(child)
-          if (el) callPendingCbs(el)
-        }
-      })
       if (!hasMove) {
         prevChildren = []
         return
       }
+
+      prevChildren.forEach(child => {
+        // pending enter/move cbs live on the element, which for interop
+        // children is not the block itself
+        const el = getTransitionElement(child)
+        if (el) callPendingCbs(el)
+      })
 
       prevChildren.forEach(recordPosition)
       const movedChildren = prevChildren.filter(applyTranslation)
@@ -509,17 +504,12 @@ function applyGroupTransitionHooks(
     const child = children[i]
     if (isValidTransitionBlock(child)) {
       if (child.$key != null) {
-        const prev = child.$transition
         child.$transition = resolveTransitionHooks(
           child,
           props,
           state,
           instance,
         )
-        // Carry the FLIP-measurement latch across hook re-resolution (a props
-        // re-apply or slot re-render can land between beforeUpdate and
-        // flushUpdated); flushUpdated resets it on the live hooks object.
-        if (prev && prev.disabled) child.$transition.disabled = true
       } else if (__DEV__) {
         warn(`<transition-group> children must be keyed`)
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed keyed list reordering so existing rows move instead of being re-entered.
  - Prevented enter transitions from running on rows relocated during a reorder.
  - Corrected transition-group position measurements while content is still pending, avoiding unnecessary measurements until resolution.
  - Ensured transition callbacks run consistently when items are moved, added, or removed.
  - Preserved expected transition behavior when new rows are added after a reorder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->