### PR TITLE
fix(suspense): don't drop nested suspense patches during hydration

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -2004,6 +2004,143 @@ describe('Suspense', () => {
     ])
   })
 
+  // toggling a nested suspensible suspense to sync content resolves the
+  // parent boundary synchronously while it is still being patched; the
+  // fallback fall-through must then be skipped or it patches the unmounted
+  // fallback and corrupts activeBranch
+  test('nested suspensible suspense toggled to sync content while parent is in fallback', async () => {
+    const route = ref('a')
+    const label = ref('first')
+
+    const AsyncChild = {
+      async setup() {
+        await new Promise(() => {}) // never resolves
+        return () => h('div', 'async child')
+      },
+    }
+    const PageA = {
+      setup: () => () => h('div', [h('span', 'page a'), h(AsyncChild)]),
+    }
+    const PageB = {
+      setup: () => () => h('div', `page b ${label.value}`),
+    }
+
+    const Comp = {
+      setup() {
+        return () =>
+          h(Suspense, null, {
+            default: h('div', { 'data-label': label.value }, [
+              h(
+                Suspense,
+                { suspensible: true },
+                {
+                  default:
+                    route.value === 'a'
+                      ? h(PageA, { key: 'a' })
+                      : h(PageB, { key: 'b' }),
+                },
+              ),
+            ]),
+            fallback: h('div', 'fallback'),
+          })
+      },
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+
+    // the nested suspense resolves synchronously, propagates, and resolves
+    // the outer boundary mid-patch
+    route.value = 'b'
+    await nextTick()
+    expect(serializeInner(root)).toBe(
+      `<div data-label="first"><div>page b first</div></div>`,
+    )
+
+    // a follow-up update must still reach the DOM
+    label.value = 'second'
+    await nextTick()
+    expect(serializeInner(root)).toBe(
+      `<div data-label="second"><div>page b second</div></div>`,
+    )
+  })
+
+  // a nested suspensible suspense resolving synchronously inside the parent's
+  // same-root patch must not resolve the parent before later siblings in the
+  // same patch have registered their async deps
+  test('nested suspensible suspense resolving the parent mid-patch while a later sibling registers an async dep', async () => {
+    const route = ref('a')
+    const show = ref(false)
+    let releaseSibling: () => void
+    const siblingGate = new Promise<void>(r => (releaseSibling = r))
+
+    const NeverChild = {
+      async setup() {
+        await new Promise(() => {}) // never resolves
+        return () => h('div', 'never')
+      },
+    }
+    const Sibling = {
+      async setup() {
+        await siblingGate
+        return () => h('div', 'sibling')
+      },
+    }
+    const PageA = {
+      setup: () => () => h('div', [h('span', 'page a'), h(NeverChild)]),
+    }
+    const PageB = {
+      setup: () => () => h('div', 'page b'),
+    }
+
+    const onResolve = vi.fn()
+    const Comp = {
+      setup() {
+        return () =>
+          h(
+            Suspense,
+            { onResolve },
+            {
+              default: h('div', [
+                h(
+                  Suspense,
+                  { suspensible: true },
+                  {
+                    default:
+                      route.value === 'a'
+                        ? h(PageA, { key: 'a' })
+                        : h(PageB, { key: 'b' }),
+                  },
+                ),
+                show.value ? h(Sibling) : null,
+              ]),
+              fallback: h('div', 'fallback'),
+            },
+          )
+      },
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+
+    // the nested suspense resolves synchronously and releases the parent's
+    // last dep, but the sibling mounted right after it is still pending
+    route.value = 'b'
+    show.value = true
+    await nextTick()
+    expect(serializeInner(root)).toBe(`<div>fallback</div>`)
+    expect(onResolve).not.toHaveBeenCalled()
+
+    releaseSibling!()
+    await new Promise(r => setTimeout(r))
+    expect(serializeInner(root)).toBe(
+      `<div><div>page b</div><div>sibling</div></div>`,
+    )
+    expect(onResolve).toHaveBeenCalledTimes(1)
+  })
+
   // #6416
   test('KeepAlive with Suspense', async () => {
     const Async = defineAsyncComponent({

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -3,11 +3,13 @@
  */
 
 import {
+  type Component,
   type ObjectDirective,
   Suspense,
   Teleport,
   Transition,
   type VNode,
+  type VNodeChild,
   createBlock,
   createCommentVNode,
   createElementBlock,
@@ -74,6 +76,75 @@ function mountWithHydration(html: string, render: () => any) {
 const triggerEvent = (type: string, el: Element) => {
   const event = new Event(type)
   el.dispatchEvent(event)
+}
+
+type SuspenseGate = (name?: string) => Promise<void>
+
+/**
+ * The Suspense hydration tests below need the app twice: rendered on the server
+ * with every async gate already resolved, then hydrated over that markup with
+ * the gates held open, so the boundary stays pending for as long as the test
+ * needs. `makeApp` is called once per side; whatever it returns next to `App`
+ * (refs, spies) is the client side's, and `release(name)` settles one gate.
+ */
+async function hydrateSuspenseApp<S extends object>(
+  makeApp: (gate: SuspenseGate) => { App: Component } & S,
+): Promise<
+  {
+    container: HTMLElement
+    ssrHtml: string
+    release: (name?: string) => void
+  } & S
+> {
+  const ssrHtml = await renderToString(h(makeApp(() => Promise.resolve()).App))
+  const container = document.createElement('div')
+  container.innerHTML = ssrHtml
+
+  const held: Record<string, Promise<void>> = {}
+  const release: Record<string, () => void> = {}
+  const client = makeApp(
+    (name = 'default') =>
+      (held[name] ||= new Promise<void>(r => (release[name] = r))),
+  )
+  createSSRApp(client.App).mount(container)
+  await nextTick()
+  return {
+    ...client,
+    container,
+    ssrHtml,
+    release: (name = 'default') => release[name](),
+  }
+}
+
+/**
+ * The shape that keeps a root <Suspense> pending for a whole hydration: a
+ * nested suspensible boundary inside it holding the content the test toggles.
+ * Only the inner view tracks that state, so an update patches the nested
+ * boundary directly - the shape a router-driven <RouterView> takes.
+ */
+function nestedSuspenseApp(opts: {
+  content: () => VNodeChild
+  onRootResolve?: () => void
+  onNestedResolve?: () => void
+  // props for a <Transition> wrapped around the nested boundary
+  transition?: Record<string, unknown>
+}): Component {
+  const View = defineComponent({
+    setup() {
+      const inner = () =>
+        h(
+          Suspense,
+          { suspensible: true, onResolve: opts.onNestedResolve },
+          { default: opts.content },
+        )
+      return () =>
+        opts.transition ? h(Transition, opts.transition, inner) : inner()
+    },
+  })
+  return defineComponent({
+    setup: () => () =>
+      h(Suspense, { onResolve: opts.onRootResolve }, () => h(View)),
+  })
 }
 
 describe('SSR hydration', () => {
@@ -1048,6 +1119,236 @@ describe('SSR hydration', () => {
     triggerEvent('click', container.querySelector('span')!)
     await nextTick()
     expect(container.innerHTML).toBe(`<span>1</span>`)
+  })
+
+  // updating the content of a nested suspensible suspense while the root
+  // suspense is still hydrating must be patched through: the root suspense
+  // keeps pending deps for the whole hydration, so the skip introduced for
+  // #8678 would drop the update and leave the stale SSR DOM on screen
+  // forever (e.g. a router navigation before hydration finishes)
+  test('Suspense: update nested suspensible suspense during hydration', async () => {
+    // hand-rolled rather than nestedSuspenseApp(): `route` is read in the root
+    // App's own render, so the update reaches the nested boundary through the
+    // root's same-root patch instead of patching it directly
+    const {
+      container,
+      ssrHtml,
+      route,
+      release,
+      onRootResolve,
+      onNestedResolve,
+    } = await hydrateSuspenseApp(gate => {
+      const route = ref('a')
+      const onRootResolve = vi.fn()
+      const onNestedResolve = vi.fn()
+
+      const AsyncChild = defineComponent({
+        async setup() {
+          await gate()
+          return () => h('div', 'async child')
+        },
+      })
+      const PageA = defineComponent({
+        setup: () => () => h('div', [h('span', 'page a'), h(AsyncChild)]),
+      })
+      const PageB = defineComponent({
+        setup: () => () => h('div', [h('span', 'page b')]),
+      })
+
+      const App = defineComponent({
+        setup() {
+          return () =>
+            h(
+              Suspense,
+              { onResolve: onRootResolve },
+              {
+                default: () =>
+                  h(
+                    Suspense,
+                    { suspensible: true, onResolve: onNestedResolve },
+                    {
+                      default: () =>
+                        route.value === 'a'
+                          ? h(PageA, { key: 'a' })
+                          : h(PageB, { key: 'b' }),
+                    },
+                  ),
+              },
+            )
+        },
+      })
+
+      return { App, route, onRootResolve, onNestedResolve }
+    })
+
+    expect(ssrHtml).toBe(`<div><span>page a</span><div>async child</div></div>`)
+    expect(onRootResolve).not.toHaveBeenCalled()
+    expect(container.innerHTML).toBe(
+      `<div><span>page a</span><div>async child</div></div>`,
+    )
+
+    // toggle the nested suspense content while hydration is still pending:
+    // the stale SSR branch is unmounted and the new content shows immediately
+    route.value = 'b'
+    await nextTick()
+    expect(container.innerHTML).toBe(`<div><span>page b</span></div>`)
+    expect(onNestedResolve).toHaveBeenCalledTimes(1)
+    expect(onRootResolve).toHaveBeenCalledTimes(1)
+
+    // the late-resolving abandoned branch must not resurrect the old content
+    release()
+    await new Promise(r => setTimeout(r))
+    expect(container.innerHTML).toBe(`<div><span>page b</span></div>`)
+    expect(onNestedResolve).toHaveBeenCalledTimes(1)
+    expect(onRootResolve).toHaveBeenCalledTimes(1)
+  })
+
+  // a nested suspense that was already toggled once during hydration has
+  // isHydrating unset, but while the root suspense is still hydrating a
+  // second toggle must also be patched through (checked via
+  // parentSuspense.isHydrating): the first toggle may leave the boundary
+  // pending on an async branch, and dropping the second toggle would strand
+  // the view on the stale SSR DOM until that abandoned branch resolves
+  test('Suspense: update nested suspensible suspense twice during hydration', async () => {
+    const { container, ssrHtml, route, release, onRootResolve, onChildSetup } =
+      await hydrateSuspenseApp(gate => {
+        const route = ref('a')
+        const onRootResolve = vi.fn()
+        const onChildSetup = vi.fn()
+
+        const asyncChild = (name: string, text: string) =>
+          defineComponent({
+            async setup() {
+              onChildSetup(text)
+              await gate(name)
+              return () => h('div', text)
+            },
+          })
+        const HydrationChild = asyncChild('hydration', 'hydration child')
+        const TargetChild = asyncChild('target', 'target child')
+
+        const PageA = defineComponent({
+          setup: () => () => h('div', [h('span', 'page a'), h(HydrationChild)]),
+        })
+        const PageB = defineComponent({
+          setup: () => () => h('div', [h('span', 'page b'), h(TargetChild)]),
+        })
+        const PageC = defineComponent({
+          setup: () => () => h('div', [h('span', 'page c')]),
+        })
+
+        const App = nestedSuspenseApp({
+          onRootResolve,
+          content: () =>
+            route.value === 'a'
+              ? h(PageA, { key: 'a' })
+              : route.value === 'b'
+                ? h(PageB, { key: 'b' })
+                : h(PageC, { key: 'c' }),
+        })
+
+        return { App, route, onRootResolve, onChildSetup }
+      })
+
+    expect(ssrHtml).toBe(
+      `<div><span>page a</span><div>hydration child</div></div>`,
+    )
+    expect(onRootResolve).not.toHaveBeenCalled()
+
+    // first toggle while hydrating: the target is mounted but pends on its
+    // async child, so the SSR DOM of page a stays visible and the boundary is
+    // no longer hydrating
+    route.value = 'b'
+    await nextTick()
+    expect(onChildSetup).toHaveBeenCalledWith('target child')
+    expect(container.innerHTML).toBe(
+      `<div><span>page a</span><div>hydration child</div></div>`,
+    )
+    expect(onRootResolve).not.toHaveBeenCalled()
+
+    // second toggle while the root suspense is still hydrating
+    route.value = 'c'
+    await nextTick()
+    expect(container.innerHTML).toBe(`<div><span>page c</span></div>`)
+    expect(onRootResolve).toHaveBeenCalledTimes(1)
+
+    // neither abandoned branch may resurrect once its gate resolves
+    release('target')
+    release('hydration')
+    await new Promise(r => setTimeout(r))
+    expect(container.innerHTML).toBe(`<div><span>page c</span></div>`)
+    expect(onRootResolve).toHaveBeenCalledTimes(1)
+  })
+
+  // the common case: navigate during hydration to a page that is itself
+  // async, then let it load. the SSR DOM stays until the target's async setup
+  // resolves, then the target replaces it and the root resolves exactly once
+  test('Suspense: update nested suspensible suspense during hydration to an async target', async () => {
+    const { container, ssrHtml, route, release, onRootResolve } =
+      await hydrateSuspenseApp(gate => {
+        const route = ref('a')
+        const onRootResolve = vi.fn()
+
+        const HydrationChild = defineComponent({
+          async setup() {
+            await gate('hydration')
+            return () => h('div', 'hydration child')
+          },
+        })
+        const TargetChild = defineComponent({
+          async setup() {
+            await gate('target')
+            return () => h('div', 'target child')
+          },
+        })
+
+        const PageA = defineComponent({
+          setup: () => () => h('div', [h('span', 'page a'), h(HydrationChild)]),
+        })
+        const PageB = defineComponent({
+          setup: () => () => h('div', [h('span', 'page b'), h(TargetChild)]),
+        })
+
+        const App = nestedSuspenseApp({
+          onRootResolve,
+          content: () =>
+            route.value === 'a'
+              ? h(PageA, { key: 'a' })
+              : h(PageB, { key: 'b' }),
+        })
+
+        return { App, route, onRootResolve }
+      })
+
+    expect(ssrHtml).toBe(
+      `<div><span>page a</span><div>hydration child</div></div>`,
+    )
+    expect(onRootResolve).not.toHaveBeenCalled()
+
+    // the target pends on its own async child: the SSR DOM stays visible
+    route.value = 'b'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      `<div><span>page a</span><div>hydration child</div></div>`,
+    )
+    expect(onRootResolve).not.toHaveBeenCalled()
+
+    // the target finishes loading: it replaces the SSR DOM and hydration
+    // completes without waiting for the abandoned branch
+    release('target')
+    await new Promise(r => setTimeout(r))
+    expect(container.innerHTML).toBe(
+      `<div><span>page b</span><div>target child</div></div>`,
+    )
+    expect(onRootResolve).toHaveBeenCalledTimes(1)
+
+    // the abandoned branch resolving must not resurrect the old content
+    release('hydration')
+    await new Promise(r => setTimeout(r))
+    expect(container.innerHTML).toBe(
+      `<div><span>page b</span><div>target child</div></div>`,
+    )
+    expect(onRootResolve).toHaveBeenCalledTimes(1)
   })
 
   test('Suspense (full integration)', async () => {

--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -1204,6 +1204,60 @@ describe('SSR hydration', () => {
     expect(onRootResolve).toHaveBeenCalledTimes(1)
   })
 
+  test('Suspense: updating resolved nested suspense does not resolve hydrating parent', async () => {
+    const { container, route, release, onRootResolve } =
+      await hydrateSuspenseApp(gate => {
+        const route = ref('a')
+        const onRootResolve = vi.fn()
+
+        const AsyncSibling = defineComponent({
+          async setup() {
+            await gate()
+            return () => h('span', 'async sibling')
+          },
+        })
+        const PageA = defineComponent({
+          setup: () => () => h('p', 'page a'),
+        })
+        const PageB = defineComponent({
+          setup: () => () => h('p', 'page b'),
+        })
+        const RouteView = defineComponent({
+          setup: () => () =>
+            h(
+              Suspense,
+              { suspensible: true },
+              {
+                default: () => (route.value === 'a' ? h(PageA) : h(PageB)),
+              },
+            ),
+        })
+        const App = defineComponent({
+          setup: () => () =>
+            h(
+              Suspense,
+              { onResolve: onRootResolve },
+              { default: () => h('div', [h(AsyncSibling), h(RouteView)]) },
+            ),
+        })
+
+        return { App, route, onRootResolve }
+      })
+
+    expect(onRootResolve).not.toHaveBeenCalled()
+
+    route.value = 'b'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      `<div><span>async sibling</span><p>page b</p></div>`,
+    )
+    expect(onRootResolve).not.toHaveBeenCalled()
+
+    release()
+    await new Promise(r => setTimeout(r))
+    expect(onRootResolve).toHaveBeenCalledTimes(1)
+  })
+
   // a nested suspense that was already toggled once during hydration has
   // isHydrating unset, but while the root suspense is still hydrating a
   // second toggle must also be patched through (checked via

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -108,10 +108,13 @@ export const SuspenseImpl = {
       //  2. mounting along with the pendingBranch of parentSuspense
       // it is necessary to skip the current patch to avoid multiple mounts
       // of inner components.
+      // but not while the parent is hydrating: its pending branch is the
+      // adopted SSR DOM, never mounted again, so skipping leaves it stale.
       if (
         parentSuspense &&
         parentSuspense.deps > 0 &&
-        !n1.suspense!.isInFallback
+        !n1.suspense!.isInFallback &&
+        !parentSuspense.isHydrating
       ) {
         n2.suspense = n1.suspense!
         n2.suspense.vnode = n2

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -246,6 +246,9 @@ function patchSuspense(
     suspense.pendingBranch = newBranch
     if (isSameVNodeType(pendingBranch, newBranch)) {
       // same root type but content may have changed.
+      // hold the boundary pending across the patch: a nested branch that
+      // resolves in here must not resolve it before later siblings register.
+      suspense.deps++
       patch(
         pendingBranch,
         newBranch,
@@ -257,6 +260,7 @@ function patchSuspense(
         slotScopeIds,
         optimized,
       )
+      suspense.deps--
       if (suspense.deps <= 0) {
         suspense.resolve()
       } else if (isInFallback) {

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -654,6 +654,7 @@ function createSuspenseBoundary(
           parentSuspense.pendingBranch &&
           parentSuspenseId === parentSuspense.pendingId
         ) {
+          parentSuspenseId = undefined
           parentSuspense.deps--
           if (parentSuspense.deps === 0 && !sync) {
             parentSuspense.resolve()


### PR DESCRIPTION
> Stacked PR - Base #15411

> nuxt/nuxt#36249 is using the patch from part of this PR for a POC to fix issues caused when users navigate during hydration.

## Issue

`<Suspense>` skips nested boundary updates when the parent has pending deps, but this should not apply during hydration because the adopted branch will not be mounted again.

This causes navigation updates to be dropped and the boundary to resolve with stale SSR content.

## Changes

Do not skip nested Suspense updates when the parent boundary is hydrating, so navigation updates can be patched correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hydration of nested Suspense boundaries so content updates are correctly reflected in the live DOM.
  - Prevented stale content when toggling nested Suspense content or navigating to asynchronous targets during hydration.
  - Fixed updates to resolved nested boundaries while a parent boundary is still hydrating.
  - Fixed keyed child insertion into pending Suspense content without prematurely resolving the boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->