### PR TITLE
fix(runtime-vapor): merge declared class, style and event props across sources

### DIFF
--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -1252,4 +1252,70 @@ describe('component: props', () => {
       },
     )
   })
+
+  test.each([undefined, 'active'])(
+    'merged class props restore defaults when all sources are undefined (%s)',
+    async initialClass => {
+      await renderParity(
+        {
+          Child: `<script setup>
+            const props = defineProps({ class: { type: String, default: 'fallback' } })
+          </script><template><div>{{ props.class }}</div></template>`,
+          App: `<template><components.Child :class="data.extra" v-bind="data.attrs" /></template>`,
+        },
+        () =>
+          ref({
+            extra: initialClass,
+            attrs: { class: undefined as string | undefined },
+          }),
+        async (data, root) => {
+          expect(root.textContent).toBe(initialClass ?? 'fallback')
+
+          data.value.extra = undefined
+          await nextTick()
+          expect(root.textContent).toBe('fallback')
+
+          data.value.attrs.class = ''
+          await nextTick()
+          expect(root.textContent).toBe('')
+
+          data.value.attrs.class = undefined
+          await nextTick()
+          expect(root.textContent).toBe('fallback')
+
+          data.value.extra = data.value.attrs.class = 'shared'
+          await nextTick()
+          expect(root.textContent).toBe('shared')
+        },
+      )
+    },
+  )
+
+  test('prop validation does not mutate class and style source arrays', async () => {
+    await renderParity(
+      {
+        Child: `<script setup>
+          const props = defineProps({ class: String, style: Object })
+        </script><template><div>{{ props.class }}|{{ JSON.stringify(props.style) }}</div></template>`,
+        App: `<template><components.Child :class="data.classes" :style="data.styles" v-bind="data.attrs" /></template>`,
+      },
+      () =>
+        ref({
+          classes: ['a'],
+          styles: [{ color: 'red' }],
+          attrs: { class: 'b', style: { margin: '1px' } },
+        }),
+      async (data, root) => {
+        expect.soft(data.value.classes).toEqual(['a'])
+        expect.soft(data.value.styles).toEqual([{ color: 'red' }])
+        expect(root.textContent).toBe('a b|{"color":"red","margin":"1px"}')
+
+        data.value.attrs = { class: 'c', style: { padding: '2px' } }
+        await nextTick()
+        expect.soft(data.value.classes).toEqual(['a'])
+        expect.soft(data.value.styles).toEqual([{ color: 'red' }])
+        expect(root.textContent).toBe('a c|{"color":"red","padding":"2px"}')
+      },
+    )
+  })
 })

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -677,6 +677,63 @@ describe('component: props', () => {
     expect('Invalid prop').not.toHaveBeenWarned()
   })
 
+  test('declared class props merge static and v-bind sources', () => {
+    const data = ref({ attrs: { class: 'b' }, extra: 'c' })
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps({ class: String })
+      </script>
+      <template><div>{{ props.class }}</div></template>`,
+      data,
+    )
+    const Parent = compile(
+      `<script setup vapor>
+        const data = _data
+        const Child = _components.Child
+      </script>
+      <template><Child class="a" v-bind="data.attrs" :class="data.extra" /></template>`,
+      data,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    expect(host.innerHTML).toBe('<div>a b c</div>')
+  })
+
+  test('declared event props merge static and v-on sources', () => {
+    const calls: string[] = []
+    const data = ref({
+      onStatic: () => calls.push('static'),
+      listeners: { click: () => calls.push('object') },
+    })
+    const Child = compile(
+      `<script setup vapor>
+        const props = defineProps({ onClick: null })
+        const trigger = () => {
+          const handlers = Array.isArray(props.onClick)
+            ? props.onClick
+            : [props.onClick]
+          handlers.forEach(handler => handler())
+        }
+      </script><template><button @click="trigger">click</button></template>`,
+      data,
+    )
+    const Parent = compile(
+      `<script setup vapor>
+        const data = _data
+        const Child = _components.Child
+      </script>
+      <template><Child @click="data.onStatic" v-on="data.listeners" /></template>`,
+      data,
+      { Child },
+    )
+
+    const { host } = define(Parent).render()
+    host.querySelector('button')!.click()
+
+    expect(calls).toEqual(['static', 'object'])
+  })
+
   test('class prop should only normalize the value that was passed', () => {
     let props: any
     const fallback = ['a', 'b']

--- a/packages/runtime-vapor/__tests__/componentProps.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentProps.spec.ts
@@ -16,7 +16,7 @@ import {
   template,
 } from '../src'
 import { resolveDynamicProps } from '../src/componentProps'
-import { compile, makeRender } from './_utils'
+import { compile, makeRender, renderParity } from './_utils'
 import { setElementText } from '../src/dom/prop'
 
 const define = makeRender<any>()
@@ -1153,5 +1153,103 @@ describe('component: props', () => {
 
     expect.soft(data.value.readStyle()).toEqual({ color: 'red' })
     expect.soft(host.innerHTML).toBe('<div>red</div>')
+  })
+
+  test.each([
+    [':on-click="data.first" v-bind="data.attrs"', ['second']],
+    ['v-bind="data.attrs" :on-click="data.first"', ['first']],
+    [
+      ':on-click="data.first" v-bind="data.attrs" :[data.key]="data.third"',
+      ['second'],
+    ],
+    ['v-bind="{ \'on-click\': data.first, ...data.attrs }"', ['second']],
+    [
+      ':on-click="data.first" v-bind="{ \'on-click\': data.third }"',
+      ['first', 'third'],
+    ],
+  ])(
+    'declared event props preserve raw key precedence (%s)',
+    async (binding, expected) => {
+      await renderParity(
+        {
+          Child: `<script setup>
+          const props = defineProps({ onClick: null })
+          const trigger = () => {
+            const handlers = Array.isArray(props.onClick)
+              ? props.onClick
+              : [props.onClick]
+            handlers.forEach(handler => handler())
+          }
+        </script><template><button @click="trigger">click</button></template>`,
+          App: `<template><components.Child ${binding} /></template>`,
+        },
+        () => {
+          const calls: string[] = []
+          return ref({
+            calls,
+            first: () => calls.push('first'),
+            attrs: { onClick: () => calls.push('second') },
+            third: () => calls.push('third'),
+            key: 'on-click',
+          })
+        },
+        async (data, root) => {
+          root.querySelector('button')!.click()
+          expect(data.value.calls).toEqual(expected)
+        },
+      )
+    },
+  )
+
+  test('declared event props update merged sources and restore defaults', async () => {
+    await renderParity(
+      {
+        Child: `<script setup>
+          const props = defineProps({
+            onClick: { default: () => () => _data.value.calls.push('default') }
+          })
+          const trigger = () => {
+            const handlers = Array.isArray(props.onClick)
+              ? props.onClick
+              : [props.onClick]
+            handlers.forEach(handler => handler())
+          }
+        </script><template><button @click="trigger">click</button></template>`,
+        App: `<template><components.Child v-on="data.listeners" v-bind="data.attrs" /></template>`,
+      },
+      () => {
+        const calls: string[] = []
+        const first = () => calls.push('first')
+        const second = () => calls.push('second')
+        return ref({
+          calls,
+          listeners: { click: [first, second] } as Record<string, unknown>,
+          attrs: { onClick: first } as Record<string, unknown>,
+        })
+      },
+      async (data, root) => {
+        const button = root.querySelector('button')!
+        button.click()
+        expect(data.value.calls).toEqual(['first', 'second'])
+
+        data.value.calls.length = 0
+        data.value.attrs = { 'on-click': () => data.value.calls.push('third') }
+        await nextTick()
+        button.click()
+        expect(data.value.calls).toEqual(['third'])
+
+        data.value.calls.length = 0
+        data.value.attrs = {}
+        await nextTick()
+        button.click()
+        expect(data.value.calls).toEqual(['first', 'second'])
+
+        data.value.calls.length = 0
+        data.value.listeners = {}
+        await nextTick()
+        button.click()
+        expect(data.value.calls).toEqual(['default'])
+      },
+    )
   })
 })

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -348,6 +348,11 @@ export function getPropsProxyHandlers(
     if (!isProp(key)) return
     const rawProps = instance.rawProps
     const dynamicSources = rawProps.$
+    const isEvent = dynamicSources && isOn(key)
+    const merged =
+      dynamicSources && (key === 'class' || key === 'style' || isEvent)
+        ? ([] as unknown[])
+        : undefined
     if (dynamicSources) {
       let i = dynamicSources.length
       let source, isDynamic, rawKey
@@ -361,38 +366,57 @@ export function getPropsProxyHandlers(
           : source
         for (rawKey in source) {
           if (camelize(rawKey) === key) {
-            return resolvePropValue(
-              propsOptions!,
-              key,
-              normalizeRawProp(
+            const value = isDynamic
+              ? source[rawKey]
+              : resolveSource(source[rawKey])
+            if (merged) {
+              merged.push(value)
+            } else {
+              return resolvePropValue(
+                propsOptions!,
                 key,
-                isDynamic ? source[rawKey] : resolveSource(source[rawKey]),
-              ),
-              instance,
-              resolveDefault,
-            )
+                normalizeRawProp(key, value),
+                instance,
+                resolveDefault,
+              )
+            }
           }
         }
       }
     }
     for (const rawKey in rawProps) {
       if (camelize(rawKey) === key) {
-        return resolvePropValue(
-          propsOptions!,
-          key,
-          normalizeRawProp(key, resolveSource(rawProps[rawKey])),
-          instance,
-          resolveDefault,
-        )
+        const value = resolveSource(rawProps[rawKey])
+        if (merged) {
+          merged.push(value)
+        } else {
+          return resolvePropValue(
+            propsOptions!,
+            key,
+            normalizeRawProp(key, value),
+            instance,
+            resolveDefault,
+          )
+        }
+      }
+    }
+    const hasMerged = !!(merged && merged.length)
+    let value
+    if (hasMerged) {
+      if (merged.length > 1) {
+        merged.reverse()
+        value = isEvent ? merged.reduce(mergeEventHandlers) : merged
+      } else {
+        value = merged[0]
       }
     }
     return resolvePropValue(
       propsOptions!,
       key,
-      undefined,
+      normalizeRawProp(key, value),
       instance,
       resolveDefault,
-      true,
+      !hasMerged,
     )
   }
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -348,9 +348,36 @@ export function getPropsProxyHandlers(
     if (!isProp(key)) return
     const rawProps = instance.rawProps
     const dynamicSources = rawProps.$
-    const isEvent = dynamicSources && isOn(key)
+    if (dynamicSources && isOn(key)) {
+      const handlers: Record<string, unknown> = {}
+      let matchedKey: string | undefined
+      // Match mergeProps: merge exact raw keys in source order before
+      // resolving camelized aliases in their first occurrence order.
+      for (let i = -1; i < dynamicSources.length; i++) {
+        const source = i < 0 ? rawProps : dynamicSources[i]
+        const isDynamic = isFunction(source)
+        const resolved = isDynamic ? resolveFunctionSource(source) : source
+        for (const rawKey in resolved) {
+          if (camelize(rawKey) === key) {
+            if (!hasOwn(handlers, rawKey)) matchedKey = rawKey
+            const value = isDynamic
+              ? resolved[rawKey]
+              : resolveSource(resolved[rawKey])
+            handlers[rawKey] = mergeEventHandlers(handlers[rawKey], value)
+          }
+        }
+      }
+      return resolvePropValue(
+        propsOptions!,
+        key,
+        matchedKey === undefined ? undefined : handlers[matchedKey],
+        instance,
+        resolveDefault,
+        matchedKey === undefined,
+      )
+    }
     const merged =
-      dynamicSources && (key === 'class' || key === 'style' || isEvent)
+      dynamicSources && (key === 'class' || key === 'style')
         ? ([] as unknown[])
         : undefined
     if (dynamicSources) {
@@ -404,8 +431,7 @@ export function getPropsProxyHandlers(
     let value
     if (hasMerged) {
       if (merged.length > 1) {
-        merged.reverse()
-        value = isEvent ? merged.reduce(mergeEventHandlers) : merged
+        value = merged.reverse()
       } else {
         value = merged[0]
       }

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -430,10 +430,17 @@ export function getPropsProxyHandlers(
     const hasMerged = !!(merged && merged.length)
     let value
     if (hasMerged) {
-      if (merged.length > 1) {
-        value = merged.reverse()
-      } else {
+      if (merged.length === 1) {
         value = merged[0]
+      } else if (key === 'class') {
+        // Match mergeProps, including leaving all-undefined classes undefined.
+        for (let i = merged.length - 1; i >= 0; i--) {
+          if (value !== merged[i]) {
+            value = normalizeClass([value, merged[i]])
+          }
+        }
+      } else {
+        value = merged.reverse()
       }
     }
     return resolvePropValue(
@@ -681,11 +688,9 @@ export function resolveDynamicProps(props: RawProps): Record<string, unknown> {
         const value = isDynamic ? resolved[key] : resolveSource(source[key])
         if (key === 'class' || key === 'style') {
           const existing = mergedRawProps[key]
-          if (isArray(existing)) {
-            existing.push(value)
-          } else {
-            mergedRawProps[key] = [existing, value]
-          }
+          mergedRawProps[key] = isArray(existing)
+            ? [...existing, value]
+            : [existing, value]
         } else if (isOn(key)) {
           mergedRawProps[key] = mergeEventHandlers(mergedRawProps[key], value)
         } else {


### PR DESCRIPTION
## Vue version
3.6.0-rc.7

## Link to minimal reproduction
[Playground](https://play.vuejs.org/#eNp9U02P2jAQ/SuWLwnSrqm0VSuhQLtFHNpDuypVL5tVZYIBs8aObCelQvnvnbHzAVXhRHjzZvzmzcyJPpYlqytBJzRzhZWlJ074qiQ1L42d5Voe4NeTE7FiQxqyseZAEkhI+tCTNeXcHMo2xsYdgHUH2qIW2l/weqQl5row2nnCvbeOTOHNQnHnJiTBjPv6fiX1OiFNxxNHb/kcKUCOHGRIvT0rVnClMA7y0+eXUZ+Lb4dHck2I0UvPvSwmJB2R6SwmsZqrSrCycrs0cSGejO6QrqTzQgsL0lCjLF6vJ5rVXhQ+GZEGUkF6No42g7Xwx4tDqbgX8I+Q7MClDl/w3bsaPJjmNCrIKYk+ABJ8AmDSUQZDAB3HmuO+6EX5YRofQwOYHSxhnRfhJaOHQN91TmfZMLyu4lrWM3ICP4LhTQNPI3QhIhufNUzvqHcwjY3csr0zGlYwDCOnBZSVSthvpZcwrZyCz/EVaFop8/tLwLytRJhHyNmJ4vU/+N4dEcvpkxVO2FrktI95brfCx/Bi+RXsOwsezLpSwL4R/C6cURVqjLRPlV6D7DNeUPs5HACs5Q+3OIKFrmsKhSITVwPZcAbo6LXWB7kP7G3Ig40CF8/v7eodx7UvgYpbvxYbqQUmurQ/s6W3IJI0cCS3thSnCnMOpVhIhWl3w/53whc3flXcbXlGz+ON6UqpIC+yQe52Kyzw4/EFo2Jox8MksNajtfwPky78plF1WxEqobMf2l5aNIIT8nyBviDclWUbYxe82KUtgK+3n+kIql6/82xVeW/0cHVtE3BTAcnGkQAXdmnkrxrehZUADx/YO/bm3hbsPeLe/ewjgLMH2vwFhXj94Q==)

## What is expected?
1. Show “static from-v-bind from-binding”
2. After clicking the button, it displays "[ "static", "object" ]"

## What is actually happening?
1. Show “from-binding”
2. After clicking the button, it displays "[ "object" ]"