### PR TITLE
refactor(runtime-vapor): make DynamicFragment update hooks and branch keys explicit

### DIFF
--- a/packages/runtime-vapor/__tests__/components/Transition.spec.ts
+++ b/packages/runtime-vapor/__tests__/components/Transition.spec.ts
@@ -9,7 +9,7 @@ import {
   resolveTransitionBlock,
 } from '../../src/components/Transition'
 import { resolveTransitionBlocks } from '../../src/components/TransitionGroup'
-import { SlotFragment } from '../../src/fragment'
+import { type DynamicFragment, SlotFragment } from '../../src/fragment'
 import {
   Fragment,
   type Ref,
@@ -2016,6 +2016,38 @@ describe('Transition', () => {
     )
     expect(onBeforeLeave).toHaveBeenCalledTimes(1)
     expect(onLeave).toHaveBeenCalledTimes(1)
+  })
+
+  test('dynamic default slot re-appearing should pair beforeUpdate with updated', async () => {
+    const data = ref({ show: true })
+    const App = compile(
+      `<template>
+        <Transition :css="false">
+          <template #default v-if="data.show">
+            <div>foo</div>
+          </template>
+        </Transition>
+      </template>`,
+      data,
+    )
+    const { instance } = define(App as any).render()
+    // the hook pairing is the fragment protocol under test, so the
+    // Transition's dynamic fragment is observed directly
+    const frag = (instance!.block as any).block as DynamicFragment
+    const bu = vi.fn()
+    const u = vi.fn()
+    ;(frag.bu ||= []).push(bu)
+    ;(frag.u ||= []).push(u)
+
+    data.value.show = false
+    await nextTick()
+    expect(bu).toHaveBeenCalledTimes(1)
+    expect(u).toHaveBeenCalledTimes(1)
+
+    data.value.show = true
+    await nextTick()
+    expect(bu).toHaveBeenCalledTimes(2)
+    expect(u).toHaveBeenCalledTimes(2)
   })
 
   test('dynamic default slot source should respect reactive mode changes', async () => {

--- a/packages/runtime-vapor/src/components/KeepAlive.ts
+++ b/packages/runtime-vapor/src/components/KeepAlive.ts
@@ -375,7 +375,7 @@ const VaporKeepAliveImpl = defineVaporComponent({
         current = undefined
         deactivate(instance, storageContainer, parentSuspense)
       },
-      prepareBranchRemoval(frag, scope) {
+      prepareBranchRemoval(frag, scope, prevKey) {
         // Async-wrapper internals share this context but are not themselves
         // KeepAlive cache roots.
         if (frag !== rootFragment) {
@@ -395,12 +395,12 @@ const VaporKeepAliveImpl = defineVaporComponent({
         // Component and KeepAlive input scopes are detached from this
         // DynamicFragment scope, so this only pauses branch-owned effects.
         scope.pause()
-        cacheScope(cacheKey, scopeLookupKey(frag), scope)
+        cacheScope(cacheKey, scopeLookupKey(frag, prevKey), scope)
         return true
       },
       runBranchRender(frag, fn, useScope, removePrevious) {
         const cachedScope = useScope
-          ? deleteScope(scopeLookupKey(frag))
+          ? deleteScope(scopeLookupKey(frag, frag.current))
           : undefined
         frag.scope = useScope ? cachedScope || new EffectScope() : undefined
         if (cachedScope) cachedScope.resume()
@@ -473,8 +473,8 @@ export const VaporKeepAlive: DefineVaporComponent<{}, string, KeepAliveProps> =
 
 // A branch with a user key is cached and its scope aliased under that key,
 // so re-entering the key finds them whatever the branch identity is.
-function scopeLookupKey(frag: DynamicFragment): any {
-  return frag.branchKey !== undefined ? frag.branchKey : frag.current
+function scopeLookupKey(frag: DynamicFragment, current: any): any {
+  return frag.branchKey !== undefined ? frag.branchKey : current
 }
 
 function registerDynamicFragmentHooks(

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -492,10 +492,6 @@ function deferBranchUpdateDuringLeaveImpl(
 ): boolean {
   const transition = frag.$transition!
   if (!transition.state.isLeaving) return false
-  // Track the latest target key immediately so repeated updates during
-  // leave keep overwriting the pending branch instead of reviving stale
-  // keys when the deferred render finally runs.
-  frag.current = key
   const pending = frag.pending
   if (pending) {
     pending.render = render
@@ -572,12 +568,6 @@ function removeBranchWithLeaveImpl(
     if (mode === 'out-in') {
       // out-in owns the removal here so update() can return before
       // rendering; the next branch mounts from the afterLeave callback.
-      // Record the target key immediately (mirroring the defer path) so
-      // `current` no longer points at the outgoing branch. Otherwise a
-      // toggle back to the original key during the leave would hit the
-      // `key === current` early-return in update() and be dropped, leaving
-      // the deferred render to mount the stale branch.
-      frag.current = key
       parent && remove(frag.nodes, parent)
       return true
     }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -343,7 +343,11 @@ export class DynamicFragment extends RenderContextFragment {
   // @ts-expect-error - assigned in the constructor or hydrateDynamicFragmentAnchor()
   anchor: Node
   scope: EffectScope | undefined
-  current?: BlockFn
+  // Key of the branch update() is heading to; undefined until the first
+  // branch renders. Written before the leave/defer scheduling, so an update
+  // that targets the in-flight key during a leave is a no-op rather than a
+  // revival of the outgoing branch.
+  current?: any
   // Owned by the Transition module (deferBranchUpdateDuringLeave /
   // removeBranchWithLeave); the core update pipeline never touches it.
   pending?: { render?: BlockFn; key: any; noScope: boolean; branchKey?: any }
@@ -426,8 +430,15 @@ export class DynamicFragment extends RenderContextFragment {
     }
 
     const transition = isTransitionEnabled ? this.$transition : undefined
-    const wasMounted = this.current !== undefined
-    if (wasMounted) {
+    const prevKey = this.current
+    const wasMounted = prevKey !== undefined
+    this.current = key
+    const prevSub = setActiveSub()
+    const parent = !isHydrating ? this.getBranchParent() : null
+    // Every update after the mount-time render brackets its hooks; see the
+    // `everUpdated` field comment.
+    const isUpdate = wasMounted || (everUpdated && !!parent)
+    if (isUpdate) {
       const bu = this.bu
       if (bu) {
         for (let i = 0; i < bu.length; i++) {
@@ -441,11 +452,10 @@ export class DynamicFragment extends RenderContextFragment {
       transition &&
       deferBranchUpdateDuringLeave(this, render, key, noScope, branchKey)
     ) {
+      setActiveSub(prevSub)
       return
     }
 
-    const prevSub = setActiveSub()
-    const parent = !isHydrating ? this.getBranchParent() : null
     let removePrevious: (() => void) | undefined
     // teardown previous branch
     if (wasMounted) {
@@ -455,7 +465,11 @@ export class DynamicFragment extends RenderContextFragment {
       let deferRemoval = false
       if (scope) {
         if (this.keepAliveCtx) {
-          deferRemoval = this.keepAliveCtx.prepareBranchRemoval(this, scope)
+          deferRemoval = this.keepAliveCtx.prepareBranchRemoval(
+            this,
+            scope,
+            prevKey,
+          )
         } else {
           scope.stop()
         }
@@ -493,9 +507,7 @@ export class DynamicFragment extends RenderContextFragment {
       parent,
       key,
       noScope,
-      // notify on any update except the mount-time first render; see the
-      // `everUpdated` field comment
-      wasMounted || (everUpdated && !!parent),
+      isUpdate,
       removePrevious,
       branchKey,
     )
@@ -522,60 +534,30 @@ export class DynamicFragment extends RenderContextFragment {
     removePrevious?: () => void,
     branchKey?: any,
   ): void {
-    this.current = key
     this.branchKey = this.keyed ? key : branchKey
     if (render) {
       const keepAliveCtx = isKeepAliveEnabled ? this.keepAliveCtx : null
       // A compiler-proven static branch can skip its own EffectScope, but attrs
       // fallthrough still registers branch-owned cleanup.
       const useScope = !noScope || !!this.fallthrough
-      if (!keepAliveCtx) {
+      if (keepAliveCtx) {
+        keepAliveCtx.runBranchRender(
+          this,
+          () =>
+            this.renderNodes(
+              render,
+              useScope,
+              parent,
+              transition,
+              keepAliveCtx,
+            ),
+          useScope,
+          removePrevious,
+        )
+      } else {
         this.scope = useScope ? new EffectScope() : undefined
+        this.renderNodes(render, useScope, parent, transition, null)
       }
-
-      const renderBranch = () => {
-        try {
-          this.nodes = this.runWithRenderCtx(() => {
-            const nodes =
-              (useScope ? this.scope!.run(render) : render()) || EMPTY_BLOCK
-            // (Re-)apply fallthrough attrs for the new branch inside the
-            // render ctx, before insertion. Disconnected renders are skipped
-            // on purpose: the enclosing application traverses into them and
-            // owns their first application.
-            if (parent && this.fallthrough) this.fallthrough(nodes)
-            const bm = this.bm
-            if (bm) {
-              for (let i = 0; i < bm.length; i++) {
-                bm[i](nodes)
-              }
-            }
-            return nodes
-          }, this.scope)
-        } finally {
-          // Inherit the fragment key without overriding a child's own key.
-          const key = this.branchKey !== undefined ? this.branchKey : this.$key
-          // Only propagate branch keys when Transition or KeepAlive consumes them.
-          if (
-            key !== undefined &&
-            (transition || this.inTransition || keepAliveCtx)
-          ) {
-            setBlockKey(this.nodes, key, false)
-          }
-
-          if (isTransitionEnabled && transition) {
-            this.$transition = applyTransitionHooks(this.nodes, transition)
-          }
-        }
-      }
-
-      keepAliveCtx
-        ? keepAliveCtx.runBranchRender(
-            this,
-            renderBranch,
-            useScope,
-            removePrevious,
-          )
-        : renderBranch()
 
       // Root-only inherited ids must land on the new branch's effective root
       // before insertion so custom element callbacks observe them.
@@ -596,7 +578,50 @@ export class DynamicFragment extends RenderContextFragment {
 
     const u = this.u
     if (notifyUpdated && u) {
-      u.forEach(hook => hook(this.nodes))
+      for (let i = 0; i < u.length; i++) {
+        u[i](this.nodes)
+      }
+    }
+  }
+
+  private renderNodes(
+    render: BlockFn,
+    useScope: boolean,
+    parent: ParentNode | null,
+    transition: VaporTransitionHooks | undefined,
+    keepAliveCtx: VaporKeepAliveContext | null,
+  ): void {
+    try {
+      this.nodes = this.runWithRenderCtx(() => {
+        const nodes =
+          (useScope ? this.scope!.run(render) : render()) || EMPTY_BLOCK
+        // (Re-)apply fallthrough attrs for the new branch inside the
+        // render ctx, before insertion. Disconnected renders are skipped
+        // on purpose: the enclosing application traverses into them and
+        // owns their first application.
+        if (parent && this.fallthrough) this.fallthrough(nodes)
+        const bm = this.bm
+        if (bm) {
+          for (let i = 0; i < bm.length; i++) {
+            bm[i](nodes)
+          }
+        }
+        return nodes
+      }, this.scope)
+    } finally {
+      // Inherit the fragment key without overriding a child's own key.
+      const key = this.branchKey !== undefined ? this.branchKey : this.$key
+      // Only propagate branch keys when Transition or KeepAlive consumes them.
+      if (
+        key !== undefined &&
+        (transition || this.inTransition || keepAliveCtx)
+      ) {
+        setBlockKey(this.nodes, key, false)
+      }
+
+      if (isTransitionEnabled && transition) {
+        this.$transition = applyTransitionHooks(this.nodes, transition)
+      }
     }
   }
 }

--- a/packages/runtime-vapor/src/keepAlive.ts
+++ b/packages/runtime-vapor/src/keepAlive.ts
@@ -13,8 +13,13 @@ export interface VaporKeepAliveContext {
   isolatePropSources(rawProps: RawProps): RawProps
   isolateSlotSources(rawSlots: RawSlots): RawSlots
   // caches or stops the outgoing branch scope and returns whether its DOM
-  // removal must wait for the incoming cache decision
-  prepareBranchRemoval(frag: DynamicFragment, scope: EffectScope): boolean
+  // removal must wait for the incoming cache decision. `prevKey` is the
+  // outgoing branch key: `frag.current` already names the incoming one.
+  prepareBranchRemoval(
+    frag: DynamicFragment,
+    scope: EffectScope,
+    prevKey: any,
+  ): boolean
   // acquires the incoming branch scope, sets up the keyed cache-key context,
   // marks shape flags, then runs any deferred outgoing removal
   runBranchRender(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transition behavior for dynamic default slots, ensuring lifecycle updates remain synchronized when content is removed and reappears.
  - Improved KeepAlive branch switching so cached content is restored and removed using the correct branch state.
- **Tests**
  - Added coverage for transition updates involving conditionally rendered slot content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->