### PR TITLE
fix(runtime-vapor): copy rawProps when injecting fallthrough attrs

### DIFF
--- a/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentAttrs.spec.ts
@@ -1695,6 +1695,50 @@ describe('attribute fallthrough', () => {
     expect(host.innerHTML).toBe('<div><i>two</i></div><!--dynamic-component-->')
   })
 
+  it('does not accumulate fallthrough sources across dynamic component switches', async () => {
+    const state = ref({ current: 'A' })
+    // attrs bound onto a non-root element go through the full class merge
+    // instead of the root's incremental classList path, so a duplicated
+    // source shows up in the DOM
+    const compileInner = (text: string) =>
+      compile(
+        `<script setup vapor>
+          import { useAttrs } from 'vue'
+          defineOptions({ inheritAttrs: false })
+          const attrs = useAttrs()
+        </script>
+        <template><div><span v-bind="attrs">${text}</span></div></template>`,
+        ref(null),
+      )
+    const A = compileInner('A')
+    const B = compileInner('B')
+    const Child = compile(
+      `<template>
+        <component :is="components[data.current]" :foo="1" />
+      </template>`,
+      state,
+      { A, B },
+    )
+    const Parent = compile(
+      `<template><components.Child class="c" /></template>`,
+      ref(null),
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe(
+      '<div><span foo="1" class="c">A</span></div><!--dynamic-component-->',
+    )
+
+    for (const current of ['B', 'A', 'B']) {
+      state.value = { current }
+      await nextTick()
+    }
+    expect(host.innerHTML).toBe(
+      '<div><span foo="1" class="c">B</span></div><!--dynamic-component-->',
+    )
+  })
+
   // #15277
   it('should pass fallthrough attrs to declared props with inheritAttrs: false', () => {
     const Child = compile(

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -61,6 +61,7 @@ import {
   NOOP,
   type Prettify,
   ShapeFlags,
+  extend,
   hasOwn,
   invokeArrayFns,
   isArray,
@@ -349,10 +350,14 @@ export function createComponent(
       // that do not restore the parent as currentInstance.
       const owner = currentInstance
       const source = () => resolveFallthroughAttrs(owner)
+      // copy, never mutate: the caller's rawProps outlives this creation
+      // (dynamic component branches share one object), and every creation
+      // must see exactly one fallthrough source
       if (rawProps && rawProps !== EMPTY_OBJ) {
-        ;((rawProps as RawProps).$ || ((rawProps as RawProps).$ = [])).push(
-          source,
-        )
+        const sources = (rawProps as RawProps).$
+        rawProps = extend({}, rawProps, {
+          $: sources ? sources.concat(source) : [source],
+        }) as RawProps
       } else {
         rawProps = { $: [source] } as RawProps
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic component switching so fallthrough attributes, including classes and custom attributes, are forwarded only once instead of accumulating across switches.

* **Tests**
  * Added regression coverage for fallthrough attribute handling during repeated dynamic component changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->