### PR TITLE
fix(compiler-vapor): resolve is="vue:" on native tags as the component

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -828,6 +828,15 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: element transform > dynamic component > native element with is="vue:" prefix 1`] = `
+"import { createAssetComponent as _createAssetComponent } from 'vue';
+
+export function render(_ctx) {
+  const n0 = _createAssetComponent("foo", null, null, true)
+  return n0
+}"
+`;
+
 exports[`compiler: element transform > dynamic component > normal component with dynamic :is prop 1`] = `
 "import { createAssetComponent as _createAssetComponent } from 'vue';
 

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -965,6 +965,21 @@ describe('compiler: element transform', () => {
       })
     })
 
+    test('native element with is="vue:" prefix', () => {
+      const { code, ir, helpers } = compileWithElementTransform(
+        `<button is="vue:foo" />`,
+      )
+      expect(code).toMatchSnapshot()
+      expect(helpers).toContain('createAssetComponent')
+      expect(ir.block.dynamic.children[0].operation).toMatchObject({
+        type: IRNodeTypes.CREATE_COMPONENT_NODE,
+        tag: 'foo',
+        asset: true,
+        root: true,
+        props: [[]],
+      })
+    })
+
     test('normal component with dynamic :is prop', () => {
       const { code, ir, helpers } = compileWithElementTransform(
         `<custom-input :is="'foo'" />`,

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -290,6 +290,12 @@ function transformComponentElement(
   let asset = true
 
   if (!dynamicComponent && !useCreateElement) {
+    // <button is="vue:xxx">: the parser marks it as a component and the
+    // prefixed value names the component
+    const isProp = findProp(node, 'is')
+    if (isProp && isProp.type === NodeTypes.ATTRIBUTE && isVueIsValue(isProp)) {
+      tag = isProp.value!.content.slice(4)
+    }
     const fromSetup = resolveSetupReference(tag, context)
     if (fromSetup) {
       tag = fromSetup
@@ -342,6 +348,10 @@ function transformComponentElement(
     context.registerOperation(createSetBlockKey(id, staticKey))
   }
   context.slots = []
+}
+
+function isVueIsValue(prop: AttributeNode): boolean {
+  return !!prop.value && prop.value.content.startsWith('vue:')
 }
 
 function resolveDynamicComponent(node: ComponentNode) {
@@ -858,13 +868,13 @@ export function buildProps(
       }
     }
 
-    // exclude `is` prop only for <component>
+    // exclude `is` on <component>, and is="vue:xxx" on other tags
     if (
-      isDynamicComponent &&
-      ((prop.type === NodeTypes.ATTRIBUTE && prop.name === 'is') ||
-        (prop.type === NodeTypes.DIRECTIVE &&
+      prop.type === NodeTypes.ATTRIBUTE
+        ? prop.name === 'is' && (isDynamicComponent || isVueIsValue(prop))
+        : isDynamicComponent &&
           prop.name === 'bind' &&
-          isStaticArgOf(prop.arg, 'is')))
+          isStaticArgOf(prop.arg, 'is')
     ) {
       continue
     }

--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -113,6 +113,22 @@ describe('component', () => {
     expect(`Failed to resolve component: foo-bar`).toHaveBeenWarned()
   })
 
+  it('renders a native tag with is="vue:" as the component', () => {
+    const Foo = defineVaporComponent({
+      setup() {
+        return template('<span>foo</span>')()
+      },
+    })
+    const App = compile(
+      `<template><button is="vue:Foo" /></template>`,
+      ref(null),
+    )
+    const { app, html, mount } = define(App).create()
+    app.component('Foo', Foo)
+    mount()
+    expect(html()).toBe('<span>foo</span>')
+  })
+
   it('should pass maybeSelfReference when creating asset component', () => {
     const { host } = define({
       props: ['nested'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native elements using `is="vue:..."` can now resolve and render as Vue components.
  * The resolved component name is correctly derived from the prefixed `is` value.

* **Tests**
  * Added compiler and runtime coverage for `is="vue:..."` component resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->