### PR TITLE
fix(runtime-vapor): register async setup with the ambient suspense boundary

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Suspense.spec.ts
@@ -148,6 +148,47 @@ describe('vdom interop', () => {
     expect(container.innerHTML).toBe(`<div>inner</div>`)
   })
 
+  test('vdom suspense: nested boundaries register vapor async setup with the inner one', async () => {
+    const data = { deps: [] }
+    const { container } = await testSuspense(
+      `<script setup>
+        const components = _components;
+      </script>
+      <template>
+        <Suspense>
+          <components.Mid/>
+          <template #fallback>
+            <span>outer fallback</span>
+          </template>
+        </Suspense>
+      </template>`,
+      {
+        Inner: withAsyncScript(`<template><div>inner</div></template>`),
+        Mid: {
+          code: `<script setup>
+            const components = _components;
+          </script>
+          <template>
+            <Suspense>
+              <components.Inner/>
+              <template #fallback>
+                <span>inner fallback</span>
+              </template>
+            </Suspense>
+          </template>`,
+          vapor: false,
+        },
+      },
+      data,
+    )
+
+    expect(container.innerHTML).toBe(`<span>inner fallback</span>`)
+
+    await Promise.all(data.deps)
+    await nextTick()
+    expect(container.innerHTML).toBe(`<div>inner</div>`)
+  })
+
   test('vdom suspense: content update before suspense resolve', async () => {
     const data = reactive({ msg: 'foo', deps: [] })
     const { container } = await testSuspense(

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -346,6 +346,7 @@ export function createComponent(
     if (
       __FEATURE_SUSPENSE__ &&
       isSuspenseEnabled &&
+      !parentSuspense &&
       currentInstance &&
       currentInstance.suspense
     ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed nested Suspense behavior so asynchronous components register with the correct inner boundary.
  - Preserved the existing parent Suspense boundary instead of overwriting it, ensuring the appropriate fallback and resolved content are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->