### PR TITLE
refactor(runtime-vapor): keep composed transition-group keys off $key

### DIFF
--- a/packages-private/vapor-e2e-test/__tests__/transition-group.spec.ts
+++ b/packages-private/vapor-e2e-test/__tests__/transition-group.spec.ts
@@ -484,6 +484,44 @@ describe('vapor transition-group', () => {
   )
 
   test(
+    'enter + leave at tail',
+    async () => {
+      const btnSelector = '.enter-leave-at-tail > button'
+      const containerSelector = '.enter-leave-at-tail > div'
+
+      await expect
+        .element(css(containerSelector))
+        .toContainHTML(
+          `<div class="test">a</div>` +
+            `<div class="test">b</div>` +
+            `<div class="test">c</div>`,
+        )
+
+      // the new row lands after the leaving tail row, as in vdom
+      click(btnSelector)
+      await nextTick()
+      await nextFrame()
+      expect(html(containerSelector)).toContain(
+        `<div class="test">a</div>` +
+          `<div class="test">b</div>` +
+          `<div class="test test-leave-from test-leave-active">c</div>` +
+          `<div class="test test-enter-from test-enter-active">d</div>` +
+          `<!--for--><!--transition-group-->`,
+      )
+
+      await transitionFinish()
+      await expect
+        .element(css(containerSelector))
+        .toContainHTML(
+          `<div class="test">a</div>` +
+            `<div class="test">b</div>` +
+            `<div class="test">d</div>`,
+        )
+    },
+    E2E_TIMEOUT,
+  )
+
+  test(
     'appear',
     async () => {
       const btnSelector = '.appear > button'

--- a/packages-private/vapor-e2e-test/__tests__/transition-group.spec.ts
+++ b/packages-private/vapor-e2e-test/__tests__/transition-group.spec.ts
@@ -734,6 +734,36 @@ describe('vapor transition-group', () => {
       )
   })
 
+  // an attribute update on a plain element child re-runs a TransitionGroup
+  // owned effect, which is what triggers the FLIP measurement (vdom: the
+  // group re-renders because the slot read the changed value)
+  test('same-key element move after class change', async () => {
+    const btnSelector = '.same-key-element-move-after-class-change > button'
+    const containerSelector = '.same-key-element-move-after-class-change > div'
+
+    await expect
+      .element(css(containerSelector))
+      .toContainHTML(
+        `<div class="item-wrapper">` +
+          `<div class="item closed" id="item-1"><div class="item-inner">item 1</div></div>` +
+          `<div class="item closed" id="item-2"><div class="item-inner">item 2</div></div>` +
+          `<!--for--></div><!--transition-group-->`,
+      )
+
+    click(btnSelector)
+    await nextTick()
+    await nextFrame()
+
+    await expect
+      .element(css(containerSelector))
+      .toContainHTML(
+        `<div class="item-wrapper">` +
+          `<div class="item opened" id="item-1"><div class="item-inner">item 1</div></div>` +
+          `<div class="item closed group-move" id="item-2" style=""><div class="item-inner">item 2</div></div>` +
+          `<!--for--></div><!--transition-group-->`,
+      )
+  })
+
   test('same-key component move after prop change', async () => {
     const btnSelector = '.same-key-component-move-after-prop-change > button'
     const containerSelector = '.same-key-component-move-after-prop-change > div'

--- a/packages-private/vapor-e2e-test/transition-group/cases/vapor-transition-group/enter-leave-at-tail.vue
+++ b/packages-private/vapor-e2e-test/transition-group/cases/vapor-transition-group/enter-leave-at-tail.vue
@@ -1,0 +1,17 @@
+<script setup vapor>
+import { ref } from 'vue'
+
+const items = ref(['a', 'b', 'c'])
+const click = () => (items.value = ['a', 'b', 'd'])
+</script>
+
+<template>
+  <div class="enter-leave-at-tail">
+    <button @click="click">enter-leave-at-tail button</button>
+    <div>
+      <transition-group name="test" move-class="noop-move">
+        <div v-for="item in items" :key="item" class="test">{{ item }}</div>
+      </transition-group>
+    </div>
+  </div>
+</template>

--- a/packages-private/vapor-e2e-test/transition-group/cases/vapor-transition-group/same-key-element-move-after-class-change.vue
+++ b/packages-private/vapor-e2e-test/transition-group/cases/vapor-transition-group/same-key-element-move-after-class-change.vue
@@ -1,0 +1,54 @@
+<script setup vapor>
+import { ref } from 'vue'
+
+const items = ref([
+  { id: 1, isOpened: false },
+  { id: 2, isOpened: false },
+])
+
+function toggleExpansion() {
+  items.value[0].isOpened = true
+}
+</script>
+
+<template>
+  <div class="same-key-element-move-after-class-change">
+    <button @click="toggleExpansion">toggle expansion of first element</button>
+    <div>
+      <transition-group name="group" tag="div" class="item-wrapper">
+        <div
+          v-for="i in items"
+          :key="i.id"
+          class="item"
+          :class="i.isOpened ? 'opened' : 'closed'"
+          :id="`item-${i.id}`"
+        >
+          <div class="item-inner">item {{ i.id }}</div>
+        </div>
+      </transition-group>
+    </div>
+  </div>
+</template>
+
+<style>
+.item-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  width: 430px;
+}
+
+.same-key-element-move-after-class-change .item {
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+
+.same-key-element-move-after-class-change .item.opened {
+  width: 420px;
+}
+
+.same-key-element-move-after-class-change .group-move {
+  transition: transform 300ms ease;
+}
+</style>

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -4,7 +4,10 @@ import {
   setBlockKey,
   template,
 } from '../../src'
-import { resolveTransitionBlock } from '../../src/components/Transition'
+import {
+  getTransitionKey,
+  resolveTransitionBlock,
+} from '../../src/components/Transition'
 import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
 import {
   Fragment,
@@ -206,8 +209,8 @@ describe('Transition', () => {
 
     const resolved = resolveTransitionBlocks(child)
     expect(resolved).toEqual([child.block[1], child.block[2]])
-    expect(child.block[1].$key).toBe('foo0')
-    expect(child.block[2].$key).toBe('foo1')
+    expect(getTransitionKey(child.block[1])).toBe('foo0')
+    expect(getTransitionKey(child.block[2])).toBe('foo1')
   })
 
   test('keeps inherited group keys stable across repeated resolutions', () => {
@@ -235,8 +238,8 @@ describe('Transition', () => {
     resolveTransitionBlocks(child)
     resolveTransitionBlocks(child)
 
-    expect(child.block[1].$key).toBe('foo0')
-    expect(child.block[2].$key).toBe('foo1')
+    expect(getTransitionKey(child.block[1])).toBe('foo0')
+    expect(getTransitionKey(child.block[2])).toBe('foo1')
   })
 
   test('treats null group owner key as absent', () => {
@@ -260,8 +263,8 @@ describe('Transition', () => {
 
     resolveTransitionBlocks(child)
 
-    expect(child.block[0].$key).toBeUndefined()
-    expect(child.block[1].$key).toBeUndefined()
+    expect(getTransitionKey(child.block[0])).toBeUndefined()
+    expect(getTransitionKey(child.block[1])).toBeUndefined()
   })
 
   test('composes nested group key prefixes', () => {
@@ -285,8 +288,8 @@ describe('Transition', () => {
 
     const resolved = resolveTransitionBlocks(child)
 
-    expect(resolved[0].$key).toBe('foo0')
-    expect(resolved[1].$key).toBe('foobar')
+    expect(getTransitionKey(resolved[0])).toBe('foo0')
+    expect(getTransitionKey(resolved[1])).toBe('foobar')
   })
 
   test('allows empty transition content', async () => {

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -9,6 +9,7 @@ import {
   template,
 } from '../../src'
 import { defineComponent, h, nextTick, ref } from '@vue/runtime-dom'
+import { getTransitionKey } from '../../src/components/Transition'
 import { compile, makeInteropRender, makeRender } from '../_utils'
 
 const define = makeRender()
@@ -35,7 +36,9 @@ describe('TransitionGroup', () => {
       },
     }).render()
 
-    expect(child.block.$key).toBe('foo0')
+    expect(getTransitionKey(child.block)).toBe('foo0')
+    // the composed key never overwrites the block's own key
+    expect(child.block.$key).toBeUndefined()
     expect(child.block.$transition).toBeDefined()
   })
 
@@ -55,7 +58,7 @@ describe('TransitionGroup', () => {
       },
     }).render()
 
-    expect(frag.nodes.$key).toBe('foo0')
+    expect(getTransitionKey(frag.nodes)).toBe('foo0')
     expect(frag.nodes.$transition).toBeDefined()
   })
 
@@ -82,8 +85,8 @@ describe('TransitionGroup', () => {
       },
     }).render()
 
-    expect(child.block[0].$key).toBe('foo0')
-    expect(child.block[1].$key).toBe('foo1')
+    expect(getTransitionKey(child.block[0])).toBe('foo0')
+    expect(getTransitionKey(child.block[1])).toBe('foo1')
     expect(child.block[0].$transition).toBeDefined()
     expect(child.block[1].$transition).toBeDefined()
   })
@@ -110,8 +113,8 @@ describe('TransitionGroup', () => {
       },
     }).render()
 
-    expect(child.block[0].$key).toBe('fooa')
-    expect(child.block[1].$key).toBe('foob')
+    expect(getTransitionKey(child.block[0])).toBe('fooa')
+    expect(getTransitionKey(child.block[1])).toBe('foob')
     expect(child.block[0].$transition).toBeDefined()
     expect(child.block[1].$transition).toBeDefined()
   })
@@ -197,8 +200,8 @@ describe('TransitionGroup', () => {
 
     const nodes = list.nodes[0][0].nodes
 
-    expect(nodes[0].$key).toBe('1:0')
-    expect(nodes[1].$key).toBe('1:1')
+    expect(getTransitionKey(nodes[0])).toBe('1:0')
+    expect(getTransitionKey(nodes[1])).toBe('1:1')
     expect(nodes[0].$transition).toBeDefined()
     expect(nodes[1].$transition).toBeDefined()
   })

--- a/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/TransitionGroup.spec.ts
@@ -206,6 +206,34 @@ describe('TransitionGroup', () => {
     expect(nodes[1].$transition).toBeDefined()
   })
 
+  test('rows landing at the tail go after leaving rows (vdom order)', async () => {
+    // leave is held open so removed rows stay in the DOM as ghosts
+    const data = ref<any>({
+      items: ['a', 'b', 'c'],
+      onLeave: (_el: Element, _done: () => void) => {},
+    })
+    const App = compile(
+      `<template>
+        <TransitionGroup tag="div" :css="false" @leave="data.onLeave">
+          <div v-for="i in data.items" :key="i">{{ i }}</div>
+        </TransitionGroup>
+      </template>`,
+      data,
+    )
+    const { host } = define(App as any).render()
+    const text = () => host.querySelector('div')!.textContent
+
+    // remove the tail row and append a new one
+    data.value.items = ['a', 'b', 'd']
+    await nextTick()
+    expect(text()).toBe('abcd')
+
+    // move an existing row to the tail past the leaving one
+    data.value.items = ['b', 'd', 'a']
+    await nextTick()
+    expect(text()).toBe('bcda')
+  })
+
   test('keyed reorder does not run enter hooks on relocated rows', async () => {
     const onBeforeEnter = vi.fn()
     const data = ref<any>({ items: ['a', 'b', 'c'], onBeforeEnter })

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -401,26 +401,9 @@ export const createFor = (
             }
           }
           if (anchorNode === undefined) {
-            if (cachedAnchor === undefined) {
-              // Landing at the tail. Rows removed under a leave transition
-              // stay in the DOM until their animation ends, and
-              // `parentAnchor` alone would place this row after them,
-              // reordering them relative to a surviving neighbor they used
-              // to follow (mid-list insertions anchor on the next live row,
-              // matching vdom, so ghosts keep their place there). Ghosts
-              // never move, so the run adjacent to the anchor is exactly
-              // the trailing run of leftovers in old order — step in front
-              // of it.
-              cachedAnchor = parentAnchor
-              if (isTransitionEnabled && frag.$transition) {
-                for (let i = e2 - 1; i >= 0; i--) {
-                  const oldBlock = oldBlocks[i]
-                  if (!oldKeyIndexMap.has(oldBlock.key)) break
-                  const first = getBlockFirstNode(oldBlock.nodes)
-                  if (first && first.parentNode === parent) cachedAnchor = first
-                }
-              }
-            }
+            // Landing at the tail: after any rows still leaving, as vdom
+            // anchors on the fragment end.
+            if (cachedAnchor === undefined) cachedAnchor = parentAnchor
             anchorNode = cachedAnchor
           }
           scanFrom = index + 1

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -271,11 +271,21 @@ function getLeaveElement(
   }
 }
 
+// TransitionGroup composes owner keys onto its children (vdom's
+// getTransitionRawChildren) without touching the block's own `$key`.
+export const groupTransitionKeys: WeakMap<ResolvedTransitionBlock, any> =
+  new WeakMap()
+
+export function getTransitionKey(block: ResolvedTransitionBlock): any {
+  const key = groupTransitionKeys.get(block)
+  return key !== undefined ? key : block.$key
+}
+
 const getTransitionHooksContext = (
   block: ResolvedTransitionBlock,
   state: TransitionState,
 ) => {
-  const key = String(block.$key)
+  const key = String(getTransitionKey(block))
   const leavingNodes = getLeavingNodesForType(state, block)
   const context: TransitionHooksContext = {
     isLeaving: () => leavingNodes[key] === block,
@@ -294,7 +304,10 @@ const getTransitionHooksContext = (
       // String($key), which coerces e.g. 1 and '1' into the same slot. Compare
       // the raw keys so a number-keyed leaving node isn't force-removed by a
       // string-keyed entering node (and vice versa).
-      if (leavingNode && leavingNode.$key === block.$key) {
+      if (
+        leavingNode &&
+        getTransitionKey(leavingNode) === getTransitionKey(block)
+      ) {
         const el = getLeaveElement(leavingNode)
         if (el && el[leaveCbKey]) {
           // force early removal (not cancelled)
@@ -439,7 +452,7 @@ export function applyTransitionLeaveHooksImpl(
       delayedLeave,
     ) => {
       const leavingNodes = getLeavingNodesForType(state, leavingBlock)
-      const leavingKey = String(leavingBlock.$key)
+      const leavingKey = String(getTransitionKey(leavingBlock))
       leavingNodes[leavingKey] = leavingBlock
       // Bind cleanup to this specific handoff so an older leave callback
       // cannot clear a newer delayedLeave during rapid toggles.

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -35,6 +35,8 @@ import {
   type ResolvedTransitionBlock,
   applyTransitionHooksImpl,
   getTransitionElement,
+  getTransitionKey,
+  groupTransitionKeys,
   isValidTransitionBlock,
   resolveTransitionHooks,
   setTransitionType,
@@ -345,18 +347,9 @@ export const VaporTransitionGroup: DefineVaporComponent<
   TransitionGroupProps
 > = /*@__PURE__*/ decorate(VaporTransitionGroupImpl)
 
-type InheritedTransitionKeyRecord = {
-  generation: number
-  rawBaseKey: any
-  inheritedKey: string
-}
-
-const inheritedTransitionKeyMap = new WeakMap<
-  ResolvedTransitionBlock,
-  InheritedTransitionKeyRecord
->()
-let transitionKeyGeneration = 0
-let currentTransitionKeyGeneration = 0
+// Composed keys of the current resolution pass. Owners compose bottom-up, so
+// a child under nested keyed owners reads its inner composition here first.
+type ComposedKeys = Map<ResolvedTransitionBlock, any>
 
 export function resolveTransitionBlocks(
   block: Block,
@@ -367,17 +360,21 @@ export function resolveTransitionBlocks(
 ): ResolvedTransitionBlock[] {
   const children: ResolvedTransitionBlock[] = []
   if (collectOnly) {
-    collectTransitionBlocks(block, children, onFragment, onUpdateOwner, true)
-    return children
-  }
-  const prevGeneration = currentTransitionKeyGeneration
-  currentTransitionKeyGeneration = ++transitionKeyGeneration
-  try {
     collectTransitionBlocks(block, children, onFragment, onUpdateOwner)
     return children
-  } finally {
-    currentTransitionKeyGeneration = prevGeneration
   }
+  const composed: ComposedKeys = new Map()
+  collectTransitionBlocks(block, children, onFragment, onUpdateOwner, composed)
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i]
+    const key = composed.get(child)
+    if (key !== undefined) {
+      groupTransitionKeys.set(child, key)
+    } else {
+      groupTransitionKeys.delete(child)
+    }
+  }
+  return children
 }
 
 function collectTransitionBlocks(
@@ -385,7 +382,7 @@ function collectTransitionBlocks(
   children: ResolvedTransitionBlock[],
   onFragment?: (frag: VaporFragment) => void,
   onUpdateOwner?: (owner: TransitionGroupUpdateOwner) => void,
-  collectOnly = false,
+  composed?: ComposedKeys,
 ): void {
   if (block instanceof Node) {
     if (block instanceof Element) children.push(block)
@@ -399,15 +396,15 @@ function collectTransitionBlocks(
       children,
       onFragment,
       isRootSlot ? onUpdateOwner : undefined,
-      collectOnly,
+      composed,
     )
-    if (!collectOnly) {
+    if (composed) {
       if (!isRootSlot) {
         for (let i = start; i < children.length; i++) {
           setTransitionType(children[i], block.type)
         }
       }
-      inheritTransitionKey(children, start, block.$key)
+      inheritTransitionKey(children, start, block.$key, composed)
     }
   } else if (isArray(block)) {
     for (let i = 0; i < block.length; i++) {
@@ -416,7 +413,7 @@ function collectTransitionBlocks(
         children,
         onFragment,
         onUpdateOwner,
-        collectOnly,
+        composed,
       )
     }
   } else if (isFragment(block)) {
@@ -438,20 +435,22 @@ function collectTransitionBlocks(
         children,
         onFragment,
         onUpdateOwner,
-        collectOnly,
+        composed,
       )
-      if (collectOnly) {
-        // element collection only; keys were stamped by the apply pass
+      if (!composed) {
+        // element collection only; keys were resolved by the apply pass
       } else if (isItem) {
         const count = children.length - start
-        for (let i = start; i < children.length; i++) {
-          children[i].$key =
-            block.key != null && count > 1
-              ? `${block.key}:${i - start}`
-              : block.key
+        if (count === 1) {
+          // the row key is the single root's own key
+          children[start].$key = block.key
+        } else if (block.key != null) {
+          for (let i = start; i < children.length; i++) {
+            composed.set(children[i], `${block.key}:${i - start}`)
+          }
         }
       } else {
-        inheritTransitionKey(children, start, block.$key)
+        inheritTransitionKey(children, start, block.$key, composed)
       }
     }
   }
@@ -461,29 +460,15 @@ function inheritTransitionKey(
   children: ResolvedTransitionBlock[],
   start: number,
   key: any,
+  composed: ComposedKeys,
 ): void {
-  if (key == null || start === children.length) return
+  if (key == null) return
   for (let i = start; i < children.length; i++) {
     const child = children[i]
-    let record = inheritedTransitionKeyMap.get(child)
-    let baseKey
-    if (record && record.generation === currentTransitionKeyGeneration) {
-      baseKey = child.$key != null ? child.$key : i - start
-    } else {
-      if (!record || !Object.is(child.$key, record.inheritedKey)) {
-        record = {
-          generation: currentTransitionKeyGeneration,
-          rawBaseKey: child.$key != null ? child.$key : i - start,
-          inheritedKey: '',
-        }
-        inheritedTransitionKeyMap.set(child, record)
-      } else {
-        record.generation = currentTransitionKeyGeneration
-      }
-      baseKey = record.rawBaseKey
-    }
-    record.inheritedKey = String(key) + String(baseKey)
-    child.$key = record.inheritedKey
+    const inner = composed.get(child)
+    const base =
+      inner !== undefined ? inner : child.$key != null ? child.$key : i - start
+    composed.set(child, String(key) + String(base))
   }
 }
 
@@ -503,7 +488,7 @@ function applyGroupTransitionHooks(
   for (let i = 0; i < children.length; i++) {
     const child = children[i]
     if (isValidTransitionBlock(child)) {
-      if (child.$key != null) {
+      if (getTransitionKey(child) != null) {
         child.$transition = resolveTransitionHooks(
           child,
           props,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transition-group items being inserted in the wrong order when a new item is added while another item is leaving.
  * Fixed movement transitions not triggering after an item’s CSS class changes.
  * Improved transition handling for keyed lists, nested content, and repeated transition updates.

* **Tests**
  * Added end-to-end coverage for transition-group ordering and movement after class changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->