### PR TITLE
fix(vapor): create dynamic component element fallbacks in the template namespace

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -828,6 +828,24 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: element transform > dynamic component > element fallback namespace 1`] = `
+"import { setInsertionState as _setInsertionState, createDynamicComponent as _createDynamicComponent, resolveDynamicComponent as _resolveDynamicComponent, createComponentWithFallback as _createComponentWithFallback, template as _template } from 'vue';
+const t0 = _template("<svg>", 0, 1)
+const t1 = _template("<math>", 0, 2)
+
+export function render(_ctx) {
+  const n2 = t0()
+  _setInsertionState(n2)
+  const n0 = _createDynamicComponent(() => (_ctx.foo), null, null, 8 /* NS_SVG */)
+  _setInsertionState(n2, 1)
+  const n1 = _createComponentWithFallback(_resolveDynamicComponent("circle"), null, null, null, null, 1)
+  const n4 = t1()
+  _setInsertionState(n4)
+  const n3 = _createDynamicComponent(() => (_ctx.foo), null, null, 16 /* NS_MATHML */)
+  return [n2, n4]
+}"
+`;
+
 exports[`compiler: element transform > dynamic component > native element with is="vue:" prefix 1`] = `
 "import { createAssetComponent as _createAssetComponent } from 'vue';
 

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -945,6 +945,26 @@ describe('compiler: element transform', () => {
       })
     })
 
+    test('element fallback namespace', () => {
+      const { code, ir } = compileWithElementTransform(
+        `<svg><component :is="foo" /><component is="circle" /></svg>` +
+          `<math><component :is="foo" /></math>`,
+      )
+      expect(code).toMatchSnapshot()
+      expect(code).contains('8 /* NS_SVG */')
+      expect(code).contains('16 /* NS_MATHML */')
+      expect(code).contains(
+        '_createComponentWithFallback(_resolveDynamicComponent("circle"), null, null, null, null, 1)',
+      )
+      const ops: any[] = []
+      const collect = (dynamic: any) => {
+        if (dynamic.operation) ops.push(dynamic.operation)
+        dynamic.children.forEach(collect)
+      }
+      collect(ir.block.dynamic)
+      expect(ops.map(op => op.ns)).toEqual([1, 1, 2])
+    })
+
     // #3934
     test('normal component with is prop', () => {
       const { code, ir, helpers } = compileWithElementTransform(

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -1,4 +1,6 @@
 import {
+  type Namespace,
+  Namespaces,
   VaporDynamicComponentFlags,
   VaporSlotStability,
   camelize,
@@ -84,8 +86,15 @@ export function genCreateComponent(
     operation.dynamic && !operation.dynamic.isStatic
   )
   const dynamicComponentFlags = isRuntimeDynamicComponent
-    ? genDynamicComponentFlags(root, once, slotRoot)
+    ? genDynamicComponentFlags(root, once, slotRoot, operation.ns)
     : false
+  // helpers that may fall back to a plain element take the namespace
+  const nsArg =
+    !isRuntimeDynamicComponent &&
+    (operation.useCreateElement || operation.asset || !!operation.dynamic) &&
+    operation.ns
+      ? String(operation.ns)
+      : false
   const rawSlots = genRawSlots(slots, context)
   const [ids, handlers] = processInlineHandlers(props, context)
   const rawProps = context.withId(() => genRawProps(props, context, true), ids)
@@ -116,7 +125,8 @@ export function genCreateComponent(
       rawSlots,
       isRuntimeDynamicComponent ? dynamicComponentFlags : root ? 'true' : false,
       isRuntimeDynamicComponent ? false : once && 'true',
-      isRuntimeDynamicComponent ? false : maybeSelfReference && 'true',
+      useAssetComponentHelper ? maybeSelfReference && 'true' : nsArg,
+      useAssetComponentHelper && nsArg,
     ),
     ...genDirectivesForElement(operation.id, context),
   ]
@@ -160,6 +170,7 @@ function genDynamicComponentFlags(
   root: boolean | undefined,
   once: boolean | undefined,
   slotRoot: boolean | undefined,
+  ns: Namespace | undefined,
 ): string | false {
   let flags = 0
   const names: string[] = []
@@ -175,6 +186,13 @@ function genDynamicComponentFlags(
   if (slotRoot) {
     flags |= VaporDynamicComponentFlags.SLOT_ROOT
     names.push('SLOT_ROOT')
+  }
+  if (ns === Namespaces.SVG) {
+    flags |= VaporDynamicComponentFlags.NS_SVG
+    names.push('NS_SVG')
+  } else if (ns === Namespaces.MATH_ML) {
+    flags |= VaporDynamicComponentFlags.NS_MATHML
+    names.push('NS_MATHML')
   }
 
   if (!flags) {

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -237,6 +237,7 @@ export interface CreateComponentIRNode
   slotRoot?: boolean
   dynamic?: SimpleExpressionNode
   useCreateElement: boolean
+  ns?: Namespace
 }
 
 export interface SlotOutletIRNode

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -343,6 +343,7 @@ function transformComponentElement(
     once: context.inVOnce,
     dynamic: dynamicComponent,
     useCreateElement,
+    ns: node.ns || undefined,
   }
   if (staticKey) {
     context.registerOperation(createSetBlockKey(id, staticKey))

--- a/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
@@ -128,6 +128,29 @@ describe('api: createDynamicComponent', () => {
     expect(setups).toBe(1)
   })
 
+  test('element fallback inherits the template namespace', async () => {
+    const data = ref({ tag: 'circle' })
+    const App = compile(
+      `<template>
+        <svg><component :is="data.tag" class="shape" /></svg>
+        <math><component :is="'mi'" /></math>
+      </template>`,
+      data,
+    )
+    const { host } = define(App).render()
+    const svgNS = 'http://www.w3.org/2000/svg'
+    const circle = host.querySelector('circle')!
+    expect(circle.namespaceURI).toBe(svgNS)
+    expect(circle.getAttribute('class')).toBe('shape')
+    expect(host.querySelector('mi')!.namespaceURI).toBe(
+      'http://www.w3.org/1998/Math/MathML',
+    )
+
+    data.value.tag = 'rect'
+    await nextTick()
+    expect(host.querySelector('rect')!.namespaceURI).toBe(svgNS)
+  })
+
   test('global registration', async () => {
     const val = shallowRef('foo')
 

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -10,7 +10,7 @@ import {
   resolveDynamicComponent,
   setCurrentRenderingInstance,
 } from '@vue/runtime-dom'
-import { ShapeFlags, VaporDynamicComponentFlags } from '@vue/shared'
+import { Namespaces, ShapeFlags, VaporDynamicComponentFlags } from '@vue/shared'
 import { type Block, isBlock, removeNode } from './block'
 import {
   type VaporComponentInstance,
@@ -57,6 +57,12 @@ export function createDynamicComponent(
   const isSingleRoot = !!(flags & VaporDynamicComponentFlags.SINGLE_ROOT)
   const once = !!(flags & VaporDynamicComponentFlags.ONCE)
   const slotRoot = !!(flags & VaporDynamicComponentFlags.SLOT_ROOT)
+  const ns =
+    flags & VaporDynamicComponentFlags.NS_SVG
+      ? Namespaces.SVG
+      : flags & VaporDynamicComponentFlags.NS_MATHML
+        ? Namespaces.MATH_ML
+        : undefined
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor
   if (!isHydrating) resetInsertionState()
@@ -112,6 +118,7 @@ export function createDynamicComponent(
       normalizedRawSlots,
       isSingleRoot,
       once,
+      ns,
       appContext,
     )
   }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -59,6 +59,8 @@ import {
 import {
   EMPTY_OBJ,
   NOOP,
+  type Namespace,
+  Namespaces,
   type Prettify,
   ShapeFlags,
   extend,
@@ -1106,6 +1108,7 @@ export function createAssetComponent(
   isSingleRoot?: boolean,
   once?: boolean,
   maybeSelfReference?: boolean,
+  ns?: Namespace,
   appContext?: GenericAppContext,
 ): HTMLElement | VaporComponentInstance {
   return createComponentWithFallback(
@@ -1114,6 +1117,7 @@ export function createAssetComponent(
     rawSlots,
     isSingleRoot,
     once,
+    ns,
     appContext,
   )
 }
@@ -1129,6 +1133,7 @@ export function createComponentWithFallback(
   rawSlots?: LooseRawSlots | null,
   isSingleRoot?: boolean,
   once?: boolean,
+  ns?: Namespace,
   appContext?: GenericAppContext,
 ): HTMLElement | VaporComponentInstance {
   if (comp === NULL_DYNAMIC_COMPONENT) {
@@ -1165,7 +1170,7 @@ export function createComponentWithFallback(
     )
   }
 
-  return createPlainElement(comp, rawProps, rawSlots, isSingleRoot, once)
+  return createPlainElement(comp, rawProps, rawSlots, isSingleRoot, once, ns)
 }
 
 function isReusableNullComponentAnchor(node: Node): boolean {
@@ -1187,6 +1192,7 @@ export function createPlainElement(
   rawSlots?: LooseRawSlots | null,
   isSingleRoot?: boolean,
   once?: boolean,
+  ns?: Namespace,
 ): HTMLElement {
   rawSlots = normalizeRawSlots(rawSlots)
   const _insertionParent = insertionParent
@@ -1209,8 +1215,9 @@ export function createPlainElement(
         currentHydrationNode!,
         hydrationTemplate,
         adoptHydrationChildren,
+        ns,
       ) as HTMLElement)
-    : createElement(comp)
+    : createElement(comp, ns)
 
   // mark single root
   ;(el as any).$root = isSingleRoot
@@ -1224,8 +1231,9 @@ export function createPlainElement(
   }
 
   if (rawProps) {
+    const isSVG = ns === Namespaces.SVG
     const setFn = () =>
-      setDynamicProps(el, [resolveDynamicProps(rawProps as RawProps)])
+      setDynamicProps(el, [resolveDynamicProps(rawProps as RawProps)], isSVG)
     if (once) setFn()
     else renderEffect(setFn)
   }

--- a/packages/runtime-vapor/src/dom/node.ts
+++ b/packages/runtime-vapor/src/dom/node.ts
@@ -1,3 +1,4 @@
+import { type Namespace, Namespaces } from '@vue/shared'
 import type { ChildItem, InsertionParent } from '../insertionState'
 import {
   isHydrating,
@@ -5,9 +6,17 @@ import {
   skipUntrackedAnchors,
 } from './hydration'
 
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const MATHML_NS = 'http://www.w3.org/1998/Math/MathML'
+
 /*@__NO_SIDE_EFFECTS__*/
-export function createElement(tagName: string): HTMLElement {
-  return document.createElement(tagName)
+export function createElement(tagName: string, ns?: Namespace): HTMLElement {
+  return ns
+    ? (document.createElementNS(
+        ns === Namespaces.SVG ? SVG_NS : MATHML_NS,
+        tagName,
+      ) as HTMLElement)
+    : document.createElement(tagName)
 }
 
 /*@__NO_SIDE_EFFECTS__*/

--- a/packages/shared/src/vaporFlags.ts
+++ b/packages/shared/src/vaporFlags.ts
@@ -149,4 +149,7 @@ export enum VaporDynamicComponentFlags {
   SINGLE_ROOT = 1,
   ONCE = 1 << 1,
   SLOT_ROOT = 1 << 2,
+  // element fallback namespace, from the parser namespace of the tag
+  NS_SVG = 1 << 3,
+  NS_MATHML = 1 << 4,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic component fallbacks now preserve SVG and MathML namespaces when rendered inside those elements.
  - Dynamic updates within SVG retain the correct namespace, ensuring elements such as `circle` and `rect` render correctly.

- **Bug Fixes**
  - Corrected namespace handling for plain-element fallbacks created from dynamic components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->