### PR TITLE
fix(runtime-vapor): honor move semantics and deferred branch renders in SlotFragment

### DIFF
--- a/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/KeepAlive.spec.ts
@@ -4658,4 +4658,50 @@ describe('VaporKeepAlive', () => {
     expect(html()).toBe(`<div>child</div><!--if-->`)
     expect(slotKeys[slotKeys.length - 1]).toEqual(['b'])
   })
+
+  test('should leave and enter slot outlet content with fallback across deactivation', async () => {
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      current: 'A',
+      show: true,
+      slotName: 'default',
+      onEnter,
+      onLeave,
+    })
+    // a dynamic slot name with fallback resolves through a SlotFragment
+    const A = compile(
+      `<template><slot :name="data.slotName">fallback</slot></template>`,
+      data,
+    )
+    const B = compile(`<template><p>B</p></template>`, data)
+    const App = compile(
+      `<template>
+        <KeepAlive>
+          <components.A v-if="data.current === 'A'">
+            <Transition :css="false" @enter="data.onEnter" @leave="data.onLeave">
+              <div v-if="data.show">A</div>
+            </Transition>
+          </components.A>
+          <components.B v-else />
+        </KeepAlive>
+      </template>`,
+      data,
+      { A, B },
+    )
+    const { host } = define(App as any).render()
+    expect(host.textContent).toContain('A')
+    expect(onEnter).not.toHaveBeenCalled()
+
+    data.value.current = 'B'
+    await nextTick()
+    expect(host.textContent).toContain('B')
+    expect(onLeave).toHaveBeenCalledTimes(1)
+    expect(onEnter).not.toHaveBeenCalled()
+
+    data.value.current = 'A'
+    await nextTick()
+    expect(host.textContent).toContain('A')
+    expect(onEnter).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -9,6 +9,7 @@ import {
   resolveTransitionBlock,
 } from '../../src/components/Transition'
 import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
+import { SlotFragment } from '../../src/fragment'
 import {
   Fragment,
   type Ref,
@@ -2181,5 +2182,102 @@ describe('Transition', () => {
       expect.arrayContaining(['external-next', 'box', 'internal-next']),
     )
     expect(el.classList).toHaveLength(3)
+  })
+
+  test('keyed reorder through a slot outlet with fallback should not replay enter', async () => {
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const onLeave = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({
+      list: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      show: true,
+      slotName: 'default',
+      onEnter,
+      onLeave,
+    })
+    // a dynamic slot name with fallback resolves through a SlotFragment
+    const Child = compile(
+      `<template><slot :name="data.slotName">fallback</slot></template>`,
+      data,
+    )
+    const App = compile(
+      `<template>
+        <components.Child v-for="item in data.list" :key="item.id">
+          <Transition :css="false" @enter="data.onEnter" @leave="data.onLeave">
+            <div v-if="data.show">{{ item.id }}</div>
+          </Transition>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+    const { host, instance } = define(App as any).render()
+    const rows = (instance!.block as any).nodes[0]
+    expect(rows[0].nodes.block).toBeInstanceOf(SlotFragment)
+    expect(host.textContent).toBe('123')
+
+    data.value.list = [
+      data.value.list[2],
+      data.value.list[0],
+      data.value.list[1],
+    ]
+    await nextTick()
+    expect(host.textContent).toBe('312')
+    expect(onEnter).not.toHaveBeenCalled()
+    expect(onLeave).not.toHaveBeenCalled()
+  })
+
+  test('out-in slot content swap should keep slot fallback resolution in sync', async () => {
+    let finishLeave: (() => void) | undefined
+    const onLeave = vi.fn((_el: Element, done: () => void) => {
+      finishLeave = done
+    })
+    const onEnter = vi.fn((_el: Element, done: () => void) => done())
+    const data = ref({ a: true, showA: true, showB: true, onLeave, onEnter })
+    const Child = compile(
+      `<template>
+        <Transition
+          mode="out-in"
+          :css="false"
+          @enter="data.onEnter"
+          @leave="data.onLeave"
+        >
+          <slot><p class="fb">fallback</p></slot>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const App = compile(
+      `<template>
+        <components.Child>
+          <template v-if="data.a" #default>
+            <div v-if="data.showA" class="a">A</div>
+          </template>
+          <template v-else #default>
+            <div v-if="data.showB" class="b">B</div>
+          </template>
+        </components.Child>
+      </template>`,
+      data,
+      { Child },
+    )
+    const { host } = define(App as any).render()
+    expect(host.innerHTML).toContain('class="a"')
+
+    data.value.a = false
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledTimes(1)
+    // the leave settles asynchronously, so the next branch renders after
+    // the slot update returned
+    finishLeave!()
+    await nextTick()
+    expect(host.innerHTML).toContain('class="b"')
+
+    data.value.showB = false
+    await nextTick()
+    expect(onLeave).toHaveBeenCalledTimes(2)
+    finishLeave!()
+    await nextTick()
+    expect(host.innerHTML).not.toContain('class="b"')
+    expect(host.innerHTML).toContain('fallback')
   })
 })

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -14,6 +14,7 @@ import {
   insert,
   isValidBlock,
   isValidSlot,
+  move,
   remove,
   removeAttachedNodes,
   removeNode,
@@ -652,16 +653,43 @@ export class SlotFragment
         )
       }
     }
-    if (!isHydrating) {
-      this.insert = (parent, anchor, parentSuspense) =>
-        this.insertSlot(parent, anchor, parentSuspense)
-    }
+    this.insert = (parent, anchor, parentSuspense, _hooks, moveType) =>
+      this.insertSlot(parent, anchor, parentSuspense, moveType)
     this.remove = parent => this.removeSlot(parent)
   }
 
   // updateSlot owns hydration timing, so opt out of autoHydrate.
   protected get autoHydrate(): boolean {
     return false
+  }
+
+  renderBranch(
+    render: BlockFn | undefined,
+    transition: VaporTransitionHooks | undefined,
+    parent: ParentNode | null,
+    key: any,
+    noScope: boolean,
+    notifyUpdated: boolean,
+    removePrevious?: () => void,
+    branchKey?: any,
+  ): void {
+    super.renderBranch(
+      render,
+      transition,
+      parent,
+      key,
+      noScope,
+      notifyUpdated,
+      removePrevious,
+      branchKey,
+    )
+    // A deferred branch render (Transition out-in) lands after updateContent
+    // captured `content`; re-capture and re-resolve so the exposed block and
+    // the fallback decision follow the branch that actually rendered.
+    if (!this.isUpdating) {
+      this.content = this.nodes
+      recheckSlotResolution(this, false)
+    }
   }
 
   get boundary(): SlotBoundaryContext {
@@ -678,9 +706,16 @@ export class SlotFragment
     parent: ParentNode,
     anchor: Node | null,
     parentSuspense?: SuspenseBoundary | null,
+    moveType?: MoveType,
   ): void {
     this.disposed = false
-    insert(this.nodes, parent, anchor, parentSuspense)
+    // block.ts move() reaches fragments through insert(); a move must keep
+    // move semantics (no enter on reorder, leave on LEAVE) for the content.
+    if (moveType !== undefined) {
+      move(this.nodes, parent, anchor, moveType, undefined, parentSuspense)
+    } else {
+      insert(this.nodes, parent, anchor, parentSuspense)
+    }
     if (this.activeFallback === this.nodes) {
       this.fallbackInserted = true
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transition hooks for dynamic slot content when switching between cached components.
  * Prevented enter and leave transitions from replaying during keyed component reordering.
  * Kept slot fallback content synchronized during out-in transitions.
  * Ensured fallback content renders correctly after the active branch is hidden.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->