### PR TITLE
refactor(vapor): key dynamic component branches in place instead of a keyed fragment

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformKey.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformKey.spec.ts.snap
@@ -1,13 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`compiler: key > with dynamic key > <component is/> + key 1`] = `
-"import { createDynamicComponent as _createDynamicComponent, createKeyedFragment as _createKeyedFragment } from 'vue';
+"import { createDynamicComponent as _createDynamicComponent } from 'vue';
 
 export function render(_ctx) {
-  const n0 = _createKeyedFragment(() => (_ctx.id), () => {
-    const n1 = _createDynamicComponent(() => (_ctx.view), null, null, 1 /* SINGLE_ROOT */)
-    return n1
-  })
+  const n0 = _createDynamicComponent(() => (_ctx.view), null, null, 1 /* SINGLE_ROOT */, () => (_ctx.id))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/transformKey.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformKey.spec.ts
@@ -101,7 +101,11 @@ describe('compiler: key', () => {
     test('<component is/> + key', () => {
       const { code } = compileWithKey(`<component :is="view" :key="id" />`)
       expect(code).toMatchSnapshot()
-      expect(code).contains('_createKeyedFragment(() => (_ctx.id)')
+      // the dynamic component keys its own branches; no wrapping fragment
+      expect(code).not.contains('_createKeyedFragment(')
+      expect(code).contains(
+        '_createDynamicComponent(() => (_ctx.view), null, null, 1 /* SINGLE_ROOT */, () => (_ctx.id))',
+      )
     })
 
     test('v-if + key', () => {

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -124,7 +124,13 @@ export function genCreateComponent(
       rawProps,
       rawSlots,
       isRuntimeDynamicComponent ? dynamicComponentFlags : root ? 'true' : false,
-      isRuntimeDynamicComponent ? false : once && 'true',
+      isRuntimeDynamicComponent
+        ? operation.key && [
+            '() => (',
+            ...genExpression(operation.key, context),
+            ')',
+          ]
+        : once && 'true',
       useAssetComponentHelper ? maybeSelfReference && 'true' : nsArg,
       useAssetComponentHelper && nsArg,
     ),

--- a/packages/compiler-vapor/src/ir/index.ts
+++ b/packages/compiler-vapor/src/ir/index.ts
@@ -238,6 +238,7 @@ export interface CreateComponentIRNode
   dynamic?: SimpleExpressionNode
   useCreateElement: boolean
   ns?: Namespace
+  key?: SimpleExpressionNode
 }
 
 export interface SlotOutletIRNode

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -56,9 +56,11 @@ import { EMPTY_EXPRESSION } from './utils'
 import {
   findProp,
   isBuiltInComponent,
+  isComponentTag,
   isStaticExpression,
   resolveExpression,
 } from '../utils'
+import { dynamicComponentKeys } from './transformKey'
 import {
   IMPORT_EXP_END,
   IMPORT_EXP_START,
@@ -344,6 +346,7 @@ function transformComponentElement(
     dynamic: dynamicComponent,
     useCreateElement,
     ns: node.ns || undefined,
+    key: dynamicComponentKeys.get(node),
   }
   if (staticKey) {
     context.registerOperation(createSetBlockKey(id, staticKey))
@@ -1299,10 +1302,6 @@ function toDirectiveResult(prop: IRProp): DirectiveTransformResult {
 function mergePropValues(existing: IRProp, incoming: IRProp) {
   const newValues = incoming.values
   existing.values.push(...newValues)
-}
-
-function isComponentTag(tag: string) {
-  return tag === 'component' || tag === 'Component'
 }
 
 export function shouldUseCreateElement(

--- a/packages/compiler-vapor/src/transforms/transformKey.ts
+++ b/packages/compiler-vapor/src/transforms/transformKey.ts
@@ -1,9 +1,18 @@
-import { NodeTypes, type SimpleExpressionNode } from '@vue/compiler-dom'
+import {
+  type ElementNode,
+  NodeTypes,
+  type SimpleExpressionNode,
+} from '@vue/compiler-dom'
 import type { NodeTransform } from '../transform'
 import { DynamicFlag, IRNodeTypes } from '../ir'
 import { normalizeBindShorthand } from './vBind'
-import { findDir, findProp, isStaticExpression } from '../utils'
+import { findDir, findProp, isComponentTag, isStaticExpression } from '../utils'
 import { newBlock, wrapTemplate } from './utils'
+
+// A runtime dynamic component keys its own branches, so its `:key` is handed
+// to createDynamicComponent instead of wrapping it in a keyed fragment.
+export const dynamicComponentKeys: WeakMap<ElementNode, SimpleExpressionNode> =
+  new WeakMap()
 
 export const transformKey: NodeTransform = (node, context) => {
   if (
@@ -19,6 +28,11 @@ export const transformKey: NodeTransform = (node, context) => {
   let value: SimpleExpressionNode
   value = dir.exp || normalizeBindShorthand(dir.arg!, context)
   if (isStaticExpression(value, context.options.bindingMetadata)) return
+
+  if (isComponentTag(node.tag) && findProp(node, 'is', true, true)) {
+    dynamicComponentKeys.set(node, value)
+    return
+  }
 
   let id = context.reference()
   context.dynamic.flags |= DynamicFlag.NON_TEMPLATE | DynamicFlag.INSERT

--- a/packages/compiler-vapor/src/utils.ts
+++ b/packages/compiler-vapor/src/utils.ts
@@ -159,6 +159,10 @@ export function isTeleportTag(tag: string): boolean {
   return tag === 'teleport' || tag === 'vaporteleport'
 }
 
+export function isComponentTag(tag: string): boolean {
+  return tag === 'component' || tag === 'Component'
+}
+
 export function isBuiltInComponent(tag: string): string | undefined {
   if (isTeleportTag(tag)) {
     return 'VaporTeleport'

--- a/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
@@ -2,6 +2,8 @@ import { ref, shallowRef } from '@vue/reactivity'
 import {
   currentInstance,
   nextTick,
+  onActivated,
+  onDeactivated,
   resolveDynamicComponent,
 } from '@vue/runtime-dom'
 import { VaporDynamicComponentFlags } from '@vue/shared'
@@ -149,6 +151,135 @@ describe('api: createDynamicComponent', () => {
     data.value.tag = 'rect'
     await nextTick()
     expect(host.querySelector('rect')!.namespaceURI).toBe(svgNS)
+  })
+
+  test('compiled :key switches the branch without a wrapping fragment', async () => {
+    let setups = 0
+    const Foo = defineVaporComponent({
+      setup() {
+        setups++
+        return template('<span>foo</span>')()
+      },
+    })
+    const Bar = defineVaporComponent({
+      setup() {
+        return template('<b>bar</b>')()
+      },
+    })
+    const data = ref({ view: 'Foo', k: 1 })
+    const App = compile(
+      `<template><component :is="data.view" :key="data.k" /></template>`,
+      data,
+    )
+    const { app, html, mount } = define(App).create()
+    app.component('Foo', Foo)
+    app.component('Bar', Bar)
+    mount()
+    expect(html()).toBe('<span>foo</span><!--dynamic-component-->')
+
+    // same key, same component: no remount
+    data.value = { view: 'Foo', k: 1 }
+    await nextTick()
+    expect(setups).toBe(1)
+
+    // key change remounts
+    data.value = { view: 'Foo', k: 2 }
+    await nextTick()
+    expect(setups).toBe(2)
+
+    // same key, different component: remount
+    data.value = { view: 'Bar', k: 2 }
+    await nextTick()
+    expect(html()).toBe('<b>bar</b><!--dynamic-component-->')
+    data.value = { view: 'Foo', k: 2 }
+    await nextTick()
+    expect(setups).toBe(3)
+    expect(html()).toBe('<span>foo</span><!--dynamic-component-->')
+  })
+
+  test('compiled :key is the KeepAlive cache key', async () => {
+    const calls: string[] = []
+    const Foo = defineVaporComponent({
+      name: 'Foo',
+      props: ['id'],
+      setup(props: any) {
+        calls.push(`setup:${props.id}`)
+        onActivated(() => calls.push(`activated:${props.id}`))
+        onDeactivated(() => calls.push(`deactivated:${props.id}`))
+        return template('<span>foo</span>')()
+      },
+    })
+    const data = ref({ k: 1 })
+    const App = compile(
+      `<template>
+        <KeepAlive>
+          <component :is="components.Foo" :key="data.k" :id="data.k" />
+        </KeepAlive>
+      </template>`,
+      data,
+      { Foo },
+    )
+    define(App).render()
+    expect(calls).toEqual(['setup:1', 'activated:1'])
+
+    // the incoming branch is set up before the outgoing one deactivates
+    data.value = { k: 2 }
+    await nextTick()
+    expect(calls).toEqual([
+      'setup:1',
+      'activated:1',
+      'setup:2',
+      'deactivated:1',
+      'activated:2',
+    ])
+
+    // re-entering key 1 reactivates its cached instance instead of setting up
+    data.value = { k: 1 }
+    await nextTick()
+    expect(calls).toEqual([
+      'setup:1',
+      'activated:1',
+      'setup:2',
+      'deactivated:1',
+      'activated:2',
+      'deactivated:2',
+      'activated:1',
+    ])
+  })
+
+  // Coverage guard: the wrapping keyed fragment used to drive this; the
+  // dynamic component's own branch key must keep Transition sequencing.
+  test('compiled :key change runs leave and enter under Transition', async () => {
+    const leaves: string[] = []
+    const enters: string[] = []
+    const data = ref({
+      k: 1,
+      onLeave: (el: Element, done: () => void) => {
+        leaves.push(el.textContent!)
+        done()
+      },
+      onEnter: (el: Element, done: () => void) => {
+        enters.push(el.textContent!)
+        done()
+      },
+    })
+    const App = compile(
+      `<template>
+        <Transition :css="false" @leave="data.onLeave" @enter="data.onEnter">
+          <component :is="'div'" :key="data.k">{{ data.k }}</component>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { html } = define(App).render()
+    expect(html()).toBe('<div>1</div><!--dynamic-component-->')
+    expect(enters).toEqual([])
+
+    data.value = { ...data.value, k: 2 }
+    await nextTick()
+    expect(html()).toBe('<div>2</div><!--dynamic-component-->')
+    expect(leaves).toEqual(['1'])
+    expect(enters).toEqual(['2'])
   })
 
   test('global registration', async () => {

--- a/packages/runtime-vapor/__tests__/hydration/interopDynamic.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration/interopDynamic.spec.ts
@@ -81,22 +81,20 @@ describe('VDOM interop', () => {
     )
 
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()
-    expect(container.innerHTML).toBe(
-      '<!--[--><!----><!--keyed--><span>tail</span><!--]-->',
-    )
+    expect(container.innerHTML).toBe('<!--[--><!----><span>tail</span><!--]-->')
 
     data.value.show = true
     data.value.key = 'filled'
     await nextTick()
     expect(container.innerHTML).toBe(
-      '<!--[--><div>late</div><!--dynamic-component--><!--keyed--><span>tail</span><!--]-->',
+      '<!--[--><div>late</div><!----><span>tail</span><!--]-->',
     )
 
     data.value.msg = 'late-updated'
     data.value.tail = 'tail-updated'
     await nextTick()
     expect(container.innerHTML).toBe(
-      '<!--[--><div>late-updated</div><!--dynamic-component--><!--keyed--><span>tail-updated</span><!--]-->',
+      '<!--[--><div>late-updated</div><!----><span>tail-updated</span><!--]-->',
     )
   })
 

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -53,6 +53,7 @@ export function createDynamicComponent(
   rawProps?: RawProps | null,
   rawSlots?: LooseRawSlots | null,
   flags: number = 0,
+  key?: () => any,
 ): Block {
   const isSingleRoot = !!(flags & VaporDynamicComponentFlags.SINGLE_ROOT)
   const once = !!(flags & VaporDynamicComponentFlags.ONCE)
@@ -172,8 +173,16 @@ export function createDynamicComponent(
     _insertionAnchor,
   )
 
+  // A `:key` joins the resolved component in the branch identity, the way a
+  // vnode is matched by type and key. The pair is memoized as one token so
+  // unchanged inputs compare equal by reference.
+  let lastKey: any
+  let lastResolved: any
+  let branchToken: object | undefined
+
   renderEffect(() => {
     const value = getter()
+    const userKey = key ? key() : undefined
     const appContext = getAppContext()
     // Resolve before update: a null dynamic component is an empty branch
     // (nodes stays EMPTY_BLOCK, the fragment anchor is the only structural
@@ -186,7 +195,21 @@ export function createDynamicComponent(
       frag.update(undefined, resolved)
       return
     }
-    frag.update(() => render(value, resolved, appContext), resolved)
+    let branchKey: any = resolved
+    if (key) {
+      if (userKey !== lastKey || resolved !== lastResolved) {
+        lastKey = userKey
+        lastResolved = resolved
+        branchToken = {}
+      }
+      branchKey = branchToken
+    }
+    frag.update(
+      () => render(value, resolved, appContext),
+      branchKey,
+      false,
+      userKey,
+    )
   })
 
   finishBlockCreation(

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -183,8 +183,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
       const [innerBlock, interop] = getInnerBlock(block)
       if (!innerBlock) return
 
-      const branchKey =
-        isDynamicFragment(block) && block.keyed ? block.current : undefined
+      const branchKey = isDynamicFragment(block) ? block.branchKey : undefined
       const cacheKey = resolveCacheKeyFromBlock(innerBlock, interop, branchKey)
       // Align with VDOM KeepAlive behavior: async wrappers can enter the cache
       // before they resolve, and a later async update may resolve the same
@@ -299,8 +298,8 @@ const VaporKeepAliveImpl = defineVaporComponent({
       const block = keepAliveInstance.block!
       const [currentBlock, interop] = getInnerBlock(block)
       const branchKey =
-        isDynamicFragment(block) && block.keyed
-          ? block.current
+        isDynamicFragment(block) && block.branchKey !== undefined
+          ? block.branchKey
           : currentCacheKey
 
       return {
@@ -383,11 +382,12 @@ const VaporKeepAliveImpl = defineVaporComponent({
           scope.stop()
           return false
         }
-        const cacheKey = frag.keyed
-          ? withCurrentCacheKey(frag.current, () =>
-              processShapeFlag(frag.nodes),
-            )
-          : processShapeFlag(frag.nodes)
+        const cacheKey =
+          frag.branchKey !== undefined
+            ? withCurrentCacheKey(frag.branchKey, () =>
+                processShapeFlag(frag.nodes),
+              )
+            : processShapeFlag(frag.nodes)
         if (cacheKey === false) {
           scope.stop()
           return false
@@ -395,11 +395,13 @@ const VaporKeepAliveImpl = defineVaporComponent({
         // Component and KeepAlive input scopes are detached from this
         // DynamicFragment scope, so this only pauses branch-owned effects.
         scope.pause()
-        cacheScope(cacheKey, frag.current, scope)
+        cacheScope(cacheKey, scopeLookupKey(frag), scope)
         return true
       },
       runBranchRender(frag, fn, useScope, removePrevious) {
-        const cachedScope = useScope ? deleteScope(frag.current) : undefined
+        const cachedScope = useScope
+          ? deleteScope(scopeLookupKey(frag))
+          : undefined
         frag.scope = useScope ? cachedScope || new EffectScope() : undefined
         if (cachedScope) cachedScope.resume()
         let incomingCacheKey: CacheKey | false = false
@@ -418,7 +420,9 @@ const VaporKeepAliveImpl = defineVaporComponent({
         // before rendering, so incoming setup runs before cache pruning decides
         // whether the outgoing branch is deactivated or unmounted.
         try {
-          frag.keyed ? withCurrentCacheKey(frag.current, run) : run()
+          frag.branchKey !== undefined
+            ? withCurrentCacheKey(frag.branchKey, run)
+            : run()
           if (
             removePrevious &&
             incomingCacheKey !== false &&
@@ -466,6 +470,12 @@ const VaporKeepAliveImpl = defineVaporComponent({
 
 export const VaporKeepAlive: DefineVaporComponent<{}, string, KeepAliveProps> =
   /*@__PURE__*/ withKeepAliveEnabled(VaporKeepAliveImpl)
+
+// A branch with a user key is cached and its scope aliased under that key,
+// so re-entering the key finds them whatever the branch identity is.
+function scopeLookupKey(frag: DynamicFragment): any {
+  return frag.branchKey !== undefined ? frag.branchKey : frag.current
+}
 
 function registerDynamicFragmentHooks(
   block: Block,

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -488,6 +488,7 @@ function deferBranchUpdateDuringLeaveImpl(
   render: BlockFn | undefined,
   key: any,
   noScope: boolean,
+  branchKey: any,
 ): boolean {
   const transition = frag.$transition!
   if (!transition.state.isLeaving) return false
@@ -500,8 +501,9 @@ function deferBranchUpdateDuringLeaveImpl(
     pending.render = render
     pending.key = key
     pending.noScope = noScope
+    pending.branchKey = branchKey
   } else {
-    frag.pending = { render, key, noScope }
+    frag.pending = { render, key, noScope, branchKey }
   }
   return true
 }
@@ -513,6 +515,7 @@ function removeBranchWithLeaveImpl(
   render: BlockFn | undefined,
   key: any,
   noScope: boolean,
+  branchKey: any,
 ): boolean {
   const mode = transition.mode
   if (
@@ -547,9 +550,20 @@ function removeBranchWithLeaveImpl(
             pending.key,
             pending.noScope,
             true,
+            undefined,
+            pending.branchKey,
           )
         } else {
-          frag.renderBranch(render, transition, parent, key, noScope, true)
+          frag.renderBranch(
+            render,
+            transition,
+            parent,
+            key,
+            noScope,
+            true,
+            undefined,
+            branchKey,
+          )
         }
       } finally {
         restoreCurrentInstance(prevInstance)

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -337,11 +337,16 @@ export class DynamicFragment extends RenderContextFragment {
   current?: BlockFn
   // Owned by the Transition module (deferBranchUpdateDuringLeave /
   // removeBranchWithLeave); the core update pipeline never touches it.
-  pending?: { render?: BlockFn; key: any; noScope: boolean }
+  pending?: { render?: BlockFn; key: any; noScope: boolean; branchKey?: any }
   // Debug text for the runtime anchor comment, dev builds only. Never a
   // category signal: everything hydration branches on lives in `__vf`.
   anchorLabel?: string
   keyed?: boolean
+  // The user-facing key of the current branch: the branch key itself for
+  // keyed fragments, or the `:key` a dynamic component carries next to its
+  // resolved-component identity. KeepAlive caches by it; it reaches the
+  // branch nodes as $key.
+  branchKey?: any
   inTransition?: boolean
   /** hydration: this `v-if` branch's claim on its SSR range */
   hydrationClaim?: FragmentClaim
@@ -394,7 +399,12 @@ export class DynamicFragment extends RenderContextFragment {
     return true
   }
 
-  update(render?: BlockFn, key: any = render, noScope: boolean = false): void {
+  update(
+    render?: BlockFn,
+    key: any = render,
+    noScope: boolean = false,
+    branchKey?: any,
+  ): void {
     const everUpdated = this.everUpdated
     this.everUpdated = true
     if (key === this.current) {
@@ -420,7 +430,7 @@ export class DynamicFragment extends RenderContextFragment {
     // the leave finishes.
     if (
       transition &&
-      deferBranchUpdateDuringLeave(this, render, key, noScope)
+      deferBranchUpdateDuringLeave(this, render, key, noScope, branchKey)
     ) {
       return
     }
@@ -443,7 +453,15 @@ export class DynamicFragment extends RenderContextFragment {
       }
       if (
         transition &&
-        removeBranchWithLeave(this, transition, parent, render, key, noScope)
+        removeBranchWithLeave(
+          this,
+          transition,
+          parent,
+          render,
+          key,
+          noScope,
+          branchKey,
+        )
       ) {
         // out-in: the next branch mounts after the leave finishes.
         setActiveSub(prevSub)
@@ -470,6 +488,7 @@ export class DynamicFragment extends RenderContextFragment {
       // `everUpdated` field comment
       wasMounted || (everUpdated && !!parent),
       removePrevious,
+      branchKey,
     )
     setActiveSub(prevSub)
 
@@ -492,8 +511,10 @@ export class DynamicFragment extends RenderContextFragment {
     noScope: boolean,
     notifyUpdated: boolean,
     removePrevious?: () => void,
+    branchKey?: any,
   ): void {
     this.current = key
+    this.branchKey = this.keyed ? key : branchKey
     if (render) {
       const keepAliveCtx = isKeepAliveEnabled ? this.keepAliveCtx : null
       // A compiler-proven static branch can skip its own EffectScope, but attrs
@@ -523,7 +544,7 @@ export class DynamicFragment extends RenderContextFragment {
           }, this.scope)
         } finally {
           // Inherit the fragment key without overriding a child's own key.
-          const key = this.keyed ? this.current : this.$key
+          const key = this.branchKey !== undefined ? this.branchKey : this.$key
           // Only propagate branch keys when Transition or KeepAlive consumes them.
           if (
             key !== undefined &&

--- a/packages/runtime-vapor/src/transition.ts
+++ b/packages/runtime-vapor/src/transition.ts
@@ -19,6 +19,7 @@ type DeferBranchUpdateDuringLeaveFn = (
   render: BlockFn | undefined,
   key: any,
   noScope: boolean,
+  branchKey: any,
 ) => boolean
 type RemoveBranchWithLeaveFn = (
   frag: DynamicFragment,
@@ -27,6 +28,7 @@ type RemoveBranchWithLeaveFn = (
   render: BlockFn | undefined,
   key: any,
   noScope: boolean,
+  branchKey: any,
 ) => boolean
 
 export let applyTransitionHooks: ApplyTransitionHooksFn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dynamic components now correctly respond to key changes, including remounting when the component or key changes.
  - Improved compatibility with KeepAlive caching and Transition leave/enter behavior for keyed dynamic components.
  - Fixed hydration behavior when keyed dynamic components start empty and later render content.
  - Preserved existing behavior for dynamic components without keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->