### PR TITLE
fix(runtime-vapor): merge component event listeners across prop sources

### DIFF
--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -2190,4 +2190,56 @@ describe('attribute fallthrough', () => {
     const { html } = define(Parent).render()
     expect(html()).toBe('<div style="color: blue;"></div>')
   })
+
+  // #15442
+  it.each([true, false])(
+    'should merge static component listeners with v-on object bindings (static first: %s)',
+    async staticFirst => {
+      const calls: string[] = []
+      const onStatic = () => calls.push('static')
+      const onObject = () => calls.push('object')
+      const onExtra = () => calls.push('extra')
+      const data = ref<{
+        onStatic: () => void
+        listeners: Record<string, Function | Function[] | null | undefined>
+      }>({ onStatic, listeners: { click: onObject } })
+      const Child = compile(
+        '<template><button>click</button></template>',
+        ref(null),
+      )
+      const bindings = staticFirst
+        ? '@click="data.onStatic" v-on="data.listeners"'
+        : 'v-on="data.listeners" @click="data.onStatic"'
+      const Parent = compile(
+        `<template><components.Child ${bindings} /></template>`,
+        data,
+        { Child },
+      )
+
+      const { host } = define(Parent).render()
+      const button = host.querySelector('button')!
+      button.click()
+      expect(calls).toEqual(
+        staticFirst ? ['static', 'object'] : ['object', 'static'],
+      )
+
+      calls.length = 0
+      data.value.listeners.click = [onObject, onExtra]
+      await nextTick()
+      button.click()
+      expect(calls).toEqual(
+        staticFirst
+          ? ['static', 'object', 'extra']
+          : ['object', 'extra', 'static'],
+      )
+
+      for (const listeners of [{ click: onStatic }, { click: null }, {}]) {
+        calls.length = 0
+        data.value.listeners = listeners
+        await nextTick()
+        button.click()
+        expect(calls).toEqual(['static'])
+      }
+    },
+  )
 })

--- a/packages/runtime-vapor/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentEmits.spec.ts
@@ -608,4 +608,32 @@ describe('component: emit', () => {
     expect(calls).toEqual(['change:true'])
     expect(host.innerHTML).toBe('<!--if-->')
   })
+
+  // #15442
+  test('should merge once listeners from v-on objects', () => {
+    const onStatic = vi.fn()
+    const onObject = vi.fn()
+    const Child = compile(
+      `<script setup vapor>defineEmits(['ready'])</script>
+        <template><button @click="$emit('ready', 1)">emit</button></template>`,
+      ref(null),
+    )
+    const Parent = compile(
+      `<template>
+          <components.Child @ready.once="data.onStatic" v-on="data.listeners" />
+        </template>`,
+      ref({ onStatic, listeners: { readyOnce: onObject } }),
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    const button = host.querySelector('button')!
+    button.click()
+    expect(onStatic).toHaveBeenCalledExactlyOnceWith(1)
+    expect(onObject).toHaveBeenCalledExactlyOnceWith(1)
+
+    button.click()
+    expect(onStatic).toHaveBeenCalledTimes(1)
+    expect(onObject).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -956,6 +956,22 @@ describe('component: props', () => {
       expect(host.innerHTML).toBe('<div id="foo" class="bar">foo-bar</div>')
     })
 
+    test('resolveDynamicProps merges event listeners across sources', () => {
+      const first = vi.fn()
+      const second = vi.fn()
+      const third = vi.fn()
+      expect(
+        resolveDynamicProps({
+          onClick: () => first,
+          $: [
+            () => ({ onClick: [second, third] }),
+            { onClick: () => first },
+            () => ({ onClick: null }),
+          ],
+        }).onClick,
+      ).toEqual([first, second, third])
+    })
+
     test('resolveDynamicProps supports direct values in static object sources', () => {
       expect(
         resolveDynamicProps({

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -7223,4 +7223,38 @@ describe('vdomInterop', () => {
       expect(`returned non-block value`).toHaveBeenWarned()
     })
   })
+
+  // #15442
+  test.each([true, false])(
+    'should merge component listeners across interop (Vapor parent: %s)',
+    vaporParent => {
+      const onStatic = vi.fn()
+      const onObject = vi.fn()
+      const data = ref({ onStatic, listeners: { click: onObject } })
+      const Child = compile(
+        `<script setup ${vaporParent ? '' : 'vapor'}>
+          defineEmits(['click'])
+        </script>
+        <template><button @click="$emit('click')">click</button></template>`,
+        ref(null),
+        {},
+        { vapor: !vaporParent },
+      )
+      const Parent = compile(
+        `<script setup ${vaporParent ? 'vapor' : ''}>
+          const data = _data
+          const Child = _components.Child
+        </script>
+        <template><Child @click="data.onStatic" v-on="data.listeners" /></template>`,
+        data,
+        { Child },
+        { vapor: vaporParent },
+      )
+      const { host } = define(Parent).render()
+      const button = host.querySelector('button')!
+      button.click()
+      expect(onStatic).toHaveBeenCalledTimes(1)
+      expect(onObject).toHaveBeenCalledTimes(1)
+    },
+  )
 })

--- a/packages/runtime-vapor/src/componentEmits.ts
+++ b/packages/runtime-vapor/src/componentEmits.ts
@@ -1,8 +1,7 @@
 import { type ObjectEmitsOptions, baseEmit } from '@vue/runtime-dom'
 import type { VaporComponent, VaporComponentInstance } from './component'
-import { EMPTY_OBJ, hasOwn, isArray, isFunction, isOn } from '@vue/shared'
-import { type RawProps, resolveSource } from './componentProps'
-import { interopKey, isInteropEnabled } from './vdomInteropState'
+import { EMPTY_OBJ, isArray } from '@vue/shared'
+import { getAttrFromRawProps } from './componentProps'
 
 /**
  * The logic from core isn't too reusable so it's better to duplicate here
@@ -35,25 +34,8 @@ export function emit(
   baseEmit(
     instance,
     instance.rawProps || EMPTY_OBJ,
-    propGetter,
+    getAttrFromRawProps,
     event,
     ...rawArgs,
   )
-}
-
-function propGetter(rawProps: RawProps, key: string) {
-  const dynamicSources = rawProps.$
-  if (dynamicSources) {
-    let i = dynamicSources.length
-    while (i--) {
-      const source = resolveSource(dynamicSources[i])
-      if (source && hasOwn(source, key))
-        // for props passed from VDOM component, no need to resolve
-        return (isInteropEnabled && dynamicSources[interopKey]) ||
-          (isOn(key) && isFunction(dynamicSources[i]))
-          ? source[key]
-          : resolveSource(source[key])
-    }
-  }
-  return rawProps[key] && resolveSource(rawProps[key])
 }

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -7,6 +7,7 @@ import {
   isArray,
   isFunction,
   isObject,
+  isOn,
   isPlainObject,
   isString,
   normalizeClass,
@@ -525,9 +526,11 @@ export function getPropsProxyHandlers(
 
 export function getAttrFromRawProps(rawProps: RawProps, key: string): unknown {
   if (key === '$') return
-  // need special merging behavior for class & style
-  const merged = key === 'class' || key === 'style' ? ([] as any[]) : undefined
   const dynamicSources = rawProps.$
+  const isEvent = dynamicSources && isString(key) && isOn(key)
+  // Class, style and event listeners merge across prop sources.
+  const merged =
+    key === 'class' || key === 'style' || isEvent ? ([] as any[]) : undefined
   if (dynamicSources) {
     let i = dynamicSources.length
     let source, isDynamic
@@ -556,8 +559,18 @@ export function getAttrFromRawProps(rawProps: RawProps, key: string): unknown {
     }
   }
   if (merged && merged.length) {
-    return merged.reverse()
+    merged.reverse()
+    return isEvent ? merged.reduce(mergeEventHandlers) : merged
   }
+}
+
+function mergeEventHandlers(existing: unknown, incoming: unknown): unknown {
+  if (!existing) return incoming
+  return incoming &&
+    existing !== incoming &&
+    !(isArray(existing) && existing.includes(incoming))
+    ? ([] as unknown[]).concat(existing, incoming)
+    : existing
 }
 
 export function hasAttrFromRawProps(rawProps: RawProps, key: string): boolean {
@@ -686,6 +699,8 @@ export function resolveDynamicProps(props: RawProps): Record<string, unknown> {
           } else {
             mergedRawProps[key] = [existing, value]
           }
+        } else if (isOn(key)) {
+          mergedRawProps[key] = mergeEventHandlers(mergedRawProps[key], value)
         } else {
           mergedRawProps[key] = value
         }


### PR DESCRIPTION
close #15442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event listeners from static attributes and dynamic `v-on` bindings being merged correctly, regardless of binding order.
  * Preserved listener invocation order and flattened listener arrays consistently.
  * Ensured removing a dynamic listener leaves static listeners active.
  * Corrected `.once` behavior so each one-time listener runs only once.
  * Improved event handling across VDOM and Vapor component interoperability.

* **Tests**
  * Added coverage for listener merging, dynamic updates, one-time events, and cross-renderer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->