### PR TITLE
refactor(runtime-vapor): resolve markerless v-for hydration anchors locally

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
@@ -473,6 +473,43 @@ describe('Vapor Mode hydration', () => {
       ).not.toHaveBeenWarned()
     })
 
+    test('with tag should reuse the close marker kept by slot content', async () => {
+      // SSR only strips the slot fragment markers when the slot renders a
+      // single fragment; with a trailing sibling the v-for keeps its own
+      const data = ref({
+        items: [1, 2],
+        tail: 'tail',
+      })
+      const { container } = await testHydration(
+        `<template>
+          <components.Child>
+            <li v-for="item in data.items" :key="item">{{ item }}</li>
+            <li key="tail">{{ data.tail }}</li>
+          </components.Child>
+        </template>`,
+        {
+          Child: `<template>
+            <TransitionGroup :css="false" tag="ul"><slot /></TransitionGroup>
+          </template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      // the SSR close marker is the list anchor; no extra `<!--for-->`
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><!--]--><!--slot--><li>tail</li>`,
+      )
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><li>3</li><!--]--><!--slot--><li>tail updated</li>`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
     // #15372
     test('should drop comment children to stay in sync with SSR output', async () => {
       const data = ref({

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -537,15 +537,16 @@ export const createFor = (
           if (nextNode) setCurrentHydrationNode(nextNode)
         }
 
+        // special handling transition-group + v-for, without <!--]--> marker
         const container = markerlessHydrationContainer
-        const ref = newLength ? nextNode : currentHydrationNode
+        const curNode = newLength ? nextNode : currentHydrationNode
         if (
           container &&
           (hydrationStart === container ||
             hydrationStart.parentNode === container) &&
           // slot content keeps its own markers unless it is a single
           // fragment; a close marker right after the rows is then ours
-          !(ref && isComment(ref, ']'))
+          !(curNode && isComment(curNode, ']'))
         ) {
           // a direct child of a container rendered without fragment markers
           parentAnchor = claimAnchor(
@@ -553,8 +554,8 @@ export const createFor = (
           )
           container.insertBefore(
             parentAnchor,
-            ref && ref !== container && ref.parentNode === container
-              ? ref
+            curNode && curNode !== container && curNode.parentNode === container
+              ? curNode
               : null,
           )
           pendingHydrationAnchor = true

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -55,6 +55,7 @@ import {
   isComment,
   isHydrating,
   locateHydrationBoundaryClose,
+  markerlessHydrationContainer,
   nextLogicalSibling,
   setCurrentHydrationNode,
 } from './dom/hydration'
@@ -88,19 +89,6 @@ type ResolvedSource = {
   needsWrap: boolean
   isReadonlySource: boolean
   keys?: string[]
-}
-
-type ForHydrationAnchorResolver = (
-  hydrationStart: Node,
-  anchorNode: Node | null | undefined,
-) => Node | undefined
-
-let resolveForHydrationAnchor: ForHydrationAnchorResolver | undefined
-
-export function setForHydrationAnchorResolver(
-  resolver: ForHydrationAnchorResolver,
-): void {
-  resolveForHydrationAnchor = resolver
 }
 
 export const createFor = (
@@ -549,15 +537,26 @@ export const createFor = (
           if (nextNode) setCurrentHydrationNode(nextNode)
         }
 
-        // special handling transition-group + v-for, without <!--]--> marker
-        const resolvedAnchor =
-          resolveForHydrationAnchor &&
-          resolveForHydrationAnchor(
-            hydrationStart,
-            newLength ? nextNode : currentHydrationNode,
+        const container = markerlessHydrationContainer
+        const ref = newLength ? nextNode : currentHydrationNode
+        if (
+          container &&
+          (hydrationStart === container ||
+            hydrationStart.parentNode === container) &&
+          // slot content keeps its own markers unless it is a single
+          // fragment; a close marker right after the rows is then ours
+          !(ref && isComment(ref, ']'))
+        ) {
+          // a direct child of a container rendered without fragment markers
+          parentAnchor = claimAnchor(
+            __DEV__ ? createComment('for') : createTextNode(),
           )
-        if (resolvedAnchor) {
-          parentAnchor = resolvedAnchor
+          container.insertBefore(
+            parentAnchor,
+            ref && ref !== container && ref.parentNode === container
+              ? ref
+              : null,
+          )
           pendingHydrationAnchor = true
         } else if (slotFallbackRange && !isValidSlot(newBlocks)) {
           // Slot fallback can fall through an empty/invalid `v-for`. In that

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -47,8 +47,7 @@ import {
   isVaporComponent,
 } from '../component'
 import { type RawProps, resolveDynamicProps } from '../componentProps'
-import { setForHydrationAnchorResolver } from '../apiCreateFor'
-import { createComment, createElement, createTextNode } from '../dom/node'
+import { createElement } from '../dom/node'
 import {
   DynamicFragment,
   type VaporFragment,
@@ -63,12 +62,12 @@ import {
 import { EffectFlags, ReactiveEffect } from '@vue/reactivity'
 import {
   adoptTemplate,
-  claimAnchor,
   cleanupHydrationTail,
   currentHydrationNode,
   isHydrating,
   nextLogicalSibling,
   setCurrentHydrationNode,
+  setMarkerlessHydrationContainer,
 } from '../dom/hydration'
 import { isTransitionEnabled, registerTransitionHooks } from '../transition'
 import { isInteropEnabled } from '../vdomInteropState'
@@ -89,36 +88,6 @@ const transitionGroupUpdateOwnerMap = new WeakMap<
   TransitionGroupUpdateOwner,
   TransitionGroupUpdateHookRef
 >()
-
-let isForHydrationAnchorResolverRegistered = false
-let currentForHydrationContainer: ParentNode | undefined
-
-function ensureForHydrationAnchorResolver(): void {
-  if (isForHydrationAnchorResolverRegistered) return
-  isForHydrationAnchorResolverRegistered = true
-  setForHydrationAnchorResolver((hydrationStart, anchorNode) => {
-    const container = currentForHydrationContainer
-    if (!container) return
-    if (
-      hydrationStart !== container &&
-      hydrationStart.parentNode !== container
-    ) {
-      return
-    }
-
-    const anchor =
-      anchorNode &&
-      anchorNode !== container &&
-      anchorNode.parentNode === container
-        ? anchorNode
-        : null
-    const parentAnchor = claimAnchor(
-      __DEV__ ? createComment('for') : createTextNode(),
-    )
-    container.insertBefore(parentAnchor, anchor)
-    return parentAnchor
-  })
-}
 
 const decorate = <T extends VaporComponentOptions>(t: T): T => {
   delete (t.props! as any).mode
@@ -286,13 +255,11 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
           : createElement(tag)
         : undefined
       let nextNode: Node | null = null
-      let prevForHydrationContainer: ParentNode | undefined
+      let prevMarkerlessContainer: ParentNode | null = null
       if (isHydrating && container) {
-        // `transition-group + v-for` SSR output does not include `<!--]-->`.
-        // Expose the container so `v-for` hydration can create its own anchor.
-        ensureForHydrationAnchorResolver()
-        prevForHydrationContainer = currentForHydrationContainer
-        currentForHydrationContainer = container
+        // SSR flattens the children into the container without fragment
+        // markers; the cursor sits on the container itself when it is empty.
+        prevMarkerlessContainer = setMarkerlessHydrationContainer(container)
         nextNode = nextLogicalSibling(container)
         setCurrentHydrationNode(container.firstChild || container)
       }
@@ -327,7 +294,7 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
         }
       } finally {
         if (isHydrating && container) {
-          currentForHydrationContainer = prevForHydrationContainer
+          setMarkerlessHydrationContainer(prevMarkerlessContainer)
           setCurrentHydrationNode(nextNode)
         }
       }

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -239,6 +239,21 @@ type CommentAnchor = Comment & Anchor
 export const isComment = (node: Node, data: string): node is CommentAnchor =>
   node.nodeType === 8 && (node as Comment).data === data
 
+// Element whose direct children were server-rendered without fragment
+// markers (TransitionGroup flattens them): a list hydrating in it has no
+// close marker of its own unless the slot content kept one.
+export let markerlessHydrationContainer: ParentNode | null = null
+
+export function setMarkerlessHydrationContainer(
+  container: ParentNode | null,
+): ParentNode | null {
+  try {
+    return markerlessHydrationContainer
+  } finally {
+    markerlessHydrationContainer = container
+  }
+}
+
 export function setCurrentHydrationNode(node: Node | null): void {
   currentHydrationNode = skipUntrackedAnchors(node)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hydration for `TransitionGroup` lists with trailing sibling content.
  - Prevented unnecessary fragment markers from being emitted during hydration.
  - Eliminated hydration mismatch warnings when hydrated lists and adjacent content update.

- **Tests**
  - Added coverage for `TransitionGroup` hydration with tagged groups, `v-for` content, and trailing siblings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->