### PR TITLE
fix(runtime-vapor): resolve hydration anchors by SSR fragment range ownership

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -403,7 +403,7 @@ export function render(_ctx) {
       return n6
     }, 266 /* TRUE_MULTI_ROOT, FALSE_MULTI_ROOT, KEYED_INDEX_0 */)
     return n2
-  }, undefined, 16 /* IS_FRAGMENT */)
+  }, undefined, 80 /* IS_FRAGMENT, WRAPPED_ROWS */)
   return n0
 }"
 `;
@@ -439,7 +439,7 @@ export function render(_ctx) {
       return n4
     }, undefined, 8 /* IS_SINGLE_NODE */)
     return n2
-  }, undefined, 16 /* IS_FRAGMENT */)
+  }, undefined, 80 /* IS_FRAGMENT, WRAPPED_ROWS */)
   return n0
 }"
 `;
@@ -477,7 +477,7 @@ export function render(_ctx) {
       _setText(x3, _toDisplayString(_item))
     })
     return [n2, n3]
-  })
+  }, undefined, 64 /* WRAPPED_ROWS */)
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
@@ -521,7 +521,7 @@ describe('compiler: v-for', () => {
     )
     expect(code).matchSnapshot()
     expect(code).toContain(
-      `}, undefined, ${VaporVForFlags.IS_FRAGMENT} /* IS_FRAGMENT */)`,
+      `}, undefined, ${VaporVForFlags.IS_FRAGMENT | VaporVForFlags.WRAPPED_ROWS} /* IS_FRAGMENT, WRAPPED_ROWS */)`,
     )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).component,
@@ -540,7 +540,7 @@ describe('compiler: v-for', () => {
     )
     expect(code).matchSnapshot()
     expect(code).toContain(
-      `}, undefined, ${VaporVForFlags.IS_FRAGMENT} /* IS_FRAGMENT */)`,
+      `}, undefined, ${VaporVForFlags.IS_FRAGMENT | VaporVForFlags.WRAPPED_ROWS} /* IS_FRAGMENT, WRAPPED_ROWS */)`,
     )
     expect(
       (ir.block.dynamic.children[0].operation as ForIRNode).render.dynamic

--- a/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vFor.spec.ts
@@ -550,6 +550,13 @@ describe('compiler: v-for', () => {
     })
   })
 
+  test('v-for on template under a transition group has no wrapped rows', () => {
+    const { code } = compileWithVFor(
+      `<TransitionGroup tag="ul"><template v-for="item in items"><li>{{ item }}</li><li>b</li></template></TransitionGroup>`,
+    )
+    expect(code).not.toContain('WRAPPED_ROWS')
+  })
+
   test('v-for on template with keyed child marks fragment block', () => {
     const { code, ir } = compileWithVFor(
       `<template v-for="item in items"><div :key="item.id">{{ item.text }}</div></template>`,

--- a/packages/compiler-vapor/src/generators/for.ts
+++ b/packages/compiler-vapor/src/generators/for.ts
@@ -46,6 +46,7 @@ export function genFor(
     component,
     onlyChild,
     slotRoot,
+    wrappedRows,
   } = oper
 
   const rawValue = value && value.content
@@ -149,6 +150,7 @@ export function genFor(
     !component && isSingleNodeBlock(render),
     once,
     slotRoot,
+    wrappedRows,
   )
 
   const onResetCalls: CodeFragment[] = []
@@ -205,6 +207,7 @@ function genForFlags(
   isSingleNode: boolean,
   once: boolean | undefined,
   slotRoot: boolean | undefined,
+  wrappedRows: boolean,
 ): string | undefined {
   let flags = 0
   const names: string[] = []
@@ -232,6 +235,10 @@ function genForFlags(
   if (slotRoot) {
     flags |= VaporVForFlags.SLOT_ROOT
     names.push('SLOT_ROOT')
+  }
+  if (wrappedRows) {
+    flags |= VaporVForFlags.WRAPPED_ROWS
+    names.push('WRAPPED_ROWS')
   }
 
   if (!flags) {

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -126,6 +126,7 @@ export interface ForIRNode
   slotRoot?: boolean
   component: boolean
   onlyChild: boolean
+  wrappedRows: boolean
 }
 
 export interface KeyIRNode extends BaseIRNode, EffectBoundary, InsertionState {

--- a/packages/compiler-vapor/src/transforms/vFor.ts
+++ b/packages/compiler-vapor/src/transforms/vFor.ts
@@ -21,8 +21,7 @@ import {
   findDir,
   findProp,
   isStaticExpression,
-  isTransitionGroupNode,
-  isTransitionNode,
+  isTransitionHostNode,
   propToExpression,
 } from '../utils'
 import { newBlock, wrapTemplate } from './utils'
@@ -61,19 +60,15 @@ export function processFor(
     isTemplateWithSingleComponent(node)
   // mirrors compiler-ssr: a template row that is not a single element renders
   // as a fragment, except under Transition/TransitionGroup, whose children
-  // render without nested fragment markers. A structural directive on the
-  // child turns it into an if/for node by the time SSR decides, so it counts.
+  // render without nested fragment markers. A v-if or v-for on the child
+  // turns it into an if/for node by the time SSR decides, so it counts.
   const parentNode = context.parent && context.parent.node
   const wrappedRows =
     node.tagType === ElementTypes.TEMPLATE &&
-    !(
-      parentNode &&
-      (isTransitionNode(parentNode as ElementNode) ||
-        isTransitionGroupNode(parentNode as ElementNode))
-    ) &&
+    !(parentNode && isTransitionHostNode(parentNode)) &&
     (node.children.length !== 1 ||
       node.children[0].type !== NodeTypes.ELEMENT ||
-      !!findDir(node.children[0], /^(?:if|else(?:-if)?|for)$/, true))
+      !!findDir(node.children[0], ROW_FRAGMENT_DIR_RE))
   context.node = node = wrapTemplate(node, ['for', 'key'])
   context.dynamic.flags |= DynamicFlag.NON_TEMPLATE | DynamicFlag.INSERT
   const id = context.reference()
@@ -115,6 +110,8 @@ export function processFor(
     }
   }
 }
+
+const ROW_FRAGMENT_DIR_RE = /^(?:if|for)$/
 
 function isTemplateWithSingleComponent(node: ElementNode): boolean {
   if (node.tag !== 'template') return false

--- a/packages/compiler-vapor/src/transforms/vFor.ts
+++ b/packages/compiler-vapor/src/transforms/vFor.ts
@@ -17,7 +17,14 @@ import {
   IRNodeTypes,
   type VaporDirectiveNode,
 } from '../ir'
-import { findProp, isStaticExpression, propToExpression } from '../utils'
+import {
+  findDir,
+  findProp,
+  isStaticExpression,
+  isTransitionGroupNode,
+  isTransitionNode,
+  propToExpression,
+} from '../utils'
 import { newBlock, wrapTemplate } from './utils'
 
 export const transformVFor: NodeTransform = createStructuralDirectiveTransform(
@@ -52,24 +59,21 @@ export function processFor(
     node.tagType === ElementTypes.COMPONENT ||
     // template v-for with a single component child
     isTemplateWithSingleComponent(node)
-  // mirrors compiler-ssr: a row that is not a single element renders as a
-  // fragment. Structural directives on a template child turn it into an
-  // if/for node by the time SSR decides, so they count here as well.
-  const rowChildren =
-    node.tagType === ElementTypes.TEMPLATE ? node.children : [node]
-  const rowChild = rowChildren[0]
+  // mirrors compiler-ssr: a template row that is not a single element renders
+  // as a fragment, except under Transition/TransitionGroup, whose children
+  // render without nested fragment markers. A structural directive on the
+  // child turns it into an if/for node by the time SSR decides, so it counts.
+  const parentNode = context.parent && context.parent.node
   const wrappedRows =
-    rowChildren.length !== 1 ||
-    rowChild.type !== NodeTypes.ELEMENT ||
-    (rowChild !== node &&
-      rowChild.props.some(
-        p =>
-          p.type === NodeTypes.DIRECTIVE &&
-          (p.name === 'if' ||
-            p.name === 'else-if' ||
-            p.name === 'else' ||
-            p.name === 'for'),
-      ))
+    node.tagType === ElementTypes.TEMPLATE &&
+    !(
+      parentNode &&
+      (isTransitionNode(parentNode as ElementNode) ||
+        isTransitionGroupNode(parentNode as ElementNode))
+    ) &&
+    (node.children.length !== 1 ||
+      node.children[0].type !== NodeTypes.ELEMENT ||
+      !!findDir(node.children[0], /^(?:if|else(?:-if)?|for)$/, true))
   context.node = node = wrapTemplate(node, ['for', 'key'])
   context.dynamic.flags |= DynamicFlag.NON_TEMPLATE | DynamicFlag.INSERT
   const id = context.reference()

--- a/packages/compiler-vapor/src/transforms/vFor.ts
+++ b/packages/compiler-vapor/src/transforms/vFor.ts
@@ -52,6 +52,24 @@ export function processFor(
     node.tagType === ElementTypes.COMPONENT ||
     // template v-for with a single component child
     isTemplateWithSingleComponent(node)
+  // mirrors compiler-ssr: a row that is not a single element renders as a
+  // fragment. Structural directives on a template child turn it into an
+  // if/for node by the time SSR decides, so they count here as well.
+  const rowChildren =
+    node.tagType === ElementTypes.TEMPLATE ? node.children : [node]
+  const rowChild = rowChildren[0]
+  const wrappedRows =
+    rowChildren.length !== 1 ||
+    rowChild.type !== NodeTypes.ELEMENT ||
+    (rowChild !== node &&
+      rowChild.props.some(
+        p =>
+          p.type === NodeTypes.DIRECTIVE &&
+          (p.name === 'if' ||
+            p.name === 'else-if' ||
+            p.name === 'else' ||
+            p.name === 'for'),
+      ))
   context.node = node = wrapTemplate(node, ['for', 'key'])
   context.dynamic.flags |= DynamicFlag.NON_TEMPLATE | DynamicFlag.INSERT
   const id = context.reference()
@@ -89,6 +107,7 @@ export function processFor(
         ),
       component: isComponent,
       onlyChild: !!isOnlyChild,
+      wrappedRows,
     }
   }
 }

--- a/packages/compiler-vapor/src/transforms/vSlot.ts
+++ b/packages/compiler-vapor/src/transforms/vSlot.ts
@@ -26,8 +26,7 @@ import {
 import {
   findDir,
   findProp,
-  isTransitionGroupNode,
-  isTransitionNode,
+  isTransitionHostNode,
   propToExpression,
   resolveExpression,
 } from '../utils'
@@ -79,7 +78,7 @@ function transformComponentSlot(
   // Transition/TransitionGroup filter out comment children at runtime in
   // vdom mode and SSR omits them (#5351, #11961), so drop them here to keep
   // client render and hydration in sync with the server output (#15372)
-  const isTransitionHost = isTransitionNode(node) || isTransitionGroupNode(node)
+  const isTransitionHost = isTransitionHostNode(node)
 
   // whitespace: 'preserve'
   const emptyTextNodes: TemplateChildNode[] = []

--- a/packages/compiler-vapor/src/utils.ts
+++ b/packages/compiler-vapor/src/utils.ts
@@ -5,6 +5,7 @@ import {
   BindingTypes,
   type ElementNode,
   NodeTypes,
+  type RootNode,
   type SimpleExpressionNode,
   findDir as _findDir,
   findProp as _findProp,
@@ -124,6 +125,14 @@ export function isInTransition(
 
 export function isTransitionNode(node: ElementNode): boolean {
   return node.type === NodeTypes.ELEMENT && isTransitionTag(node.tag)
+}
+
+/** Transition or TransitionGroup: hosts whose children render specially. */
+export function isTransitionHostNode(node: RootNode | ElementNode): boolean {
+  return (
+    node.type === NodeTypes.ELEMENT &&
+    (isTransitionTag(node.tag) || isTransitionGroupTag(node.tag))
+  )
 }
 
 export function isTransitionGroupNode(node: ElementNode): boolean {

--- a/packages/runtime-vapor/__tests__/hydration/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/for.spec.ts
@@ -416,6 +416,35 @@ describe('Vapor Mode hydration', () => {
       ).not.toHaveBeenWarned()
     })
 
+    test('rows that are nested lists', async () => {
+      const data = ref({ groups: [[1, 2], [3]] })
+      const { container } = await testHydration(
+        `<template>
+          <ul>
+            <template v-for="group in data.groups" :key="group[0]">
+              <li v-for="item in group" :key="item">{{ item }}</li>
+            </template>
+          </ul>
+        </template>`,
+        {},
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><!--[--><li>1</li><li>2</li><!--]--><!--]--><!--[--><!--[--><li>3</li><!--]--><!--]--><!--]-->`,
+      )
+      data.value.groups[0].push(9)
+      data.value.groups.push([4])
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><!--[--><li>1</li><li>2</li><li>9</li><!--]--><!--]--><!--[--><!--[--><li>3</li><!--]--><!--]--><li>4</li><!--for--><!--]-->`,
+      )
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
     test('with non-hydration node', async () => {
       const data = ref({ show: true, msg: 'foo' })
       const { container } = await testHydration(

--- a/packages/runtime-vapor/__tests__/hydration/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/for.spec.ts
@@ -385,6 +385,37 @@ describe('Vapor Mode hydration', () => {
       `)
     })
 
+    test('multi-root v-if as a keyed template row', async () => {
+      const data = ref({ items: [1, 2], show: true })
+      const { container } = await testHydration(
+        `<template>
+          <ul>
+            <template v-for="item in data.items" :key="item">
+              <template v-if="data.show">
+                <li>{{ item }}a</li>
+                <li>{{ item }}b</li>
+              </template>
+            </template>
+          </ul>
+        </template>`,
+        {},
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><!--[--><li>1a</li><li>1b</li><!--]--><!--]--><!--[--><!--[--><li>2a</li><li>2b</li><!--]--><!--]--><!--]-->`,
+      )
+      data.value.show = false
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><!--[--><!--]--><!--]--><!--[--><!--[--><!--]--><!--]--><!--]-->`,
+      )
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
     test('with non-hydration node', async () => {
       const data = ref({ show: true, msg: 'foo' })
       const { container } = await testHydration(

--- a/packages/runtime-vapor/__tests__/hydration/slotsForwarded.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/slotsForwarded.spec.ts
@@ -1,4 +1,4 @@
-import { nextTick, reactive } from '@vue/runtime-dom'
+import { nextTick, reactive, ref } from '@vue/runtime-dom'
 import {
   formatHtml,
   setupHydrationTest,
@@ -156,6 +156,35 @@ describe('Vapor Mode hydration', () => {
         expect(container.textContent).toBe('content')
       },
     )
+
+    test('forwarded slot with inherited fallback keeps mixed content in order', async () => {
+      const data = ref({ items: [1, 2], tail: 'tail' })
+      const { container } = await testHydration(
+        `<template>
+          <components.Outer>
+            <li v-for="item in data.items" :key="item">{{ item }}</li>
+            <li key="tail">{{ data.tail }}</li>
+          </components.Outer>
+        </template>`,
+        {
+          Outer: `<template><components.Inner><slot /></components.Inner></template>`,
+          Inner: `<template><ul><slot><li>empty</li></slot></ul></template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--]--><!--]-->`,
+      )
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--]--><!--]-->`,
+      )
+      expect(`Hydration text mismatch`).not.toHaveBeenWarned()
+      expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    })
 
     test('forwarded keyed root slot tracks fallback across hydration and key updates', async () => {
       const data = reactive({ show: false, key: 0 })

--- a/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
@@ -739,6 +739,64 @@ describe('Vapor Mode hydration', () => {
       ).not.toHaveBeenWarned()
     })
 
+    test('with tag should anchor the slot inside the container under an outer slot', async () => {
+      const data = ref({ items: [1, 2] })
+      const { container } = await testHydration(
+        `<template>
+          <components.Wrapper>
+            <components.Child>
+              <li v-for="item in data.items" :key="item">{{ item }}</li>
+            </components.Child>
+          </components.Wrapper>
+        </template>`,
+        {
+          Wrapper: `<template><div><slot /></div></template>`,
+          Child: `<template>
+            <TransitionGroup :css="false" tag="ul"><slot /></TransitionGroup>
+          </template>`,
+        },
+        data,
+      )
+      const div = container.querySelector('div')!
+      expect(div.innerHTML).toBe(
+        `<!--[--><ul css="false"><li>1</li><li>2</li><!--for--><!--slot--></ul><!--transition-group--><!--]-->`,
+      )
+      data.value.items.push(3)
+      await nextTick()
+      expect(div.innerHTML).toBe(
+        `<!--[--><ul css="false"><li>1</li><li>2</li><li>3</li><!--for--><!--slot--></ul><!--transition-group--><!--]-->`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should reuse the placeholder of an empty slot list', async () => {
+      const data = ref({ items: [] as number[] })
+      const { container } = await testHydration(
+        `<template>
+          <components.Child>
+            <li v-for="item in data.items" :key="item">{{ item }}</li>
+          </components.Child>
+        </template>`,
+        {
+          Child: `<template>
+            <TransitionGroup :css="false" tag="ul"><slot /></TransitionGroup>
+          </template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(`<!----><!--slot-->`)
+      data.value.items.push(3)
+      await nextTick()
+      expect(ul.innerHTML).toBe(`<li>3</li><!----><!--slot-->`)
+      expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
     // #15372
     test('should drop comment children to stay in sync with SSR output', async () => {
       const data = ref({

--- a/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
@@ -495,15 +495,211 @@ describe('Vapor Mode hydration', () => {
         data,
       )
       const ul = container.querySelector('ul')!
-      // the SSR close marker is the list anchor; no extra `<!--for-->`
+      // the SSR close marker is the list anchor (no extra `<!--for-->`), and
+      // the slot anchor follows all of the slot content
       expect(ul.innerHTML).toBe(
-        `<!--[--><li>1</li><li>2</li><!--]--><!--slot--><li>tail</li>`,
+        `<!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--slot-->`,
       )
       data.value.items.push(3)
       data.value.tail = 'tail updated'
       await nextTick()
       expect(ul.innerHTML).toBe(
-        `<!--[--><li>1</li><li>2</li><li>3</li><!--]--><!--slot--><li>tail updated</li>`,
+        `<!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--slot-->`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should keep the forwarded slot anchors after mixed slot content', async () => {
+      const data = ref({
+        items: [1, 2],
+        tail: 'tail',
+      })
+      const { container } = await testHydration(
+        `<template>
+          <components.Outer>
+            <li v-for="item in data.items" :key="item">{{ item }}</li>
+            <li key="tail">{{ data.tail }}</li>
+          </components.Outer>
+        </template>`,
+        {
+          Outer: `<template><components.Inner><slot /></components.Inner></template>`,
+          Inner: `<template>
+            <TransitionGroup :css="false" tag="ul"><slot /></TransitionGroup>
+          </template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--slot--><!--slot-->`,
+      )
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--slot--><!--slot-->`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should keep the forwarded slot anchors after mixed slot content with an inherited fallback', async () => {
+      const data = ref({
+        items: [1, 2],
+        tail: 'tail',
+      })
+      const { container } = await testHydration(
+        `<template>
+          <components.Outer>
+            <li v-for="item in data.items" :key="item">{{ item }}</li>
+            <li key="tail">{{ data.tail }}</li>
+          </components.Outer>
+        </template>`,
+        {
+          Outer: `<template><components.Inner><slot /></components.Inner></template>`,
+          Inner: `<template>
+            <TransitionGroup :css="false" tag="ul">
+              <slot><li>empty</li></slot>
+            </TransitionGroup>
+          </template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--slot--><!--slot-->`,
+      )
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--slot--><!--slot-->`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should reuse the markers a forwarded slot kept', async () => {
+      const data = ref({
+        items: [1, 2],
+        tail: 'tail',
+      })
+      const { container } = await testHydration(
+        `<template>
+          <components.Outer>
+            <li v-for="item in data.items" :key="item">{{ item }}</li>
+            <li key="tail">{{ data.tail }}</li>
+          </components.Outer>
+        </template>`,
+        {
+          // the sibling after the outlet keeps the outlet's own SSR markers
+          Outer: `<template>
+            <components.Inner><slot /><li key="last">last</li></components.Inner>
+          </template>`,
+          Inner: `<template>
+            <TransitionGroup :css="false" tag="ul"><slot /></TransitionGroup>
+          </template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--]--><!--slot--><li>last</li>`,
+      )
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--]--><!--slot--><li>last</li>`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should hydrate a multi-root v-if branch without markers', async () => {
+      const data = ref({ show: true, tail: 'tail' })
+      const { container } = await testHydration(
+        `<template>
+          <TransitionGroup :css="false" tag="ul">
+            <template v-if="data.show">
+              <li key="a">a</li>
+              <li key="b">b</li>
+            </template>
+            <li key="tail">{{ data.tail }}</li>
+          </TransitionGroup>
+        </template>`,
+        {},
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(`<li>a</li><li>b</li><!--if--><li>tail</li>`)
+      data.value.show = false
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(`<!--if--><li>tail updated</li>`)
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should hydrate a multi-root v-if branch that starts with a list', async () => {
+      const data = ref({ show: true, items: [1, 2], tail: 'tail' })
+      const { container } = await testHydration(
+        `<template>
+          <TransitionGroup :css="false" tag="ul">
+            <template v-if="data.show">
+              <li v-for="item in data.items" :key="item">{{ item }}</li>
+              <li key="tail">{{ data.tail }}</li>
+            </template>
+          </TransitionGroup>
+        </template>`,
+        {},
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--if-->`,
+      )
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--if-->`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should hydrate rows that are lists', async () => {
+      const data = ref({ groups: [[1, 2], [3]], tail: 'tail' })
+      const { container } = await testHydration(
+        `<template>
+          <TransitionGroup :css="false" tag="ul">
+            <template v-for="group in data.groups" :key="group[0]">
+              <li v-for="item in group" :key="item">{{ item }}</li>
+            </template>
+            <li key="tail">{{ data.tail }}</li>
+          </TransitionGroup>
+        </template>`,
+        {},
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><!--]--><!--[--><li>3</li><!--]--><!--for--><li>tail</li>`,
+      )
+      data.value.groups[0].push(9)
+      data.value.groups.push([4])
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><li>1</li><li>2</li><li>9</li><!--]--><!--[--><li>3</li><!--]--><li>4</li><!--for--><!--for--><li>tail updated</li>`,
       )
       expect(
         `Hydration completed but contains mismatches.`,

--- a/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/transition.spec.ts
@@ -608,13 +608,13 @@ describe('Vapor Mode hydration', () => {
       )
       const ul = container.querySelector('ul')!
       expect(ul.innerHTML).toBe(
-        `<!--[--><!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--]--><!--slot--><li>last</li>`,
+        `<!--[--><!--[--><li>1</li><li>2</li><!--]--><li>tail</li><!--]--><li>last</li><!--slot-->`,
       )
       data.value.items.push(3)
       data.value.tail = 'tail updated'
       await nextTick()
       expect(ul.innerHTML).toBe(
-        `<!--[--><!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--]--><!--slot--><li>last</li>`,
+        `<!--[--><!--[--><li>1</li><li>2</li><li>3</li><!--]--><li>tail updated</li><!--]--><li>last</li><!--slot-->`,
       )
       expect(
         `Hydration completed but contains mismatches.`,
@@ -700,6 +700,39 @@ describe('Vapor Mode hydration', () => {
       await nextTick()
       expect(ul.innerHTML).toBe(
         `<!--[--><li>1</li><li>2</li><li>9</li><!--]--><!--[--><li>3</li><!--]--><li>4</li><!--for--><!--for--><li>tail updated</li>`,
+      )
+      expect(
+        `Hydration completed but contains mismatches.`,
+      ).not.toHaveBeenWarned()
+    })
+
+    test('with tag should hydrate slot rows the server wrapped', async () => {
+      const data = ref({ items: [1, 2], show: true, tail: 'tail' })
+      const { container } = await testHydration(
+        `<template>
+          <components.Child>
+            <template v-for="item in data.items" :key="item">
+              <template v-if="data.show"><li>{{ item }}</li></template>
+            </template>
+            <li key="tail">{{ data.tail }}</li>
+          </components.Child>
+        </template>`,
+        {
+          Child: `<template>
+            <TransitionGroup :css="false" tag="ul"><slot /></TransitionGroup>
+          </template>`,
+        },
+        data,
+      )
+      const ul = container.querySelector('ul')!
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><li>1</li><!--if--><!--]--><!--[--><li>2</li><!--if--><!--]--><!--]--><li>tail</li><!--slot-->`,
+      )
+      data.value.items.push(3)
+      data.value.tail = 'tail updated'
+      await nextTick()
+      expect(ul.innerHTML).toBe(
+        `<!--[--><!--[--><li>1</li><!--if--><!--]--><!--[--><li>2</li><!--if--><!--]--><li>3</li><!--if--><!--]--><li>tail updated</li><!--slot-->`,
       )
       expect(
         `Hydration completed but contains mismatches.`,

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -134,7 +134,9 @@ export function createDynamicComponent(
           owner && (() => resolveFallthroughAttrs(owner)),
         )
         if (isHydrating) {
-          locateHydrationNode(shouldConsumeFragmentStart(value))
+          locateHydrationNode(
+            shouldConsumeFragmentStart(value) ? { start: null } : undefined,
+          )
           frag.hydrate()
         }
         return frag

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -33,6 +33,7 @@ import {
 import {
   type HydrationCursor,
   captureHydrationCursor,
+  createFragmentClaim,
   isHydrating,
   locateHydrationNode,
 } from './dom/hydration'
@@ -135,7 +136,9 @@ export function createDynamicComponent(
         )
         if (isHydrating) {
           locateHydrationNode(
-            shouldConsumeFragmentStart(value) ? { start: null } : undefined,
+            shouldConsumeFragmentStart(value)
+              ? createFragmentClaim()
+              : undefined,
           )
           frag.hydrate()
         }

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -50,6 +50,7 @@ import {
   advanceHydrationNode,
   claimAnchor,
   claimUntrackedAnchor,
+  createFragmentClaim,
   currentHydrationNode,
   enterHydrationBoundary,
   enterHydrationCursor,
@@ -108,7 +109,7 @@ export const createFor = (
   let hydrationCursor: HydrationCursor | null = null
   let hydrationClaim: FragmentClaim | undefined
   if (isHydrating) {
-    hydrationClaim = { start: null }
+    hydrationClaim = createFragmentClaim()
     hydrationCursor = enterHydrationCursor(hydrationClaim)
   } else {
     resetInsertionState()
@@ -516,6 +517,12 @@ export const createFor = (
     const slotEndAnchor = getCurrentSlotEndAnchor()
     const slotFallbackRange = isPendingSlotContent() && slotEndAnchor
 
+    // claiming a close marker as the anchor also bounds the cleanup to it
+    const reuseBoundaryClose = (close: Node): void => {
+      parentAnchor = claimAnchor(close)
+      exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
+    }
+
     try {
       for (let i = 0; i < newLength; i++) {
         const node = currentHydrationNode!
@@ -524,7 +531,6 @@ export const createFor = (
         if (isComment(node, ']')) {
           // fewer server rows: the rest mount before the close marker
           nextNode = claimAnchor(node)
-          setCurrentHydrationNode(nextNode)
         } else if (wrappedRows && isComment(node, '[')) {
           // the row resumes after its wrapper's close marker
           nextNode = nextLogicalSibling(node)
@@ -536,8 +542,7 @@ export const createFor = (
 
       if (claim.start) {
         // the list owns its SSR range: its close marker is the anchor
-        parentAnchor = claimAnchor(locateClaimedEnd(claim.start)!)
-        exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
+        reuseBoundaryClose(locateClaimedEnd(claim.start)!)
 
         // optimization: cache the fragment end anchor as $llc (last logical child)
         // so that locateChildByLogicalIndex can skip the entire fragment.
@@ -612,13 +617,13 @@ export const createFor = (
       } else {
         // a marked list always finds its own range: only malformed server
         // output gets here. Adopt the cursor so prod keeps going.
-        parentAnchor = claimAnchor(currentHydrationNode!)
-        exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
-        if (__DEV__ && !isComment(parentAnchor, ']')) {
+        const close = currentHydrationNode!
+        if (__DEV__ && !isComment(close, ']')) {
           throw new Error(
             `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
           )
         }
+        reuseBoundaryClose(close)
       }
     } finally {
       exitHydrationBoundary && exitHydrationBoundary()

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -55,9 +55,9 @@ import {
   enterHydrationCursor,
   isComment,
   isHydrating,
+  locateEndAnchor,
   locateHydrationBoundaryClose,
   markerlessHydrationContainer,
-  nextLogicalSibling,
   setCurrentHydrationNode,
 } from './dom/hydration'
 import {
@@ -146,6 +146,7 @@ export const createFor = (
     !!(flags & VaporVForFlags.FAST_REMOVE) && !isComponent
   const isSingleNode = !!(flags & VaporVForFlags.IS_SINGLE_NODE)
   const isFragment = !!(flags & VaporVForFlags.IS_FRAGMENT)
+  const wrappedRows = !!(flags & VaporVForFlags.WRAPPED_ROWS)
 
   const slotOwner = currentSlotOwner
   const slotBoundary = currentSlotBoundary
@@ -517,23 +518,23 @@ export const createFor = (
 
     try {
       for (let i = 0; i < newLength; i++) {
-        const ownedStart = claim.start
-        if (isComment(currentHydrationNode!, ']')) {
-          nextNode = claimAnchor(currentHydrationNode!)
+        const node = currentHydrationNode!
+        if (isComment(node, ']')) {
+          // fewer server rows: the rest mount before the close marker
+          nextNode = claimAnchor(node)
           setCurrentHydrationNode(nextNode)
-        } else if (markerlessHydrationContainer && !ownedStart) {
-          // rows of a markerless list have no wrappers either: the row's
-          // own hydration decides where the next one starts
-          nextNode = null
+        } else if (wrappedRows && claim.start && isComment(node, '[')) {
+          // the row resumes after its wrapper's close marker; a markerless
+          // list loses its row wrappers along with its own markers
+          const rowEnd = locateEndAnchor(node)
+          setCurrentHydrationNode(node.nextSibling)
+          nextNode = rowEnd && rowEnd.nextSibling
         } else {
-          nextNode = nextLogicalSibling(currentHydrationNode!)
+          // an unwrapped row is a single node: its own hydration moves on
+          nextNode = null
         }
         mount(source, i, parentAnchor)
-        // the row's content took the opening marker over (see
-        // `FragmentClaim`): this list is markerless after all
-        if (nextNode && !(ownedStart && !claim.start)) {
-          setCurrentHydrationNode(nextNode)
-        }
+        if (nextNode) setCurrentHydrationNode(nextNode)
       }
 
       // special handling transition-group + v-for, without <!--]--> marker

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -57,6 +57,7 @@ import {
   isHydrating,
   locateEndAnchor,
   markerlessHydrationContainer,
+  nextLogicalSibling,
   setCurrentHydrationNode,
 } from './dom/hydration'
 import {
@@ -107,7 +108,8 @@ export const createFor = (
   let hydrationCursor: HydrationCursor | null = null
   let hydrationClaim: FragmentClaim | undefined
   if (isHydrating) {
-    hydrationCursor = enterHydrationCursor((hydrationClaim = { start: null }))
+    hydrationClaim = { start: null }
+    hydrationCursor = enterHydrationCursor(hydrationClaim)
   } else {
     resetInsertionState()
   }
@@ -511,26 +513,22 @@ export const createFor = (
     const hydrationStart = currentHydrationNode!
     const claim = hydrationClaim!
     let exitHydrationBoundary: (() => void) | undefined
-    let nextNode
     const slotEndAnchor = getCurrentSlotEndAnchor()
     const slotFallbackRange = isPendingSlotContent() && slotEndAnchor
 
     try {
       for (let i = 0; i < newLength; i++) {
         const node = currentHydrationNode!
+        // an unwrapped row is a single node: its own hydration moves on
+        let nextNode: Node | null = null
         if (isComment(node, ']')) {
           // fewer server rows: the rest mount before the close marker
           nextNode = claimAnchor(node)
           setCurrentHydrationNode(nextNode)
-        } else if (wrappedRows && claim.start && isComment(node, '[')) {
-          // the row resumes after its wrapper's close marker; a markerless
-          // list loses its row wrappers along with its own markers
-          const rowEnd = locateEndAnchor(node)
+        } else if (wrappedRows && isComment(node, '[')) {
+          // the row resumes after its wrapper's close marker
+          nextNode = nextLogicalSibling(node)
           setCurrentHydrationNode(node.nextSibling)
-          nextNode = rowEnd && rowEnd.nextSibling
-        } else {
-          // an unwrapped row is a single node: its own hydration moves on
-          nextNode = null
         }
         mount(source, i, parentAnchor)
         if (nextNode) setCurrentHydrationNode(nextNode)
@@ -612,7 +610,8 @@ export const createFor = (
           pendingHydrationAnchor = true
         }
       } else {
-        // mismatch recovery: nothing to reuse, adopt whatever the cursor sits on
+        // a marked list always finds its own range: only malformed server
+        // output gets here. Adopt the cursor so prod keeps going.
         parentAnchor = claimAnchor(currentHydrationNode!)
         exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
         if (__DEV__ && !isComment(parentAnchor, ']')) {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -56,7 +56,6 @@ import {
   isComment,
   isHydrating,
   locateEndAnchor,
-  locateHydrationBoundaryClose,
   markerlessHydrationContainer,
   setCurrentHydrationNode,
 } from './dom/hydration'
@@ -587,7 +586,8 @@ export const createFor = (
         if (!queued) queuePostFlushCb(attachAnchor)
       } else {
         parentAnchor = claimAnchor(
-          locateHydrationBoundaryClose(currentHydrationNode!),
+          (claim.start && locateEndAnchor(claim.start)) ||
+            currentHydrationNode!,
         )
         exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
         if (__DEV__ && !isComment(parentAnchor, ']')) {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -536,18 +536,27 @@ export const createFor = (
         if (nextNode) setCurrentHydrationNode(nextNode)
       }
 
-      // special handling transition-group + v-for, without <!--]--> marker
-      const container = markerlessHydrationContainer
-      if (container && !claim.start) {
-        const afterRows = currentHydrationNode
-        parentAnchor = claimAnchor(
-          __DEV__ ? createComment('for') : createTextNode(),
-        )
-        container.insertBefore(
-          parentAnchor,
-          afterRows && afterRows.parentNode === container ? afterRows : null,
-        )
-        pendingHydrationAnchor = true
+      if (claim.start) {
+        // the list owns its SSR range: its close marker is the anchor
+        parentAnchor = claimAnchor(locateEndAnchor(claim.start)!)
+        exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
+
+        // optimization: cache the fragment end anchor as $llc (last logical child)
+        // so that locateChildByLogicalIndex can skip the entire fragment.
+        // For anchored inserts, reuse the unit index the locator stamped on
+        // the anchor; if it is unstamped (reached via a cache-missed
+        // `next()`), leave `$llc` untouched — `0` is a valid unit index, so
+        // a fallback would alias a stale cache entry to "unit 0", while
+        // skipping the install only costs a restart walk.
+        if (_insertionParent) {
+          const idx = _insertionAnchor
+            ? (_insertionAnchor as any as ChildItem).$idx
+            : _insertionIndex || 0
+          if (idx !== undefined) {
+            ;(parentAnchor as any as ChildItem).$idx = idx
+            _insertionParent.$llc = parentAnchor
+          }
+        }
       } else if (slotFallbackRange && !isValidSlot(newBlocks)) {
         // Slot fallback can fall through an empty/invalid `v-for`. In that
         // case SSR only rendered the parent slot range, so this `v-for` has no
@@ -584,33 +593,32 @@ export const createFor = (
           onFallback: () => {},
         })
         if (!queued) queuePostFlushCb(attachAnchor)
+      } else if (markerlessHydrationContainer) {
+        // special handling transition-group + v-for, without <!--]--> marker
+        const afterRows = currentHydrationNode
+        if (!newLength && afterRows && isComment(afterRows, '')) {
+          // the server rendered the empty transition slot as a placeholder
+          parentAnchor = claimAnchor(afterRows)
+        } else {
+          parentAnchor = claimAnchor(
+            __DEV__ ? createComment('for') : createTextNode(),
+          )
+          markerlessHydrationContainer.insertBefore(
+            parentAnchor,
+            afterRows && afterRows.parentNode === markerlessHydrationContainer
+              ? afterRows
+              : null,
+          )
+          pendingHydrationAnchor = true
+        }
       } else {
-        parentAnchor = claimAnchor(
-          (claim.start && locateEndAnchor(claim.start)) ||
-            currentHydrationNode!,
-        )
+        // mismatch recovery: nothing to reuse, adopt whatever the cursor sits on
+        parentAnchor = claimAnchor(currentHydrationNode!)
         exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
         if (__DEV__ && !isComment(parentAnchor, ']')) {
           throw new Error(
             `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
           )
-        }
-
-        // optimization: cache the fragment end anchor as $llc (last logical child)
-        // so that locateChildByLogicalIndex can skip the entire fragment.
-        // For anchored inserts, reuse the unit index the locator stamped on
-        // the anchor; if it is unstamped (reached via a cache-missed
-        // `next()`), leave `$llc` untouched — `0` is a valid unit index, so
-        // a fallback would alias a stale cache entry to "unit 0", while
-        // skipping the install only costs a restart walk.
-        if (_insertionParent && isComment(parentAnchor, ']')) {
-          const idx = _insertionAnchor
-            ? (_insertionAnchor as any as ChildItem).$idx
-            : _insertionIndex || 0
-          if (idx !== undefined) {
-            ;(parentAnchor as any as ChildItem).$idx = idx
-            _insertionParent.$llc = parentAnchor
-          }
         }
       }
     } finally {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -45,6 +45,7 @@ import { currentSlotScopeIds, setCurrentSlotScopeIds } from './scopeId'
 import { renderEffect } from './renderEffect'
 import { VaporVForFlags } from '@vue/shared'
 import {
+  type FragmentClaim,
   type HydrationCursor,
   advanceHydrationNode,
   claimAnchor,
@@ -105,8 +106,9 @@ export const createFor = (
   const _insertionAnchor = insertionAnchor
   const _insertionIndex = insertionIndex
   let hydrationCursor: HydrationCursor | null = null
+  let hydrationClaim: FragmentClaim | undefined
   if (isHydrating) {
-    hydrationCursor = enterHydrationCursor(true)
+    hydrationCursor = enterHydrationCursor((hydrationClaim = { start: null }))
   } else {
     resetInsertionState()
   }
@@ -507,118 +509,106 @@ export const createFor = (
 
   function hydrateList(source: ResolvedSource, newLength: number): void {
     const hydrationStart = currentHydrationNode!
+    const claim = hydrationClaim!
     let exitHydrationBoundary: (() => void) | undefined
     let nextNode
-    const emptyLocalRange =
-      isComment(hydrationStart, ']') &&
-      isComment(hydrationStart.previousSibling!, '[')
     const slotEndAnchor = getCurrentSlotEndAnchor()
     const slotFallbackRange = isPendingSlotContent() && slotEndAnchor
 
-    const reuseBoundaryClose = (close: Node): void => {
-      parentAnchor = claimAnchor(close)
-      exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
-    }
-
     try {
-      if (emptyLocalRange && newLength) {
-        reuseBoundaryClose(hydrationStart)
-        mountAll(source, newLength)
-        setCurrentHydrationNode(parentAnchor)
+      for (let i = 0; i < newLength; i++) {
+        const ownedStart = claim.start
+        if (isComment(currentHydrationNode!, ']')) {
+          nextNode = claimAnchor(currentHydrationNode!)
+          setCurrentHydrationNode(nextNode)
+        } else if (markerlessHydrationContainer && !ownedStart) {
+          // rows of a markerless list have no wrappers either: the row's
+          // own hydration decides where the next one starts
+          nextNode = null
+        } else {
+          nextNode = nextLogicalSibling(currentHydrationNode!)
+        }
+        mount(source, i, parentAnchor)
+        // the row's content took the opening marker over (see
+        // `FragmentClaim`): this list is markerless after all
+        if (nextNode && !(ownedStart && !claim.start)) {
+          setCurrentHydrationNode(nextNode)
+        }
+      }
+
+      // special handling transition-group + v-for, without <!--]--> marker
+      const container = markerlessHydrationContainer
+      if (container && !claim.start) {
+        const afterRows = currentHydrationNode
+        parentAnchor = claimAnchor(
+          __DEV__ ? createComment('for') : createTextNode(),
+        )
+        container.insertBefore(
+          parentAnchor,
+          afterRows && afterRows.parentNode === container ? afterRows : null,
+        )
+        pendingHydrationAnchor = true
+      } else if (slotFallbackRange && !isValidSlot(newBlocks)) {
+        // Slot fallback can fall through an empty/invalid `v-for`. In that
+        // case SSR only rendered the parent slot range, so this `v-for` has no
+        // own `<!--]-->` to reuse. Keep its runtime anchor detached if
+        // fallback wins; if content wins, insert it at the local slot-content
+        // boundary below.
+        const anchor =
+          // The invalid list still consumed local SSR item ranges.
+          currentHydrationNode !== hydrationStart
+            ? currentHydrationNode!
+            : // Empty source with trailing slot siblings.
+              hydrationStart !== slotEndAnchor
+              ? hydrationStart.nextSibling!
+              : slotEndAnchor!
+        parentAnchor = claimUntrackedAnchor(
+          __DEV__ ? createComment('for') : createTextNode(),
+        )
+        const hydrationAnchor = parentAnchor
+        pendingHydrationAnchor = true
+        if (
+          currentHydrationNode === hydrationStart ||
+          currentHydrationNode === slotEndAnchor
+        ) {
+          setCurrentHydrationNode(hydrationStart)
+        }
+        const attachAnchor = () => {
+          const parentNode = anchor.parentNode
+          if (parentNode) parentNode.insertBefore(hydrationAnchor, anchor)
+        }
+        // Post-flush even after the verdict: the reference node's final
+        // position is only stable once the whole pass has finished.
+        const queued = queuePendingSlotContentAnchor({
+          onContent: () => queuePostFlushCb(attachAnchor),
+          onFallback: () => {},
+        })
+        if (!queued) queuePostFlushCb(attachAnchor)
       } else {
-        for (let i = 0; i < newLength; i++) {
-          if (isComment(currentHydrationNode!, ']')) {
-            nextNode = claimAnchor(currentHydrationNode!)
-            setCurrentHydrationNode(nextNode)
-          } else {
-            nextNode = nextLogicalSibling(currentHydrationNode!)
-          }
-          mount(source, i, parentAnchor)
-          if (nextNode) setCurrentHydrationNode(nextNode)
+        parentAnchor = claimAnchor(
+          locateHydrationBoundaryClose(currentHydrationNode!),
+        )
+        exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
+        if (__DEV__ && !isComment(parentAnchor, ']')) {
+          throw new Error(
+            `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
+          )
         }
 
-        // special handling transition-group + v-for, without <!--]--> marker
-        const container = markerlessHydrationContainer
-        const curNode = newLength ? nextNode : currentHydrationNode
-        if (
-          container &&
-          (hydrationStart === container ||
-            hydrationStart.parentNode === container) &&
-          // slot content keeps its own markers unless it is a single
-          // fragment; a close marker right after the rows is then ours
-          !(curNode && isComment(curNode, ']'))
-        ) {
-          // a direct child of a container rendered without fragment markers
-          parentAnchor = claimAnchor(
-            __DEV__ ? createComment('for') : createTextNode(),
-          )
-          container.insertBefore(
-            parentAnchor,
-            curNode && curNode !== container && curNode.parentNode === container
-              ? curNode
-              : null,
-          )
-          pendingHydrationAnchor = true
-        } else if (slotFallbackRange && !isValidSlot(newBlocks)) {
-          // Slot fallback can fall through an empty/invalid `v-for`. In that
-          // case SSR only rendered the parent slot range, so this `v-for` has no
-          // own `<!--]-->` to reuse. Keep its runtime anchor detached if
-          // fallback wins; if content wins, insert it at the local slot-content
-          // boundary below.
-          const anchor =
-            // The invalid list still consumed local SSR item ranges.
-            currentHydrationNode !== hydrationStart
-              ? currentHydrationNode!
-              : // Empty source with trailing slot siblings.
-                hydrationStart !== slotEndAnchor
-                ? hydrationStart.nextSibling!
-                : slotEndAnchor!
-          parentAnchor = claimUntrackedAnchor(
-            __DEV__ ? createComment('for') : createTextNode(),
-          )
-          const hydrationAnchor = parentAnchor
-          pendingHydrationAnchor = true
-          if (
-            currentHydrationNode === hydrationStart ||
-            currentHydrationNode === slotEndAnchor
-          ) {
-            setCurrentHydrationNode(hydrationStart)
-          }
-          const attachAnchor = () => {
-            const parentNode = anchor.parentNode
-            if (parentNode) parentNode.insertBefore(hydrationAnchor, anchor)
-          }
-          // Post-flush even after the verdict: the reference node's final
-          // position is only stable once the whole pass has finished.
-          const queued = queuePendingSlotContentAnchor({
-            onContent: () => queuePostFlushCb(attachAnchor),
-            onFallback: () => {},
-          })
-          if (!queued) queuePostFlushCb(attachAnchor)
-        } else {
-          const close = locateHydrationBoundaryClose(currentHydrationNode!)
-          reuseBoundaryClose(close)
-          if (__DEV__ && !isComment(parentAnchor, ']')) {
-            throw new Error(
-              `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
-            )
-          }
-
-          // optimization: cache the fragment end anchor as $llc (last logical child)
-          // so that locateChildByLogicalIndex can skip the entire fragment.
-          // For anchored inserts, reuse the unit index the locator stamped on
-          // the anchor; if it is unstamped (reached via a cache-missed
-          // `next()`), leave `$llc` untouched — `0` is a valid unit index, so
-          // a fallback would alias a stale cache entry to "unit 0", while
-          // skipping the install only costs a restart walk.
-          if (_insertionParent && isComment(parentAnchor, ']')) {
-            const idx = _insertionAnchor
-              ? (_insertionAnchor as any as ChildItem).$idx
-              : _insertionIndex || 0
-            if (idx !== undefined) {
-              ;(parentAnchor as any as ChildItem).$idx = idx
-              _insertionParent.$llc = parentAnchor
-            }
+        // optimization: cache the fragment end anchor as $llc (last logical child)
+        // so that locateChildByLogicalIndex can skip the entire fragment.
+        // For anchored inserts, reuse the unit index the locator stamped on
+        // the anchor; if it is unstamped (reached via a cache-missed
+        // `next()`), leave `$llc` untouched — `0` is a valid unit index, so
+        // a fallback would alias a stale cache entry to "unit 0", while
+        // skipping the install only costs a restart walk.
+        if (_insertionParent && isComment(parentAnchor, ']')) {
+          const idx = _insertionAnchor
+            ? (_insertionAnchor as any as ChildItem).$idx
+            : _insertionIndex || 0
+          if (idx !== undefined) {
+            ;(parentAnchor as any as ChildItem).$idx = idx
+            _insertionParent.$llc = parentAnchor
           }
         }
       }

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -55,7 +55,7 @@ import {
   enterHydrationCursor,
   isComment,
   isHydrating,
-  locateEndAnchor,
+  locateClaimedEnd,
   markerlessHydrationContainer,
   nextLogicalSibling,
   setCurrentHydrationNode,
@@ -536,7 +536,7 @@ export const createFor = (
 
       if (claim.start) {
         // the list owns its SSR range: its close marker is the anchor
-        parentAnchor = claimAnchor(locateEndAnchor(claim.start)!)
+        parentAnchor = claimAnchor(locateClaimedEnd(claim.start)!)
         exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
 
         // optimization: cache the fragment end anchor as $llc (last logical child)

--- a/packages/runtime-vapor/src/apiCreateIf.ts
+++ b/packages/runtime-vapor/src/apiCreateIf.ts
@@ -41,7 +41,9 @@ export function createIf(
     if (isHydrating) {
       branchShape = decodeIfShape(flags, ok)
       hydrationCursor = enterHydrationCursor(
-        branchShape === VaporBlockShape.MULTI_ROOT,
+        branchShape === VaporBlockShape.MULTI_ROOT
+          ? { start: null }
+          : undefined,
       )
     }
     frag = ok
@@ -82,9 +84,11 @@ export function createIf(
       const ok = condition()
       if (isHydrating) {
         branchShape = decodeIfShape(flags, ok)
-        hydrationCursor = enterHydrationCursor(
-          branchShape === VaporBlockShape.MULTI_ROOT,
-        )
+        dynamicFragment.hydrationClaim =
+          branchShape === VaporBlockShape.MULTI_ROOT
+            ? { start: null }
+            : undefined
+        hydrationCursor = enterHydrationCursor(dynamicFragment.hydrationClaim)
       }
       dynamicFragment.update(
         ok ? b1 : b2,

--- a/packages/runtime-vapor/src/apiCreateIf.ts
+++ b/packages/runtime-vapor/src/apiCreateIf.ts
@@ -3,6 +3,7 @@ import {
   type HydrationCursor,
   advanceHydrationNode,
   claimUntrackedAnchor,
+  createFragmentClaim,
   currentHydrationNode,
   enterHydrationCursor,
   isComment,
@@ -42,7 +43,7 @@ export function createIf(
       branchShape = decodeIfShape(flags, ok)
       hydrationCursor = enterHydrationCursor(
         branchShape === VaporBlockShape.MULTI_ROOT
-          ? { start: null }
+          ? createFragmentClaim()
           : undefined,
       )
     }
@@ -86,7 +87,7 @@ export function createIf(
         branchShape = decodeIfShape(flags, ok)
         dynamicFragment.hydrationClaim =
           branchShape === VaporBlockShape.MULTI_ROOT
-            ? { start: null }
+            ? createFragmentClaim()
             : undefined
         hydrationCursor = enterHydrationCursor(dynamicFragment.hydrationClaim)
       }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -101,6 +101,7 @@ import {
   adoptTemplate,
   advanceHydrationNode,
   claimAnchor,
+  createFragmentClaim,
   currentHydrationNode,
   enterHydrationBoundary,
   enterHydrationCursor,
@@ -306,7 +307,7 @@ export function createComponent(
   }
   if (isHydrating) {
     resolvePendingSlotContent()
-    if (component.__multiRoot) hydrationClaim = { start: null }
+    if (component.__multiRoot) hydrationClaim = createFragmentClaim()
     hydrationCursor = enterHydrationCursor(hydrationClaim, true)
     if (hydrationClaim && hydrationClaim.start) {
       hydrationClose = locateEndAnchor(hydrationClaim.start)

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -96,6 +96,7 @@ import {
 } from './componentSlots'
 import { hmrReload, hmrRerender } from './hmr'
 import {
+  type FragmentClaim,
   type HydrationCursor,
   adoptTemplate,
   advanceHydrationNode,
@@ -293,6 +294,7 @@ export function createComponent(
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor
   let hydrationClose: Node | null = null
+  let hydrationClaim: FragmentClaim | undefined
   let hydrationCursor: HydrationCursor | null = null
   let exitHydrationBoundary: (() => void) | undefined
   let deferHydrationBoundary = false
@@ -304,13 +306,13 @@ export function createComponent(
   }
   if (isHydrating) {
     resolvePendingSlotContent()
-    hydrationCursor = enterHydrationCursor()
-    if (component.__multiRoot && isComment(currentHydrationNode!, '[')) {
-      hydrationClose = locateEndAnchor(currentHydrationNode!)
+    if (component.__multiRoot) hydrationClaim = { start: null }
+    hydrationCursor = enterHydrationCursor(hydrationClaim, true)
+    if (hydrationClaim && hydrationClaim.start) {
+      hydrationClose = locateEndAnchor(hydrationClaim.start)
       exitHydrationBoundary = enterHydrationBoundary(
         hydrationClose && claimAnchor(hydrationClose),
       )
-      setCurrentHydrationNode(currentHydrationNode!.nextSibling)
     }
   } else {
     resetInsertionState()
@@ -543,7 +545,8 @@ export function createComponent(
           // Async setup cannot create `block` yet. Capture the adopted SSR
           // range for pending move/removal before hydration advances past it.
           const pendingBlock: Node[] = []
-          let node = hydrationCursor!.start!
+          let node: Node =
+            (hydrationClaim && hydrationClaim.start) || hydrationCursor!.start!
           const hydrationNext = nextLogicalSibling(node)
           do {
             pendingBlock.push(node)

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -66,6 +66,7 @@ import {
   nextLogicalSibling,
   setCurrentHydrationNode,
   setMarkerlessHydrationContainer,
+  setTransitionChildPending,
 } from '../dom/hydration'
 import { isTransitionEnabled, registerTransitionHooks } from '../transition'
 import { isInteropEnabled } from '../vdomInteropState'
@@ -250,10 +251,12 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
         : undefined
       let nextNode: Node | null = null
       let prevMarkerlessContainer: ParentNode | null = null
+      let prevTransitionChildPending = false
       if (isHydrating && container) {
         // SSR flattens the children into the container without fragment
         // markers; the cursor sits on the container itself when it is empty.
         prevMarkerlessContainer = setMarkerlessHydrationContainer(container)
+        prevTransitionChildPending = setTransitionChildPending(true)
         nextNode = nextLogicalSibling(container)
         setCurrentHydrationNode(container.firstChild || container)
       }
@@ -289,6 +292,7 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
       } finally {
         if (isHydrating && container) {
           setMarkerlessHydrationContainer(prevMarkerlessContainer)
+          setTransitionChildPending(prevTransitionChildPending)
           setCurrentHydrationNode(nextNode)
         }
       }

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -10,6 +10,7 @@ import {
   isClaimedAnchor,
   isComment,
   isInDeferredHydrationBoundary,
+  locateClaimedEnd,
   locateFragmentEnd,
   locateHydrationNode,
   nextLogicalSibling,
@@ -548,9 +549,9 @@ function planReuseOwnClose(frag: DynamicFragment): AnchorPlan | undefined {
   const close =
     frag.__vf & SLOT
       ? currentSlotHydrationSession && currentSlotHydrationSession.ownEndAnchor
-      : locateFragmentEnd(
-          frag.hydrationClaim ? frag.hydrationClaim.start : null,
-        )
+      : frag.hydrationClaim && frag.hydrationClaim.start
+        ? locateClaimedEnd(frag.hydrationClaim.start)
+        : null
   // reuse it once, or create a fresh runtime anchor after it when the pending
   // slot machinery already claimed it
   if (close) return reuseOrCreateAfterAnchor(close)

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -11,7 +11,6 @@ import {
   isComment,
   isInDeferredHydrationBoundary,
   locateEndAnchor,
-  locateHydrationBoundaryClose,
   locateHydrationNode,
   nextLogicalSibling,
   setCurrentHydrationNode,
@@ -660,10 +659,11 @@ function planReuseBoundaryClose(frag: DynamicFragment): AnchorPlan | undefined {
   // SSR wraps slots and multi-root `v-if` branches with `<!--[-->...<!--]-->`.
   // The close marker is a valid stable anchor candidate: reuse it once, or
   // create a fresh runtime anchor after it when another fragment already did.
-  // A branch whose claim was taken over (see `FragmentClaim`) has none.
-  if (slotAnchor || (frag.hydrationClaim && frag.hydrationClaim.start)) {
-    const anchor =
-      slotAnchor || locateHydrationBoundaryClose(currentHydrationNode!)
+  // A branch entered as a transition child, or whose claim was taken over
+  // (see `FragmentClaim`), has none.
+  const ifStart = frag.hydrationClaim ? frag.hydrationClaim.start : null
+  if (slotAnchor || ifStart) {
+    const anchor = slotAnchor || locateEndAnchor(ifStart!)
     if (isComment(anchor!, ']')) {
       return reuseOrCreateAfterAnchor(anchor)
     } else if (__DEV__) {

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -10,7 +10,7 @@ import {
   isClaimedAnchor,
   isComment,
   isInDeferredHydrationBoundary,
-  locateEndAnchor,
+  locateFragmentEnd,
   locateHydrationNode,
   nextLogicalSibling,
   setCurrentHydrationNode,
@@ -43,7 +43,8 @@ interface DeferredSlotAnchor {
  * claiming server nodes is destructive (the cursor advances, anchors get
  * claimed). So while a slot is still deciding which side owns its SSR range,
  * anchor claims are *deferred* into a ledger and settled once the decision
- * lands. A session is that ledger plus the boundary's end anchor.
+ * lands. A session is that ledger plus the boundary's claim on its SSR range,
+ * from which its end anchor derives (or is inherited).
  *
  * Structure:
  * - One session per slot boundary, stacked for nesting
@@ -86,8 +87,13 @@ class SlotHydrationSession {
 
   /** The close marker of the range this boundary itself owns, if any. */
   get ownEndAnchor(): Node | null {
-    const start = this.claim.start
-    return start ? locateEndAnchor(start) : null
+    return locateFragmentEnd(this.claim.start)
+  }
+
+  /** Trim the range's unclaimed tail; a range the content took over has none. */
+  exitBoundary(): void {
+    const close = this.ownEndAnchor
+    if (close) enterHydrationBoundary(close)()
   }
 
   /** Record a claim in the ledger; false = no pending window, act now. */
@@ -163,44 +169,23 @@ export function getCurrentSlotEndAnchor(): Node | null {
     : null
 }
 
-function getCurrentSlotOwnEndAnchor(): Node | null {
-  return currentSlotHydrationSession
-    ? currentSlotHydrationSession.ownEndAnchor
-    : null
-}
-
 /** Locate this boundary's SSR range and consume its opening marker. */
-function enterSlotBoundaryRange(pending: boolean): {
-  session: SlotHydrationSession
-  exit: () => void
-} {
+function enterSlotBoundaryRange(pending: boolean): SlotHydrationSession {
   const claim: FragmentClaim = { start: null }
   locateHydrationNode(claim)
-  const session = new SlotHydrationSession(
-    claim,
-    currentSlotHydrationSession,
-    pending,
-  )
-  return {
-    session,
-    // trim the range's unclaimed tail; nothing to trim once the content's
-    // first block owns the range
-    exit: () => {
-      if (claim.start) enterHydrationBoundary(session.endAnchor)()
-    },
-  }
+  return new SlotHydrationSession(claim, currentSlotHydrationSession, pending)
 }
 
 export function withHydratingSlotBoundary<R>(fn: () => R): R {
-  const range = enterSlotBoundaryRange(false)
+  const session = enterSlotBoundaryRange(false)
   const prevSession = currentSlotHydrationSession
-  currentSlotHydrationSession = range.session
+  currentSlotHydrationSession = session
 
   try {
     return fn()
   } finally {
     currentSlotHydrationSession = prevSession
-    range.exit()
+    session.exitBoundary()
   }
 }
 
@@ -213,8 +198,7 @@ export function withHydratingSlotBoundary<R>(fn: () => R): R {
 export function withPendingHydratingSlotBoundary<R>(fn: () => R): R {
   const parentSession = currentSlotHydrationSession!
   const contentStart = currentHydrationNode
-  const range = enterSlotBoundaryRange(true)
-  const session = range.session
+  const session = enterSlotBoundaryRange(true)
   currentSlotHydrationSession = session
   let completed = false
 
@@ -225,12 +209,12 @@ export function withPendingHydratingSlotBoundary<R>(fn: () => R): R {
   } finally {
     currentSlotHydrationSession = parentSession
     if (!completed) {
-      range.exit()
+      session.exitBoundary()
     } else if (session.pending) {
       session.adoptInto(parentSession)
       setCurrentHydrationNode(contentStart)
     } else {
-      range.exit()
+      session.exitBoundary()
       parentSession.settleAsContent()
     }
   }
@@ -559,23 +543,17 @@ function planReuseInjectedAnchor(
 
 /** Rule 3: the fragment owns an SSR range; its close marker is the anchor. */
 function planReuseOwnClose(frag: DynamicFragment): AnchorPlan | undefined {
+  // a slot reads the current session: the forwarded path in `fragment.ts`
+  // opens none of its own and resolves against the enclosing boundary
   const close =
     frag.__vf & SLOT
-      ? getCurrentSlotOwnEndAnchor()
-      : frag.hydrationClaim && frag.hydrationClaim.start
-        ? locateEndAnchor(frag.hydrationClaim.start)
-        : null
-  if (close) {
-    if (isComment(close, ']')) {
-      // reuse it once, or create a fresh runtime anchor after it when the
-      // pending slot machinery already claimed it
-      return reuseOrCreateAfterAnchor(close)
-    } else if (__DEV__) {
-      throw new Error(
-        `Failed to locate ${frag.anchorLabel} fragment anchor. this is likely a Vue internal bug.`,
-      )
-    }
-  }
+      ? currentSlotHydrationSession && currentSlotHydrationSession.ownEndAnchor
+      : locateFragmentEnd(
+          frag.hydrationClaim ? frag.hydrationClaim.start : null,
+        )
+  // reuse it once, or create a fresh runtime anchor after it when the pending
+  // slot machinery already claimed it
+  if (close) return reuseOrCreateAfterAnchor(close)
 }
 
 /** Rule 4: the client rendered nothing and owns no range. */
@@ -684,7 +662,8 @@ function planRestartFromRuntimeComment(
 
 /** Rule 6: derive the anchor position from the hydrated block itself. */
 function planFromBlockBoundary(frag: DynamicFragment): AnchorPlan {
-  // Covers: dynamic component, async component, keyed fragment.
+  // Covers: dynamic component, async component, keyed fragment, and any
+  // fragment whose SSR range was stripped.
   const node = findBlockBoundary(frag.nodes)
   return { kind: 'create', parent: node.parentNode!, next: node.nextNode }
 }

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -5,6 +5,7 @@ import {
   claimAnchor,
   claimUntrackedAnchor,
   cleanupHydrationTail,
+  createFragmentClaim,
   currentHydrationNode,
   enterHydrationBoundary,
   isClaimedAnchor,
@@ -15,6 +16,7 @@ import {
   locateHydrationNode,
   nextLogicalSibling,
   setCurrentHydrationNode,
+  trimHydrationBoundary,
 } from './hydration'
 import {
   createComment,
@@ -94,7 +96,7 @@ class SlotHydrationSession {
   /** Trim the range's unclaimed tail; a range the content took over has none. */
   exitBoundary(): void {
     const close = this.ownEndAnchor
-    if (close) enterHydrationBoundary(close)()
+    if (close) trimHydrationBoundary(close)
   }
 
   /** Record a claim in the ledger; false = no pending window, act now. */
@@ -172,7 +174,7 @@ export function getCurrentSlotEndAnchor(): Node | null {
 
 /** Locate this boundary's SSR range and consume its opening marker. */
 function enterSlotBoundaryRange(pending: boolean): SlotHydrationSession {
-  const claim: FragmentClaim = { start: null }
+  const claim = createFragmentClaim()
   locateHydrationNode(claim)
   return new SlotHydrationSession(claim, currentSlotHydrationSession, pending)
 }

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -1,5 +1,6 @@
-import { NOOP, isArray } from '@vue/shared'
+import { NOOP } from '@vue/shared'
 import {
+  type FragmentClaim,
   advanceHydrationNode,
   claimAnchor,
   claimUntrackedAnchor,
@@ -70,9 +71,24 @@ class SlotHydrationSession {
   private deferred: DeferredSlotAnchor[] | null = null
 
   constructor(
-    readonly endAnchor: Node | null,
+    private readonly claim: FragmentClaim,
+    private readonly parent: SlotHydrationSession | null,
     public pending: boolean,
   ) {}
+
+  /**
+   * The boundary's SSR close marker while it owns its range, else the
+   * inherited one. Derived on read: the content's first block may take the
+   * range over mid-content (see `FragmentClaim`).
+   */
+  get endAnchor(): Node | null {
+    const start = this.claim.start
+    return start
+      ? locateEndAnchor(start)
+      : this.parent
+        ? this.parent.endAnchor
+        : null
+  }
 
   /** Record a claim in the ledger; false = no pending window, act now. */
   defer(anchor: DeferredSlotAnchor): boolean {
@@ -148,32 +164,37 @@ export function getCurrentSlotEndAnchor(): Node | null {
 }
 
 /** Locate this boundary's SSR range and consume its opening marker. */
-function enterSlotBoundaryRange(): {
-  endAnchor: Node | null
-  exitHydrationBoundary: (() => void) | undefined
+function enterSlotBoundaryRange(pending: boolean): {
+  session: SlotHydrationSession
+  exit: () => void
 } {
-  let endAnchor = getCurrentSlotEndAnchor()
-  let exitHydrationBoundary: (() => void) | undefined
-
-  locateHydrationNode()
-  if (isComment(currentHydrationNode!, '[')) {
-    endAnchor = locateEndAnchor(currentHydrationNode)
-    setCurrentHydrationNode(currentHydrationNode.nextSibling)
-    exitHydrationBoundary = enterHydrationBoundary(endAnchor)
+  const claim: FragmentClaim = { start: null }
+  locateHydrationNode(claim)
+  const session = new SlotHydrationSession(
+    claim,
+    currentSlotHydrationSession,
+    pending,
+  )
+  return {
+    session,
+    // trim the range's unclaimed tail; nothing to trim once the content's
+    // first block owns the range
+    exit: () => {
+      if (claim.start) enterHydrationBoundary(session.endAnchor)()
+    },
   }
-  return { endAnchor, exitHydrationBoundary }
 }
 
 export function withHydratingSlotBoundary<R>(fn: () => R): R {
-  const { endAnchor, exitHydrationBoundary } = enterSlotBoundaryRange()
+  const range = enterSlotBoundaryRange(false)
   const prevSession = currentSlotHydrationSession
-  currentSlotHydrationSession = new SlotHydrationSession(endAnchor, false)
+  currentSlotHydrationSession = range.session
 
   try {
     return fn()
   } finally {
     currentSlotHydrationSession = prevSession
-    exitHydrationBoundary && exitHydrationBoundary()
+    range.exit()
   }
 }
 
@@ -186,8 +207,8 @@ export function withHydratingSlotBoundary<R>(fn: () => R): R {
 export function withPendingHydratingSlotBoundary<R>(fn: () => R): R {
   const parentSession = currentSlotHydrationSession!
   const contentStart = currentHydrationNode
-  const { endAnchor, exitHydrationBoundary } = enterSlotBoundaryRange()
-  const session = new SlotHydrationSession(endAnchor, true)
+  const range = enterSlotBoundaryRange(true)
+  const session = range.session
   currentSlotHydrationSession = session
   let completed = false
 
@@ -198,12 +219,12 @@ export function withPendingHydratingSlotBoundary<R>(fn: () => R): R {
   } finally {
     currentSlotHydrationSession = parentSession
     if (!completed) {
-      exitHydrationBoundary && exitHydrationBoundary()
+      range.exit()
     } else if (session.pending) {
       session.adoptInto(parentSession)
       setCurrentHydrationNode(contentStart)
     } else {
-      exitHydrationBoundary && exitHydrationBoundary()
+      range.exit()
       parentSession.settleAsContent()
     }
   }
@@ -639,14 +660,10 @@ function planReuseBoundaryClose(frag: DynamicFragment): AnchorPlan | undefined {
   // SSR wraps slots and multi-root `v-if` branches with `<!--[-->...<!--]-->`.
   // The close marker is a valid stable anchor candidate: reuse it once, or
   // create a fresh runtime anchor after it when another fragment already did.
-  if (
-    slotAnchor ||
-    (!!(frag.__vf & IF) && isArray(frag.nodes) && frag.nodes.length > 1)
-  ) {
-    const anchor = locateHydrationBoundaryClose(
-      slotAnchor || currentHydrationNode!,
-      slotAnchor || null,
-    )
+  // A branch whose claim was taken over (see `FragmentClaim`) has none.
+  if (slotAnchor || (frag.hydrationClaim && frag.hydrationClaim.start)) {
+    const anchor =
+      slotAnchor || locateHydrationBoundaryClose(currentHydrationNode!)
     if (isComment(anchor!, ']')) {
       return reuseOrCreateAfterAnchor(anchor)
     } else if (__DEV__) {

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -81,12 +81,13 @@ class SlotHydrationSession {
    * range over mid-content (see `FragmentClaim`).
    */
   get endAnchor(): Node | null {
+    return this.ownEndAnchor || (this.parent ? this.parent.endAnchor : null)
+  }
+
+  /** The close marker of the range this boundary itself owns, if any. */
+  get ownEndAnchor(): Node | null {
     const start = this.claim.start
-    return start
-      ? locateEndAnchor(start)
-      : this.parent
-        ? this.parent.endAnchor
-        : null
+    return start ? locateEndAnchor(start) : null
   }
 
   /** Record a claim in the ledger; false = no pending window, act now. */
@@ -159,6 +160,12 @@ let currentSlotHydrationSession: SlotHydrationSession | null = null
 export function getCurrentSlotEndAnchor(): Node | null {
   return currentSlotHydrationSession
     ? currentSlotHydrationSession.endAnchor
+    : null
+}
+
+function getCurrentSlotOwnEndAnchor(): Node | null {
+  return currentSlotHydrationSession
+    ? currentSlotHydrationSession.ownEndAnchor
     : null
 }
 
@@ -490,17 +497,20 @@ export type AnchorPlan =
  *    Defer the whole decision (`pending`).
  * 2. `planReuseInjectedAnchor` — a native-children fragment finds the anchor
  *    `createPlainElement` seeded for it still under the cursor: adopt it.
- * 3. `planEmptyBranch` — the client rendered nothing. Claim a reusable SSR
- *    comment at the cursor, insert before a structural teleport anchor, or
- *    trim the unclaimed SSR range the empty branch leaves behind.
- * 4. `planRestartFromRuntimeComment` — the block is a bare runtime comment
+ * 3. `planReuseOwnClose` — the fragment claimed its own SSR
+ *    `<!--[-->…<!--]-->` range (slot outlets, multi-root `v-if` branches,
+ *    see `FragmentClaim`): its close marker is the anchor, whatever the
+ *    content turned out to be.
+ * 4. `planEmptyBranch` — the client rendered nothing and owns no range.
+ *    Claim a reusable SSR comment at the cursor, insert before a structural
+ *    teleport anchor, or trim the unclaimed SSR range the empty branch
+ *    leaves behind.
+ * 5. `planRestartFromRuntimeComment` — the block is a bare runtime comment
  *    (an empty branch created earlier in this same pass): reuse it if it is
  *    still in the DOM, otherwise restart from the cursor and trim.
- * 5. `planReuseBoundaryClose` — slots and multi-root `v-if` branches sit in
- *    an SSR `<!--[-->…<!--]-->` range whose close marker is a stable anchor.
  * 6. `planFromBlockBoundary` — fallback: derive parent/next from the
  *    hydrated block itself (dynamic component, async component, keyed
- *    fragment with single-root content).
+ *    fragment with single-root content, anything whose range was stripped).
  *
  * Marker discipline: a plan that adopts an SSR node claims it with
  * `claimAnchor` (it keeps its logical position); a plan that creates a
@@ -547,7 +557,28 @@ function planReuseInjectedAnchor(
   }
 }
 
-/** Rule 3: the client rendered nothing for this branch. */
+/** Rule 3: the fragment owns an SSR range; its close marker is the anchor. */
+function planReuseOwnClose(frag: DynamicFragment): AnchorPlan | undefined {
+  const close =
+    frag.__vf & SLOT
+      ? getCurrentSlotOwnEndAnchor()
+      : frag.hydrationClaim && frag.hydrationClaim.start
+        ? locateEndAnchor(frag.hydrationClaim.start)
+        : null
+  if (close) {
+    if (isComment(close, ']')) {
+      // reuse it once, or create a fresh runtime anchor after it when the
+      // pending slot machinery already claimed it
+      return reuseOrCreateAfterAnchor(close)
+    } else if (__DEV__) {
+      throw new Error(
+        `Failed to locate ${frag.anchorLabel} fragment anchor. this is likely a Vue internal bug.`,
+      )
+    }
+  }
+}
+
+/** Rule 4: the client rendered nothing and owns no range. */
 function planEmptyBranch(frag: DynamicFragment): AnchorPlan | undefined {
   const flags = frag.__vf
 
@@ -616,7 +647,7 @@ function planTrimFromCursor(parent: Node, next: Node | null): AnchorPlan {
   }
 }
 
-/** Rule 4: the block is a bare runtime comment from earlier in this pass. */
+/** Rule 5: the block is a bare runtime comment from earlier in this pass. */
 function planRestartFromRuntimeComment(
   frag: DynamicFragment,
 ): AnchorPlan | undefined {
@@ -651,29 +682,6 @@ function planRestartFromRuntimeComment(
   }
 }
 
-/** Rule 5: slots and multi-root `v-if` reuse their SSR range's close marker. */
-function planReuseBoundaryClose(frag: DynamicFragment): AnchorPlan | undefined {
-  // Non-null only for slots, so it doubles as the "is a slot" test below.
-  const slotAnchor = frag.__vf & SLOT ? getCurrentSlotEndAnchor() : null
-
-  // SSR wraps slots and multi-root `v-if` branches with `<!--[-->...<!--]-->`.
-  // The close marker is a valid stable anchor candidate: reuse it once, or
-  // create a fresh runtime anchor after it when another fragment already did.
-  // A branch entered as a transition child, or whose claim was taken over
-  // (see `FragmentClaim`), has none.
-  const ifStart = frag.hydrationClaim ? frag.hydrationClaim.start : null
-  if (slotAnchor || ifStart) {
-    const anchor = slotAnchor || locateEndAnchor(ifStart!)
-    if (isComment(anchor!, ']')) {
-      return reuseOrCreateAfterAnchor(anchor)
-    } else if (__DEV__) {
-      throw new Error(
-        `Failed to locate ${frag.anchorLabel} fragment anchor. this is likely a Vue internal bug.`,
-      )
-    }
-  }
-}
-
 /** Rule 6: derive the anchor position from the hydrated block itself. */
 function planFromBlockBoundary(frag: DynamicFragment): AnchorPlan {
   // Covers: dynamic component, async component, keyed fragment.
@@ -688,9 +696,9 @@ export function resolveDynamicAnchor(
   return (
     planPendingSlotDecision(frag, isEmpty) ||
     planReuseInjectedAnchor(frag) ||
+    planReuseOwnClose(frag) ||
     (isEmpty ? planEmptyBranch(frag) : undefined) ||
     planRestartFromRuntimeComment(frag) ||
-    planReuseBoundaryClose(frag) ||
     planFromBlockBoundary(frag)
   )
 }

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -259,19 +259,23 @@ export function setMarkerlessHydrationContainer(
  * Direct children of a TransitionGroup container are server-rendered without
  * fragment markers of their own (compiler-ssr disables nested fragments
  * there), so a `v-if`, `v-for` or slot outlet entered as one must not claim
- * the `[` under its cursor. The group arms the flag around its children; the
- * cursor protocol hands it to each block entered at that level and clears it
- * for the block's own content (`enterBlockScope`). Component roots keep their
+ * the `[` under its cursor. The group arms `Pending` around its children;
+ * opening a block scope turns it into `Child` for that block and clears it
+ * for the block's own content (`openBlockScope`). Component roots keep their
  * markers and claim regardless.
  */
-let transitionChildPending = false
-let isTransitionChild = false
+const enum TransitionChild {
+  None,
+  Pending,
+  Child,
+}
+let transitionChild = TransitionChild.None
 
 export function setTransitionChildPending(pending: boolean): boolean {
   try {
-    return transitionChildPending
+    return transitionChild === TransitionChild.Pending
   } finally {
-    transitionChildPending = pending
+    transitionChild = pending ? TransitionChild.Pending : TransitionChild.None
   }
 }
 
@@ -295,7 +299,7 @@ let innermostFragmentClaim: FragmentClaim | null = null
  */
 function claimFragmentStart(claim: FragmentClaim): void {
   const node = currentHydrationNode
-  if (!node || isTransitionChild) return
+  if (!node || transitionChild === TransitionChild.Child) return
   if (isComment(node, '[')) {
     claim.start = node
     setCurrentHydrationNode(node.nextSibling)
@@ -365,8 +369,7 @@ export type HydrationCursor = {
   start: Node | null
   resume: Node | null | undefined
   /** the enclosing block's scope, restored on exit (see `openBlockScope`) */
-  transitionChildPending: boolean
-  isTransitionChild: boolean
+  transitionChild: TransitionChild
   innermostFragmentClaim: FragmentClaim | null
   /** dev-only: set once handed back, so a second exit can be caught */
   exited?: boolean
@@ -380,9 +383,12 @@ export type HydrationCursor = {
  * content.
  */
 function openBlockScope(keepsMarkers?: boolean): void {
-  isTransitionChild =
-    transitionChildPending && !insertionParent && !keepsMarkers
-  transitionChildPending = false
+  transitionChild =
+    transitionChild === TransitionChild.Pending &&
+    !insertionParent &&
+    !keepsMarkers
+      ? TransitionChild.Child
+      : TransitionChild.None
 }
 
 export function enterHydrationCursor(
@@ -407,8 +413,7 @@ export function captureHydrationCursor(
   const cursor: HydrationCursor = {
     start: null,
     resume: insertionParent ? currentHydrationNode : undefined,
-    transitionChildPending,
-    isTransitionChild,
+    transitionChild,
     innermostFragmentClaim,
   }
   openBlockScope(keepsMarkers)
@@ -432,8 +437,7 @@ export function exitHydrationCursor(cursor: HydrationCursor | null): void {
     cursor.exited = true
     liveCursors--
   }
-  transitionChildPending = cursor.transitionChildPending
-  isTransitionChild = cursor.isTransitionChild
+  transitionChild = cursor.transitionChild
   innermostFragmentClaim = cursor.innermostFragmentClaim
   if (cursor.resume !== undefined) {
     setCurrentHydrationNode(cursor.resume)

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -201,7 +201,10 @@ export let adoptTemplate: (
   ns?: Namespace,
   target?: AdoptTarget,
 ) => Node | null
-export let locateHydrationNode: (claim?: FragmentClaim) => void
+export let locateHydrationNode: (
+  claim?: FragmentClaim,
+  keepsMarkers?: boolean,
+) => void
 export let parseAdoptTarget: (template: string) => AdoptTarget
 
 const enum AnchorFlags {
@@ -256,11 +259,32 @@ export function setMarkerlessHydrationContainer(
 }
 
 /**
+ * Direct children of a TransitionGroup container are server-rendered without
+ * fragment markers of their own (compiler-ssr disables nested fragments
+ * there), so a `v-if`, `v-for` or slot outlet entered as one must not claim
+ * the `[` under its cursor. The group arms the flag around its children; the
+ * cursor protocol hands it to each block entered at that level and clears it
+ * for the block's own content (`enterBlockScope`). Component roots keep their
+ * markers and claim regardless.
+ */
+let transitionChildPending = false
+let isTransitionChild = false
+
+export function setTransitionChildPending(pending: boolean): boolean {
+  try {
+    return transitionChildPending
+  } finally {
+    transitionChildPending = pending
+  }
+}
+
+/**
  * A block's claim on the `<!--[-->` opening its SSR range. In a markerless
- * container the server strips only the outermost markers, so a marker
- * consumed by an outer block belongs to the innermost block that starts right
- * after it: that block takes the claim over and the outer one loses its
- * `start`. Owners read `start` late for that reason.
+ * container the server also strips the range of a slot outlet that is the
+ * single fragment of a transition slot's content, so a marker consumed by
+ * such an outlet belongs to the innermost block that starts right after it:
+ * that block takes the claim over and the outer one loses its `start`.
+ * Owners read `start` late for that reason.
  */
 export interface FragmentClaim {
   start: CommentAnchor | null
@@ -272,9 +296,9 @@ let innermostFragmentClaim: FragmentClaim | null = null
  * Consume the fragment start under the cursor for `claim`, or take over the
  * one the enclosing block consumed when nothing was hydrated in between.
  */
-function claimFragmentStart(claim: FragmentClaim): void {
+function claimFragmentStart(claim: FragmentClaim, keepsMarkers?: boolean) {
   const node = currentHydrationNode
-  if (!node) return
+  if (!node || (isTransitionChild && !keepsMarkers)) return
   if (isComment(node, '[')) {
     claim.start = node
     setCurrentHydrationNode(node.nextSibling)
@@ -343,17 +367,47 @@ export function advanceHydrationNode(node: Node): void {
 export type HydrationCursor = {
   start: Node | null
   resume: Node | null | undefined
+  /** the enclosing block's scope, restored on exit */
+  scope: BlockScope
   /** dev-only: set once handed back, so a second exit can be caught */
   exited?: boolean
 }
 
-export function enterHydrationCursor(claim?: FragmentClaim): HydrationCursor {
+type BlockScope = {
+  transitionChildPending: boolean
+  isTransitionChild: boolean
+  innermostFragmentClaim: FragmentClaim | null
+}
+
+/**
+ * Open the block being entered: it is a transition child when the flag was
+ * armed for its level (element children carry insertion state and are not),
+ * and its own content is not. Claims registered while it is open are only
+ * takeover targets for its content.
+ */
+function enterBlockScope(): BlockScope {
+  const scope = {
+    transitionChildPending,
+    isTransitionChild,
+    innermostFragmentClaim,
+  }
+  isTransitionChild = transitionChildPending && !insertionParent
+  transitionChildPending = false
+  return scope
+}
+
+export function enterHydrationCursor(
+  claim?: FragmentClaim,
+  keepsMarkers?: boolean,
+): HydrationCursor {
   const resume = insertionParent ? currentHydrationNode : undefined
-  locateHydrationNode(claim)
+  const scope = enterBlockScope()
+  locateHydrationNode(claim, keepsMarkers)
   if (__DEV__) liveCursors++
   return {
     start: currentHydrationNode,
     resume,
+    scope,
   }
 }
 
@@ -367,6 +421,7 @@ export function captureHydrationCursor(): HydrationCursor {
   return {
     start: null,
     resume: insertionParent ? currentHydrationNode : undefined,
+    scope: enterBlockScope(),
   }
 }
 
@@ -387,6 +442,10 @@ export function exitHydrationCursor(cursor: HydrationCursor | null): void {
     cursor.exited = true
     liveCursors--
   }
+  const scope = cursor.scope
+  transitionChildPending = scope.transitionChildPending
+  isTransitionChild = scope.isTransitionChild
+  innermostFragmentClaim = scope.innermostFragmentClaim
   if (cursor.resume !== undefined) {
     setCurrentHydrationNode(cursor.resume)
   }
@@ -444,7 +503,10 @@ export function skipUntrackedAnchors(node: Node | null): Node | null {
   return node
 }
 
-function locateHydrationNodeImpl(claim?: FragmentClaim) {
+function locateHydrationNodeImpl(
+  claim?: FragmentClaim,
+  keepsMarkers?: boolean,
+) {
   let node: Node | null
 
   if (insertionAnchor) {
@@ -468,7 +530,7 @@ function locateHydrationNodeImpl(claim?: FragmentClaim) {
 
   resetInsertionState()
   setCurrentHydrationNode(node)
-  if (claim) claimFragmentStart(claim)
+  if (claim) claimFragmentStart(claim, keepsMarkers)
 }
 
 /**
@@ -504,15 +566,6 @@ export function locateEndAnchor(
   }
 
   return null
-}
-
-// Find the SSR close marker for the current owner.
-export function locateHydrationBoundaryClose(node: Node): Node {
-  let close: Node | null = node
-  while (close && !isComment(close, ']')) {
-    close = nextLogicalSibling(close)
-  }
-  return close || node
 }
 
 function handleMismatch(

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -201,10 +201,7 @@ export let adoptTemplate: (
   ns?: Namespace,
   target?: AdoptTarget,
 ) => Node | null
-export let locateHydrationNode: (
-  claim?: FragmentClaim,
-  keepsMarkers?: boolean,
-) => void
+export let locateHydrationNode: (claim?: FragmentClaim) => void
 export let parseAdoptTarget: (template: string) => AdoptTarget
 
 const enum AnchorFlags {
@@ -296,9 +293,9 @@ let innermostFragmentClaim: FragmentClaim | null = null
  * Consume the fragment start under the cursor for `claim`, or take over the
  * one the enclosing block consumed when nothing was hydrated in between.
  */
-function claimFragmentStart(claim: FragmentClaim, keepsMarkers?: boolean) {
+function claimFragmentStart(claim: FragmentClaim): void {
   const node = currentHydrationNode
-  if (!node || (isTransitionChild && !keepsMarkers)) return
+  if (!node || isTransitionChild) return
   if (isComment(node, '[')) {
     claim.start = node
     setCurrentHydrationNode(node.nextSibling)
@@ -367,48 +364,35 @@ export function advanceHydrationNode(node: Node): void {
 export type HydrationCursor = {
   start: Node | null
   resume: Node | null | undefined
-  /** the enclosing block's scope, restored on exit */
-  scope: BlockScope
+  /** the enclosing block's scope, restored on exit (see `openBlockScope`) */
+  transitionChildPending: boolean
+  isTransitionChild: boolean
+  innermostFragmentClaim: FragmentClaim | null
   /** dev-only: set once handed back, so a second exit can be caught */
   exited?: boolean
 }
 
-type BlockScope = {
-  transitionChildPending: boolean
-  isTransitionChild: boolean
-  innermostFragmentClaim: FragmentClaim | null
-}
-
 /**
  * Open the block being entered: it is a transition child when the flag was
- * armed for its level (element children carry insertion state and are not),
- * and its own content is not. Claims registered while it is open are only
- * takeover targets for its content.
+ * armed for its level (element children carry insertion state and are not)
+ * unless it keeps its markers (component roots); its own content is not.
+ * Claims registered while it is open are only takeover targets for its
+ * content.
  */
-function enterBlockScope(): BlockScope {
-  const scope = {
-    transitionChildPending,
-    isTransitionChild,
-    innermostFragmentClaim,
-  }
-  isTransitionChild = transitionChildPending && !insertionParent
+function openBlockScope(keepsMarkers?: boolean): void {
+  isTransitionChild =
+    transitionChildPending && !insertionParent && !keepsMarkers
   transitionChildPending = false
-  return scope
 }
 
 export function enterHydrationCursor(
   claim?: FragmentClaim,
   keepsMarkers?: boolean,
 ): HydrationCursor {
-  const resume = insertionParent ? currentHydrationNode : undefined
-  const scope = enterBlockScope()
-  locateHydrationNode(claim, keepsMarkers)
-  if (__DEV__) liveCursors++
-  return {
-    start: currentHydrationNode,
-    resume,
-    scope,
-  }
+  const cursor = captureHydrationCursor(keepsMarkers)
+  locateHydrationNode(claim)
+  cursor.start = currentHydrationNode
+  return cursor
 }
 
 /**
@@ -416,13 +400,19 @@ export function enterHydrationCursor(
  * locates the local start later, after the selected inner path is known.
  * This avoids consuming insertion state too early.
  */
-export function captureHydrationCursor(): HydrationCursor {
+export function captureHydrationCursor(
+  keepsMarkers?: boolean,
+): HydrationCursor {
   if (__DEV__) liveCursors++
-  return {
+  const cursor: HydrationCursor = {
     start: null,
     resume: insertionParent ? currentHydrationNode : undefined,
-    scope: enterBlockScope(),
+    transitionChildPending,
+    isTransitionChild,
+    innermostFragmentClaim,
   }
+  openBlockScope(keepsMarkers)
+  return cursor
 }
 
 export function exitHydrationCursor(cursor: HydrationCursor | null): void {
@@ -442,10 +432,9 @@ export function exitHydrationCursor(cursor: HydrationCursor | null): void {
     cursor.exited = true
     liveCursors--
   }
-  const scope = cursor.scope
-  transitionChildPending = scope.transitionChildPending
-  isTransitionChild = scope.isTransitionChild
-  innermostFragmentClaim = scope.innermostFragmentClaim
+  transitionChildPending = cursor.transitionChildPending
+  isTransitionChild = cursor.isTransitionChild
+  innermostFragmentClaim = cursor.innermostFragmentClaim
   if (cursor.resume !== undefined) {
     setCurrentHydrationNode(cursor.resume)
   }
@@ -503,10 +492,7 @@ export function skipUntrackedAnchors(node: Node | null): Node | null {
   return node
 }
 
-function locateHydrationNodeImpl(
-  claim?: FragmentClaim,
-  keepsMarkers?: boolean,
-) {
+function locateHydrationNodeImpl(claim?: FragmentClaim) {
   let node: Node | null
 
   if (insertionAnchor) {
@@ -530,7 +516,7 @@ function locateHydrationNodeImpl(
 
   resetInsertionState()
   setCurrentHydrationNode(node)
-  if (claim) claimFragmentStart(claim, keepsMarkers)
+  if (claim) claimFragmentStart(claim)
 }
 
 /**

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -542,7 +542,12 @@ export function locateEndAnchor(
   while ((node = _next(node) as CommentAnchor) && stack.length > 0) {
     if (node.nodeType === 8) {
       if (node.data === open) {
-        stack.push(node)
+        // a nested range walked before is skipped through its cached end
+        if (node.$fe) {
+          node = node.$fe as CommentAnchor
+        } else {
+          stack.push(node)
+        }
       } else if (node.data === close) {
         const matchingOpen = stack.pop()!
         matchingOpen.$fe = node
@@ -552,6 +557,18 @@ export function locateEndAnchor(
   }
 
   return null
+}
+
+/**
+ * The close marker of a claimed range once its content hydrated. The cursor
+ * normally rests on it, so only a mismatch pays for the walk from `start`.
+ */
+export function locateClaimedEnd(start: CommentAnchor): Node | null {
+  const node = currentHydrationNode
+  if (node && isComment(node, ']') && !isClaimedAnchor(node)) {
+    return (start.$fe = node)
+  }
+  return locateEndAnchor(start)
 }
 
 function handleMismatch(

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -201,7 +201,7 @@ export let adoptTemplate: (
   ns?: Namespace,
   target?: AdoptTarget,
 ) => Node | null
-export let locateHydrationNode: (consumeFragmentStart?: boolean) => void
+export let locateHydrationNode: (claim?: FragmentClaim) => void
 export let parseAdoptTarget: (template: string) => AdoptTarget
 
 const enum AnchorFlags {
@@ -251,7 +251,46 @@ export function setMarkerlessHydrationContainer(
     return markerlessHydrationContainer
   } finally {
     markerlessHydrationContainer = container
+    innermostFragmentClaim = null
   }
+}
+
+/**
+ * A block's claim on the `<!--[-->` opening its SSR range. In a markerless
+ * container the server strips only the outermost markers, so a marker
+ * consumed by an outer block belongs to the innermost block that starts right
+ * after it: that block takes the claim over and the outer one loses its
+ * `start`. Owners read `start` late for that reason.
+ */
+export interface FragmentClaim {
+  start: CommentAnchor | null
+}
+
+let innermostFragmentClaim: FragmentClaim | null = null
+
+/**
+ * Consume the fragment start under the cursor for `claim`, or take over the
+ * one the enclosing block consumed when nothing was hydrated in between.
+ */
+function claimFragmentStart(claim: FragmentClaim): void {
+  const node = currentHydrationNode
+  if (!node) return
+  if (isComment(node, '[')) {
+    claim.start = node
+    setCurrentHydrationNode(node.nextSibling)
+  } else {
+    const outer = innermostFragmentClaim
+    if (
+      !outer ||
+      !outer.start ||
+      node !== skipUntrackedAnchors(outer.start.nextSibling)
+    ) {
+      return
+    }
+    claim.start = outer.start
+    outer.start = null
+  }
+  if (markerlessHydrationContainer) innermostFragmentClaim = claim
 }
 
 export function setCurrentHydrationNode(node: Node | null): void {
@@ -282,11 +321,11 @@ export function advanceHydrationNode(node: Node): void {
  * (`currentHydrationNode`). Every block-creating API borrows it and must hand
  * it back, which is what these three helpers express:
  *
- * - `enterHydrationCursor(consumeFragmentStart)` — locate this block's own
- *   start node *and* remember where the enclosing scope should resume. Pass
- *   `true` when the block's server output is wrapped in `<!--[-->…<!--]-->`
- *   and the body should start after the opening marker (multi-root branches,
- *   `v-for` lists).
+ * - `enterHydrationCursor(claim)` — locate this block's own start node *and*
+ *   remember where the enclosing scope should resume. Pass a `FragmentClaim`
+ *   when the block's server output is wrapped in `<!--[-->…<!--]-->` and the
+ *   body should start after the opening marker (multi-root branches, `v-for`
+ *   lists); the claim records whether the block owns the marker.
  * - `captureHydrationCursor()` — remember the resume point *without* locating
  *   a start node, for wrappers whose inner owner locates its own start later
  *   (dynamic components, keyed fragments, slot outlets). Locating early would
@@ -308,11 +347,9 @@ export type HydrationCursor = {
   exited?: boolean
 }
 
-export function enterHydrationCursor(
-  consumeFragmentStart = false,
-): HydrationCursor {
+export function enterHydrationCursor(claim?: FragmentClaim): HydrationCursor {
   const resume = insertionParent ? currentHydrationNode : undefined
-  locateHydrationNode(consumeFragmentStart)
+  locateHydrationNode(claim)
   if (__DEV__) liveCursors++
   return {
     start: currentHydrationNode,
@@ -407,7 +444,7 @@ export function skipUntrackedAnchors(node: Node | null): Node | null {
   return node
 }
 
-function locateHydrationNodeImpl(consumeFragmentStart = false) {
+function locateHydrationNodeImpl(claim?: FragmentClaim) {
   let node: Node | null
 
   if (insertionAnchor) {
@@ -422,11 +459,6 @@ function locateHydrationNodeImpl(consumeFragmentStart = false) {
     node = currentHydrationNode
   }
 
-  // consume fragment start anchor if needed
-  if (consumeFragmentStart && node && isComment(node, '[')) {
-    node = node.nextSibling
-  }
-
   if (__DEV__ && !node) {
     throw new Error(
       `No current hydration node was found.\n` +
@@ -436,6 +468,7 @@ function locateHydrationNodeImpl(consumeFragmentStart = false) {
 
   resetInsertionState()
   setCurrentHydrationNode(node)
+  if (claim) claimFragmentStart(claim)
 }
 
 /**
@@ -474,28 +507,12 @@ export function locateEndAnchor(
 }
 
 // Find the SSR close marker for the current owner.
-export function locateHydrationBoundaryClose(
-  node: Node,
-  closeHint: Node | null = null,
-): Node {
-  let close = closeHint
-  if (!close || !isComment(close, ']')) {
-    if (isComment(node, ']')) {
-      close = node
-    } else {
-      let candidate = nextLogicalSibling(node)
-      while (candidate && !isComment(candidate, ']')) {
-        candidate = nextLogicalSibling(candidate)
-      }
-      close = candidate
-    }
+export function locateHydrationBoundaryClose(node: Node): Node {
+  let close: Node | null = node
+  while (close && !isComment(close, ']')) {
+    close = nextLogicalSibling(close)
   }
-
-  if (!close) {
-    return node
-  }
-
-  return close
+  return close || node
 }
 
 function handleMismatch(

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -291,6 +291,10 @@ export interface FragmentClaim {
   start: CommentAnchor | null
 }
 
+export function createFragmentClaim(): FragmentClaim {
+  return { start: null }
+}
+
 let innermostFragmentClaim: FragmentClaim | null = null
 
 /**
@@ -355,7 +359,11 @@ export function advanceHydrationNode(node: Node): void {
  *   a start node, for wrappers whose inner owner locates its own start later
  *   (dynamic components, keyed fragments, slot outlets). Locating early would
  *   consume the insertion state before the inner path is known.
- * - `exitHydrationCursor(cursor)` — restore the enclosing scope's resume point.
+ * - Both constructors also open the block's scope (`openBlockScope`):
+ *   transition-child status and the innermost claim are decided per block
+ *   and snapshotted on the cursor.
+ * - `exitHydrationCursor(cursor)` — restore the enclosing scope's resume point
+ *   and block scope.
  *   Every cursor from either constructor must reach this exactly once;
  *   `finishBlockCreation` in `fragment.ts` is the shared tail for the
  *   block-creating APIs.
@@ -402,9 +410,10 @@ export function enterHydrationCursor(
 }
 
 /**
- * Capture only the outer resume cursor for dynamic wrappers whose inner owner
- * locates the local start later, after the selected inner path is known.
- * This avoids consuming insertion state too early.
+ * Capture the outer resume cursor and open the block scope without locating
+ * a start node, for dynamic wrappers whose inner owner locates the local
+ * start later, after the selected inner path is known. This avoids consuming
+ * insertion state too early.
  */
 export function captureHydrationCursor(
   keepsMarkers?: boolean,
@@ -924,28 +933,28 @@ function warnHydrationChildrenMismatch(container: Element | null): void {
 }
 
 export function enterHydrationBoundary(close: Node | null): () => void {
-  return () => {
-    // Once the hydration cursor has already reached `close`, this scope has
-    // no unclaimed SSR nodes left to trim. Single-root paths commonly end up
-    // here, so there is no children-count mismatch to report.
-    const node = currentHydrationNode
-    if (
-      close &&
-      node &&
-      node !== close &&
-      // The cursor can also have advanced *past* `close`: a fragment that
-      // claims the close marker as its own anchor moves beyond it, and
-      // `advanceHydrationNode` climbs to the parent's next sibling at the end
-      // of a child list. `cleanupHydrationTail` detects that and bails, but
-      // only after walking forward for a node that is already behind us —
-      // once per boundary, which is quadratic over a list of them. Ask the
-      // DOM instead.
-      !(
-        close.compareDocumentPosition(node) &
-        4 /* DOCUMENT_POSITION_FOLLOWING */
-      )
-    ) {
-      cleanupHydrationTail(node, undefined, close)
-    }
+  return () => trimHydrationBoundary(close)
+}
+
+/** Trim the unclaimed SSR nodes left between the cursor and `close`. */
+export function trimHydrationBoundary(close: Node | null): void {
+  // Once the hydration cursor has already reached `close`, this scope has
+  // no unclaimed SSR nodes left to trim. Single-root paths commonly end up
+  // here, so there is no children-count mismatch to report.
+  const node = currentHydrationNode
+  if (
+    close &&
+    node &&
+    node !== close &&
+    // The cursor can also have advanced *past* `close`: a fragment that
+    // claims the close marker as its own anchor moves beyond it, and
+    // `advanceHydrationNode` climbs to the parent's next sibling at the end
+    // of a child list. `cleanupHydrationTail` detects that and bails, but
+    // only after walking forward for a node that is already behind us —
+    // once per boundary, which is quadratic over a list of them. Ask the
+    // DOM instead.
+    !(close.compareDocumentPosition(node) & 4 /* DOCUMENT_POSITION_FOLLOWING */)
+  ) {
+    cleanupHydrationTail(node, undefined, close)
   }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -40,7 +40,7 @@ import {
   currentHydrationNode,
   exitHydrationCursor,
   isHydrating,
-  locateEndAnchor,
+  locateFragmentEnd,
   locateHydrationNode,
 } from './dom/hydration'
 import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
@@ -745,7 +745,7 @@ export class SlotFragment
             slotRender,
             key,
           )
-          const end = claim.start ? locateEndAnchor(claim.start) : null
+          const end = locateFragmentEnd(claim.start)
           let exposedValid = contentValid
           if (this.sharedFallback) {
             recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -32,6 +32,7 @@ import {
 import type { VaporComponentInstance } from './component'
 import type { NodeRef } from './apiTemplateRef'
 import {
+  type FragmentClaim,
   type HydrationCursor,
   advanceHydrationNode,
   claimAnchor,
@@ -39,7 +40,7 @@ import {
   currentHydrationNode,
   exitHydrationCursor,
   isHydrating,
-  locateFragmentEnd,
+  locateEndAnchor,
   locateHydrationNode,
 } from './dom/hydration'
 import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
@@ -341,6 +342,8 @@ export class DynamicFragment extends RenderContextFragment {
   anchorLabel?: string
   keyed?: boolean
   inTransition?: boolean
+  /** hydration: this `v-if` branch's claim on its SSR range */
+  hydrationClaim?: FragmentClaim
   // Fallthrough (re-)application for this fragment's branches, installed by
   // the owning component when the fragment sits on its fallthrough root
   // chain. Invoked inside the branch render ctx so created effects capture
@@ -736,11 +739,13 @@ export class SlotFragment
         // their exposed branch. The receiver decides its fallback after all
         // shared roots have reported their final content/local-fallback result.
         if (this.sharedFallback || (this.inheritFallback && !fallback)) {
+          const claim: FragmentClaim = { start: null }
+          locateHydrationNode(claim)
           const { contentStart, contentValid } = this.updateHydratingContent(
             slotRender,
             key,
           )
-          const end = locateFragmentEnd(contentStart)
+          const end = claim.start ? locateEndAnchor(claim.start) : null
           let exposedValid = contentValid
           if (this.sharedFallback) {
             recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -37,6 +37,7 @@ import {
   advanceHydrationNode,
   claimAnchor,
   claimUntrackedAnchor,
+  createFragmentClaim,
   currentHydrationNode,
   exitHydrationCursor,
   isHydrating,
@@ -739,7 +740,7 @@ export class SlotFragment
         // their exposed branch. The receiver decides its fallback after all
         // shared roots have reported their final content/local-fallback result.
         if (this.sharedFallback || (this.inheritFallback && !fallback)) {
-          const claim: FragmentClaim = { start: null }
+          const claim = createFragmentClaim()
           locateHydrationNode(claim)
           const { contentStart, contentValid } = this.updateHydratingContent(
             slotRender,

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -33,6 +33,13 @@ export enum VaporVForFlags {
    * validity.
    */
   SLOT_ROOT = 1 << 5,
+  /**
+   * The server wraps every row in `<!--[-->...<!--]-->`: the row template is
+   * not a single element (compiler-ssr `needFragmentWrapper`). Hydration
+   * treats a leading `<!--[-->` as the row wrapper rather than as the row
+   * content's own marker.
+   */
+  WRAPPED_ROWS = 1 << 6,
 }
 
 export enum VaporBlockShape {

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -35,7 +35,8 @@ export enum VaporVForFlags {
   SLOT_ROOT = 1 << 5,
   /**
    * The server wraps every row in `<!--[-->...<!--]-->`: the row template is
-   * not a single element (compiler-ssr `needFragmentWrapper`). Hydration
+   * not a single element and the list is not a direct child of a Transition
+   * or TransitionGroup (compiler-ssr `needFragmentWrapper`). Hydration then
    * treats a leading `<!--[-->` as the row wrapper rather than as the row
    * content's own marker.
    */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vapor Mode hydration for complex `v-for` lists, nested lists, multi-root conditional content, forwarded slots, and transition groups.
  * Preserved correct DOM ordering and fragment boundaries during hydration and reactive updates.
  * Reduced hydration mismatch warnings across supported fragment and slot scenarios.
  * Improved handling of dynamic components and multi-root content during hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->