### PR TITLE
fix(compiler-vapor): emit createElement-backed children nested in a template

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -908,6 +908,58 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: element transform > nested custom element with dynamic child 1`] = `
+"import { setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, insert as _insert, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<span> ")
+const t1 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n2 = t1()
+  _setInsertionState(n2)
+  const n1 = _createPlainElement("my-custom-element")
+  const n0 = t0()
+  _insert(n0, n1)
+  const x0 = _txt(n0)
+  _renderEffect(() => _setText(x0, _toDisplayString(_ctx.msg)))
+  return n2
+}"
+`;
+
+exports[`compiler: element transform > nested plain template element anchored before a template sibling 1`] = `
+"import { child as _child, setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, insert as _insert, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<span> ")
+const t1 = _template("<div><!><b>", 1)
+
+export function render(_ctx) {
+  const n3 = t1()
+  const n2 = _child(n3)
+  _setInsertionState(n3, n2)
+  const n1 = _createPlainElement("template")
+  const n0 = t0()
+  _insert(n0, n1)
+  const x0 = _txt(n0)
+  _renderEffect(() => _setText(x0, _toDisplayString(_ctx.msg)))
+  return n3
+}"
+`;
+
+exports[`compiler: element transform > nested plain template element with dynamic child 1`] = `
+"import { setInsertionState as _setInsertionState, createPlainElement as _createPlainElement, insert as _insert, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<span> ")
+const t1 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n2 = t1()
+  _setInsertionState(n2)
+  const n1 = _createPlainElement("template")
+  const n0 = t0()
+  _insert(n0, n1)
+  const x0 = _txt(n0)
+  _renderEffect(() => _setText(x0, _toDisplayString(_ctx.msg)))
+  return n2
+}"
+`;
+
 exports[`compiler: element transform > object literal v-bind before dynamic key tracks the original source 1`] = `
 "import { setDynamicProps as _setDynamicProps, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>", 1)

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -1690,6 +1690,38 @@ describe('compiler: element transform', () => {
     expect(code).not.toContain('_txt(n0)')
   })
 
+  test('nested custom element with dynamic child', () => {
+    const { code } = compileWithElementTransform(
+      '<div><my-custom-element><span>{{ msg }}</span></my-custom-element></div>',
+      {
+        isCustomElement: tag => tag === 'my-custom-element',
+      },
+    )
+    expect(code).toMatchSnapshot()
+    expect(code).toContain('_setInsertionState(n')
+    expect(code).toContain('createPlainElement("my-custom-element"')
+    expect(code).not.toContain('_nthChild(')
+  })
+
+  test('nested plain template element with dynamic child', () => {
+    const { code } = compileWithElementTransform(
+      '<div><template><span>{{ msg }}</span></template></div>',
+    )
+    expect(code).toMatchSnapshot()
+    expect(code).toContain('_setInsertionState(n')
+    expect(code).toContain('createPlainElement("template"')
+    expect(code).not.toContain('_nthChild(')
+  })
+
+  test('nested plain template element anchored before a template sibling', () => {
+    const { code } = compileWithElementTransform(
+      '<div><template><span>{{ msg }}</span></template><b/></div>',
+    )
+    expect(code).toMatchSnapshot()
+    expect(code).toContain('_template("<div><!><b>')
+    expect(code).toContain('createPlainElement("template"')
+  })
+
   test('svg', () => {
     const t = `<svg><circle r="40"></circle></svg>`
     const { code, ir } = compileWithElementTransform(t)

--- a/packages/compiler-vapor/src/generators/template.ts
+++ b/packages/compiler-vapor/src/generators/template.ts
@@ -118,8 +118,12 @@ export function genChildren(
           ? child.anchor
           : child.id
         : undefined
+    // A child created by its own operation (component, block, createElement-
+    // backed element) owns its subtree through genSelf; only children that
+    // sit in the parent template are descended into from here.
+    const ownsSubtree = child.operation !== undefined
 
-    if (id === undefined && !child.hasDynamicChild) {
+    if (id === undefined && (!child.hasDynamicChild || ownsSubtree)) {
       flushBeforeDynamic && flushBeforeDynamic(child, push)
       push(...genSelf(child, context, flushBeforeDynamic))
       continue
@@ -181,7 +185,7 @@ export function genChildren(
       )
     }
 
-    if (id === child.anchor && !child.hasDynamicChild) {
+    if (id === child.anchor && (!child.hasDynamicChild || ownsSubtree)) {
       flushBeforeDynamic && flushBeforeDynamic(child, push)
       push(...genSelf(child, context, flushBeforeDynamic))
     }
@@ -191,9 +195,11 @@ export function genChildren(
     }
 
     prev = [variable, elementIndex, id === undefined]
-    push(
-      ...genChildren(child, context, pushBlock, variable, flushBeforeDynamic),
-    )
+    if (!ownsSubtree) {
+      push(
+        ...genChildren(child, context, pushBlock, variable, flushBeforeDynamic),
+      )
+    }
   }
 
   return frag

--- a/packages/runtime-vapor/__tests__/dom/template.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/template.spec.ts
@@ -1,4 +1,6 @@
 import { template } from '../../src/dom/template'
+import { nextTick, ref } from '@vue/runtime-dom'
+import { compile, makeRender } from '../_utils'
 import { child, next, nthChild } from '../../src/dom/node'
 
 describe('api: template', () => {
@@ -60,5 +62,32 @@ describe('api: template', () => {
       expect(root.getAttribute('id')).toBe('foo>bar')
       expect(root.getAttribute('class')).toBe('has whitespace')
     }
+  })
+})
+
+describe('createElement-backed children', () => {
+  const define = makeRender()
+
+  test('nested plain <template> element inserts and updates its children', async () => {
+    const data = ref({ msg: 'a' })
+    const { host } = define(
+      compile(
+        `<template><div><template><i>{{ data.msg }}</i></template><b/></div></template>`,
+        data,
+      ),
+    ).render()
+    // children are inserted as child nodes (like vdom's createElement path),
+    // which template serialization does not show; the `<!>` placeholder that
+    // anchored the insertion stays in place.
+    expect(host.innerHTML).toBe(
+      '<div><template></template><!----><b></b></div>',
+    )
+    const tpl = host.querySelector('template')!
+    expect(tpl.childNodes.length).toBe(1)
+    expect(tpl.firstChild!.textContent).toBe('a')
+
+    data.value.msg = 'b'
+    await nextTick()
+    expect(tpl.firstChild!.textContent).toBe('b')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of nested custom and plain template elements.
  * Improved handling of dynamic content inside template elements, including reactive text updates.
  * Preserved template anchors and child placement when templates are nested or positioned alongside sibling elements.
  * Corrected generated output for template structures to ensure consistent DOM insertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->