### PR TITLE
refactor(runtime-vapor): mount dynamic component vnodes through the interop and warn on invalid types

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -288,7 +288,7 @@ export interface VdomInVaporInterface {
   mountVNode: (
     vnode: VNode,
     parentComponent: any, // VaporComponentInstance
-    getFallthroughAttrs?: () => Record<string, any>,
+    isSingleRoot?: boolean,
   ) => any
 }
 

--- a/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
+++ b/packages/runtime-vapor/__tests__/apiCreateDynamicComponent.spec.ts
@@ -282,6 +282,19 @@ describe('api: createDynamicComponent', () => {
     expect(enters).toEqual(['2'])
   })
 
+  test('warns on an invalid is value and renders an empty branch', async () => {
+    const data = shallowRef<any>(true)
+    const App = compile(`<template><component :is="data" /></template>`, data)
+    const { html } = define(App).render()
+    expect(html()).toBe('<!--dynamic-component-->')
+    expect('Invalid dynamic component type: true (boolean)').toHaveBeenWarned()
+
+    data.value = 123
+    await nextTick()
+    expect(html()).toBe('<!--dynamic-component-->')
+    expect('Invalid dynamic component type: 123 (number)').toHaveBeenWarned()
+  })
+
   test('global registration', async () => {
     const val = shallowRef('foo')
 

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -164,6 +164,9 @@ export function createDynamicComponent(
       }
       branchKey = branchToken
     }
+    // update() returns early on an unchanged key; skip building the branch
+    // closure for it. Hydration still goes through update for its anchor.
+    if (branchKey === frag.current && !isHydrating) return
     frag.update(
       () => render(value, resolved, appContext),
       branchKey,

--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -1,23 +1,19 @@
 import {
   type ComponentInternalInstance,
-  Fragment,
   type GenericAppContext,
   NULL_DYNAMIC_COMPONENT,
-  type VNode,
   currentInstance,
-  isKeepAlive,
   isVNode,
   resolveDynamicComponent,
   setCurrentRenderingInstance,
+  warn,
 } from '@vue/runtime-dom'
-import { Namespaces, ShapeFlags, VaporDynamicComponentFlags } from '@vue/shared'
+import { Namespaces, VaporDynamicComponentFlags } from '@vue/shared'
 import { type Block, isBlock, removeNode } from './block'
 import {
   type VaporComponentInstance,
   createComponentWithFallback,
   emptyContext,
-  isVaporComponent,
-  resolveFallthroughAttrs,
 } from './component'
 import { renderEffect } from './renderEffect'
 import type { RawProps } from './componentProps'
@@ -34,19 +30,11 @@ import {
 import {
   type HydrationCursor,
   captureHydrationCursor,
-  createFragmentClaim,
   enterHydrationCursor,
   isHydrating,
-  locateHydrationNode,
 } from './dom/hydration'
-import {
-  DynamicFragment,
-  type VaporFragment,
-  finishBlockCreation,
-} from './fragment'
-import type { KeepAliveInstance } from './components/KeepAlive'
+import { DynamicFragment, finishBlockCreation } from './fragment'
 import { isInteropEnabled } from './vdomInteropState'
-import { enableKeepAlive } from './keepAlive'
 
 export function createDynamicComponent(
   getter: () => any,
@@ -79,38 +67,10 @@ export function createDynamicComponent(
     // Support integration with VaporRouterView/VaporRouterLink by accepting blocks
     if (isBlock(value)) return value
 
-    // Handles VNodes passed from VDOM components (e.g., `h(VaporComp)` from slots)
+    // vnodes handed down from vdom slots (`h(VaporComp)`) mount through the
+    // interop, which owns their KeepAlive lookup, fallthrough and hydration
     if (isInteropEnabled && appContext.vdom && isVNode(value)) {
-      if (isKeepAlive(currentInstance)) {
-        enableKeepAlive()
-        const cached = (
-          currentInstance as KeepAliveInstance
-        ).ctx.getCachedComponent(value.type, value.key) as VaporFragment
-        if (cached) return cached
-      }
-
-      // A vnode standing in as this component's effective root inherits
-      // fallthrough attrs; the normal component path folds them into
-      // rawProps at creation, this one merges them into the vnode's props.
-      const owner =
-        isSingleRoot &&
-        isVaporComponent(currentInstance) &&
-        currentInstance.hasFallthrough &&
-        currentInstance.type.inheritAttrs !== false
-          ? currentInstance
-          : undefined
-      const frag = appContext.vdom.mountVNode(
-        value,
-        currentInstance,
-        owner && (() => resolveFallthroughAttrs(owner)),
-      )
-      if (isHydrating) {
-        locateHydrationNode(
-          shouldConsumeFragmentStart(value) ? createFragmentClaim() : undefined,
-        )
-        frag.hydrate()
-      }
-      return frag
+      return appContext.vdom.mountVNode(value, currentInstance, isSingleRoot)
     }
 
     return createComponentWithFallback(
@@ -233,10 +193,30 @@ function resolveValue(
   appContext: GenericAppContext,
   scopeOwner: VaporComponentInstance | null,
 ): any {
-  return isBlock(value) ||
+  if (
+    isBlock(value) ||
     (isInteropEnabled && appContext.vdom && isVNode(value))
-    ? value
-    : withScopeOwner(scopeOwner, () => resolveDynamicComponent(value))
+  ) {
+    return value
+  }
+  const resolved = withScopeOwner(scopeOwner, () =>
+    resolveDynamicComponent(value),
+  )
+  // strings are tags, objects and functions are components, symbols are
+  // vdom types the interop mounts; anything else is an empty branch
+  const type = typeof resolved
+  if (
+    type !== 'string' &&
+    type !== 'object' &&
+    type !== 'function' &&
+    type !== 'symbol'
+  ) {
+    if (__DEV__) {
+      warn(`Invalid dynamic component type: ${String(resolved)} (${type})`)
+    }
+    return NULL_DYNAMIC_COMPONENT
+  }
+  return resolved
 }
 
 function withScopeOwner(owner: VaporComponentInstance | null, fn: () => any) {
@@ -248,19 +228,4 @@ function withScopeOwner(owner: VaporComponentInstance | null, fn: () => any) {
   } finally {
     setCurrentRenderingInstance(prev)
   }
-}
-
-function shouldConsumeFragmentStart(vnode: VNode): boolean {
-  if (vnode.type === Fragment) {
-    return false
-  }
-
-  // Only Vapor component VNodes carry `__multiRoot`
-  // e.g. `h(VaporComp)`
-  if (vnode.shapeFlag & ShapeFlags.COMPONENT) {
-    const type = vnode.type as { __vapor?: boolean; __multiRoot?: boolean }
-    return !!type.__vapor && !type.__multiRoot
-  }
-
-  return true
 }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -278,6 +278,23 @@ function useVdomInterop(
   return isInteropEnabled && !!appContext.vdom && !component.__vapor
 }
 
+// The instance whose fallthrough attrs a block created right now inherits:
+// its single root, or any child of a Transition (which passes attrs through).
+export function resolveFallthroughOwner(
+  isSingleRoot?: boolean,
+): VaporComponentInstance | undefined {
+  const instance = currentInstance
+  if (
+    (isSingleRoot ||
+      (isTransitionEnabled && instance && isVaporTransition(instance.type))) &&
+    isVaporComponent(instance) &&
+    instance.type.inheritAttrs !== false &&
+    instance.hasFallthrough
+  ) {
+    return instance
+  }
+}
+
 export function createComponent(
   component: VaporComponent,
   rawProps?: LooseRawProps | null,
@@ -336,21 +353,11 @@ export function createComponent(
       hasParentSuspense = true
     }
 
-    if (
-      (isSingleRoot ||
-        // transition has attrs fallthrough
-        (isTransitionEnabled
-          ? currentInstance && isVaporTransition(currentInstance!.type)
-          : false)) &&
-      isVaporComponent(currentInstance) &&
-      currentInstance.type.inheritAttrs !== false &&
-      currentInstance.hasFallthrough
-    ) {
-      // check if we are the single root of the parent
-      // if yes, inject parent attrs as dynamic props source.
-      // capture the owner: dynamic sources can be resolved from read paths
-      // that do not restore the parent as currentInstance.
-      const owner = currentInstance
+    const owner = resolveFallthroughOwner(isSingleRoot)
+    if (owner) {
+      // inject the parent attrs as a dynamic props source; the owner is
+      // captured because sources resolve from read paths that do not
+      // restore it as currentInstance
       const source = () => resolveFallthroughAttrs(owner)
       // copy, never mutate: the caller's rawProps outlives this creation
       // (dynamic component branches share one object), and every creation

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -78,6 +78,8 @@ import {
   getRootElement,
   isVaporComponent,
   mountComponent,
+  resolveFallthroughAttrs,
+  resolveFallthroughOwner,
   unmountComponent,
 } from './component'
 import {
@@ -129,12 +131,14 @@ import {
   advanceHydrationNode,
   claimAnchor,
   claimUntrackedAnchor,
+  createFragmentClaim,
   currentHydrationNode,
   isClaimedAnchor,
   isComment,
   isHydrating,
   locateEndAnchor,
   locateFragmentEnd,
+  locateHydrationNode,
   setCurrentHydrationNode,
   hydrateNode as vaporHydrateNode,
 } from './dom/hydration'
@@ -1086,6 +1090,56 @@ function createVNodeFragment(vnode: VNode): {
     content.resolved ? isValidBlock(frag.nodes, componentAsValid) : true
   trackFragmentVNodeUpdates(frag, vnode, syncNodes)
   return { frag, syncNodes }
+}
+
+/**
+ * Mount a vnode as a dynamic component branch (`<component :is="vnode">`
+ * in a vapor template). The KeepAlive lookup, fallthrough and hydration of
+ * the vnode live here so the dynamic component only sees a block.
+ */
+function mountDynamicVNode(
+  internals: RendererInternals,
+  vnode: VNode,
+  parentComponent: VaporComponentInstance | null,
+  isSingleRoot?: boolean,
+): VaporFragment {
+  if (parentComponent && isKeepAlive(parentComponent)) {
+    const cached = (
+      parentComponent as KeepAliveInstance
+    ).ctx.getCachedComponent(vnode.type, vnode.key) as VaporFragment
+    if (cached) return cached
+  }
+  // A vnode standing in as the parent's effective root inherits fallthrough
+  // attrs merged into its props (see mountVNode).
+  const owner = resolveFallthroughOwner(isSingleRoot)
+  const frag = mountVNode(
+    internals,
+    vnode,
+    parentComponent,
+    owner && (() => resolveFallthroughAttrs(owner)),
+  )
+  if (isHydrating) {
+    locateHydrationNode(
+      shouldConsumeFragmentStart(vnode) ? createFragmentClaim() : undefined,
+    )
+    frag.hydrate!()
+  }
+  return frag
+}
+
+function shouldConsumeFragmentStart(vnode: VNode): boolean {
+  if (vnode.type === Fragment) {
+    return false
+  }
+
+  // Only Vapor component VNodes carry `__multiRoot`
+  // e.g. `h(VaporComp)`
+  if (vnode.shapeFlag & ShapeFlags.COMPONENT) {
+    const type = vnode.type as { __vapor?: boolean; __multiRoot?: boolean }
+    return !!type.__vapor && !type.__multiRoot
+  }
+
+  return true
 }
 
 /**
@@ -2590,7 +2644,7 @@ export const vaporInteropPlugin: Plugin = app => {
   app._context.vdom = {
     mount: createVDOMComponent.bind(null, internals),
     slot: renderVDOMSlot.bind(null, internals),
-    mountVNode: mountVNode.bind(null, internals),
+    mountVNode: mountDynamicVNode.bind(null, internals),
   } satisfies VdomInVaporInterface
   const mount = app.mount
   app.mount = ((...args) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dynamic component rendering when components are passed between rendering modes.
  - Preserved attribute inheritance for single-root and transition-based components.
  - Improved hydration and caching behavior for dynamically rendered components.
  - Invalid dynamic component values now render an empty branch and display a clear development warning.

- **Refactor**
  - Simplified dynamic component mounting while preserving expected attribute inheritance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->