### PR TITLE
refactor(runtime-vapor): split fragment move from insert and declare in SlotFragment

### DIFF
--- a/packages/runtime-vapor/__tests__/block.spec.ts
+++ b/packages/runtime-vapor/__tests__/block.spec.ts
@@ -19,7 +19,7 @@ import {
   isForFragment,
   isFragment,
   isInteropFragment,
-  isSlotFragment,
+  isVaporSlotOutlet,
 } from '../src/fragment'
 import { TeleportFragment } from '../src/components/Teleport'
 import { isTeleportFragment } from '../src/teleport'
@@ -161,12 +161,12 @@ describe('fragment protocol flags', () => {
       expect(isFragment(value)).toBe(true)
     }
     expect(isDynamicFragment(dynamic)).toBe(true)
-    expect(isSlotFragment(slot)).toBe(true)
+    expect(isVaporSlotOutlet(slot)).toBe(true)
     expect(isForFragment(forFragment)).toBe(true)
     expect(isForBlock(forBlock)).toBe(true)
     expect(isTeleportFragment(teleport)).toBe(true)
 
-    expect(isSlotFragment(dynamic)).toBe(false)
+    expect(isVaporSlotOutlet(dynamic)).toBe(false)
     expect(isDynamicFragment(fragment)).toBe(false)
     expect(isForFragment(forBlock)).toBe(false)
     expect(isForBlock(forFragment)).toBe(false)

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -59,7 +59,11 @@ import {
   setCurrentHydrationNode,
   setIsHydratingEnabled,
 } from '../src/dom/hydration'
-import { DynamicFragment, SlotFragment, isSlotFragment } from '../src/fragment'
+import {
+  DynamicFragment,
+  SlotFragment,
+  isVaporSlotOutlet,
+} from '../src/fragment'
 import { IF } from '../src/fragmentFlags'
 import {
   type SlotBoundaryContext,
@@ -3889,7 +3893,7 @@ describe('component: slots', () => {
 
           expect(slotBlock).toBeInstanceOf(DynamicFragment)
           expect(slotBlock).not.toBeInstanceOf(SlotFragment)
-          expect(isSlotFragment(slotBlock)).toBe(true)
+          expect(isVaporSlotOutlet(slotBlock)).toBe(true)
           expect(observedBoundary).toBe(null)
         })
 

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -4331,6 +4331,49 @@ describe('vdomInterop', () => {
       expect(beforeUpdateSpy).toHaveBeenCalledTimes(0)
       expect(updatedSpy).toHaveBeenCalledTimes(0)
     })
+    test('deactivating a vapor child should move vdom slot content with leave semantics', async () => {
+      const onEnter = vi.fn((_el: Element, done: () => void) => done())
+      const onLeave = vi.fn((_el: Element, done: () => void) => done())
+      const data = ref({ current: 'A', show: true, onEnter, onLeave })
+      // a vapor outlet rendering vdom slot content
+      const A = compile(`<template><slot>fallback</slot></template>`, data)
+      const B = compile(
+        `<script setup>const data = _data;</script><template><p>B</p></template>`,
+        data,
+        {},
+        { vapor: false },
+      )
+      const App = compile(
+        `<script setup>const data = _data; const components = _components;</script>
+        <template>
+          <KeepAlive>
+            <components.A v-if="data.current === 'A'">
+              <Transition :css="false" @enter="data.onEnter" @leave="data.onLeave">
+                <div v-if="data.show">A</div>
+              </Transition>
+            </components.A>
+            <components.B v-else />
+          </KeepAlive>
+        </template>`,
+        data,
+        { A, B },
+        { vapor: false },
+      )
+      const { host } = define(App).render()
+      expect(host.textContent).toContain('A')
+      expect(onEnter).not.toHaveBeenCalled()
+
+      data.value.current = 'B'
+      await nextTick()
+      expect(host.textContent).toContain('B')
+      expect(onLeave).toHaveBeenCalledTimes(1)
+      expect(onEnter).not.toHaveBeenCalled()
+
+      data.value.current = 'A'
+      await nextTick()
+      expect(host.textContent).toContain('A')
+      expect(onEnter).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('Teleport', () => {

--- a/packages/runtime-vapor/src/block.ts
+++ b/packages/runtime-vapor/src/block.ts
@@ -297,13 +297,14 @@ export function move(
       anchor = block.anchor
     }
     // fragment
-    if (block.insert) {
-      block.insert(
+    if (block.move) {
+      block.move(
         parent,
         anchor,
+        moveType,
+        parentComponent,
         parentSuspense,
         (block as TransitionBlock).$transition,
-        moveType,
       )
     } else {
       move(
@@ -399,9 +400,7 @@ export function removeFragment(
     remove(block.nodes, parent)
   }
   if (block.anchor) removeNode(block.anchor, parent)
-  if ((block as DynamicFragment).scope) {
-    ;(block as DynamicFragment).scope!.stop()
-  }
+  if (block.scope) block.scope.stop()
 }
 
 /**

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1796,7 +1796,7 @@ function applyFallthroughAttrs(
 ): void {
   const state = new FallthroughResolveState(scope)
   const root = resolveFallthroughRoot(block, state)
-  const { fragments, innermost, hasSlotFragment } = state
+  const { fragments, innermost, hasSlotOutlet } = state
 
   if (fragments) {
     for (const frag of fragments) {
@@ -1807,7 +1807,7 @@ function applyFallthroughAttrs(
     }
   }
 
-  if (root && !hasSlotFragment) {
+  if (root && !hasSlotOutlet) {
     let ownerScope = scope
     if (innermost) {
       // A compiler-proven no-scope branch may have rendered without a scope;
@@ -1829,7 +1829,7 @@ function applyFallthroughAttrs(
     const fallthroughAttrs = resolveFallthroughAttrs(instance)
     if (
       Object.keys(fallthroughAttrs).length &&
-      (hasSlotFragment ||
+      (hasSlotOutlet ||
         (fragments && state.hasNonSingleRoot) ||
         (isTeleportEnabled && containsTeleportFragment(block)) ||
         (!accessedAttrs &&
@@ -1849,7 +1849,7 @@ class FallthroughResolveState implements RootChainVisitor {
   innermost?: DynamicFragment
   // nearest enclosing branch scope; lifecycle parent for retrofitted scopes
   parentScope?: EffectScope
-  hasSlotFragment?: boolean
+  hasSlotOutlet?: boolean
   // the innermost fragment's current branch is multi-root: fragments stay
   // registered for future branches while the current render warns
   hasNonSingleRoot?: boolean
@@ -1866,7 +1866,7 @@ class FallthroughResolveState implements RootChainVisitor {
     // must not register a fallthrough hook — a later branch switch would
     // re-apply from the branch alone, with the slot boundary out of view.
     if (frag.__vf & SLOT) {
-      this.hasSlotFragment = true
+      this.hasSlotOutlet = true
       return true
     }
     ;(this.fragments ||= []).push(frag)

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -31,7 +31,11 @@ import {
   parentNode,
   querySelector,
 } from '../dom/node'
-import { type LooseRawProps, isVaporComponent } from '../component'
+import {
+  type LooseRawProps,
+  type VaporComponentInstance,
+  isVaporComponent,
+} from '../component'
 import { rawPropsProxyHandlers } from '../componentProps'
 import { renderEffect } from '../renderEffect'
 import { extend, isArray } from '@vue/shared'
@@ -96,7 +100,7 @@ export class TeleportFragment extends RenderContextFragment {
   private readonly childrenScope = getCurrentScope()
   // One scope per slot run, so a re-run can stop the previous run's effects
   // (the DynamicFragment branch-scope discipline, and the same field name).
-  private scope?: EffectScope
+  scope?: EffectScope
 
   target?: ParentNode | null
   targetAnchor?: Node | null
@@ -367,11 +371,11 @@ export class TeleportFragment extends RenderContextFragment {
     }
   }
 
-  insert = (
+  insert(
     container: ParentNode,
     anchor: Node | null,
     parentSuspense?: SuspenseBoundary | null,
-  ): void => {
+  ): void {
     if (isHydrating) return
 
     if (parentSuspense !== undefined) this.parentSuspense = parentSuspense
@@ -397,6 +401,16 @@ export class TeleportFragment extends RenderContextFragment {
     if (!wasMountedInTarget) {
       this.handlePropsUpdate()
     }
+  }
+
+  move(
+    container: ParentNode,
+    anchor: Node | null,
+    _moveType: MoveType,
+    _parentComponent?: VaporComponentInstance,
+    parentSuspense?: SuspenseBoundary | null,
+  ): void {
+    this.insert(container, anchor, parentSuspense)
   }
 
   private cancelMountToTarget(): void {
@@ -457,7 +471,7 @@ export class TeleportFragment extends RenderContextFragment {
     this.mountState = { location: TeleportMountLocation.None }
   }
 
-  remove = (_parent?: ParentNode): void => {
+  remove(): void {
     this.dispose()
 
     if (this.anchor) {

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -52,7 +52,7 @@ import {
   isDynamicFragment,
   isForFragment,
   isFragment,
-  isSlotFragment,
+  isVaporSlotOutlet,
 } from '../fragment'
 import {
   currentHydrationNode,
@@ -360,8 +360,8 @@ export function applyTransitionHooksImpl(
   if (
     hooks.applyGroup &&
     (isForFragment(block) ||
-      isSlotFragment(block) ||
-      (isVaporComponent(block) && isSlotFragment(block.block)))
+      isVaporSlotOutlet(block) ||
+      (isVaporComponent(block) && isVaporSlotOutlet(block.block)))
   ) {
     hooks.applyGroup(block, hooks.props, hooks.state, hooks.instance)
     return hooks
@@ -408,7 +408,7 @@ function isPersistedRoot(block: Block | undefined): boolean {
       block = block.find(b => !(b instanceof Comment))
     } else if (
       isFragment(block) &&
-      (isSlotFragment(block) ||
+      (isVaporSlotOutlet(block) ||
         !(isDynamicFragment(block) || isForFragment(block)))
     ) {
       block = block.nodes

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -52,7 +52,7 @@ import {
   type VaporFragment,
   isForBlock,
   isFragment,
-  isSlotFragment,
+  isVaporSlotOutlet,
 } from '../fragment'
 import {
   type DefineVaporComponent,
@@ -352,7 +352,7 @@ function collectTransitionBlocks(
   if (block instanceof Node) {
     if (block instanceof Element) children.push(block)
   } else if (isVaporComponent(block)) {
-    const isRootSlot = block.block && isSlotFragment(block.block)
+    const isRootSlot = block.block && isVaporSlotOutlet(block.block)
     if (onUpdateOwner && !isRootSlot) onUpdateOwner(block)
 
     const start = children.length

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -122,15 +122,23 @@ export class VaporFragment<
   vnode?: VNode | null
   anchor?: Node
   isBlockValid?: (componentAsValid?: boolean) => boolean
-  insert?: (
+  insert?(
     parent: ParentNode,
     anchor: Node | null,
     parentSuspense?: SuspenseBoundary | null,
     transitionHooks?: TransitionHooks,
-    moveType?: MoveType,
-  ) => void
-  remove?: (parent?: ParentNode, transitionHooks?: TransitionHooks) => void
+  ): void
+  move?(
+    parent: ParentNode,
+    anchor: Node | null,
+    moveType: MoveType,
+    parentComponent?: VaporComponentInstance,
+    parentSuspense?: SuspenseBoundary | null,
+    transitionHooks?: TransitionHooks,
+  ): void
+  remove?(parent?: ParentNode, transitionHooks?: TransitionHooks): void
   hydrate?(...args: any[]): void
+  scope?: EffectScope
   setRef?: (
     instance: VaporComponentInstance,
     ref: NodeRef,
@@ -653,9 +661,6 @@ export class SlotFragment
         )
       }
     }
-    this.insert = (parent, anchor, parentSuspense, _hooks, moveType) =>
-      this.insertSlot(parent, anchor, parentSuspense, moveType)
-    this.remove = parent => this.removeSlot(parent)
   }
 
   // updateSlot owns hydration timing, so opt out of autoHydrate.
@@ -702,26 +707,32 @@ export class SlotFragment
     ))
   }
 
-  private insertSlot(
+  insert(
     parent: ParentNode,
     anchor: Node | null,
     parentSuspense?: SuspenseBoundary | null,
-    moveType?: MoveType,
   ): void {
     this.disposed = false
-    // block.ts move() reaches fragments through insert(); a move must keep
-    // move semantics (no enter on reorder, leave on LEAVE) for the content.
-    if (moveType !== undefined) {
-      move(this.nodes, parent, anchor, moveType, undefined, parentSuspense)
-    } else {
-      insert(this.nodes, parent, anchor, parentSuspense)
-    }
+    insert(this.nodes, parent, anchor, parentSuspense)
     if (this.activeFallback === this.nodes) {
       this.fallbackInserted = true
     }
   }
 
-  private removeSlot(parent?: ParentNode): void {
+  move(
+    parent: ParentNode,
+    anchor: Node | null,
+    moveType: MoveType,
+    parentComponent?: VaporComponentInstance,
+    parentSuspense?: SuspenseBoundary | null,
+  ): void {
+    move(this.nodes, parent, anchor, moveType, parentComponent, parentSuspense)
+    if (this.activeFallback === this.nodes) {
+      this.fallbackInserted = true
+    }
+  }
+
+  remove(parent?: ParentNode): void {
     this.disposed = true
     const nodes = this.nodes
     remove(nodes, parent)
@@ -1033,7 +1044,7 @@ export function isForBlock(val: unknown): val is ForBlock {
   return !!(val && (val as any).__vf & FOR_ITEM)
 }
 
-export function isSlotFragment(val: unknown): val is SlotFragment {
+export function isVaporSlotOutlet(val: unknown): val is DynamicFragment {
   return !!(val && (val as any).__vf & SLOT)
 }
 

--- a/packages/runtime-vapor/src/slotFragment.ts
+++ b/packages/runtime-vapor/src/slotFragment.ts
@@ -1,9 +1,11 @@
 import { EffectScope } from '@vue/reactivity'
+import type { MoveType } from '@vue/runtime-dom'
 import {
   type Block,
   type VaporTransitionHooks,
   insert,
   isValidSlot,
+  move,
   remove,
   removeAttachedNodes,
 } from './block'
@@ -243,7 +245,10 @@ function renderFallbackInScope(
   }
 }
 
-export function insertActiveSlotFallback(state: SlotResolutionState): void {
+export function insertActiveSlotFallback(
+  state: SlotResolutionState,
+  moveType?: MoveType,
+): void {
   const fallback = state.activeFallback
   if (isHydrating || !fallback || !isValidSlot(fallback)) {
     return
@@ -252,7 +257,11 @@ export function insertActiveSlotFallback(state: SlotResolutionState): void {
   if (!parentNode) {
     return
   }
-  insert(fallback, parentNode, state.getAnchor())
+  if (moveType === undefined) {
+    insert(fallback, parentNode, state.getAnchor())
+  } else {
+    move(fallback, parentNode, state.getAnchor(), moveType)
+  }
   state.fallbackInserted = true
 }
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -1209,11 +1209,11 @@ function mountVNode(
     syncNodes()
   }
 
-  frag.insert = (
-    parentNode,
-    anchor,
-    parentSuspense,
-    transition,
+  const place = (
+    parentNode: ParentNode,
+    anchor: Node | null,
+    parentSuspense: SuspenseBoundary | null | undefined,
+    transition: TransitionHooks | undefined,
     moveType = MoveType.REORDER,
   ) => {
     if (isHydrating) return
@@ -1275,6 +1275,16 @@ function mountVNode(
     syncNodes()
     if (isMounted && frag.u) frag.u.forEach(hook => hook())
   }
+  frag.insert = (parentNode, anchor, parentSuspense, transition) =>
+    place(parentNode, anchor, parentSuspense, transition)
+  frag.move = (
+    parentNode,
+    anchor,
+    moveType,
+    _parentComponent,
+    parentSuspense,
+    transition,
+  ) => place(parentNode, anchor, parentSuspense, transition, moveType)
 
   if (getFallthroughAttrs) {
     // Re-clone and let VDOM patch the change through, mirroring how a VDOM
@@ -1466,11 +1476,11 @@ function createVDOMComponent(
   vnode.scopeId = getCurrentScopeId() || null
   vnode.slotScopeIds = currentSlotScopeIds
 
-  frag.insert = (
-    parentNode,
-    anchor,
-    parentSuspense,
-    transition,
+  const place = (
+    parentNode: ParentNode,
+    anchor: Node | null,
+    parentSuspense: SuspenseBoundary | null | undefined,
+    transition: TransitionHooks | undefined,
     moveType = MoveType.REORDER,
   ) => {
     if (isHydrating) return
@@ -1524,6 +1534,16 @@ function createVDOMComponent(
     syncNodes()
     if (isMounted && frag.u) frag.u.forEach(hook => hook())
   }
+  frag.insert = (parentNode, anchor, parentSuspense, transition) =>
+    place(parentNode, anchor, parentSuspense, transition)
+  frag.move = (
+    parentNode,
+    anchor,
+    moveType,
+    _parentComponent,
+    parentSuspense,
+    transition,
+  ) => place(parentNode, anchor, parentSuspense, transition, moveType)
 
   frag.remove = unmount
 
@@ -1894,7 +1914,12 @@ function renderVDOMSlot(
       : () => fallback(internals, parentComponent)
     : undefined
 
-  frag.insert = (parentNode, anchor, parentSuspense) => {
+  const place = (
+    parentNode: ParentNode,
+    anchor: Node | null,
+    parentSuspense: SuspenseBoundary | null | undefined,
+    moveType?: MoveType,
+  ) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
     // A non-inherited local fallback can revive independently of sibling
@@ -1927,22 +1952,35 @@ function renderVDOMSlot(
           rendered,
           parentNode,
           anchor,
-          MoveType.REORDER,
+          moveType === undefined ? MoveType.REORDER : moveType,
           parentComponent as any,
           suspense,
         )
       } else if (rendered) {
         // move vapor content
-        insert(rendered, parentNode, anchor, suspense)
+        if (moveType === undefined) {
+          insert(rendered, parentNode, anchor, suspense)
+        } else {
+          move(rendered, parentNode, anchor, moveType, undefined, suspense)
+        }
       }
 
       if (!sharedContentParked) {
-        insertActiveSlotFallback(slotResolutionState)
+        insertActiveSlotFallback(slotResolutionState, moveType)
       }
     }
 
     notifyUpdated()
   }
+  frag.insert = (parentNode, anchor, parentSuspense) =>
+    place(parentNode, anchor, parentSuspense)
+  frag.move = (
+    parentNode,
+    anchor,
+    moveType,
+    _parentComponent,
+    parentSuspense,
+  ) => place(parentNode, anchor, parentSuspense, moveType)
 
   frag.remove = parentNode => {
     const storage = sharedContentStorage
@@ -2987,6 +3025,28 @@ function renderVaporSlot(
           insert(frag.nodes, parentNode, anchor, parentSuspense)
         }
       }
+      frag.move = (
+        parentNode,
+        anchor,
+        moveType,
+        parentComponent,
+        parentSuspense,
+      ) => {
+        currentParentNode = parentNode
+        currentAnchor = anchor
+        if (slotResolutionState.activeFallback) {
+          insertActiveSlotFallback(slotResolutionState, moveType)
+        } else {
+          move(
+            frag.nodes,
+            parentNode,
+            anchor,
+            moveType,
+            parentComponent,
+            parentSuspense,
+          )
+        }
+      }
       frag.remove = parentNode => {
         if (!slotResolutionState.activeFallback) {
           remove(frag.nodes, parentNode)
@@ -3317,7 +3377,12 @@ function createVNodeChildrenFragment(
     startRenderEffect()
   }
 
-  frag.insert = (parentNode, anchor, parentSuspense) => {
+  const place = (
+    parentNode: ParentNode,
+    anchor: Node | null,
+    parentSuspense: SuspenseBoundary | null | undefined,
+    moveType = MoveType.REORDER,
+  ) => {
     if (isHydrating) return
     if (parentSuspense !== undefined) suspense = parentSuspense
     currentParentNode = parentNode
@@ -3354,13 +3419,22 @@ function createVNodeChildrenFragment(
           vnode,
           parentNode,
           anchor,
-          MoveType.REORDER,
+          moveType,
           parentComponent as any,
           suspense,
         )
       })
     }
   }
+  frag.insert = (parentNode, anchor, parentSuspense) =>
+    place(parentNode, anchor, parentSuspense)
+  frag.move = (
+    parentNode,
+    anchor,
+    moveType,
+    _parentComponent,
+    parentSuspense,
+  ) => place(parentNode, anchor, parentSuspense, moveType)
 
   frag.remove = parentNode => {
     scope.stop()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of content movement when switching between Vapor and VDOM-rendered content.
  - Fixed transition behavior so leave and enter animations run correctly when changing rendered branches.
  - Improved slot fallback placement during content reordering, helping preserve the correct rendered output.

- **Refactor**
  - Standardized slot outlet handling across rendering and transition features without changing expected application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->