### PR TITLE
fix(runtime-dom): normalize class/style bound with the .attr modifier

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -275,6 +275,16 @@ describe('runtime-dom: props patching', () => {
     expect(el.getAttribute('x')).toBe('2')
   })
 
+  test('force patch as attribute still normalizes class and style', () => {
+    const el = document.createElement('div')
+    patchProp(el, '^class', null, { foo: true, bar: false })
+    expect(el.className).toBe('foo')
+    patchProp(el, '^class', null, ['foo', 'bar'])
+    expect(el.className).toBe('foo bar')
+    patchProp(el, '^style', null, { fontSize: '12px' })
+    expect(el.style.fontSize).toBe('12px')
+  })
+
   test('input with size (number property)', () => {
     const el = document.createElement('input')
     patchProp(el, 'size', null, 100)

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -9,6 +9,8 @@ import {
   isModelListener,
   isOn,
   isString,
+  normalizeClass,
+  normalizeStyle,
 } from '@vue/shared'
 import type { RendererOptions } from '@vue/runtime-core'
 import type { VueElement } from './apiCustomElement'
@@ -31,6 +33,18 @@ export const patchProp: DOMRendererOptions['patchProp'] = (
   parentComponent,
 ) => {
   const isSVG = namespace === 'svg'
+  // `class` and `style` are attributes already, so `.attr` only has to strip
+  // the modifier. createVNode normalizes `class`/`style` only, so the raw
+  // value still has to be normalized here - `ssrRenderAttrs` does the same by
+  // routing `^class`/`^style` through ssrRenderClass/ssrRenderStyle.
+  if (
+    key.charCodeAt(0) === 94 /* ^ */ &&
+    (key === '^class' || key === '^style')
+  ) {
+    key = key.slice(1)
+    nextValue =
+      key === 'class' ? normalizeClass(nextValue) : normalizeStyle(nextValue)
+  }
   if (key === 'class') {
     patchClass(el, nextValue, isSVG)
   } else if (key === 'style') {


### PR DESCRIPTION
`createVNode` normalizes `props.class` / `props.style` only, and `patchProp` dispatches on the raw key, so a `class`/`style` binding carrying `.attr` reaches `setAttribute` un-normalized.

`ssrRenderAttrs` strips `^` *before* its `class`/`style` branches ([c2f5964](https://github.com/vuejs/core/commit/c2f5964c), fix #14262); `patchProp` strips it *after*. SSR and the client disagree:

```js
h('div', { '^class': { a: true, b: false } })
// SSR <div class="a">   client <div class="[object Object]">
h('div', { '^class': ['a', 'b'] })
// SSR <div class="a b"> client <div class="a,b">
h('div', { '^style': { fontSize: '12px' } })
// SSR <div style="font-size:12px;"> client <div style="[object Object]">
```

Same vnode, one process. Controls in the same run: plain `class` and `^title` already match. After the fix all three match SSR; `^style` keeps only the CSSOM whitespace difference plain `style` has too. That commit's only test uses `'^attr': 'attr'`, never class/style.

Perf, measured: 2M `patchProp` calls per run, 9 interleaved runs per variant, one process. Baseline median 714.4 ms, with guard 710.7 — inside the 19.0 ms spread, so noise. A deliberately expensive guard, as control, moved the same harness +347.9 ms (+48.7%), so it resolves real cost.

Reverting only `patchProp.ts` fails the new test and nothing else (26/27). Stripping the modifier without normalizing fails identically, so both halves are load-bearing. 3687 passing.

🤖 Written with Claude Code (claude-opus-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed forced attribute updates for `class` and `style` so values are normalized consistently.
  - Object and array class values now produce the expected class output when using forced attribute patching.
  - Object-based style values, such as font sizes, are now applied correctly in this mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->