### PR TITLE
fix(runtime-vapor): dispose component instances that never mounted

### DIFF
--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -988,6 +988,49 @@ describe('component', () => {
     await nextTick()
     expect(input.getAttribute('type')).toBe('text')
   })
+
+  it('should dispose a component that was created but never mounted', () => {
+    // a render error after a root-chain child is created leaves that child
+    // owned by the parent scope without ever reaching mountComponent
+    const dispose = vi.fn()
+    const unmounted = vi.fn()
+    const Child = compile(
+      `<script vapor setup>
+      import { onScopeDispose, onUnmounted } from 'vue'
+      onScopeDispose(_components.dispose)
+      onUnmounted(_components.unmounted)
+      </script>
+      <template><div>child</div></template>`,
+      ref(null),
+      { dispose, unmounted },
+    )
+    const Parent = compile(
+      `<script vapor setup>
+      const Child = _components.Child
+      const boom = () => {
+        throw new Error('boom')
+      }
+      </script>
+      <template>
+        <Child />
+        <span>{{ boom() }}</span>
+      </template>`,
+      ref(null),
+      { Child },
+    )
+    const { app, mount } = define(Parent).create()
+    const handler = (app.config.errorHandler = vi.fn())
+    mount()
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(
+      `Vapor component setup() returned non-block value`,
+    ).toHaveBeenWarned()
+    expect(dispose).not.toHaveBeenCalled()
+
+    app.unmount()
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(unmounted).not.toHaveBeenCalled()
+  })
 })
 
 function getEffectsCount(scope: EffectScope): number {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1522,21 +1522,21 @@ export function unmountComponent(
   const pendingAsyncSetup =
     __FEATURE_SUSPENSE__ && !!instance.asyncDep && !instance.asyncResolved
 
-  if (
-    !instance.isUnmounted &&
-    (instance.isMounted ||
-      // An async setup component can be unmounted before it finishes mounting.
-      // It still needs normal unmount cleanup and must be marked unmounted so
-      // a later async resolution is ignored.
-      pendingAsyncSetup)
-  ) {
+  if (!instance.isUnmounted) {
+    // Unmount hooks belong to mounted instances, plus async setup ones torn
+    // down before they finish mounting (a later resolution must see
+    // isUnmounted). A created but never mounted instance still owns its
+    // setup effects, so disposal itself is unconditional.
+    const hasLifecycle = instance.isMounted || pendingAsyncSetup
     if (__DEV__) {
       unregisterHMR(instance)
     }
-    invalidateMount(instance.m)
-    invalidateMount(instance.a)
-    if (instance.bum) {
-      invokeArrayFns(instance.bum)
+    if (hasLifecycle) {
+      invalidateMount(instance.m)
+      invalidateMount(instance.a)
+      if (instance.bum) {
+        invokeArrayFns(instance.bum)
+      }
     }
 
     if (isKeepAliveEnabled) {
@@ -1545,7 +1545,7 @@ export function unmountComponent(
     }
     instance.scope.stop()
 
-    if (instance.um) {
+    if (hasLifecycle && instance.um) {
       queuePostRenderEffect(instance.um!, undefined, parentSuspense)
     }
     instance.isUnmounted = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured components that fail before mounting are properly cleaned up when the application is unmounted.
  - Prevented stale development reload registrations for components that were created but never mounted.
  - Preserved existing lifecycle-hook behavior for components that do not complete mounting.

- **Tests**
  - Added coverage for cleanup behavior when rendering fails before a component is mounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->