### PR TITLE
fix(vapor): correct v-once handling for components, slots and directives

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
@@ -25,6 +25,20 @@ export function render(_ctx, $props, $emit, $attrs, $slots) {
 }"
 `;
 
+exports[`compiler: v-once > component slot content keeps its effects 1`] = `
+"import { toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createAssetComponent as _createAssetComponent, template as _template } from 'vue';
+const t0 = _template(" ")
+
+export function render(_ctx) {
+  const n3 = _createAssetComponent("Comp", { id: () => (_ctx.foo) }, (_slotProps0) => {
+    const n0 = t0()
+    _renderEffect(() => _setText(n0, _toDisplayString(_slotProps0.n) + _toDisplayString(_ctx.msg)))
+    return n0
+  }, true, true)
+  return n3
+}"
+`;
+
 exports[`compiler: v-once > inside v-once 1`] = `
 "import { template as _template } from 'vue';
 const t0 = _template("<div><div>", 3)
@@ -68,6 +82,18 @@ export function render(_ctx) {
   _setInsertionState(n1)
   const n0 = _createSlot("default", null, null, 2 /* ONCE */)
   return n1
+}"
+`;
+
+exports[`compiler: v-once > with custom directive 1`] = `
+"import { resolveDirective as _resolveDirective, withVaporDirectives as _withVaporDirectives, withOnce as _withOnce, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const _directive_dir = _resolveDirective("dir")
+  const n0 = t0()
+  _withOnce(() => _withVaporDirectives(n0, [[_directive_dir, () => (_ctx.val)]]))
+  return n0
 }"
 `;
 
@@ -120,6 +146,28 @@ export function render(_ctx) {
     const n4 = t1()
     return n4
   }, 85 /* TRUE_SINGLE_ROOT, FALSE_SINGLE_ROOT, FALSE_NO_SCOPE, ONCE */)
+  return n0
+}"
+`;
+
+exports[`compiler: v-once > with v-model 1`] = `
+"import { applyTextModel as _applyTextModel, withOnce as _withOnce, template as _template } from 'vue';
+const t0 = _template("<input>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _withOnce(() => _applyTextModel(n0, () => (_ctx.text), _value => (_ctx.text = _value)))
+  return n0
+}"
+`;
+
+exports[`compiler: v-once > with v-show 1`] = `
+"import { applyVShow as _applyVShow, withOnce as _withOnce, template as _template } from 'vue';
+const t0 = _template("<div>", 1)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _withOnce(() => _applyVShow(n0, () => (_ctx.show)))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
@@ -147,6 +147,19 @@ describe('compiler: v-once', () => {
     expect(code).contains('_renderEffect(() => _setText(')
   })
 
+  test('children of parent-rendered built-ins stay static', () => {
+    for (const tag of ['KeepAlive', 'Teleport', 'Suspense']) {
+      const { code } = compileWithOnce(
+        `<${tag} v-once><div>{{ msg }}</div></${tag}>`,
+      )
+      expect(code).not.contains('renderEffect')
+    }
+    const { code } = compileWithOnce(
+      `<Transition v-once><div>{{ msg }}</div></Transition>`,
+    )
+    expect(code).contains('renderEffect')
+  })
+
   test('on slot outlet', () => {
     const { ir, code } = compileWithOnce(`<div><slot v-once /></div>`)
     expect(code).toMatchSnapshot()

--- a/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
@@ -147,19 +147,6 @@ describe('compiler: v-once', () => {
     expect(code).contains('_renderEffect(() => _setText(')
   })
 
-  test('children of parent-rendered built-ins stay static', () => {
-    for (const tag of ['KeepAlive', 'Teleport', 'Suspense']) {
-      const { code } = compileWithOnce(
-        `<${tag} v-once><div>{{ msg }}</div></${tag}>`,
-      )
-      expect(code).not.contains('renderEffect')
-    }
-    const { code } = compileWithOnce(
-      `<Transition v-once><div>{{ msg }}</div></Transition>`,
-    )
-    expect(code).contains('renderEffect')
-  })
-
   test('on slot outlet', () => {
     const { ir, code } = compileWithOnce(`<div><slot v-once /></div>`)
     expect(code).toMatchSnapshot()

--- a/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
@@ -135,6 +135,18 @@ describe('compiler: v-once', () => {
     })
   })
 
+  test('component slot content keeps its effects', () => {
+    const { code } = compileWithOnce(
+      `<Comp v-once :id="foo"><template #default="{ n }">{{ n }}{{ msg }}</template></Comp>`,
+    )
+    expect(code).toMatchSnapshot()
+    // The component itself is once; its slot content is executed by the child.
+    expect(code).contains(
+      '_createAssetComponent("Comp", { id: () => (_ctx.foo) }, (_slotProps0) => {',
+    )
+    expect(code).contains('_renderEffect(() => _setText(')
+  })
+
   test('on slot outlet', () => {
     const { ir, code } = compileWithOnce(`<div><slot v-once /></div>`)
     expect(code).toMatchSnapshot()
@@ -221,6 +233,32 @@ describe('compiler: v-once', () => {
       id: 0,
       once: true,
     })
+  })
+
+  test('with v-show', () => {
+    const { code } = compileWithOnce(`<div v-show="show" v-once />`)
+    expect(code).toMatchSnapshot()
+    expect(code).contains('_withOnce(() => _applyVShow(n0, () => (_ctx.show)))')
+    expect(code).not.contains('effect')
+  })
+
+  test('with v-model', () => {
+    const { code } = compileWithOnce(`<input v-model="text" v-once />`)
+    expect(code).toMatchSnapshot()
+    expect(code).contains('_withOnce(() => _applyTextModel(')
+  })
+
+  test('with custom directive', () => {
+    const { code } = compileWithOnce(`<div v-dir="val" v-once />`)
+    expect(code).toMatchSnapshot()
+    expect(code).contains('_withOnce(() => _withVaporDirectives(')
+  })
+
+  test('directives outside v-once are not wrapped', () => {
+    const { code } = compileWithOnce(
+      `<div v-show="show" v-dir="val" /><div v-once />`,
+    )
+    expect(code).not.contains('withOnce')
   })
 
   test('with key', () => {

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -9,6 +9,7 @@ import {
   NEWLINE,
   genCall,
   genMulti,
+  genOnce,
 } from './utils'
 import { type DirectiveIRNode, IRNodeTypes, type OperationNode } from '../ir'
 import { genVShow } from './vShow'
@@ -52,7 +53,11 @@ function genCustomDirectives(
 
   return [
     NEWLINE,
-    ...genCall(helper('withVaporDirectives'), element, directives),
+    ...genOnce(
+      genCall(helper('withVaporDirectives'), element, directives),
+      opers[0].once,
+      context,
+    ),
   ]
 
   function genDirectiveItem({

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -20,14 +20,18 @@ export function genBuiltinDirective(
   oper: DirectiveIRNode,
   context: CodegenContext,
 ): CodeFragment[] {
+  let call: CodeFragment[]
   switch (oper.name) {
     case 'show':
-      return genVShow(oper, context)
+      call = genVShow(oper, context)
+      break
     case 'model':
-      return genVModel(oper, context)
+      call = genVModel(oper, context)
+      break
     default:
       return []
   }
+  return [NEWLINE, ...genOnce(call, oper.once, context)]
 }
 
 /**

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -31,7 +31,7 @@ export function genBuiltinDirective(
     default:
       return []
   }
-  return [NEWLINE, ...genOnce(call, oper.once, context)]
+  return [NEWLINE, ...(oper.once ? genOnce(call, context) : call)]
 }
 
 /**
@@ -55,14 +55,8 @@ function genCustomDirectives(
   const directiveItems = opers.map(genDirectiveItem)
   const directives = genMulti(DELIMITERS_ARRAY, ...directiveItems)
 
-  return [
-    NEWLINE,
-    ...genOnce(
-      genCall(helper('withVaporDirectives'), element, directives),
-      opers[0].once,
-      context,
-    ),
-  ]
+  const call = genCall(helper('withVaporDirectives'), element, directives)
+  return [NEWLINE, ...(opers[0].once ? genOnce(call, context) : call)]
 
   function genDirectiveItem({
     dir,

--- a/packages/compiler-vapor/src/generators/utils.ts
+++ b/packages/compiler-vapor/src/generators/utils.ts
@@ -12,15 +12,14 @@ import type { CodegenContext } from '../generate'
 import type { ParserOptions } from '@babel/parser'
 
 /**
- * A helper that creates its own effects runs inside the once ambient at a
- * v-once site, so those effects run once like compiled ones do.
+ * Run a helper call inside the once ambient: a helper that creates its own
+ * effects at a v-once site has them run once like compiled ones do.
  */
 export function genOnce(
   call: CodeFragment[],
-  once: boolean | undefined,
   context: CodegenContext,
 ): CodeFragment[] {
-  return once ? genCall(context.helper('withOnce'), ['() => ', ...call]) : call
+  return genCall(context.helper('withOnce'), ['() => ', ...call])
 }
 
 export const IMPORT_EXP_START = '__IMPORT_EXP_START__'

--- a/packages/compiler-vapor/src/generators/utils.ts
+++ b/packages/compiler-vapor/src/generators/utils.ts
@@ -11,6 +11,18 @@ import { isArray, isString } from '@vue/shared'
 import type { CodegenContext } from '../generate'
 import type { ParserOptions } from '@babel/parser'
 
+/**
+ * A helper that creates its own effects runs inside the once ambient at a
+ * v-once site, so those effects run once like compiled ones do.
+ */
+export function genOnce(
+  call: CodeFragment[],
+  once: boolean | undefined,
+  context: CodegenContext,
+): CodeFragment[] {
+  return once ? genCall(context.helper('withOnce'), ['() => ', ...call]) : call
+}
+
 export const IMPORT_EXP_START = '__IMPORT_EXP_START__'
 export const IMPORT_EXP_END = '__IMPORT_EXP_END__'
 export const IMPORT_EXPR_RE: RegExp = new RegExp(

--- a/packages/compiler-vapor/src/generators/vModel.ts
+++ b/packages/compiler-vapor/src/generators/vModel.ts
@@ -1,6 +1,6 @@
 import type { CodegenContext } from '../generate'
 import type { DirectiveIRNode } from '../ir'
-import { type CodeFragment, NEWLINE, genCall, genOnce } from './utils'
+import { type CodeFragment, genCall } from './utils'
 import { genExpression } from './expression'
 import type { SimpleExpressionNode } from '@vue/compiler-dom'
 import { genDirectiveModifiers } from './modifier'
@@ -24,25 +24,18 @@ export function genVModel(
     dir: { exp, modifiers },
   } = oper
 
-  return [
-    NEWLINE,
-    ...genOnce(
-      genCall(
-        context.helper(helperMap[modelType!]),
-        `n${element}`,
-        // getter
-        [`() => (`, ...genExpression(exp!, context), `)`],
-        // setter
-        genModelHandler(exp!, context),
-        // modifiers
-        modifiers.length
-          ? `{ ${genDirectiveModifiers(modifiers.map(e => e.content))} }`
-          : undefined,
-      ),
-      oper.once,
-      context,
-    ),
-  ]
+  return genCall(
+    context.helper(helperMap[modelType!]),
+    `n${element}`,
+    // getter
+    [`() => (`, ...genExpression(exp!, context), `)`],
+    // setter
+    genModelHandler(exp!, context),
+    // modifiers
+    modifiers.length
+      ? `{ ${genDirectiveModifiers(modifiers.map(e => e.content))} }`
+      : undefined,
+  )
 }
 
 export function genModelHandler(

--- a/packages/compiler-vapor/src/generators/vModel.ts
+++ b/packages/compiler-vapor/src/generators/vModel.ts
@@ -1,6 +1,6 @@
 import type { CodegenContext } from '../generate'
 import type { DirectiveIRNode } from '../ir'
-import { type CodeFragment, NEWLINE, genCall } from './utils'
+import { type CodeFragment, NEWLINE, genCall, genOnce } from './utils'
 import { genExpression } from './expression'
 import type { SimpleExpressionNode } from '@vue/compiler-dom'
 import { genDirectiveModifiers } from './modifier'
@@ -26,17 +26,21 @@ export function genVModel(
 
   return [
     NEWLINE,
-    ...genCall(
-      context.helper(helperMap[modelType!]),
-      `n${element}`,
-      // getter
-      [`() => (`, ...genExpression(exp!, context), `)`],
-      // setter
-      genModelHandler(exp!, context),
-      // modifiers
-      modifiers.length
-        ? `{ ${genDirectiveModifiers(modifiers.map(e => e.content))} }`
-        : undefined,
+    ...genOnce(
+      genCall(
+        context.helper(helperMap[modelType!]),
+        `n${element}`,
+        // getter
+        [`() => (`, ...genExpression(exp!, context), `)`],
+        // setter
+        genModelHandler(exp!, context),
+        // modifiers
+        modifiers.length
+          ? `{ ${genDirectiveModifiers(modifiers.map(e => e.content))} }`
+          : undefined,
+      ),
+      oper.once,
+      context,
     ),
   ]
 }

--- a/packages/compiler-vapor/src/generators/vShow.ts
+++ b/packages/compiler-vapor/src/generators/vShow.ts
@@ -1,7 +1,7 @@
 import type { CodegenContext } from '../generate'
 import type { DirectiveIRNode } from '../ir'
 import { genExpression } from './expression'
-import { type CodeFragment, NEWLINE, genCall } from './utils'
+import { type CodeFragment, NEWLINE, genCall, genOnce } from './utils'
 
 export function genVShow(
   oper: DirectiveIRNode,
@@ -10,10 +10,14 @@ export function genVShow(
   const { element } = oper
   return [
     NEWLINE,
-    ...genCall(context.helper('applyVShow'), `n${element}`, [
-      `() => (`,
-      ...genExpression(oper.dir.exp!, context),
-      `)`,
-    ]),
+    ...genOnce(
+      genCall(context.helper('applyVShow'), `n${element}`, [
+        `() => (`,
+        ...genExpression(oper.dir.exp!, context),
+        `)`,
+      ]),
+      oper.once,
+      context,
+    ),
   ]
 }

--- a/packages/compiler-vapor/src/generators/vShow.ts
+++ b/packages/compiler-vapor/src/generators/vShow.ts
@@ -1,23 +1,16 @@
 import type { CodegenContext } from '../generate'
 import type { DirectiveIRNode } from '../ir'
 import { genExpression } from './expression'
-import { type CodeFragment, NEWLINE, genCall, genOnce } from './utils'
+import { type CodeFragment, genCall } from './utils'
 
 export function genVShow(
   oper: DirectiveIRNode,
   context: CodegenContext,
 ): CodeFragment[] {
   const { element } = oper
-  return [
-    NEWLINE,
-    ...genOnce(
-      genCall(context.helper('applyVShow'), `n${element}`, [
-        `() => (`,
-        ...genExpression(oper.dir.exp!, context),
-        `)`,
-      ]),
-      oper.once,
-      context,
-    ),
-  ]
+  return genCall(context.helper('applyVShow'), `n${element}`, [
+    `() => (`,
+    ...genExpression(oper.dir.exp!, context),
+    `)`,
+  ])
 }

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -219,6 +219,9 @@ export interface DirectiveIRNode extends BaseIRNode {
   builtin?: boolean
   asset?: boolean
   modelType?: 'text' | 'dynamic' | 'radio' | 'checkbox' | 'select'
+  // The helper creates its own effects, so a v-once site runs it in the once
+  // ambient instead of eliding a compiler effect.
+  once?: boolean
 }
 
 export interface CreateComponentIRNode

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -32,8 +32,8 @@ import {
   isBlockOperation,
 } from './ir'
 import {
-  isBuiltInComponent,
   isConstantExpression,
+  isParentRenderedBuiltIn,
   isStaticExpression,
   isTransitionNode,
 } from './utils'
@@ -634,11 +634,10 @@ export function getNextId(
   return n
 }
 
-// Teleport is not a boundary: its content renders in place.
 function isComponentBoundary(node: AllNode): boolean {
   return (
     node.type === NodeTypes.ELEMENT &&
     node.tagType === ElementTypes.COMPONENT &&
-    isBuiltInComponent(node.tag) !== 'VaporTeleport'
+    !isParentRenderedBuiltIn(node.tag)
   )
 }

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -33,7 +33,6 @@ import {
 } from './ir'
 import {
   isConstantExpression,
-  isParentRenderedBuiltIn,
   isStaticExpression,
   isTransitionNode,
 } from './utils'
@@ -348,7 +347,7 @@ export class TransformContext<T extends AllNode = AllNode> {
       index,
       // Slot content is executed by the child component, which re-runs it on
       // its own updates (vdom parity), so v-once does not reach into it.
-      inVOnce: this.inVOnce && !isComponentBoundary(this.node),
+      inVOnce: this.inVOnce && !isComponentNode(this.node),
 
       template: '',
       templateRoot: false,
@@ -634,10 +633,8 @@ export function getNextId(
   return n
 }
 
-function isComponentBoundary(node: AllNode): boolean {
+function isComponentNode(node: AllNode): boolean {
   return (
-    node.type === NodeTypes.ELEMENT &&
-    node.tagType === ElementTypes.COMPONENT &&
-    !isParentRenderedBuiltIn(node.tag)
+    node.type === NodeTypes.ELEMENT && node.tagType === ElementTypes.COMPONENT
   )
 }

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -32,6 +32,7 @@ import {
   isBlockOperation,
 } from './ir'
 import {
+  isBuiltInComponent,
   isConstantExpression,
   isStaticExpression,
   isTransitionNode,
@@ -345,6 +346,9 @@ export class TransformContext<T extends AllNode = AllNode> {
       node,
       parent: this as any,
       index,
+      // Slot content is executed by the child component, which re-runs it on
+      // its own updates (vdom parity), so v-once does not reach into it.
+      inVOnce: this.inVOnce && !isComponentBoundary(this.node),
 
       template: '',
       templateRoot: false,
@@ -628,4 +632,13 @@ export function getNextId(
 ): number {
   if (map && map.has(n)) return map.get(n)!
   return n
+}
+
+// Teleport is not a boundary: its content renders in place.
+function isComponentBoundary(node: AllNode): boolean {
+  return (
+    node.type === NodeTypes.ELEMENT &&
+    node.tagType === ElementTypes.COMPONENT &&
+    isBuiltInComponent(node.tag) !== 'VaporTeleport'
+  )
 }

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -1231,6 +1231,7 @@ function transformProp(
       dir: prop,
       name,
       asset: !fromSetup,
+      once: context.inVOnce,
     })
   }
 }

--- a/packages/compiler-vapor/src/transforms/vModel.ts
+++ b/packages/compiler-vapor/src/transforms/vModel.ts
@@ -146,6 +146,7 @@ export const transformVModel: DirectiveTransform = (dir, node, context) => {
       name: 'model',
       modelType,
       builtin: true,
+      once: context.inVOnce,
     })
 
   function checkDuplicatedValue() {

--- a/packages/compiler-vapor/src/transforms/vOnce.ts
+++ b/packages/compiler-vapor/src/transforms/vOnce.ts
@@ -2,11 +2,7 @@ import { NodeTypes, findDir } from '@vue/compiler-dom'
 import type { NodeTransform } from '../transform'
 
 export const transformVOnce: NodeTransform = (node, context) => {
-  if (
-    // !context.inSSR &&
-    node.type === NodeTypes.ELEMENT &&
-    findDir(node, 'once', true)
-  ) {
+  if (node.type === NodeTypes.ELEMENT && findDir(node, 'once', true)) {
     context.inVOnce = true
   }
 }

--- a/packages/compiler-vapor/src/transforms/vShow.ts
+++ b/packages/compiler-vapor/src/transforms/vShow.ts
@@ -33,5 +33,6 @@ export const transformVShow: DirectiveTransform = (dir, node, context) => {
     dir,
     name: 'show',
     builtin: true,
+    once: context.inVOnce,
   })
 }

--- a/packages/compiler-vapor/src/utils.ts
+++ b/packages/compiler-vapor/src/utils.ts
@@ -159,21 +159,6 @@ export function isTeleportTag(tag: string): boolean {
   return tag === 'teleport' || tag === 'vaporteleport'
 }
 
-/**
- * Built-ins whose children are rendered by the parent rather than by the
- * component's own render, so they freeze with the parent under v-once
- * (vdom parity: Teleport / KeepAlive children are not built as slots and
- * Suspense slots are evaluated at vnode creation).
- */
-export function isParentRenderedBuiltIn(tag: string): boolean {
-  return (
-    isTeleportTag(tag) ||
-    isKeepAliveTag(tag) ||
-    tag === 'Suspense' ||
-    tag === 'suspense'
-  )
-}
-
 export function isBuiltInComponent(tag: string): string | undefined {
   if (isTeleportTag(tag)) {
     return 'VaporTeleport'

--- a/packages/compiler-vapor/src/utils.ts
+++ b/packages/compiler-vapor/src/utils.ts
@@ -159,6 +159,21 @@ export function isTeleportTag(tag: string): boolean {
   return tag === 'teleport' || tag === 'vaporteleport'
 }
 
+/**
+ * Built-ins whose children are rendered by the parent rather than by the
+ * component's own render, so they freeze with the parent under v-once
+ * (vdom parity: Teleport / KeepAlive children are not built as slots and
+ * Suspense slots are evaluated at vnode creation).
+ */
+export function isParentRenderedBuiltIn(tag: string): boolean {
+  return (
+    isTeleportTag(tag) ||
+    isKeepAliveTag(tag) ||
+    tag === 'Suspense' ||
+    tag === 'suspense'
+  )
+}
+
 export function isBuiltInComponent(tag: string): string | undefined {
   if (isTeleportTag(tag)) {
     return 'VaporTeleport'

--- a/packages/runtime-vapor/__tests__/_utils.ts
+++ b/packages/runtime-vapor/__tests__/_utils.ts
@@ -211,6 +211,58 @@ export function compile(
   )
 }
 
+export interface ParityResult {
+  before: string
+  after: string
+  text: string
+}
+
+/**
+ * Mount the same SFC sources as a vdom app and as a vapor app in turn
+ * (`srcs.App` is the root; the rest register on `_components` in order),
+ * run `act`, and return each mode's html before/after plus the final text.
+ * Sources use plain `<script setup>`; the mode comes from the compile option.
+ * `extra` components are shared by both modes as given.
+ */
+export async function renderParity(
+  srcs: Record<string, string>,
+  makeData: () => runtimeDom.Ref<any>,
+  act: (data: runtimeDom.Ref<any>) => void | Promise<void>,
+  extra: Record<string, any> = {},
+): Promise<{ vdom: ParityResult; vapor: ParityResult }> {
+  const results = {} as { vdom: ParityResult; vapor: ParityResult }
+  for (const vapor of [false, true]) {
+    const data = makeData()
+    const components: Record<string, any> = { ...extra }
+    const withScript = (src: string) =>
+      src.includes('<script')
+        ? src
+        : `<script setup>const data = _data; const components = _components;</script>` +
+          src
+    for (const name in srcs) {
+      if (name !== 'App') {
+        components[name] = compile(withScript(srcs[name]), data, components, {
+          vapor,
+        })
+      }
+    }
+    const App = compile(withScript(srcs.App), data, components, { vapor })
+    const root = document.createElement('div')
+    const app = vapor ? createVaporApp(App) : createApp(App)
+    app.use(vaporInteropPlugin).mount(root)
+    const before = root.innerHTML
+    await act(data)
+    await runtimeDom.nextTick()
+    results[vapor ? 'vapor' : 'vdom'] = {
+      before,
+      after: root.innerHTML,
+      text: root.textContent!,
+    }
+    app.unmount()
+  }
+  return results
+}
+
 export function compileToVaporRender(
   template: string,
   options?: CompilerOptions,

--- a/packages/runtime-vapor/__tests__/_utils.ts
+++ b/packages/runtime-vapor/__tests__/_utils.ts
@@ -227,7 +227,7 @@ export interface ParityResult {
 export async function renderParity(
   srcs: Record<string, string>,
   makeData: () => runtimeDom.Ref<any>,
-  act: (data: runtimeDom.Ref<any>) => void | Promise<void>,
+  act: (data: runtimeDom.Ref<any>, root: HTMLElement) => void | Promise<void>,
   extra: Record<string, any> = {},
 ): Promise<{ vdom: ParityResult; vapor: ParityResult }> {
   const results = {} as { vdom: ParityResult; vapor: ParityResult }
@@ -251,7 +251,7 @@ export async function renderParity(
     const app = vapor ? createVaporApp(App) : createApp(App)
     app.use(vaporInteropPlugin).mount(root)
     const before = root.innerHTML
-    await act(data)
+    await act(data, root)
     await runtimeDom.nextTick()
     results[vapor ? 'vapor' : 'vdom'] = {
       before,

--- a/packages/runtime-vapor/__tests__/_utils.ts
+++ b/packages/runtime-vapor/__tests__/_utils.ts
@@ -212,7 +212,6 @@ export function compile(
 }
 
 export interface ParityResult {
-  before: string
   after: string
   text: string
 }
@@ -220,8 +219,9 @@ export interface ParityResult {
 /**
  * Mount the same SFC sources as a vdom app and as a vapor app in turn
  * (`srcs.App` is the root; the rest register on `_components` in order),
- * run `act`, and return each mode's html before/after plus the final text.
- * Sources use plain `<script setup>`; the mode comes from the compile option.
+ * run `act`, and return each mode's final html and text. Sources without a
+ * `<script>` get a plain `<script setup>` so the mode comes from the compile
+ * option (`compile()` would inject `<script vapor>`, which forces vapor).
  * `extra` components are shared by both modes as given.
  */
 export async function renderParity(
@@ -250,11 +250,9 @@ export async function renderParity(
     const root = document.createElement('div')
     const app = vapor ? createVaporApp(App) : createApp(App)
     app.use(vaporInteropPlugin).mount(root)
-    const before = root.innerHTML
     await act(data, root)
     await runtimeDom.nextTick()
     results[vapor ? 'vapor' : 'vdom'] = {
-      before,
       after: root.innerHTML,
       text: root.textContent!,
     }

--- a/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
@@ -144,11 +144,32 @@ describe('api: createDynamicComponent', () => {
       },
     }).render()
 
-    expect(html()).toBe('AAA<!--dynamic-component-->')
+    // resolved once: no fragment, no anchor
+    expect(html()).toBe('AAA')
 
     val.value = B
     await nextTick()
-    expect(html()).toBe('AAA<!--dynamic-component-->') // still AAA
+    expect(html()).toBe('AAA') // still AAA
+  })
+
+  test('null with v-once', async () => {
+    const val = shallowRef<any>(null)
+    const { html } = define({
+      setup() {
+        return createDynamicComponent(
+          () => val.value,
+          null,
+          null,
+          VaporDynamicComponentFlags.ONCE,
+        )
+      },
+    }).render()
+
+    expect(html()).toBe('<!--ndc-->')
+
+    val.value = A
+    await nextTick()
+    expect(html()).toBe('<!--ndc-->')
   })
 
   test('fallback with v-once', async () => {
@@ -166,11 +187,11 @@ describe('api: createDynamicComponent', () => {
       },
     }).render()
 
-    expect(html()).toBe('<button id="0"></button><!--dynamic-component-->')
+    expect(html()).toBe('<button id="0"></button>')
 
     id.value++
     await nextTick()
-    expect(html()).toBe('<button id="0"></button><!--dynamic-component-->')
+    expect(html()).toBe('<button id="0"></button>')
   })
 
   test('render fallback with insertionState', async () => {

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -1004,4 +1004,43 @@ describe('component: props', () => {
       })
     })
   })
+
+  test.each([
+    ':class="data.classes"',
+    ':class="[data.classes]"',
+    'v-bind="data.input"',
+    'v-bind="{}" :class="data.classes"',
+    ':[data.key]="data.classes"',
+  ])('v-once snapshots normalized declared class props (%s)', async binding => {
+    const classes = { active: true }
+    const data = ref({
+      classes,
+      input: { class: classes },
+      key: 'class',
+      readClass: () => '',
+    })
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps({ class: String })
+        _data.value.readClass = () => props.class
+      </script>
+      <template><div>{{ props.class }}</div></template>`,
+      data,
+    )
+    const Parent = compile(
+      `<template><components.Child v-once ${binding} /></template>`,
+      data,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(data.value.readClass()).toBe('active')
+    expect(host.innerHTML).toBe('<div>active</div>')
+
+    data.value.classes.active = false
+    await nextTick()
+
+    expect.soft(data.value.readClass()).toBe('active')
+    expect.soft(host.innerHTML).toBe('<div>active</div>')
+  })
 })

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -618,6 +618,40 @@ describe('component: props', () => {
     expect(cb).not.toHaveBeenCalled()
   })
 
+  test('v-once snapshots sources without caching computeds on them', () => {
+    const source = (() => ({ a: 1 })) as (() => any) & { _cache?: unknown }
+    const getter = (() => 2) as (() => any) & { _cache?: unknown }
+    const Child = defineVaporComponent({
+      props: ['a', 'b'],
+      setup(props: any) {
+        expect(props.a).toBe(1)
+        expect(props.b).toBe(2)
+        return []
+      },
+    })
+
+    // Nest one level: sources are only cached under an instance with a parent.
+    const Parent = defineVaporComponent({
+      setup() {
+        return createComponent(
+          Child,
+          { b: getter, $: [source] },
+          null,
+          true,
+          true,
+        )
+      },
+    })
+    define({
+      setup() {
+        return createComponent(Parent)
+      },
+    }).render()
+
+    expect(source._cache).toBeUndefined()
+    expect(getter._cache).toBeUndefined()
+  })
+
   // #15227
   test('declared class prop should be normalized', () => {
     const data = ref({ skin: { b: true, c: false } })

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -1043,4 +1043,42 @@ describe('component: props', () => {
     expect.soft(data.value.readClass()).toBe('active')
     expect.soft(host.innerHTML).toBe('<div>active</div>')
   })
+
+  test.each([
+    ':style="[data.styles]"',
+    'v-bind="data.input"',
+    'v-bind="{}" :style="[data.styles]"',
+    ':[data.key]="[data.styles]"',
+  ])('v-once snapshots normalized declared style props (%s)', async binding => {
+    const styles = { color: 'red' }
+    const data = ref({
+      styles,
+      input: { style: [styles] },
+      key: 'style',
+      readStyle: () => ({ color: '' }),
+    })
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps({ style: Object })
+        _data.value.readStyle = () => props.style
+      </script>
+      <template><div>{{ props.style.color }}</div></template>`,
+      data,
+    )
+    const Parent = compile(
+      `<template><components.Child v-once ${binding} /></template>`,
+      data,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(data.value.readStyle()).toEqual({ color: 'red' })
+    expect(host.innerHTML).toBe('<div>red</div>')
+
+    data.value.styles.color = 'blue'
+    await nextTick()
+
+    expect.soft(data.value.readStyle()).toEqual({ color: 'red' })
+    expect.soft(host.innerHTML).toBe('<div>red</div>')
+  })
 })

--- a/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/templateRef.spec.ts
@@ -153,7 +153,7 @@ describe('api: template ref', () => {
         }
       },
       render() {
-        const n0 = createDynamicComponent(() => Child)
+        const n0 = createDynamicComponent(() => Child) as any
         frag = n0
         setTemplateRefBinding(n0, () => refKey.value)
         return n0
@@ -198,7 +198,7 @@ describe('api: template ref', () => {
         return { foo, bar }
       },
       render() {
-        const n0 = createDynamicComponent(() => views[view.value])
+        const n0 = createDynamicComponent(() => views[view.value]) as any
         setTemplateRefBinding(n0, () => refKey.value)
         return n0
       },

--- a/packages/runtime-vapor/__tests__/hydration/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/component.spec.ts
@@ -795,6 +795,57 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test('dynamic component with v-once', async () => {
+      const { container, data } = await testHydration(
+        `<template>
+          <div>
+            <span/>
+            <component :is="components[data]" v-once/>
+            <span/>
+          </div>
+        </template>`,
+        {
+          foo: `<template><div>foo</div></template>`,
+          bar: `<template><div>bar</div></template>`,
+        },
+        ref('foo'),
+      )
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<div><span></span><div>foo</div><span></span></div>"`,
+      )
+
+      data.value = 'bar'
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<div><span></span><div>foo</div><span></span></div>"`,
+      )
+    })
+
+    test('null dynamic component with v-once', async () => {
+      const { container, data } = await testHydration(
+        `<template>
+          <div>
+            <span/>
+            <component :is="components[data]" v-once/>
+            <span/>
+          </div>
+        </template>`,
+        {
+          foo: `<template><div>foo</div></template>`,
+        },
+        ref('missing'),
+      )
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<div><span></span><!----><span></span></div>"`,
+      )
+
+      data.value = 'foo'
+      await nextTick()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<div><span></span><!----><span></span></div>"`,
+      )
+    })
+
     test('dynamic component fallback', async () => {
       const { container, data } = await testHydration(
         `<template>

--- a/packages/runtime-vapor/__tests__/vOnce.spec.ts
+++ b/packages/runtime-vapor/__tests__/vOnce.spec.ts
@@ -14,6 +14,21 @@ const vDir = (el: Element, b: any) => {
 const withDir = (template: string) =>
   `<script setup>const data = _data; const components = _components; const vDir = components.vDir</script>${template}`
 
+// The input's `.value` after a programmatic model change, per mode.
+async function inputValues(srcs: Record<string, string>): Promise<string[]> {
+  const values: string[] = []
+  await renderParity(
+    srcs,
+    () => ref({ text: 'a' }),
+    async (data, root) => {
+      data.value.text = 'b'
+      await nextTick()
+      values.push((root.querySelector('input') as HTMLInputElement).value)
+    },
+  )
+  return values
+}
+
 describe('v-once', () => {
   describe('directive helpers inside a compiled v-once region', () => {
     test('v-show on an element and on a component', async () => {
@@ -34,17 +49,11 @@ describe('v-once', () => {
     })
 
     test('native v-model', async () => {
-      const values: string[] = []
-      await renderParity(
-        { App: `<template><input v-model="data.text" v-once></template>` },
-        () => ref({ text: 'a' }),
-        async (data, root) => {
-          data.value.text = 'b'
-          await nextTick()
-          values.push((root.querySelector('input') as HTMLInputElement).value)
-        },
-      )
-      expect(values).toEqual(['a', 'a'])
+      expect(
+        await inputValues({
+          App: `<template><input v-model="data.text" v-once></template>`,
+        }),
+      ).toEqual(['a', 'a'])
     })
 
     test('custom directive', async () => {
@@ -97,20 +106,12 @@ describe('v-once', () => {
         '<div><div data-v="a">x</div><!--slot--></div>',
       )
 
-      const values: string[] = []
-      await renderParity(
-        {
+      expect(
+        await inputValues({
           Child,
           App: `<template><components.Child><input v-model="data.text"></components.Child></template>`,
-        },
-        () => ref({ text: 'a' }),
-        async (data, root) => {
-          data.value.text = 'b'
-          await nextTick()
-          values.push((root.querySelector('input') as HTMLInputElement).value)
-        },
-      )
-      expect(values).toEqual(['a', 'a'])
+        }),
+      ).toEqual(['a', 'a'])
     })
   })
 
@@ -158,6 +159,22 @@ describe('v-once', () => {
       )
       expect(vdom.text).toBe('ab')
       expect(vapor.text).toBe(vdom.text)
+    })
+
+    test('children of parent-rendered built-ins stay frozen', async () => {
+      const Leaf = `<script setup>const props = defineProps(['label'])</script><template><i>{{ props.label }}</i></template>`
+      const keepAlive = await renderParity(
+        {
+          Leaf,
+          App: `<template><div><KeepAlive v-once><components.Leaf :label="data.msg"/></KeepAlive></div></template>`,
+        },
+        () => ref({ msg: 'a' }),
+        data => {
+          data.value.msg = 'b'
+        },
+      )
+      expect(keepAlive.vdom.text).toBe('a')
+      expect(keepAlive.vapor.text).toBe('a')
     })
 
     test('the slot set stays frozen', async () => {

--- a/packages/runtime-vapor/__tests__/vOnce.spec.ts
+++ b/packages/runtime-vapor/__tests__/vOnce.spec.ts
@@ -1,0 +1,258 @@
+import { nextTick, ref } from '@vue/runtime-dom'
+import { renderEffect } from '../src'
+import { renderParity } from './_utils'
+
+// Works as a vdom function directive (mounted + updated with a binding) and
+// as a vapor directive (a getter), so one definition serves both modes.
+const vDir = (el: Element, b: any) => {
+  if (typeof b === 'function') {
+    renderEffect(() => el.setAttribute('data-v', b()))
+  } else {
+    el.setAttribute('data-v', b.value)
+  }
+}
+const withDir = (template: string) =>
+  `<script setup>const data = _data; const components = _components; const vDir = components.vDir</script>${template}`
+
+describe('v-once', () => {
+  describe('directive helpers inside a compiled v-once region', () => {
+    test('v-show on an element and on a component', async () => {
+      for (const App of [
+        `<template><div v-show="data.show" v-once>x</div></template>`,
+        `<template><components.Leaf v-show="data.show" v-once/></template>`,
+      ]) {
+        const { vdom, vapor } = await renderParity(
+          { Leaf: `<template><div>x</div></template>`, App },
+          () => ref({ show: true }),
+          data => {
+            data.value.show = false
+          },
+        )
+        expect(vdom.after).toBe('<div>x</div>')
+        expect(vapor.after).toBe(vdom.after)
+      }
+    })
+
+    test('native v-model', async () => {
+      const values: string[] = []
+      await renderParity(
+        { App: `<template><input v-model="data.text" v-once></template>` },
+        () => ref({ text: 'a' }),
+        async (data, root) => {
+          data.value.text = 'b'
+          await nextTick()
+          values.push((root.querySelector('input') as HTMLInputElement).value)
+        },
+      )
+      expect(values).toEqual(['a', 'a'])
+    })
+
+    test('custom directive', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          App: withDir(
+            `<template><div v-dir="data.val" v-once>x</div></template>`,
+          ),
+        },
+        () => ref({ val: 'a' }),
+        data => {
+          data.value.val = 'b'
+        },
+        { vDir },
+      )
+      expect(vdom.after).toBe('<div data-v="a">x</div>')
+      expect(vapor.after).toBe(vdom.after)
+    })
+
+    test('the same helpers stay frozen inside <slot v-once> content', async () => {
+      const Child = `<template><div><slot v-once/></div></template>`
+      const show = await renderParity(
+        {
+          Child,
+          App: `<template><components.Child><div v-show="data.show">x</div></components.Child></template>`,
+        },
+        () => ref({ show: true }),
+        data => {
+          data.value.show = false
+        },
+      )
+      expect(show.vdom.after).toBe('<div><div>x</div></div>')
+      expect(show.vapor.after).toBe('<div><div>x</div><!--slot--></div>')
+
+      const dir = await renderParity(
+        {
+          Child,
+          App: withDir(
+            `<template><components.Child><div v-dir="data.val">x</div></components.Child></template>`,
+          ),
+        },
+        () => ref({ val: 'a' }),
+        data => {
+          data.value.val = 'b'
+        },
+        { vDir },
+      )
+      expect(dir.vdom.after).toBe('<div><div data-v="a">x</div></div>')
+      expect(dir.vapor.after).toBe(
+        '<div><div data-v="a">x</div><!--slot--></div>',
+      )
+
+      const values: string[] = []
+      await renderParity(
+        {
+          Child,
+          App: `<template><components.Child><input v-model="data.text"></components.Child></template>`,
+        },
+        () => ref({ text: 'a' }),
+        async (data, root) => {
+          data.value.text = 'b'
+          await nextTick()
+          values.push((root.querySelector('input') as HTMLInputElement).value)
+        },
+      )
+      expect(values).toEqual(['a', 'a'])
+    })
+  })
+
+  describe('slot content of a v-once component', () => {
+    const Child = `<script setup>import { ref } from 'vue'; const data = _data; const n = ref(0); data.value.bump = () => n.value++</script><template><div>{{ n }}<slot :n="n"/></div></template>`
+
+    test('stays live for parent state (the child re-runs it)', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          Child,
+          App: `<template><components.Child v-once><span>{{ data.msg }}</span></components.Child></template>`,
+        },
+        () => ref({ msg: 'a' }),
+        data => {
+          data.value.msg = 'b'
+        },
+      )
+      expect(vdom.text).toBe('0b')
+      expect(vapor.text).toBe(vdom.text)
+    })
+
+    test('stays live for child-driven scoped slot props', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          Child,
+          App: `<template><components.Child v-once><template #default="{ n }"><span>{{ n }}</span></template></components.Child></template>`,
+        },
+        () => ref({}),
+        data => data.value.bump(),
+      )
+      expect(vdom.text).toBe('11')
+      expect(vapor.text).toBe(vdom.text)
+    })
+
+    test('props stay frozen while the slot content is live', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          Leaf: `<script setup>const props = defineProps(['label']); const data = _data; </script><template><div>{{ props.label }}<slot/></div></template>`,
+          App: `<template><components.Leaf v-once :label="data.msg"><i>{{ data.msg }}</i></components.Leaf></template>`,
+        },
+        () => ref({ msg: 'a' }),
+        data => {
+          data.value.msg = 'b'
+        },
+      )
+      expect(vdom.text).toBe('ab')
+      expect(vapor.text).toBe(vdom.text)
+    })
+
+    test('the slot set stays frozen', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          Named: `<template><div><slot name="b"/></div></template>`,
+          App: `<template><components.Named v-once><template v-for="n in data.names" #[n]>{{ n }}</template></components.Named></template>`,
+        },
+        () => ref({ names: ['a'] }),
+        data => {
+          data.value.names = ['a', 'b']
+        },
+      )
+      expect(vdom.text).toBe('')
+      expect(vapor.text).toBe(vdom.text)
+    })
+  })
+
+  // vdom caches the v-once vnode per component instance (`_cache[i]`) and
+  // drops v-once where nothing can be cached. Vapor freezes per creation
+  // instead; these cells pin that on purpose, with the vdom result recorded.
+  describe('intentionally not aligned with vdom', () => {
+    test('v-once inside v-for freezes each row separately', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          App: `<template><div v-for="i in data.list" :key="i"><span v-once>{{ i }}</span></div></template>`,
+        },
+        () => ref({ list: [1, 2] }),
+        data => {
+          data.value.list = [1, 2, 3]
+        },
+      )
+      expect(vdom.text).toBe('111')
+      expect(vapor.text).toBe('123')
+    })
+
+    test('v-once on v-else freezes the branch instance', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          App: `<template><p v-if="data.a">A</p><p v-else v-once>{{ data.msg }}</p></template>`,
+        },
+        () => ref({ a: false, msg: 'x' }),
+        data => {
+          data.value.msg = 'y'
+        },
+      )
+      expect(vdom.text).toBe('y')
+      expect(vapor.text).toBe('x')
+    })
+
+    test('v-once on a slot template freezes that slot', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          Child: `<template><div><slot/></div></template>`,
+          App: `<template><components.Child><template #default v-once><span>{{ data.msg }}</span></template></components.Child></template>`,
+        },
+        () => ref({ msg: 'a' }),
+        data => {
+          data.value.msg = 'b'
+        },
+      )
+      expect(vdom.text).toBe('b')
+      expect(vapor.text).toBe('a')
+    })
+
+    test('fallthrough attrs onto a v-once single root stay frozen', async () => {
+      const { vdom, vapor } = await renderParity(
+        {
+          Leaf: `<template><div>leaf</div></template>`,
+          Wrapper: `<template><components.Leaf v-once/></template>`,
+          App: `<template><components.Wrapper :class="data.cls"/></template>`,
+        },
+        () => ref({ cls: 'a' }),
+        data => {
+          data.value.cls = 'b'
+        },
+      )
+      expect(vdom.after).toBe('<div class="b">leaf</div>')
+      expect(vapor.after).toBe('<div class="a">leaf</div>')
+    })
+
+    test('event handlers read the current binding', async () => {
+      const calls: string[] = []
+      await renderParity(
+        {
+          App: `<template><button v-once @click="data.fn">x</button></template>`,
+        },
+        () => ref({ fn: () => calls.push('old') }),
+        async (data, root) => {
+          data.value.fn = () => calls.push('new')
+          await nextTick()
+          ;(root.querySelector('button') as HTMLButtonElement).click()
+        },
+      )
+      expect(calls).toEqual(['old', 'new'])
+    })
+  })
+})

--- a/packages/runtime-vapor/__tests__/vOnce.spec.ts
+++ b/packages/runtime-vapor/__tests__/vOnce.spec.ts
@@ -161,22 +161,6 @@ describe('v-once', () => {
       expect(vapor.text).toBe(vdom.text)
     })
 
-    test('children of parent-rendered built-ins stay frozen', async () => {
-      const Leaf = `<script setup>const props = defineProps(['label'])</script><template><i>{{ props.label }}</i></template>`
-      const keepAlive = await renderParity(
-        {
-          Leaf,
-          App: `<template><div><KeepAlive v-once><components.Leaf :label="data.msg"/></KeepAlive></div></template>`,
-        },
-        () => ref({ msg: 'a' }),
-        data => {
-          data.value.msg = 'b'
-        },
-      )
-      expect(keepAlive.vdom.text).toBe('a')
-      expect(keepAlive.vapor.text).toBe('a')
-    })
-
     test('the slot set stays frozen', async () => {
       const { vdom, vapor } = await renderParity(
         {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -38,7 +38,7 @@ import {
 } from '@vue/runtime-dom'
 import { VaporDynamicComponentFlags, VaporSlotFlags } from '@vue/shared'
 import { VaporSlot } from '../../runtime-core/src/vnode'
-import { compile, makeInteropRender } from './_utils'
+import { compile, makeInteropRender, renderParity } from './_utils'
 import { type DynamicFragment, isInteropFragment } from '../src/fragment'
 import {
   type VaporComponentInstance,
@@ -1487,6 +1487,57 @@ describe('vdomInterop', () => {
       increment()
       await nextTick()
       expect(html()).toBe('<span>1</span>')
+    })
+
+    test('keeps a VDOM component live inside v-once slot content regardless of nesting', async () => {
+      const VdomMid = defineComponent({
+        setup(_, { slots }) {
+          return () => h('b', slots.default && slots.default())
+        },
+      })
+      const Child = `<template><div><slot v-once/></div></template>`
+      for (const content of [
+        `<components.VdomMid>{{ data.msg }}</components.VdomMid>`,
+        `<div><components.VdomMid>{{ data.msg }}</components.VdomMid></div>`,
+      ]) {
+        const { vdom, vapor } = await renderParity(
+          {
+            Child,
+            App: `<template><components.Child>${content}</components.Child></template>`,
+          },
+          () => ref({ msg: 'a' }),
+          data => {
+            data.value.msg = 'b'
+          },
+          { VdomMid },
+        )
+        expect(vdom.text).toBe('b')
+        expect(vapor.text).toBe('b')
+      }
+    })
+
+    test('keeps VDOM-owned props live on Vapor descendants inside v-once slot content', async () => {
+      let bump!: () => void
+      const VdomMid = defineComponent({
+        setup(_, { slots }) {
+          const n = ref(0)
+          bump = () => n.value++
+          return () =>
+            h('b', [n.value, slots.default && slots.default({ n: n.value })])
+        },
+      })
+      const { vdom, vapor } = await renderParity(
+        {
+          Leaf: `<script setup>const props = defineProps(['n'])</script><template><i>{{ props.n }}</i></template>`,
+          Child: `<template><div><slot v-once/></div></template>`,
+          App: `<template><components.Child><div><components.VdomMid v-slot="{ n }"><components.Leaf :n="n"/></components.VdomMid></div></components.Child></template>`,
+        },
+        () => ref({}),
+        () => bump(),
+        { VdomMid },
+      )
+      expect(vdom.text).toBe('11')
+      expect(vapor.text).toBe('11')
     })
 
     test('falls through to outlet fallback when vdom local fallback is invalidated or removed from VaporSlot', async () => {

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -2437,7 +2437,7 @@ describe('vdomInterop', () => {
         },
         render() {
           const setRef = createTemplateRefSetter()
-          const n0 = createDynamicComponent(() => VdomChild)
+          const n0 = createDynamicComponent(() => VdomChild) as DynamicFragment
           setRef(n0, vdomRef, false, 'vdomRef')
           return n0
         },
@@ -2503,7 +2503,7 @@ describe('vdomInterop', () => {
       const VaporChild = defineVaporComponent({
         setup() {
           const setRef = createTemplateRefSetter()
-          const n0 = createDynamicComponent(() => VdomChild)
+          const n0 = createDynamicComponent(() => VdomChild) as DynamicFragment
           renderEffect(() => {
             setRef(n0, useA.value ? refA : refB, false, 'vdomRef')
           })

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -1,6 +1,7 @@
 import {
   type ComponentInternalInstance,
   Fragment,
+  type GenericAppContext,
   NULL_DYNAMIC_COMPONENT,
   type VNode,
   currentInstance,
@@ -62,18 +63,11 @@ export function createDynamicComponent(
 
   const normalizedRawSlots = normalizeRawSlots(rawSlots)
   const scopeOwner = getScopeOwner()
-  const getAppContext = () =>
-    (currentInstance && currentInstance.appContext) || emptyContext
-
-  const resolve = (value: any, appContext: ReturnType<typeof getAppContext>) =>
-    isBlock(value) || (isInteropEnabled && appContext.vdom && isVNode(value))
-      ? value
-      : withScopeOwner(scopeOwner, () => resolveDynamicComponent(value))
 
   const render = (
     value: any,
     resolved: any,
-    appContext: ReturnType<typeof getAppContext>,
+    appContext: GenericAppContext,
   ): Block => {
     // Support integration with VaporRouterView/VaporRouterLink by accepting blocks
     if (isBlock(value)) return value
@@ -129,7 +123,11 @@ export function createDynamicComponent(
     const hydrationCursor = isHydrating ? enterHydrationCursor() : null
     const value = getter()
     const appContext = getAppContext()
-    const block = render(value, resolve(value, appContext), appContext)
+    const block = render(
+      value,
+      resolveValue(value, appContext, scopeOwner),
+      appContext,
+    )
     finishBlockCreation(
       block,
       undefined,
@@ -176,7 +174,7 @@ export function createDynamicComponent(
     // instead would put a build-dependent node (dev comment / prod text) into
     // the semantic content tree — prod hydration then mistakes the detached
     // text for valid content and crashes deriving an anchor from it.
-    const resolved = resolve(value, appContext)
+    const resolved = resolveValue(value, appContext, scopeOwner)
     if (resolved === NULL_DYNAMIC_COMPONENT) {
       frag.update(undefined, resolved)
       return
@@ -192,6 +190,23 @@ export function createDynamicComponent(
     _insertionAnchor,
   )
   return frag
+}
+
+function getAppContext(): GenericAppContext {
+  return (currentInstance && currentInstance.appContext) || emptyContext
+}
+
+// Blocks and vnodes are rendered as they are; anything else is a component
+// definition or a name to resolve in the slot owner's context.
+function resolveValue(
+  value: any,
+  appContext: GenericAppContext,
+  scopeOwner: VaporComponentInstance | null,
+): any {
+  return isBlock(value) ||
+    (isInteropEnabled && appContext.vdom && isVNode(value))
+    ? value
+    : withScopeOwner(scopeOwner, () => resolveDynamicComponent(value))
 }
 
 function withScopeOwner(owner: VaporComponentInstance | null, fn: () => any) {

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -10,7 +10,7 @@ import {
   setCurrentRenderingInstance,
 } from '@vue/runtime-dom'
 import { ShapeFlags, VaporDynamicComponentFlags } from '@vue/shared'
-import { isBlock, removeNode } from './block'
+import { type Block, isBlock, removeNode } from './block'
 import {
   type VaporComponentInstance,
   createComponentWithFallback,
@@ -34,6 +34,7 @@ import {
   type HydrationCursor,
   captureHydrationCursor,
   createFragmentClaim,
+  enterHydrationCursor,
   isHydrating,
   locateHydrationNode,
 } from './dom/hydration'
@@ -51,13 +52,94 @@ export function createDynamicComponent(
   rawProps?: RawProps | null,
   rawSlots?: LooseRawSlots | null,
   flags: number = 0,
-): VaporFragment {
+): Block {
   const isSingleRoot = !!(flags & VaporDynamicComponentFlags.SINGLE_ROOT)
   const once = !!(flags & VaporDynamicComponentFlags.ONCE)
   const slotRoot = !!(flags & VaporDynamicComponentFlags.SLOT_ROOT)
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor
   if (!isHydrating) resetInsertionState()
+
+  const normalizedRawSlots = normalizeRawSlots(rawSlots)
+  const scopeOwner = getScopeOwner()
+  const getAppContext = () =>
+    (currentInstance && currentInstance.appContext) || emptyContext
+
+  const resolve = (value: any, appContext: ReturnType<typeof getAppContext>) =>
+    isBlock(value) || (isInteropEnabled && appContext.vdom && isVNode(value))
+      ? value
+      : withScopeOwner(scopeOwner, () => resolveDynamicComponent(value))
+
+  const render = (
+    value: any,
+    resolved: any,
+    appContext: ReturnType<typeof getAppContext>,
+  ): Block => {
+    // Support integration with VaporRouterView/VaporRouterLink by accepting blocks
+    if (isBlock(value)) return value
+
+    // Handles VNodes passed from VDOM components (e.g., `h(VaporComp)` from slots)
+    if (isInteropEnabled && appContext.vdom && isVNode(value)) {
+      if (isKeepAlive(currentInstance)) {
+        enableKeepAlive()
+        const cached = (
+          currentInstance as KeepAliveInstance
+        ).ctx.getCachedComponent(value.type, value.key) as VaporFragment
+        if (cached) return cached
+      }
+
+      // A vnode standing in as this component's effective root inherits
+      // fallthrough attrs; the normal component path folds them into
+      // rawProps at creation, this one merges them into the vnode's props.
+      const owner =
+        isSingleRoot &&
+        isVaporComponent(currentInstance) &&
+        currentInstance.hasFallthrough &&
+        currentInstance.type.inheritAttrs !== false
+          ? currentInstance
+          : undefined
+      const frag = appContext.vdom.mountVNode(
+        value,
+        currentInstance,
+        owner && (() => resolveFallthroughAttrs(owner)),
+      )
+      if (isHydrating) {
+        locateHydrationNode(
+          shouldConsumeFragmentStart(value) ? createFragmentClaim() : undefined,
+        )
+        frag.hydrate()
+      }
+      return frag
+    }
+
+    return createComponentWithFallback(
+      resolved,
+      rawProps,
+      normalizedRawSlots,
+      isSingleRoot,
+      once,
+      appContext,
+    )
+  }
+
+  if (once) {
+    // Resolved exactly once, so there is nothing for a fragment to switch:
+    // render the block in place, like `createIf` once. A null component
+    // renders the fallback's placeholder node.
+    const hydrationCursor = isHydrating ? enterHydrationCursor() : null
+    const value = getter()
+    const appContext = getAppContext()
+    const block = render(value, resolve(value, appContext), appContext)
+    finishBlockCreation(
+      block,
+      undefined,
+      hydrationCursor,
+      _insertionParent,
+      _insertionAnchor,
+    )
+    return block
+  }
+
   const hydrationCursor: HydrationCursor | null = isHydrating
     ? captureHydrationCursor()
     : null
@@ -85,79 +167,22 @@ export function createDynamicComponent(
     _insertionAnchor,
   )
 
-  const normalizedRawSlots = normalizeRawSlots(rawSlots)
-  const scopeOwner = getScopeOwner()
-  const renderFn = () => {
+  renderEffect(() => {
     const value = getter()
-    const appContext =
-      (currentInstance && currentInstance.appContext) || emptyContext
+    const appContext = getAppContext()
     // Resolve before update: a null dynamic component is an empty branch
     // (nodes stays EMPTY_BLOCK, the fragment anchor is the only structural
     // node), the same shape as v-if=false. Rendering a fake placeholder node
     // instead would put a build-dependent node (dev comment / prod text) into
     // the semantic content tree — prod hydration then mistakes the detached
     // text for valid content and crashes deriving an anchor from it.
-    const resolved =
-      isBlock(value) || (isInteropEnabled && appContext.vdom && isVNode(value))
-        ? value
-        : withScopeOwner(scopeOwner, () => resolveDynamicComponent(value))
+    const resolved = resolve(value, appContext)
     if (resolved === NULL_DYNAMIC_COMPONENT) {
       frag.update(undefined, resolved)
       return
     }
-    frag.update(() => {
-      // Support integration with VaporRouterView/VaporRouterLink by accepting blocks
-      if (isBlock(value)) return value
-
-      // Handles VNodes passed from VDOM components (e.g., `h(VaporComp)` from slots)
-      if (isInteropEnabled && appContext.vdom && isVNode(value)) {
-        if (isKeepAlive(currentInstance)) {
-          enableKeepAlive()
-          const frag = (
-            currentInstance as KeepAliveInstance
-          ).ctx.getCachedComponent(value.type, value.key) as VaporFragment
-          if (frag) return frag
-        }
-
-        // A vnode standing in as this component's effective root inherits
-        // fallthrough attrs; the normal component path folds them into
-        // rawProps at creation, this one merges them into the vnode's props.
-        const owner =
-          isSingleRoot &&
-          isVaporComponent(currentInstance) &&
-          currentInstance.hasFallthrough &&
-          currentInstance.type.inheritAttrs !== false
-            ? currentInstance
-            : undefined
-        const frag = appContext.vdom.mountVNode(
-          value,
-          currentInstance,
-          owner && (() => resolveFallthroughAttrs(owner)),
-        )
-        if (isHydrating) {
-          locateHydrationNode(
-            shouldConsumeFragmentStart(value)
-              ? createFragmentClaim()
-              : undefined,
-          )
-          frag.hydrate()
-        }
-        return frag
-      }
-
-      return createComponentWithFallback(
-        resolved,
-        rawProps,
-        normalizedRawSlots,
-        isSingleRoot,
-        once,
-        appContext,
-      )
-    }, value)
-  }
-
-  if (once) renderFn()
-  else renderEffect(renderFn)
+    frag.update(() => render(value, resolved, appContext), value)
+  })
 
   finishBlockCreation(
     frag,

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -299,9 +299,8 @@ function createInnerComp(
       // rawProps is shared and already contains fallthrough attrs.
       // so isSingleRoot should be undefined
       undefined,
-      // The resolved inner component is the real input boundary for async
-      // components, so it must inherit the wrapper's v-once state.
-      parent.isOnce,
+      // The wrapper already snapshotted rawProps when it is v-once.
+      undefined,
       parent.appContext,
     )
   } finally {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -89,11 +89,11 @@ import {
   type StaticSlots,
   dynamicSlotsProxyHandlers,
   getSlot,
-  inOnceSlot,
   normalizeRawSlots,
   setCurrentSlotOwner,
-  withOnceSlot,
+  snapshotRawSlots,
 } from './componentSlots'
+import { inOnce, withOnce } from './once'
 import { hmrReload, hmrRerender } from './hmr'
 import {
   type FragmentClaim,
@@ -289,8 +289,8 @@ export function createComponent(
 ): VaporComponentInstance {
   // A component created while rendering a v-once slot should receive frozen
   // parent inputs, but its own render effects should still be live.
-  const wasInOnceSlot = inOnceSlot
-  if (wasInOnceSlot) once = true
+  const wasInOnce = inOnce
+  if (wasInOnce) once = true
 
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor
@@ -436,17 +436,18 @@ export function createComponent(
     let inputScope: EffectScope | undefined
     if (
       keepAliveCtx &&
-      ((rawProps && !once) || (rawSlots && (rawSlots as RawSlots).$))
+      !once &&
+      (rawProps || (rawSlots && (rawSlots as RawSlots).$))
     ) {
       // The cached component keeps its detached scope active, so commit only
       // its direct inputs through a cache-owned scope. Descendants read from
       // the same committed inputs and need no additional isolation.
-      // v-once snapshots raw props in the instance constructor, so it does not
-      // need a live commit effect after creation.
+      // v-once snapshots raw props and the slot set in the instance
+      // constructor, so it does not need a live commit effect after creation.
       const scope = new EffectScope(true)
       let isolated = false
       scope.run(() => {
-        if (rawProps && !once) {
+        if (rawProps) {
           const next = keepAliveCtx!.isolatePropSources(rawProps as RawProps)
           isolated = next !== rawProps
           rawProps = next
@@ -527,11 +528,11 @@ export function createComponent(
           instance,
           // Async hydration re-enters setup later, so preserve the component
           // boundary rule above when the delayed setup actually runs.
-          wasInOnceSlot ? () => withOnceSlot(setup, false) : setup,
+          wasInOnce ? () => withOnce(setup, false) : setup,
         )
       } else {
-        if (wasInOnceSlot) {
-          withOnceSlot(() => setupComponent(instance, component), false)
+        if (wasInOnce) {
+          withOnce(() => setupComponent(instance, component), false)
         } else {
           setupComponent(instance, component)
         }
@@ -913,11 +914,6 @@ export class VaporComponentInstance<
 
   ce?: ComponentCustomElementInterface
 
-  // for v-once: caches props/attrs values to ensure they remain frozen
-  // even when the component re-renders due to local state changes
-  oncePropsCache?: Record<string | symbol, any>
-  isOnce: boolean
-
   // lifecycle hooks
   isMounted: boolean
   isUnmounted: boolean
@@ -996,7 +992,6 @@ export class VaporComponentInstance<
 
     this.block = null! // to be set
     this.scope = new EffectScope(true)
-    this.isOnce = !!once
 
     this.emit = emit.bind(null, this) as EmitFn<Emits>
     this.expose = expose.bind(null, this) as any
@@ -1023,9 +1018,7 @@ export class VaporComponentInstance<
     // Snapshot raw parent inputs before creating proxies so delayed reads from
     // v-once children cannot observe later parent updates.
     this.rawProps =
-      this.isOnce && rawProps
-        ? snapshotRawProps(rawProps)
-        : rawProps || EMPTY_OBJ
+      once && rawProps ? snapshotRawProps(rawProps) : rawProps || EMPTY_OBJ
     // a custom element host mutates its props object after creation, so its
     // attrs key set is never static
     this.hasFallthrough = !!ce || hasFallthroughAttrs(comp, this.rawProps)
@@ -1044,7 +1037,10 @@ export class VaporComponentInstance<
     }
 
     // init slots
-    const normalizedRawSlots = normalizeRawSlots(rawSlots)
+    let normalizedRawSlots = normalizeRawSlots(rawSlots)
+    if (once && normalizedRawSlots && normalizedRawSlots.$) {
+      normalizedRawSlots = snapshotRawSlots(normalizedRawSlots)
+    }
     this.rawSlots = normalizedRawSlots || EMPTY_OBJ
     this.slots = (
       normalizedRawSlots

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1038,7 +1038,7 @@ export class VaporComponentInstance<
 
     // init slots
     let normalizedRawSlots = normalizeRawSlots(rawSlots)
-    if (once && normalizedRawSlots && normalizedRawSlots.$) {
+    if (once && normalizedRawSlots) {
       normalizedRawSlots = snapshotRawSlots(normalizedRawSlots)
     }
     this.rawSlots = normalizedRawSlots || EMPTY_OBJ

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -287,10 +287,11 @@ export function createComponent(
   managedMount = false,
   ce?: (instance: VaporComponentInstance) => void,
 ): VaporComponentInstance {
-  // A component created while rendering a v-once slot should receive frozen
-  // parent inputs, but its own render effects should still be live.
+  // A component created while rendering a v-once region receives frozen
+  // parent inputs, but its own render effects stay live. A vdom-managed mount
+  // is a boundary of its own: the vdom render owns that component's inputs.
   const wasInOnce = inOnce
-  if (wasInOnce) once = true
+  if (wasInOnce && !managedMount) once = true
 
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -38,7 +38,6 @@ import {
 } from '@vue/reactivity'
 import { normalizeEmitsOptions } from './componentEmits'
 import { renderEffect } from './renderEffect'
-import { pauseTracking, resetTracking } from '@vue/reactivity'
 import type { interopKey } from './vdomInteropState'
 
 export type RawProps = Record<string, unknown> & {
@@ -226,10 +225,13 @@ export function resolveFunctionSource<T>(
 export function snapshotRawProps(rawProps: RawProps): RawProps {
   // Freeze the parent-provided raw source, not the child props proxy. This
   // keeps prop defaults lazy while preserving v-once input semantics.
+  // Sources are read directly: the caller is the instance that defined them,
+  // and a one-time read has no use for the computed `resolveFunctionSource`
+  // would allocate.
   const snapshot: RawProps = Object.create(null)
   for (const key in rawProps) {
     if (key !== '$') {
-      const value = resolveSource(rawProps[key])
+      const value = readSource(rawProps[key])
       snapshot[key] = () => value
     }
   }
@@ -241,22 +243,19 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
     } = []
     for (let i = 0; i < dynamicSources.length; i++) {
       const source = dynamicSources[i]
+      const isDynamic = isFunction(source)
+      const resolved =
+        (isDynamic
+          ? (source as () => Record<string, unknown>)()
+          : (source as Record<string, unknown>)) || EMPTY_OBJ
+      // Object sources are read without a per-source computed, so a resolved
+      // function source is stored in that shape.
       const value: Record<string, unknown> = Object.create(null)
-      if (isFunction(source)) {
-        const resolved = resolveFunctionSource(
-          source as () => Record<string, unknown>,
-        )
-        for (const key in resolved) {
-          value[key] = resolved[key]
-        }
-        snapshotSources[i] = () => value
-      } else {
-        for (const key in source) {
-          const resolved = resolveSource(source[key])
-          value[key] = () => resolved
-        }
-        snapshotSources[i] = value
+      for (const key in resolved) {
+        const v = isDynamic ? resolved[key] : readSource(resolved[key])
+        value[key] = () => v
       }
+      snapshotSources[i] = value
     }
     const symbols = Object.getOwnPropertySymbols(dynamicSources)
     for (let i = 0; i < symbols.length; i++) {
@@ -268,6 +267,10 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
   }
 
   return snapshot
+}
+
+function readSource<T>(source: T | (() => T)): T {
+  return isFunction(source) ? (source as () => T)() : source
 }
 
 function stabilizeDynamicSourceValue<T>(oldValue: T | undefined, value: T): T {
@@ -387,35 +390,9 @@ export function getPropsProxyHandlers(
     )
   }
 
-  const withOnceCache = <
-    T extends (instance: VaporComponentInstance, key: string | symbol) => any,
-  >(
-    getter: T,
-  ): T => {
-    return ((instance: VaporComponentInstance, key: string | symbol) => {
-      const cache =
-        instance.oncePropsCache ||
-        (instance.oncePropsCache = Object.create(null))
-      if (!hasOwn(cache, key)) {
-        pauseTracking()
-        try {
-          cache[key] = getter(instance, key)
-        } finally {
-          resetTracking()
-        }
-      }
-      return cache[key]
-    }) as T
-  }
-
-  const getOnceProp = withOnceCache(getProp)
-  const getMaybeOnceProp = (
-    instance: VaporComponentInstance,
-    key: string | symbol,
-  ) => (instance.isOnce ? getOnceProp : getProp)(instance, key)
   const propsHandlers = propsOptions
     ? ({
-        get: getMaybeOnceProp,
+        get: getProp,
         has: (_, key) => isProp(key),
         ownKeys: () => Object.keys(propsOptions),
         getOwnPropertyDescriptor(target, key) {
@@ -423,7 +400,7 @@ export function getPropsProxyHandlers(
             return {
               configurable: true,
               enumerable: true,
-              get: () => getMaybeOnceProp(target, key),
+              get: () => getProp(target, key),
             }
           }
         },
@@ -451,63 +428,18 @@ export function getPropsProxyHandlers(
     }
   }
 
-  const getOnceAttr = withOnceCache((instance, key) =>
-    getAttr(instance.rawProps, key),
-  )
-  const onceAttrKeys = Symbol()
   const getAttrKeys = (target: VaporComponentInstance) =>
     getKeysFromRawProps(target.rawProps).filter(isAttr)
-  const getOnceAttrKeys = (target: VaporComponentInstance) => {
-    const cache =
-      target.oncePropsCache || (target.oncePropsCache = Object.create(null))
-    if (!hasOwn(cache, onceAttrKeys)) {
-      pauseTracking()
-      try {
-        // Freeze both the attr key set and its initial values so direct
-        // delayed reads do not see attrs added after the once boundary.
-        const keys = getAttrKeys(target)
-        cache[onceAttrKeys] = keys
-        for (let i = 0; i < keys.length; i++) {
-          const key = keys[i]
-          if (!hasOwn(cache, key)) {
-            cache[key] = getAttr(target.rawProps, key)
-          }
-        }
-      } finally {
-        resetTracking()
-      }
-    }
-    return cache[onceAttrKeys] as string[]
-  }
-  const getMaybeOnceAttrKeys = (target: VaporComponentInstance) =>
-    target.isOnce ? getOnceAttrKeys(target) : getAttrKeys(target)
-  const getMaybeOnceAttr = (
-    instance: VaporComponentInstance,
-    key: string | symbol,
-  ) =>
-    instance.isOnce
-      ? getOnceAttrKeys(instance).includes(key as string)
-        ? getOnceAttr(instance, key)
-        : undefined
-      : getAttr(instance.rawProps, key)
   const attrsHandlers = {
-    get: getMaybeOnceAttr,
-    has: (target, key: string | symbol) =>
-      target.isOnce
-        ? getOnceAttrKeys(target).includes(key as string)
-        : hasAttr(target.rawProps, key),
-    ownKeys: getMaybeOnceAttrKeys,
+    get: (target, key: string | symbol) => getAttr(target.rawProps, key),
+    has: (target, key: string | symbol) => hasAttr(target.rawProps, key),
+    ownKeys: getAttrKeys,
     getOwnPropertyDescriptor(target, key: string | symbol) {
-      if (
-        isString(key) &&
-        (target.isOnce
-          ? getOnceAttrKeys(target).includes(key)
-          : hasAttr(target.rawProps, key))
-      ) {
+      if (isString(key) && hasAttr(target.rawProps, key)) {
         return {
           configurable: true,
           enumerable: true,
-          get: () => getMaybeOnceAttr(target, key),
+          get: () => getAttr(target.rawProps, key),
         }
       }
     },

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -232,7 +232,7 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
   const snapshot: RawProps = Object.create(null)
   for (const key in rawProps) {
     if (key !== '$') {
-      snapshot[key] = freezeValue(readSource(rawProps[key]))
+      snapshot[key] = freezeValue(key, readSource(rawProps[key]))
     }
   }
 
@@ -250,6 +250,7 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
       const value: Record<string, unknown> = Object.create(null)
       for (const key in resolved) {
         value[key] = freezeValue(
+          key,
           isDynamic ? resolved[key] : readSource(resolved[key]),
         )
       }
@@ -271,7 +272,8 @@ function readSource<T>(source: T | (() => T)): T {
   return isFunction(source) ? (source as () => T)() : source
 }
 
-function freezeValue(value: unknown): unknown {
+function freezeValue(key: string, value: unknown): unknown {
+  if (key === 'class' && value && !isString(value)) return normalizeClass(value)
   return isFunction(value) ? () => value : value
 }
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -227,12 +227,12 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
   // keeps prop defaults lazy while preserving v-once input semantics.
   // Sources are read directly: the caller is the instance that defined them,
   // and a one-time read has no use for the computed `resolveFunctionSource`
-  // would allocate.
+  // would allocate. Values are stored plain; only a function value needs a
+  // getter so readers do not invoke it.
   const snapshot: RawProps = Object.create(null)
   for (const key in rawProps) {
     if (key !== '$') {
-      const value = readSource(rawProps[key])
-      snapshot[key] = () => value
+      snapshot[key] = freezeValue(readSource(rawProps[key]))
     }
   }
 
@@ -244,16 +244,14 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
     for (let i = 0; i < dynamicSources.length; i++) {
       const source = dynamicSources[i]
       const isDynamic = isFunction(source)
-      const resolved =
-        (isDynamic
-          ? (source as () => Record<string, unknown>)()
-          : (source as Record<string, unknown>)) || EMPTY_OBJ
+      const resolved = readSource(source) || EMPTY_OBJ
       // Object sources are read without a per-source computed, so a resolved
       // function source is stored in that shape.
       const value: Record<string, unknown> = Object.create(null)
       for (const key in resolved) {
-        const v = isDynamic ? resolved[key] : readSource(resolved[key])
-        value[key] = () => v
+        value[key] = freezeValue(
+          isDynamic ? resolved[key] : readSource(resolved[key]),
+        )
       }
       snapshotSources[i] = value
     }
@@ -271,6 +269,10 @@ export function snapshotRawProps(rawProps: RawProps): RawProps {
 
 function readSource<T>(source: T | (() => T)): T {
   return isFunction(source) ? (source as () => T)() : source
+}
+
+function freezeValue(value: unknown): unknown {
+  return isFunction(value) ? () => value : value
 }
 
 function stabilizeDynamicSourceValue<T>(oldValue: T | undefined, value: T): T {

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -274,6 +274,7 @@ function readSource<T>(source: T | (() => T)): T {
 
 function freezeValue(key: string, value: unknown): unknown {
   if (key === 'class' && value && !isString(value)) return normalizeClass(value)
+  if (key === 'style' && isArray(value)) return normalizeStyle(value)
   return isFunction(value) ? () => value : value
 }
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -105,17 +105,19 @@ export function normalizeRawSlots(
  * live; the child re-runs them on its own updates.
  */
 export function snapshotRawSlots(rawSlots: RawSlots): RawSlots {
+  const dynamicSources = rawSlots.$
+  if (!dynamicSources) return rawSlots
   const snapshot: RawSlots = {}
   for (const key in rawSlots) {
     if (key !== '$') snapshot[key] = rawSlots[key]
   }
-  for (const source of rawSlots.$!) {
+  for (const source of dynamicSources) {
     if (isFunction(source)) {
       const slot = withSlotOwner(rawSlots, () => source())
-      if (slot) {
-        for (const s of isArray(slot) ? slot : [slot]) {
-          snapshot[String(s.name)] = s.fn
-        }
+      if (isArray(slot)) {
+        for (const s of slot) snapshot[String(s.name)] = s.fn
+      } else if (slot) {
+        snapshot[String(slot.name)] = slot.fn
       }
     } else {
       for (const key in source) snapshot[key] = source[key]

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -61,6 +61,7 @@ import { withHydratingSlotBoundary } from './dom/hydrateFragment'
 export let inOnceSlot = false
 
 export function withOnceSlot<T>(fn: () => T, value = true): T {
+  if (inOnceSlot === value) return fn()
   const prev = inOnceSlot
   try {
     inOnceSlot = value

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -53,23 +53,7 @@ import {
   setElementScopeIds,
 } from './scopeId'
 import { withHydratingSlotBoundary } from './dom/hydrateFragment'
-
-/**
- * Flag to indicate if we are executing a once slot.
- * When true, renderEffect should skip creating reactive effect.
- */
-export let inOnceSlot = false
-
-export function withOnceSlot<T>(fn: () => T, value = true): T {
-  if (inOnceSlot === value) return fn()
-  const prev = inOnceSlot
-  try {
-    inOnceSlot = value
-    return fn()
-  } finally {
-    inOnceSlot = prev
-  }
-}
+import { withOnce } from './once'
 
 export type RawSlots = Record<string, VaporSlot> & {
   $?: DynamicSlotSource[]
@@ -113,6 +97,35 @@ export function normalizeRawSlots(
     rawSlotsOwnerMap.set(normalized, getScopeOwner())
   }
   return normalized
+}
+
+/**
+ * Freeze the slot set of a v-once component: dynamic sources resolve once,
+ * in `resolveSlot` precedence, into plain entries. The slot functions stay
+ * live; the child re-runs them on its own updates.
+ */
+export function snapshotRawSlots(rawSlots: RawSlots): RawSlots {
+  const snapshot: RawSlots = {}
+  for (const key in rawSlots) {
+    if (key !== '$') snapshot[key] = rawSlots[key]
+  }
+  for (const source of rawSlots.$!) {
+    if (isFunction(source)) {
+      const slot = withSlotOwner(rawSlots, () => source())
+      if (slot) {
+        for (const s of isArray(slot) ? slot : [slot]) {
+          snapshot[String(s.name)] = s.fn
+        }
+      }
+    } else {
+      for (const key in source) snapshot[key] = source[key]
+    }
+  }
+  for (const symbol of Object.getOwnPropertySymbols(rawSlots)) {
+    ;(snapshot as any)[symbol] = (rawSlots as any)[symbol]
+  }
+  rawSlotsOwnerMap.set(snapshot, rawSlotsOwnerMap.get(rawSlots) || null)
+  return snapshot
 }
 
 function withSlotOwner<T>(slots: RawSlots, fn: () => T): T {
@@ -319,8 +332,7 @@ export function createSlot(
     // non-interop paths wrap here.
     if (once && fallback) {
       const originalFallback = fallback
-      fallback = (...args: any[]) =>
-        withOnceSlot(() => originalFallback(...args))
+      fallback = (...args: any[]) => withOnce(() => originalFallback(...args))
     }
     if (isHydrating) hydrationCursor = captureHydrationCursor()
     // A definition that resolves to another async wrapper mounts that wrapper
@@ -446,7 +458,7 @@ export function createSlot(
         // the fragment's render seam) and catches up out-of-window content.
         cachedBoundSlot = () =>
           renderWithSlotScopeIds(slotScopeIds, () =>
-            once ? withOnceSlot(() => slot(slotProps)) : slot(slotProps),
+            once ? withOnce(() => slot(slotProps)) : slot(slotProps),
           )
       }
       return cachedBoundSlot!

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -19,6 +19,7 @@ import {
 import { isAsyncComponentEnabled } from '../asyncComponentState'
 import { type VaporFragment, isFragment, isInteropFragment } from '../fragment'
 import { isInteropEnabled } from '../vdomInteropState'
+import { inOnce, withOnce } from '../once'
 
 // !! vapor directive is different from vdom directives
 export type VaporDirective<
@@ -58,6 +59,8 @@ export function withVaporDirectives(
   }
 
   const instance = currentInstance
+  // Deferred (re)application keeps the once ambient it was created under.
+  const once = inOnce
   const trackedBlocks = new WeakSet<VaporFragment | VaporComponentInstance>()
   let currentElement: Element | null | undefined = null
   let directiveScope: EffectScope | undefined
@@ -107,7 +110,11 @@ export function withVaporDirectives(
     // Re-apply in the original directive owner's component context
     const prev = setCurrentInstance(instance, directiveScope)
     try {
-      applyDirectivesToElement(element, dirs)
+      if (once) {
+        withOnce(() => applyDirectivesToElement(element, dirs))
+      } else {
+        applyDirectivesToElement(element, dirs)
+      }
     } finally {
       restoreCurrentInstance(prev)
     }

--- a/packages/runtime-vapor/src/directives/vModel.ts
+++ b/packages/runtime-vapor/src/directives/vModel.ts
@@ -10,6 +10,7 @@ import {
   vModelTextUpdate,
 } from '@vue/runtime-dom'
 import { renderEffect } from '../renderEffect'
+import { inOnce, withOnce } from '../once'
 import { looseEqual } from '@vue/shared'
 import { traverse } from '@vue/reactivity'
 
@@ -30,7 +31,8 @@ function ensureMounted(cb: () => void) {
   if (currentInstance!.isMounted) {
     cb()
   } else {
-    onMounted(cb)
+    // Deferred work keeps the once ambient it was created under.
+    onMounted(inOnce ? () => withOnce(cb) : cb)
   }
 }
 

--- a/packages/runtime-vapor/src/index.ts
+++ b/packages/runtime-vapor/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from './component'
 export { renderEffect } from './renderEffect'
 export { createSlot } from './componentSlots'
+export { withOnce } from './once'
 export { template } from './dom/template'
 export { createTextNode, child, nthChild, next, txt } from './dom/node'
 export {

--- a/packages/runtime-vapor/src/once.ts
+++ b/packages/runtime-vapor/src/once.ts
@@ -8,6 +8,10 @@
  */
 export let inOnce = false
 
+export function setInOnce(value: boolean): void {
+  inOnce = value
+}
+
 export function withOnce<T>(fn: () => T, value = true): T {
   if (inOnce === value) return fn()
   const prev = inOnce

--- a/packages/runtime-vapor/src/once.ts
+++ b/packages/runtime-vapor/src/once.ts
@@ -8,10 +8,6 @@
  */
 export let inOnce = false
 
-export function setInOnce(value: boolean): void {
-  inOnce = value
-}
-
 export function withOnce<T>(fn: () => T, value = true): T {
   if (inOnce === value) return fn()
   const prev = inOnce

--- a/packages/runtime-vapor/src/once.ts
+++ b/packages/runtime-vapor/src/once.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether the code running now belongs to a v-once region: slot content or
+ * fallback rendered by a `<slot v-once>`, or a compiled v-once directive.
+ * While set, renderEffect runs its function once instead of creating an
+ * effect. Every component boundary resets it (Vapor setup, vdom mount), and
+ * deferred work captures it at creation. Call sites test `inOnce` first so
+ * the common path pays neither the closure nor the call.
+ */
+export let inOnce = false
+
+export function withOnce<T>(fn: () => T, value = true): T {
+  if (inOnce === value) return fn()
+  const prev = inOnce
+  try {
+    inOnce = value
+    return fn()
+  } finally {
+    inOnce = prev
+  }
+}

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -17,7 +17,7 @@ import {
   isVaporComponent,
   settleDeferredKeepAliveUpdates,
 } from './component'
-import { inOnceSlot } from './componentSlots'
+import { inOnce } from './once'
 import { invokeArrayFns } from '@vue/shared'
 import { isSuspenseEnabled } from './suspense'
 
@@ -143,8 +143,7 @@ export class RenderEffect extends ReactiveEffect {
 }
 
 export function renderEffect(fn: () => void, noLifecycle = false): void {
-  // in once slot, just run the function directly
-  if (inOnceSlot) return fn()
+  if (inOnce) return fn()
 
   const effect = new RenderEffect(fn, noLifecycle)
   effect.run()

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -121,7 +121,7 @@ import {
 } from './componentProps'
 import type { RawSlots, VaporSlot } from './componentSlots'
 import { dynamicSlotsProxyHandlers, getSlot } from './componentSlots'
-import { inOnce, withOnce } from './once'
+import { inOnce, setInOnce, withOnce } from './once'
 import { renderEffect } from './renderEffect'
 import { createTextNode, parentNode } from './dom/node'
 import { optimizePropertyLookup } from './dom/prop'
@@ -349,6 +349,10 @@ const vaporInteropImpl: VaporInVdomInterface = {
     container.insertBefore(selfAnchor, anchor)
     const prev = currentInstance
     simpleSetCurrentInstance(parentComponent)
+    // vdom is a boundary: a vapor component it creates is not part of the
+    // v-once extent the vdom render itself may be running in.
+    const prevOnce = inOnce
+    if (prevOnce) setInOnce(false)
 
     const propsRef = shallowRef(filterReservedProps(vnode.props))
     const slotsRef = shallowRef(normalizeInteropSlots(vnode.children))
@@ -377,6 +381,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
       // VDOM interop owns the explicit mount below
       true,
     ))
+    if (prevOnce) setInOnce(true)
     instance.rawPropsRef = propsRef
     instance.rawSlotsRef = slotsRef
     const vnodeHookState = ensureVNodeHookState(instance, vnode)
@@ -1149,14 +1154,7 @@ function mountVNode(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    if (inOnce) {
-      withOnce(
-        () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
-        false,
-      )
-    } else {
-      hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
-    }
+    hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
     onScopeDispose(unmount, true)
     isMounted = true
     syncNodes()
@@ -1195,34 +1193,16 @@ function mountVNode(
       if (!isMounted) {
         if (transition) setVNodeTransitionHooks(vnode, transition)
         namespace = getContainerType(parentNode as Element)
-        if (inOnce) {
-          // Component vnodes render here; see createVDOMComponent.
-          withOnce(
-            () =>
-              internals.p(
-                null,
-                vnode,
-                parentNode,
-                anchor,
-                parentComponent as any,
-                operationSuspense,
-                namespace,
-                frag.slotScopeIds,
-              ),
-            false,
-          )
-        } else {
-          internals.p(
-            null,
-            vnode,
-            parentNode,
-            anchor,
-            parentComponent as any,
-            operationSuspense,
-            namespace,
-            frag.slotScopeIds,
-          )
-        }
+        internals.p(
+          null,
+          vnode,
+          parentNode,
+          anchor,
+          parentComponent as any,
+          operationSuspense,
+          namespace,
+          frag.slotScopeIds,
+        )
         onScopeDispose(unmount, true)
         isMounted = true
       } else {
@@ -1429,14 +1409,7 @@ function createVDOMComponent(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    if (inOnce) {
-      withOnce(
-        () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
-        false,
-      )
-    } else {
-      hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
-    }
+    hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
     isMounted = true
     syncNodes()
   }
@@ -1470,33 +1443,15 @@ function createVDOMComponent(
       simpleSetCurrentInstance(parentComponent)
       if (!isMounted) {
         if (transition) setVNodeTransitionHooks(vnode, transition)
-        if (inOnce) {
-          // A VDOM component is a boundary: its own render must create live
-          // effects even when it is mounted inside a v-once extent.
-          withOnce(
-            () =>
-              internals.mt(
-                vnode,
-                parentNode,
-                anchor,
-                parentComponent as any,
-                operationSuspense,
-                getContainerType(parentNode as Element),
-                false,
-              ),
-            false,
-          )
-        } else {
-          internals.mt(
-            vnode,
-            parentNode,
-            anchor,
-            parentComponent as any,
-            operationSuspense,
-            getContainerType(parentNode as Element),
-            false,
-          )
-        }
+        internals.mt(
+          vnode,
+          parentNode,
+          anchor,
+          parentComponent as any,
+          operationSuspense,
+          getContainerType(parentNode as Element),
+          false,
+        )
         // set ref
         if (rawRef) vdomSetRef(rawRef, null, operationSuspense, vnode)
         isMounted = true
@@ -3029,9 +2984,11 @@ function invokeVaporSlot(vnode: VNode): Block {
   const scope = effectScope()
   vnode.vs!.scope = scope
   try {
-    return scope.run(() =>
-      vnode.vs!.slot(new Proxy(propsRef, vaporSlotPropsProxyHandler)),
-    )!
+    const run = () =>
+      vnode.vs!.slot(new Proxy(propsRef, vaporSlotPropsProxyHandler))
+    // vdom is a boundary: the slot it invokes runs live even when the vdom
+    // render sits inside a v-once extent.
+    return (inOnce ? withOnce(() => scope.run(run), false) : scope.run(run))!
   } catch (e) {
     vnode.vs!.scope = undefined
     scope.stop()

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -120,11 +120,8 @@ import {
   setupPropsValidation,
 } from './componentProps'
 import type { RawSlots, VaporSlot } from './componentSlots'
-import {
-  dynamicSlotsProxyHandlers,
-  getSlot,
-  withOnceSlot,
-} from './componentSlots'
+import { dynamicSlotsProxyHandlers, getSlot } from './componentSlots'
+import { inOnce, withOnce } from './once'
 import { renderEffect } from './renderEffect'
 import { createTextNode, parentNode } from './dom/node'
 import { optimizePropertyLookup } from './dom/prop'
@@ -1152,10 +1149,14 @@ function mountVNode(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    withOnceSlot(
-      () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
-      false,
-    )
+    if (inOnce) {
+      withOnce(
+        () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
+        false,
+      )
+    } else {
+      hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
+    }
     onScopeDispose(unmount, true)
     isMounted = true
     syncNodes()
@@ -1194,21 +1195,34 @@ function mountVNode(
       if (!isMounted) {
         if (transition) setVNodeTransitionHooks(vnode, transition)
         namespace = getContainerType(parentNode as Element)
-        // Component vnodes render here; see createVDOMComponent.
-        withOnceSlot(
-          () =>
-            internals.p(
-              null,
-              vnode,
-              parentNode,
-              anchor,
-              parentComponent as any,
-              operationSuspense,
-              namespace,
-              frag.slotScopeIds,
-            ),
-          false,
-        )
+        if (inOnce) {
+          // Component vnodes render here; see createVDOMComponent.
+          withOnce(
+            () =>
+              internals.p(
+                null,
+                vnode,
+                parentNode,
+                anchor,
+                parentComponent as any,
+                operationSuspense,
+                namespace,
+                frag.slotScopeIds,
+              ),
+            false,
+          )
+        } else {
+          internals.p(
+            null,
+            vnode,
+            parentNode,
+            anchor,
+            parentComponent as any,
+            operationSuspense,
+            namespace,
+            frag.slotScopeIds,
+          )
+        }
         onScopeDispose(unmount, true)
         isMounted = true
       } else {
@@ -1415,10 +1429,14 @@ function createVDOMComponent(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    withOnceSlot(
-      () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
-      false,
-    )
+    if (inOnce) {
+      withOnce(
+        () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
+        false,
+      )
+    } else {
+      hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
+    }
     isMounted = true
     syncNodes()
   }
@@ -1452,21 +1470,33 @@ function createVDOMComponent(
       simpleSetCurrentInstance(parentComponent)
       if (!isMounted) {
         if (transition) setVNodeTransitionHooks(vnode, transition)
-        // A VDOM component is a boundary: its own render must create live
-        // effects even when it is mounted inside a v-once extent.
-        withOnceSlot(
-          () =>
-            internals.mt(
-              vnode,
-              parentNode,
-              anchor,
-              parentComponent as any,
-              operationSuspense,
-              getContainerType(parentNode as Element),
-              false,
-            ),
-          false,
-        )
+        if (inOnce) {
+          // A VDOM component is a boundary: its own render must create live
+          // effects even when it is mounted inside a v-once extent.
+          withOnce(
+            () =>
+              internals.mt(
+                vnode,
+                parentNode,
+                anchor,
+                parentComponent as any,
+                operationSuspense,
+                getContainerType(parentNode as Element),
+                false,
+              ),
+            false,
+          )
+        } else {
+          internals.mt(
+            vnode,
+            parentNode,
+            anchor,
+            parentComponent as any,
+            operationSuspense,
+            getContainerType(parentNode as Element),
+            false,
+          )
+        }
         // set ref
         if (rawRef) vdomSetRef(rawRef, null, operationSuspense, vnode)
         isMounted = true
@@ -1856,7 +1886,7 @@ function renderVDOMSlot(
   }
   localFallback = fallback
     ? once
-      ? () => withOnceSlot(() => fallback(internals, parentComponent))
+      ? () => withOnce(() => fallback(internals, parentComponent))
       : () => fallback(internals, parentComponent)
     : undefined
 
@@ -2186,7 +2216,7 @@ function renderVDOMSlot(
     if (slotsRef.value) {
       const renderContent = () =>
         renderSlot(slotsRef.value, isFunction(name) ? name() : name, props)
-      slotContent = once ? withOnceSlot(renderContent) : renderContent()
+      slotContent = once ? withOnce(renderContent) : renderContent()
 
       if (isVNode(slotContent)) {
         if (slotContent.type === Fragment) {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -121,7 +121,7 @@ import {
 } from './componentProps'
 import type { RawSlots, VaporSlot } from './componentSlots'
 import { dynamicSlotsProxyHandlers, getSlot } from './componentSlots'
-import { inOnce, setInOnce, withOnce } from './once'
+import { inOnce, withOnce } from './once'
 import { renderEffect } from './renderEffect'
 import { createTextNode, parentNode } from './dom/node'
 import { optimizePropertyLookup } from './dom/prop'
@@ -349,10 +349,6 @@ const vaporInteropImpl: VaporInVdomInterface = {
     container.insertBefore(selfAnchor, anchor)
     const prev = currentInstance
     simpleSetCurrentInstance(parentComponent)
-    // vdom is a boundary: a vapor component it creates is not part of the
-    // v-once extent the vdom render itself may be running in.
-    const prevOnce = inOnce
-    if (prevOnce) setInOnce(false)
 
     const propsRef = shallowRef(filterReservedProps(vnode.props))
     const slotsRef = shallowRef(normalizeInteropSlots(vnode.children))
@@ -381,7 +377,6 @@ const vaporInteropImpl: VaporInVdomInterface = {
       // VDOM interop owns the explicit mount below
       true,
     ))
-    if (prevOnce) setInOnce(true)
     instance.rawPropsRef = propsRef
     instance.rawSlotsRef = slotsRef
     const vnodeHookState = ensureVNodeHookState(instance, vnode)

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1152,7 +1152,10 @@ function mountVNode(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
+    withOnceSlot(
+      () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
+      false,
+    )
     onScopeDispose(unmount, true)
     isMounted = true
     syncNodes()
@@ -1191,15 +1194,20 @@ function mountVNode(
       if (!isMounted) {
         if (transition) setVNodeTransitionHooks(vnode, transition)
         namespace = getContainerType(parentNode as Element)
-        internals.p(
-          null,
-          vnode,
-          parentNode,
-          anchor,
-          parentComponent as any,
-          operationSuspense,
-          namespace,
-          frag.slotScopeIds,
+        // Component vnodes render here; see createVDOMComponent.
+        withOnceSlot(
+          () =>
+            internals.p(
+              null,
+              vnode,
+              parentNode,
+              anchor,
+              parentComponent as any,
+              operationSuspense,
+              namespace,
+              frag.slotScopeIds,
+            ),
+          false,
         )
         onScopeDispose(unmount, true)
         isMounted = true
@@ -1407,7 +1415,10 @@ function createVDOMComponent(
 
   frag.hydrate = () => {
     if (!isHydrating) return
-    hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds)
+    withOnceSlot(
+      () => hydrateVNode(vnode, parentComponent as any, frag.slotScopeIds),
+      false,
+    )
     isMounted = true
     syncNodes()
   }
@@ -1441,13 +1452,19 @@ function createVDOMComponent(
       simpleSetCurrentInstance(parentComponent)
       if (!isMounted) {
         if (transition) setVNodeTransitionHooks(vnode, transition)
-        internals.mt(
-          vnode,
-          parentNode,
-          anchor,
-          parentComponent as any,
-          operationSuspense,
-          getContainerType(parentNode as Element),
+        // A VDOM component is a boundary: its own render must create live
+        // effects even when it is mounted inside a v-once extent.
+        withOnceSlot(
+          () =>
+            internals.mt(
+              vnode,
+              parentNode,
+              anchor,
+              parentComponent as any,
+              operationSuspense,
+              getContainerType(parentNode as Element),
+              false,
+            ),
           false,
         )
         // set ref


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `v-once` behavior in Vapor applications so content, props, slots, and directive values remain consistently frozen after initial rendering.
  * Fixed `v-once` handling for dynamic components, including unresolved components and hydration scenarios.
  * Preserved live updates for component slot content where appropriate, including VDOM and Vapor interoperability.
  * Improved behavior for `v-show`, `v-model`, custom directives, and parent-rendered built-ins used with `v-once`.
  * Removed unnecessary placeholder nodes from once-rendered dynamic components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->