### PR TITLE
fix(runtime-core): unmount v-once children after parent rerenders

### DIFF
--- a/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
+++ b/packages/runtime-core/__tests__/rendererOptimizedMode.spec.ts
@@ -1313,58 +1313,75 @@ describe('renderer: optimized mode', () => {
     expect(inner(root)).toBe('<div><!--comment--><div>bar</div></div>')
   })
 
-  test('should not take unmount children fast path if children contain cached nodes', async () => {
-    const show = ref(true)
-    const spyUnmounted = vi.fn()
+  test.each(['block', 'full diff', 'disabled tracking'])(
+    'should unmount cached children after %s updates',
+    async mode => {
+      const show = ref(true)
+      const count = ref(0)
+      const spyUnmounted = vi.fn()
 
-    const Child = {
-      setup() {
-        onUnmounted(spyUnmounted)
-        return () => createVNode('div', null, 'Child')
-      },
-    }
+      const Child = {
+        setup() {
+          onUnmounted(spyUnmounted)
+          return () => createVNode('div', null, 'Child')
+        },
+      }
 
-    const app = createApp({
-      render(_: any, cache: any) {
-        return show.value
-          ? (openBlock(),
-            createBlock('div', null, [
-              createVNode('div', null, [
-                cache[0] ||
-                  (setBlockTracking(-1, true),
-                  ((cache[0] = createVNode('div', null, [
-                    createVNode(Child),
-                  ])).cacheIndex = 0),
-                  setBlockTracking(1),
-                  cache[0]),
-              ]),
-            ]))
-          : createCommentVNode('v-if', true)
-      },
-    })
+      const app = createApp({
+        render(_: any, cache: any) {
+          return show.value
+            ? (openBlock(mode === 'disabled tracking' && count.value === 1),
+              createBlock('div', null, [
+                createVNode('div', null, [
+                  cache[0] ||
+                    (setBlockTracking(-1, true),
+                    ((cache[0] = createVNode('div', null, [
+                      createVNode(Child),
+                    ])).cacheIndex = 0),
+                    setBlockTracking(1),
+                    cache[0]),
+                ]),
+                createTextVNode(String(count.value), PatchFlags.TEXT),
+                // Exercise the non-isomorphic block fallback as well as block patching.
+                ...(mode === 'full diff' && count.value
+                  ? [createTextVNode('', PatchFlags.TEXT)]
+                  : []),
+              ]))
+            : createCommentVNode('v-if', true)
+        },
+      })
 
-    app.mount(root)
-    expect(inner(root)).toBe(
-      '<div><div><div><div>Child</div></div></div></div>',
-    )
+      app.mount(root)
+      expect(inner(root)).toBe(
+        '<div><div><div><div>Child</div></div></div>0</div>',
+      )
 
-    show.value = false
-    await nextTick()
-    expect(inner(root)).toBe('<!--v-if-->')
-    expect(spyUnmounted).toHaveBeenCalledTimes(1)
+      count.value++
+      await nextTick()
+      count.value++
+      await nextTick()
+      expect(inner(root)).toBe(
+        '<div><div><div><div>Child</div></div></div>2</div>',
+      )
 
-    show.value = true
-    await nextTick()
-    expect(inner(root)).toBe(
-      '<div><div><div><div>Child</div></div></div></div>',
-    )
+      show.value = false
+      await nextTick()
+      expect(inner(root)).toBe('<!--v-if-->')
+      expect(spyUnmounted).toHaveBeenCalledTimes(1)
 
-    // should unmount again, this verifies previous cache was properly cleared
-    show.value = false
-    await nextTick()
-    expect(inner(root)).toBe('<!--v-if-->')
-    expect(spyUnmounted).toHaveBeenCalledTimes(2)
-  })
+      show.value = true
+      await nextTick()
+      expect(inner(root)).toBe(
+        '<div><div><div><div>Child</div></div></div>2</div>',
+      )
+
+      // should unmount again, this verifies previous cache was properly cleared
+      show.value = false
+      await nextTick()
+      expect(inner(root)).toBe('<!--v-if-->')
+      expect(spyUnmounted).toHaveBeenCalledTimes(2)
+    },
+  )
 
   // #12371
   test('unmount children when the user calls a compiled slot', async () => {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -403,6 +403,19 @@ function baseCreateRenderer(
       n2.dynamicChildren = null
     }
 
+    // Cached v-once nodes skip block tracking on subsequent renders.
+    if (
+      n2.dynamicChildren &&
+      n1 &&
+      n1.dynamicChildren &&
+      n1.dynamicChildren.hasOnce
+    ) {
+      if (n2.dynamicChildren === (EMPTY_ARR as any)) {
+        n2.dynamicChildren = []
+      }
+      n2.dynamicChildren.hasOnce = true
+    }
+
     const { type, ref, shapeFlag } = n2
     switch (type) {
       case Text:
@@ -2171,7 +2184,7 @@ function baseCreateRenderer(
 
     // #6593 should clean memo cache when unmount
     if (cacheIndex != null) {
-      parentComponent!.renderCache[cacheIndex] = undefined
+      ;(vnode.ctx || parentComponent)!.renderCache[cacheIndex] = undefined
     }
 
     if (shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2183,18 +2183,9 @@ function baseCreateRenderer(
     }
 
     // #6593 should clean memo cache when unmount
-    if (cacheIndex != null) {
-      const cache = (vnode.ctx || parentComponent)!.renderCache
-      const cached = cache[cacheIndex] as VNode | undefined
-      // A cloned slot can belong to a different mounted instance.
-      if (
-        cached &&
-        (cached.component
-          ? cached.component === vnode.component
-          : cached.el === vnode.el)
-      ) {
-        cache[cacheIndex] = undefined
-      }
+    // Slot receivers must not invalidate caches owned by the slot author.
+    if (cacheIndex != null && (!vnode.ctx || vnode.ctx === parentComponent)) {
+      parentComponent!.renderCache[cacheIndex] = undefined
     }
 
     if (shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2184,7 +2184,17 @@ function baseCreateRenderer(
 
     // #6593 should clean memo cache when unmount
     if (cacheIndex != null) {
-      ;(vnode.ctx || parentComponent)!.renderCache[cacheIndex] = undefined
+      const cache = (vnode.ctx || parentComponent)!.renderCache
+      const cached = cache[cacheIndex] as VNode | undefined
+      // A cloned slot can belong to a different mounted instance.
+      if (
+        cached &&
+        (cached.component
+          ? cached.component === vnode.component
+          : cached.el === vnode.el)
+      ) {
+        cache[cacheIndex] = undefined
+      }
     }
 
     if (shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2171,7 +2171,10 @@ function baseCreateRenderer(
       memo,
     } = vnode
 
-    if (patchFlag === PatchFlags.BAIL) {
+    if (
+      patchFlag === PatchFlags.BAIL ||
+      (dynamicChildren && dynamicChildren.hasOnce)
+    ) {
       optimized = false
     }
 

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -737,6 +737,7 @@ export function cloneVNode<T, U>(
     anchor: vnode.anchor,
     ctx: vnode.ctx,
     ce: vnode.ce,
+    cacheIndex: vnode.cacheIndex,
   }
 
   // if the vnode will be replaced by the cloned one, it is necessary

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -354,43 +354,58 @@ describe('compiler + runtime integration', () => {
     expect(unmounted).toHaveBeenNthCalledWith(2, 2)
   })
 
-  test('preserves a mounted v-once slot when a duplicate is removed', async () => {
-    const show = ref(true)
-    const count = ref(0)
-    const tick = ref(0)
-    const container = document.createElement('div')
-    const app = createApp({
-      components: {
-        Child: { props: ['value'], template: '<p>{{ value }}</p>' },
-        Twice: {
-          setup(_, { slots }) {
-            return () => {
-              tick.value
-              return Vue.h('div', [
-                Vue.h('section', slots.default!()),
-                show.value ? Vue.h('aside', slots.default!()) : null,
-              ])
-            }
+  test.each([
+    [0, '<Child v-once :value="count" />'],
+    [1, '<Child v-once :value="count" />'],
+    [0, '<p v-once>{{ count }}</p>'],
+    [1, '<p v-once>{{ count }}</p>'],
+  ])(
+    'preserves cached slot content after removing outlet %i: %s',
+    async (removeIndex, template) => {
+      const show = ref(true)
+      const count = ref(0)
+      const tick = ref(0)
+      const container = document.createElement('div')
+      const app = createApp({
+        components: {
+          Child: { props: ['value'], template: '<p>{{ value }}</p>' },
+          Twice: {
+            setup(_, { slots }) {
+              return () => {
+                tick.value
+                return Vue.h(
+                  'div',
+                  ['section', 'aside'].map((tag, index) =>
+                    show.value || index !== removeIndex
+                      ? Vue.h(tag, slots.default!())
+                      : null,
+                  ),
+                )
+              }
+            },
           },
         },
-      },
-      setup: () => ({ count }),
-      template: '<Twice><Child v-once :value="count" /></Twice>',
-    })
+        setup: () => ({ count }),
+        template: `<Twice>${template}</Twice>`,
+      })
 
-    app.mount(container)
-    expect(container.textContent).toBe('00')
-    show.value = false
-    await nextTick()
-    expect(container.textContent).toBe('0')
-    count.value++
-    tick.value++
-    await nextTick()
-    expect(container.textContent).toBe('0')
-    app.unmount()
-  })
+      app.mount(container)
+      expect(container.textContent).toBe('00')
+      show.value = false
+      await nextTick()
+      expect(container.textContent).toBe('0')
+      count.value++
+      tick.value++
+      await nextTick()
+      expect(container.textContent).toBe('0')
+      show.value = true
+      await nextTick()
+      expect(container.textContent).toBe('00')
+      app.unmount()
+    },
+  )
 
-  test('clears a cloned v-once slot from its owner cache', async () => {
+  test('does not clear the receiver cache when a cloned v-once slot unmounts', async () => {
     const show = ref(true)
     const count = ref(0)
     const render = compileToFunction(

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { BindingTypes, type CompilerOptions } from '@vue/compiler-core'
 import { compile } from '@vue/compiler-dom'
-import { EMPTY_ARR } from '@vue/shared'
+import { EMPTY_ARR, PatchFlags } from '@vue/shared'
 import { type VNode, createApp, nextTick, reactive, ref } from '../src'
 import * as Vue from '../src'
 import type { InternalRenderFunction } from '../../runtime-core/src/component'
@@ -288,6 +288,106 @@ describe('compiler + runtime integration', () => {
     ok.value = false
     await nextTick()
     expect(container.innerHTML).toBe(`<div>false<div>true</div></div>`)
+  })
+
+  test.each([
+    '<div><Child v-once />{{ count }}</div>',
+    '<Child v-once />{{ count }}',
+  ])('unmounts a v-once child after rerendering: %s', async template => {
+    const count = ref(0)
+    const unmounted = vi.fn()
+    const container = document.createElement('div')
+    const app = createApp({
+      components: {
+        Child: { template: 'child', unmounted },
+      },
+      setup: () => ({ count }),
+      template,
+    })
+
+    app.mount(container)
+    expect(container.textContent).toBe('child0')
+    count.value++
+    await nextTick()
+    expect(container.textContent).toBe('child1')
+
+    app.unmount()
+    expect(unmounted).toHaveBeenCalledTimes(1)
+  })
+
+  test('unmounts separate instances of a v-once slot', async () => {
+    const show = ref(true)
+    const unmounted = vi.fn()
+    let id = 0
+    const container = document.createElement('div')
+    const app = createApp({
+      components: {
+        Child: {
+          data: () => ({ id: ++id }),
+          template: '{{ id }}',
+          unmounted() {
+            unmounted(this.id)
+          },
+        },
+        Twice: {
+          setup(_, { slots }) {
+            return () =>
+              Vue.h('div', [
+                show.value ? Vue.h('section', slots.default!()) : null,
+                Vue.h('aside', slots.default!()),
+              ])
+          },
+        },
+      },
+      template: '<Twice><Child v-once /></Twice>',
+    })
+
+    app.mount(container)
+    expect(container.textContent).toBe('12')
+    show.value = false
+    await nextTick()
+    expect(container.textContent).toBe('2')
+    expect(unmounted).toHaveBeenCalledTimes(1)
+    expect(unmounted).toHaveBeenNthCalledWith(1, 1)
+    app.unmount()
+    expect(unmounted).toHaveBeenCalledTimes(2)
+    expect(unmounted).toHaveBeenNthCalledWith(2, 2)
+  })
+
+  test('clears a cloned v-once slot from its owner cache', async () => {
+    const show = ref(true)
+    const count = ref(0)
+    const render = compileToFunction(
+      '<div><p v-once>{{ count }}</p><section><slot /></section><aside v-if="show"><slot /></aside><b>{{ count }}</b></div>',
+    )
+    const fullDiffRender: InternalRenderFunction = (...args) => {
+      const vnode = render(...args) as VNode
+      vnode.patchFlag = PatchFlags.BAIL
+      return vnode
+    }
+    fullDiffRender._rc = true
+    const container = document.createElement('div')
+    const app = createApp({
+      components: {
+        Child: { template: 'child' },
+        Twice: {
+          setup: () => ({ count, show }),
+          render: fullDiffRender,
+        },
+      },
+      setup: () => ({ enabled: true }),
+      template:
+        '<Twice><template #default v-if="enabled"><Child v-once /></template></Twice>',
+    })
+
+    app.mount(container)
+    show.value = false
+    await nextTick()
+    count.value++
+    await nextTick()
+    expect(container.querySelector('p')!.textContent).toBe('0')
+    expect(container.querySelector('b')!.textContent).toBe('1')
+    app.unmount()
   })
 
   test('v-for + v-once', async () => {

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -354,6 +354,42 @@ describe('compiler + runtime integration', () => {
     expect(unmounted).toHaveBeenNthCalledWith(2, 2)
   })
 
+  test('preserves a mounted v-once slot when a duplicate is removed', async () => {
+    const show = ref(true)
+    const count = ref(0)
+    const tick = ref(0)
+    const container = document.createElement('div')
+    const app = createApp({
+      components: {
+        Child: { props: ['value'], template: '<p>{{ value }}</p>' },
+        Twice: {
+          setup(_, { slots }) {
+            return () => {
+              tick.value
+              return Vue.h('div', [
+                Vue.h('section', slots.default!()),
+                show.value ? Vue.h('aside', slots.default!()) : null,
+              ])
+            }
+          },
+        },
+      },
+      setup: () => ({ count }),
+      template: '<Twice><Child v-once :value="count" /></Twice>',
+    })
+
+    app.mount(container)
+    expect(container.textContent).toBe('00')
+    show.value = false
+    await nextTick()
+    expect(container.textContent).toBe('0')
+    count.value++
+    tick.value++
+    await nextTick()
+    expect(container.textContent).toBe('0')
+    app.unmount()
+  })
+
   test('clears a cloned v-once slot from its owner cache', async () => {
     const show = ref(true)
     const count = ref(0)

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -620,4 +620,37 @@ describe('compiler + runtime integration', () => {
       app.unmount()
     })
   })
+
+  test.each([false, true])(
+    'unmounts all children of a nested v-once block (updated: %s)',
+    async updated => {
+      const count = ref(0)
+      const onceUnmounted = vi.fn()
+      const liveUnmounted = vi.fn()
+      const container = document.createElement('div')
+      const app = createApp({
+        components: {
+          OnceChild: { template: 'once', unmounted: onceUnmounted },
+          LiveChild: { template: 'live', unmounted: liveUnmounted },
+        },
+        setup: () => ({ count, show: true }),
+        template:
+          '<div><section v-if="show"><OnceChild v-once /><LiveChild />{{ count }}</section></div>',
+      })
+
+      app.mount(container)
+      expect(container.textContent).toBe('oncelive0')
+      if (updated) {
+        count.value++
+        await nextTick()
+        expect(container.textContent).toBe('oncelive1')
+      }
+
+      app.unmount()
+      expect({
+        once: onceUnmounted.mock.calls.length,
+        live: liveUnmounted.mock.calls.length,
+      }).toEqual({ once: 1, live: 1 })
+    },
+  )
 })

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { BindingTypes, type CompilerOptions } from '@vue/compiler-core'
 import { compile } from '@vue/compiler-dom'
-import { EMPTY_ARR, PatchFlags } from '@vue/shared'
+import { EMPTY_ARR } from '@vue/shared'
 import { type VNode, createApp, nextTick, reactive, ref } from '../src'
 import * as Vue from '../src'
 import type { InternalRenderFunction } from '../../runtime-core/src/component'
@@ -315,60 +315,25 @@ describe('compiler + runtime integration', () => {
     expect(unmounted).toHaveBeenCalledTimes(1)
   })
 
-  test('unmounts separate instances of a v-once slot', async () => {
-    const show = ref(true)
-    const unmounted = vi.fn()
-    let id = 0
-    const container = document.createElement('div')
-    const app = createApp({
-      components: {
-        Child: {
-          data: () => ({ id: ++id }),
-          template: '{{ id }}',
-          unmounted() {
-            unmounted(this.id)
-          },
-        },
-        Twice: {
-          setup(_, { slots }) {
-            return () =>
-              Vue.h('div', [
-                show.value ? Vue.h('section', slots.default!()) : null,
-                Vue.h('aside', slots.default!()),
-              ])
-          },
-        },
-      },
-      template: '<Twice><Child v-once /></Twice>',
-    })
-
-    app.mount(container)
-    expect(container.textContent).toBe('12')
-    show.value = false
-    await nextTick()
-    expect(container.textContent).toBe('2')
-    expect(unmounted).toHaveBeenCalledTimes(1)
-    expect(unmounted).toHaveBeenNthCalledWith(1, 1)
-    app.unmount()
-    expect(unmounted).toHaveBeenCalledTimes(2)
-    expect(unmounted).toHaveBeenNthCalledWith(2, 2)
-  })
-
-  test.each([
-    [0, '<Child v-once :value="count" />'],
-    [1, '<Child v-once :value="count" />'],
-    [0, '<p v-once>{{ count }}</p>'],
-    [1, '<p v-once>{{ count }}</p>'],
-  ])(
-    'preserves cached slot content after removing outlet %i: %s',
-    async (removeIndex, template) => {
+  test.each([0, 1])(
+    'preserves cached slot content after removing outlet %i',
+    async removeIndex => {
       const show = ref(true)
       const count = ref(0)
       const tick = ref(0)
+      const unmounted = vi.fn()
+      let id = 0
       const container = document.createElement('div')
       const app = createApp({
         components: {
-          Child: { props: ['value'], template: '<p>{{ value }}</p>' },
+          Child: {
+            props: ['value'],
+            data: () => ({ id: ++id }),
+            template: '<p>{{ value }}</p>',
+            unmounted() {
+              unmounted(this.id)
+            },
+          },
           Twice: {
             setup(_, { slots }) {
               return () => {
@@ -386,7 +351,7 @@ describe('compiler + runtime integration', () => {
           },
         },
         setup: () => ({ count }),
-        template: `<Twice>${template}</Twice>`,
+        template: '<Twice><Child v-once :value="count" /></Twice>',
       })
 
       app.mount(container)
@@ -394,6 +359,8 @@ describe('compiler + runtime integration', () => {
       show.value = false
       await nextTick()
       expect(container.textContent).toBe('0')
+      expect(unmounted).toHaveBeenCalledTimes(1)
+      expect(unmounted).toHaveBeenLastCalledWith(removeIndex + 1)
       count.value++
       tick.value++
       await nextTick()
@@ -402,28 +369,24 @@ describe('compiler + runtime integration', () => {
       await nextTick()
       expect(container.textContent).toBe('00')
       app.unmount()
+      expect(unmounted.mock.calls.map(([id]) => id).sort()).toEqual([1, 2, 3])
     },
   )
 
   test('does not clear the receiver cache when a cloned v-once slot unmounts', async () => {
     const show = ref(true)
     const count = ref(0)
-    const render = compileToFunction(
-      '<div><p v-once>{{ count }}</p><section><slot /></section><aside v-if="show"><slot /></aside><b>{{ count }}</b></div>',
-    )
-    const fullDiffRender: InternalRenderFunction = (...args) => {
-      const vnode = render(...args) as VNode
-      vnode.patchFlag = PatchFlags.BAIL
-      return vnode
-    }
-    fullDiffRender._rc = true
     const container = document.createElement('div')
     const app = createApp({
       components: {
         Child: { template: 'child' },
         Twice: {
+          components: {
+            OwnChild: { props: ['value'], template: '<p>{{ value }}</p>' },
+          },
           setup: () => ({ count, show }),
-          render: fullDiffRender,
+          template:
+            '<div><OwnChild v-once :value="count" /><slot /><slot v-if="show" /><b>{{ count }}</b></div>',
         },
       },
       setup: () => ({ enabled: true }),


### PR DESCRIPTION
After a parent rerenders, unmounting it can skip a component inside `v-once`. Preserve the block's `hasOnce` marker across updates and the cache index when cloning vnodes. During unmount, clear only the current component's cache so removing one slot instance cannot invalidate another.

Related to #5154 and the teardown failure in [nuxt/nuxt#32154](https://github.com/nuxt/nuxt/issues/32154). This retains the whole-block marking approach from [#8809](https://github.com/vuejs/core/pull/8809#issuecomment-2226908022).

| | Description | GitHub |
| --- | --- | --- |
| Before | Parent rerenders, then unmounts; child unmount hook is skipped. | [Source](https://github.com/onmax/repros/tree/repro/vue-v-once-unmount/vue-v-once-unmount) |
| After | Same sequence with the runtime patch; child unmount hook runs once. | [Source](https://github.com/onmax/repros/tree/repro/vue-v-once-unmount/vue-v-once-unmount-fix) |

The linked READMEs provide the CLI commands and StackBlitz import links. Results above are from Node with happy-dom; StackBlitz terminal execution could not be verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lifecycle handling for cached and static content during updates, unmounts, and remounts.
  * Improved cleanup when cached content is rendered through multiple slots or duplicated and removed.
  * Preserved cached rendering behavior when content is cloned.
  * Ensured static content remains intact while associated cached content is properly cleared.
  * Improved `v-once` lifecycle behavior across rerenders and slot updates.
  * Preserved memoized content correctly when rendered nodes are cloned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->