### PR TITLE
fix(runtime-vapor): key dynamic component branches by the resolved component

### DIFF
--- a/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
@@ -104,6 +104,30 @@ describe('api: createDynamicComponent', () => {
     host.remove()
   })
 
+  test('keeps the branch when a name resolves to the current component', async () => {
+    let setups = 0
+    const Foo = defineVaporComponent({
+      setup() {
+        setups++
+        return template('<span>foo</span>')()
+      },
+    })
+    const data = shallowRef<any>('Foo')
+    const App = compile(`<template><component :is="data" /></template>`, data)
+    const host = document.createElement('div')
+    const app = createVaporApp(App)
+    app.component('Foo', Foo)
+    app.mount(host)
+    expect(host.innerHTML).toBe('<span>foo</span><!--dynamic-component-->')
+
+    data.value = Foo
+    await nextTick()
+    data.value = 'foo'
+    await nextTick()
+    expect(host.innerHTML).toBe('<span>foo</span><!--dynamic-component-->')
+    expect(setups).toBe(1)
+  })
+
   test('global registration', async () => {
     const val = shallowRef('foo')
 

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -179,7 +179,7 @@ export function createDynamicComponent(
       frag.update(undefined, resolved)
       return
     }
-    frag.update(() => render(value, resolved, appContext), value)
+    frag.update(() => render(value, resolved, appContext), resolved)
   })
 
   finishBlockCreation(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed dynamic components switching between string names and component references so the correct component branch remains rendered.
  - Prevented unnecessary component reinitialization during dynamic component updates.

- **Tests**
  - Added coverage for dynamic component resolution and repeated switching between equivalent component values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->