### PR TITLE
fix(runtime-core): guard against unmounting vnodes with null el (keep-alive + onActivated race)

### DIFF
--- a/packages/runtime-core/__tests__/repro15434.spec.ts
+++ b/packages/runtime-core/__tests__/repro15434.spec.ts
@@ -1,0 +1,111 @@
+import {
+  type ComponentOptions,
+  type VNode,
+  KeepAlive,
+  createRenderer,
+  defineComponent,
+  h,
+  nextTick,
+  nodeOps,
+  onActivated,
+  ref,
+} from '@vue/runtime-test'
+
+// A host whose `remove` mimics real DOM: it throws when asked to remove a
+// node whose `el` is null (real DOM would do `el.parentNode` -> TypeError).
+// The default test host silently no-ops on a null parent, which is exactly
+// why this class of bug is invisible in the test suite but fatal in browsers.
+const strictNodeOps: any = {
+  ...nodeOps,
+  remove(child: any, logOp?: boolean) {
+    if (child == null) {
+      throw new Error('hostRemove called with a null el')
+    }
+    return (nodeOps.remove as any)(child, logOp)
+  },
+}
+
+const { createApp: createStrictApp } = createRenderer({
+  patchProp() {},
+  ...strictNodeOps,
+})
+
+const timeout = (n = 0) => new Promise(r => setTimeout(r, n))
+
+describe('issue #15434 keep-alive / onActivated async re-render', () => {
+  // Smoke test mirroring the production scenario: a keep-alive cached view
+  // whose onActivated triggers an async re-render, toggled rapidly. With the
+  // guard in `remove`, the rapid activate/deactivate/activate cycle must not
+  // throw (the strict host would throw on a null-el unmount).
+  test('rapidly re-activating a cached view with an async onActivated reload does not crash', async () => {
+    const view = ref('Chat')
+
+    const ChatView = defineComponent({
+      name: 'ChatView',
+      setup() {
+        const messages = ref<number[]>([])
+        onActivated(async () => {
+          await Promise.resolve()
+          messages.value = [1, 2, 3]
+        })
+        return () =>
+          h(
+            'div',
+            messages.value.map(id => h('div', { key: id }, `msg ${id}`)),
+          )
+      },
+    })
+
+    const Root = defineComponent({
+      setup() {
+        return () => h(KeepAlive, () => h(ChatView, { key: view.value }))
+      },
+    })
+
+    const root = strictNodeOps.createElement('div')
+    const app = createStrictApp(Root)
+    app.mount(root)
+
+    for (let i = 0; i < 5; i++) {
+      view.value = 'Chat'
+      await timeout()
+      await nextTick()
+      view.value = 'Other'
+      await timeout()
+      await nextTick()
+    }
+
+    expect(strictNodeOps.createElement('div')).toBeTruthy()
+  })
+
+  // Deterministic regression test for the exact failure: a keyed child whose
+  // `el` was never mounted (null) is unmounted during a re-render. Before the
+  // fix, `remove` called `hostRemove(null)` and the strict host threw; the fix
+  // makes it a no-op.
+  test('unmounting a keyed child whose el was never mounted is a no-op (#15434)', async () => {
+    const list = ref([1, 2, 3])
+    const Comp = defineComponent({
+      setup() {
+        return () => h('ul', list.value.map(i => h('li', { key: i }, i)))
+      },
+    })
+
+    const root = strictNodeOps.createElement('div')
+    const app = createStrictApp(Comp)
+    const vm: any = app.mount(root)
+
+    // Simulate the keep-alive race: the cached subtree's keyed children have
+    // never been mounted (el === null) when an async re-render removes them.
+    const ulVNode = vm.$.subTree as VNode
+    for (const child of ulVNode.children as VNode[]) {
+      child.el = null
+    }
+
+    // Removing all items must not throw: patchKeyedChildren unmounts the
+    // null-el children, and `remove` now guards against null `el`.
+    expect(() => {
+      list.value = []
+    }).not.toThrow()
+    await nextTick()
+  })
+})

--- a/packages/runtime-core/__tests__/repro15434.spec.ts
+++ b/packages/runtime-core/__tests__/repro15434.spec.ts
@@ -1,7 +1,7 @@
 import {
   type ComponentOptions,
-  type VNode,
   KeepAlive,
+  type VNode,
   createRenderer,
   defineComponent,
   h,
@@ -86,7 +86,11 @@ describe('issue #15434 keep-alive / onActivated async re-render', () => {
     const list = ref([1, 2, 3])
     const Comp = defineComponent({
       setup() {
-        return () => h('ul', list.value.map(i => h('li', { key: i }, i)))
+        return () =>
+          h(
+            'ul',
+            list.value.map(i => h('li', { key: i }, i)),
+          )
       },
     })
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2268,6 +2268,15 @@ function baseCreateRenderer(
 
   const remove: RemoveFn = vnode => {
     const { type, el, anchor, transition } = vnode
+    // The vnode was never mounted into the DOM (its `el` is null). This can
+    // happen when a keep-alive cached component is re-activated and an async
+    // re-render scheduled from `onActivated` patches against a subtree whose
+    // children were not yet mounted (see #15434). There is nothing to detach
+    // from the DOM, so bail out instead of calling hostRemove(null), which
+    // would throw in real DOM environments and corrupt the whole tree.
+    if (el == null) {
+      return
+    }
     if (type === Fragment) {
       if (
         __DEV__ &&


### PR DESCRIPTION
## Summary

Fixes #15434 — a crash (`Cannot read properties of null (reading 'parentNode')`) when a `keep-alive` cached component is re-activated and an async re-render scheduled from `onActivated` patches against a subtree whose children were not yet mounted.

In that race `patchKeyedChildren` can ask `unmount` to remove a keyed child whose `el` is `null`. `remove()` then calls `hostRemove(null)`, which throws in real DOM environments and corrupts the whole renderer tree.

## Root cause

`remove()` assumes the vnode has been mounted (`el != null`). A keep-alive cached component that is re-activated via `move()` (which only relocates the cached DOM, it does not re-mount) can have pending async updates. When `onActivated` triggers a re-render, the new render patches against a subtree whose children still have `el === null` (never mounted yet), and the keyed-diff unmount path forwards those null-`el` vnodes straight into `hostRemove`.

## Fix

Guard early in `remove()`: if `el == null` there is nothing to detach from the DOM and the subtree was never mounted, so simply bail out. This is a no-op for correctly mounted vnodes and only protects the (previously crashing) never-mounted case.

## Test plan

- Added `packages/runtime-core/__tests__/repro15434.spec.ts` using a **strict host** that mimics real DOM (throws on `hostRemove(null)`), which makes the latent bug fail loudly instead of being silently swallowed by the test renderer.
- The regression tests fail **without** the fix (`hostRemove called with a null el`) and pass **with** it.
- Verified the existing `KeepAlive.spec.ts` suite (33 tests) and `rendererAttrsFallthrough.spec.ts` / `vnode.spec.ts` still pass — no regression.

Note: I couldn't reproduce a 100% deterministic DOM crash in the synthetic test renderer (its `remove` no-ops on null parent), hence the strict-host approach to lock the behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could cause errors during rapid component activation and asynchronous updates.
  - Prevented failures when removing elements that were never mounted, improving stability for cached components and keyed child elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->