### PR TITLE
refactor(runtime-vapor): reify the vapor render context

### DIFF
--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -28,13 +28,14 @@ import {
 } from '../src'
 import { compile, compileToVaporRender, makeRender } from './_utils'
 import { type VaporComponentInstance, currentInstance } from '../src/component'
-import { currentSlotOwner, setCurrentSlotOwner } from '../src/componentSlots'
 import { setElementText, setText } from '../src/dom/prop'
+import { enableSuspense } from '../src/suspense'
 import {
-  enableSuspense,
-  parentSuspense,
-  setParentSuspense,
-} from '../src/suspense'
+  currentRenderContext,
+  deriveSlotOwner,
+  deriveSuspense,
+  setRenderContext,
+} from '../src/renderContext'
 
 const define = makeRender()
 
@@ -952,17 +953,20 @@ describe('component', () => {
         const instance = currentInstance as VaporComponentInstance
         instance.suspense = activeSuspense
 
-        const prevOwner = setCurrentSlotOwner(owner)
-        const prevSuspense = setParentSuspense(previousSuspense)
+        const prevCtx = setRenderContext(
+          deriveSuspense(
+            deriveSlotOwner(currentRenderContext, owner),
+            previousSuspense,
+          ),
+        )
         try {
           createComponent(Child)
         } catch (e) {
           caught = e
         }
-        ownerAfterThrow = currentSlotOwner
-        suspenseAfterThrow = parentSuspense
-        setCurrentSlotOwner(prevOwner)
-        setParentSuspense(prevSuspense)
+        ownerAfterThrow = currentRenderContext.slotOwner
+        suspenseAfterThrow = currentRenderContext.suspense
+        setRenderContext(prevCtx)
         return []
       },
     }).render()

--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -67,10 +67,10 @@ import {
 import { IF } from '../src/fragmentFlags'
 import {
   type SlotBoundaryContext,
-  currentSlotBoundary,
   trackSlotBoundaryDirtying,
   withSlotBoundary,
 } from '../src/slotBoundary'
+import { currentRenderContext } from '../src/renderContext'
 import {
   type SlotResolutionState,
   markSlotResolutionDirty,
@@ -361,7 +361,7 @@ describe('component: slots', () => {
       let fallbackBoundary: any
 
       frag.updateSlot(undefined, () => {
-        fallbackBoundary = currentSlotBoundary
+        fallbackBoundary = currentRenderContext.slotBoundary
         return []
       })
 
@@ -567,8 +567,8 @@ describe('component: slots', () => {
           { id: 2, show: true },
         ],
         capture: () => {
-          if (currentSlotBoundary) {
-            boundary = currentSlotBoundary
+          if (currentRenderContext.slotBoundary) {
+            boundary = currentRenderContext.slotBoundary
           }
           return true
         },
@@ -606,8 +606,8 @@ describe('component: slots', () => {
         outer: true,
         inner: true,
         capture: () => {
-          if (currentSlotBoundary) {
-            boundary = currentSlotBoundary
+          if (currentRenderContext.slotBoundary) {
+            boundary = currentRenderContext.slotBoundary
           }
           return true
         },
@@ -644,8 +644,8 @@ describe('component: slots', () => {
         outer: true,
         inner: false,
         capture: () => {
-          if (currentSlotBoundary) {
-            boundary = currentSlotBoundary
+          if (currentRenderContext.slotBoundary) {
+            boundary = currentRenderContext.slotBoundary
           }
           return true
         },
@@ -1809,7 +1809,7 @@ describe('component: slots', () => {
       const vdom = (app._context as any).vdom
       const slotsRef = shallowRef({
         default: () => {
-          observedBoundary = currentSlotBoundary
+          observedBoundary = currentRenderContext.slotBoundary
           return [h('div', 'content')]
         },
       })
@@ -3885,7 +3885,7 @@ describe('component: slots', () => {
           define(() =>
             createComponent(Comp, null, {
               default: () => {
-                observedBoundary = currentSlotBoundary
+                observedBoundary = currentRenderContext.slotBoundary
                 return template('content')()
               },
             }),
@@ -3917,7 +3917,7 @@ describe('component: slots', () => {
           const { host } = define(() =>
             createComponent(Comp, null, {
               default: () => {
-                observedBoundary = currentSlotBoundary
+                observedBoundary = currentRenderContext.slotBoundary
                 return createIf(
                   () => show.value,
                   () => template('<span>content</span>')(),

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -35,13 +35,7 @@ import {
 } from './block'
 import { MoveType, queuePostFlushCb, warn } from '@vue/runtime-dom'
 import { currentInstance } from './component'
-import {
-  type DynamicSlot,
-  type VaporSlot,
-  currentSlotOwner,
-  setCurrentSlotOwner,
-} from './componentSlots'
-import { currentSlotScopeIds, setCurrentSlotScopeIds } from './scopeId'
+import type { DynamicSlot, VaporSlot } from './componentSlots'
 import { renderEffect } from './renderEffect'
 import { VaporVForFlags } from '@vue/shared'
 import {
@@ -82,7 +76,7 @@ import {
 } from './insertionState'
 import { applyTransitionHooks, isTransitionEnabled } from './transition'
 import { setBlockKey } from './helpers/setKey'
-import { currentSlotBoundary, setCurrentSlotBoundary } from './slotBoundary'
+import { currentRenderContext, withRenderContext } from './renderContext'
 
 type Source = any[] | Record<any, any> | number | Set<any> | Map<any, any>
 
@@ -150,9 +144,7 @@ export const createFor = (
   const isFragment = !!(flags & VaporVForFlags.IS_FRAGMENT)
   const wrappedRows = !!(flags & VaporVForFlags.WRAPPED_ROWS)
 
-  const slotOwner = currentSlotOwner
-  const slotBoundary = currentSlotBoundary
-  const slotScopeIds = currentSlotScopeIds
+  const ctx = currentRenderContext
 
   if (__DEV__ && !instance) {
     warn('createFor() can only be used inside setup()')
@@ -666,19 +658,7 @@ export const createFor = (
   } else {
     renderEffect(() => {
       if (!isMounted) return renderList()
-      const prevOwner = setCurrentSlotOwner(slotOwner)
-      const restoreBoundary = currentSlotBoundary !== slotBoundary
-      const prevBoundary = restoreBoundary
-        ? setCurrentSlotBoundary(slotBoundary)
-        : null
-      const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
-      try {
-        renderList()
-      } finally {
-        setCurrentSlotScopeIds(prevSlotScopeIds)
-        if (restoreBoundary) setCurrentSlotBoundary(prevBoundary)
-        setCurrentSlotOwner(prevOwner)
-      }
+      withRenderContext(ctx, renderList)
     })
   }
 

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -43,7 +43,7 @@ import {
   unsetRef,
 } from './refCleanup'
 import { renderEffect } from './renderEffect'
-import { parentSuspense } from './suspense'
+import { currentRenderContext } from './renderContext'
 
 export type NodeRef =
   | string
@@ -125,7 +125,10 @@ export function createTemplateRefSetter(): setRefFn {
   return (el, ref, refFor, refKey) => {
     let state = stateMap.get(el)
     if (!state) {
-      stateMap.set(el, (state = { ref, suspense: parentSuspense }))
+      stateMap.set(
+        el,
+        (state = { ref, suspense: currentRenderContext.suspense }),
+      )
     }
     setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
   }
@@ -188,7 +191,7 @@ export function setStaticTemplateRef(
   refKey?: string,
 ): void {
   const instance = getScopeOwner()!
-  const suspense = parentSuspense
+  const suspense = currentRenderContext.suspense
   setRef(instance, suspense, el, ref, undefined, refFor, refKey)
   registerFragmentRefUpdate(el, undefined, () => {
     setRef(instance, suspense, el, ref, ref, refFor, refKey)
@@ -209,7 +212,7 @@ export function setTemplateRefBinding(
   let state: TemplateRefState | undefined
   renderEffect(() => {
     const ref = getter()
-    if (!state) state = { ref, suspense: parentSuspense }
+    if (!state) state = { ref, suspense: currentRenderContext.suspense }
     setTemplateRefWithState(instance, el, state, ref, refFor, refKey)
   })
 }

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -93,9 +93,14 @@ import {
   dynamicSlotsProxyHandlers,
   getSlot,
   normalizeRawSlots,
-  setCurrentSlotOwner,
   snapshotRawSlots,
 } from './componentSlots'
+import {
+  currentRenderContext,
+  deriveRenderContext,
+  deriveSuspense,
+  setRenderContext,
+} from './renderContext'
 import { inOnce, withOnce } from './once'
 import { hmrReload, hmrRerender } from './hmr'
 import {
@@ -154,20 +159,16 @@ import type { VaporElement } from './apiDefineCustomElement'
 import {
   currentUnmountSuspense,
   isSuspenseEnabled,
-  parentSuspense,
   resolveUnmountSuspense,
   runWithUnmountSuspense,
-  setParentSuspense,
 } from './suspense'
 import { isInteropEnabled } from './vdomInteropState'
 import {
   applyComponentScopeIds,
-  currentSlotScopeIds,
   getCurrentScopeId,
   hydrateComponentScopeIds,
-  setCurrentSlotScopeIds,
-  setElementScopeIds,
 } from './scopeId'
+import { setElementScopeIds } from './dom/scopeIdStamp'
 import { isTransitionEnabled, isVaporTransition } from './transition'
 
 export { currentInstance } from '@vue/runtime-dom'
@@ -331,18 +332,16 @@ export function createComponent(
     resetInsertionState()
   }
 
-  let prevSuspense: SuspenseBoundary | null = null
-  let hasParentSuspense = false
+  const prevCtx = currentRenderContext
   try {
     if (
       __FEATURE_SUSPENSE__ &&
       isSuspenseEnabled &&
-      !parentSuspense &&
+      !prevCtx.suspense &&
       currentInstance &&
       currentInstance.suspense
     ) {
-      prevSuspense = setParentSuspense(currentInstance.suspense)
-      hasParentSuspense = true
+      setRenderContext(deriveSuspense(prevCtx, currentInstance.suspense))
     }
 
     const owner = resolveFallthroughOwner(isSingleRoot)
@@ -403,7 +402,12 @@ export function createComponent(
       )
       if (!isHydrating) {
         if (_insertionParent) {
-          insert(frag, _insertionParent, _insertionAnchor, parentSuspense)
+          insert(
+            frag,
+            _insertionParent,
+            _insertionAnchor,
+            currentRenderContext.suspense,
+          )
         }
       } else {
         frag.hydrate()
@@ -431,7 +435,12 @@ export function createComponent(
       }
       if (!isHydrating) {
         if (_insertionParent) {
-          insert(frag, _insertionParent, _insertionAnchor, parentSuspense)
+          insert(
+            frag,
+            _insertionParent,
+            _insertionAnchor,
+            currentRenderContext.suspense,
+          )
         }
       } else {
         frag.hydrate()
@@ -497,11 +506,19 @@ export function createComponent(
       if (keepAliveCtx) keepAliveCtx.processShapeFlag(instance)
     }
 
-    // reset currentSlotOwner to null to avoid affecting the child components
-    const prevSlotOwner = setCurrentSlotOwner(null)
-    // Slot scope ids stop at component boundaries; the instance captured
-    // them above for root-only application.
-    const prevSlotScopeIds = setCurrentSlotScopeIds(null)
+    // The slot owner and slot scope ids stop at component boundaries: setup
+    // must not see the parent's slot context (the instance captured the ids
+    // above for root-only application).
+    const outerCtx = currentRenderContext
+    setRenderContext(
+      deriveRenderContext(
+        outerCtx,
+        null,
+        outerCtx.slotBoundary,
+        null,
+        outerCtx.suspense,
+      ),
+    )
     let hasWarningContext = false
     let hasInitMeasure = false
     try {
@@ -575,12 +592,7 @@ export function createComponent(
           endMeasure(instance, 'init')
         }
       }
-      setCurrentSlotScopeIds(prevSlotScopeIds)
-      setCurrentSlotOwner(prevSlotOwner)
-      if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && hasParentSuspense) {
-        setParentSuspense(prevSuspense)
-        hasParentSuspense = false
-      }
+      setRenderContext(prevCtx)
     }
     onScopeDispose(
       () =>
@@ -618,9 +630,7 @@ export function createComponent(
 
     return instance
   } finally {
-    if (hasParentSuspense) {
-      setParentSuspense(prevSuspense)
-    }
+    setRenderContext(prevCtx)
     if (isHydrating && !deferHydrationBoundary) {
       // Boundary cleanup still needs the component-local cursor. Only after
       // that do we restore the outer cursor's resume point.
@@ -1023,8 +1033,8 @@ export class VaporComponentInstance<
     this.suspense = null
     this.suspenseId = 0
     if (__FEATURE_SUSPENSE__ && isSuspenseEnabled) {
-      this.suspense = parentSuspense
-      this.suspenseId = parentSuspense ? parentSuspense.pendingId : 0
+      const suspense = (this.suspense = currentRenderContext.suspense)
+      this.suspenseId = suspense ? suspense.pendingId : 0
     }
     this.asyncDep = null
     this.asyncResolved = false
@@ -1070,7 +1080,7 @@ export class VaporComponentInstance<
     ) as Slots
 
     this.scopeId = getCurrentScopeId()
-    this.slotScopeIds = currentSlotScopeIds
+    this.slotScopeIds = currentRenderContext.slotScopeIds
 
     // apply custom element special handling
     if (ce) {
@@ -1240,7 +1250,8 @@ export function createPlainElement(
   if (!isHydrating || isRecreatedNode(el)) {
     const scopeId = getCurrentScopeId()
     if (scopeId) el.setAttribute(scopeId, '')
-    if (currentSlotScopeIds) setElementScopeIds(el, currentSlotScopeIds)
+    const slotScopeIds = currentRenderContext.slotScopeIds
+    if (slotScopeIds) setElementScopeIds(el, slotScopeIds)
   }
 
   if (rawProps) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -276,7 +276,7 @@ function useVdomInterop(
   component: VaporComponent,
   appContext: GenericAppContext,
 ): boolean {
-  return isInteropEnabled && !!appContext.vdom && !component.__vapor
+  return !!appContext.vdom && !component.__vapor
 }
 
 // The instance whose fallthrough attrs a block created right now inherits:
@@ -386,13 +386,16 @@ export function createComponent(
     let asyncBoundary = false
     if (isAsyncComponentEnabled && !isHydrating) {
       const resolved = component.__asyncResolved
-      if (resolved && !useVdomInterop(resolved, appContext)) {
+      if (
+        resolved &&
+        !(isInteropEnabled && useVdomInterop(resolved, appContext))
+      ) {
         component = resolved
         asyncBoundary = true
       }
     }
 
-    if (useVdomInterop(component, appContext)) {
+    if (isInteropEnabled && useVdomInterop(component, appContext)) {
       const frag = appContext.vdom!.mount(
         component as any,
         currentInstance as any,

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -41,17 +41,19 @@ import {
   isInteropFragment,
 } from './fragment'
 import { SLOT_FRAGMENT } from './fragmentFlags'
-import { currentSlotBoundary, withSlotBoundary } from './slotBoundary'
+import {
+  currentRenderContext,
+  deriveRenderContext,
+  deriveSlotOwner,
+  deriveSlotScopeIds,
+  withRenderContext,
+} from './renderContext'
 import { createElement } from './dom/node'
 import { setDynamicProps } from './dom/prop'
 import { interopSlotsKey, isInteropEnabled } from './vdomInteropState'
 import { isAsyncComponentEnabled } from './asyncComponentState'
-import {
-  currentSlotScopeIds,
-  renderWithSlotScopeIds,
-  setCurrentSlotScopeIds,
-  setElementScopeIds,
-} from './scopeId'
+import { renderWithSlotScopeIds } from './scopeId'
+import { setElementScopeIds } from './dom/scopeIdStamp'
 import { withHydratingSlotBoundary } from './dom/hydrateFragment'
 import { withOnce } from './once'
 
@@ -131,15 +133,11 @@ export function snapshotRawSlots(rawSlots: RawSlots): RawSlots {
 }
 
 function withSlotOwner<T>(slots: RawSlots, fn: () => T): T {
-  if (!rawSlotsOwnerMap.has(slots)) {
+  const owner = rawSlotsOwnerMap.get(slots)
+  if (owner === undefined) {
     return fn()
   }
-  const prevOwner = setCurrentSlotOwner(rawSlotsOwnerMap.get(slots) || null)
-  try {
-    return fn()
-  } finally {
-    setCurrentSlotOwner(prevOwner)
-  }
+  return withRenderContext(deriveSlotOwner(currentRenderContext, owner), fn)
 }
 
 function getOwnedSlot(
@@ -249,29 +247,12 @@ function resolveSlot(
 }
 
 /**
- * Tracks the slot owner (the component that defines the slot content).
- * This is used for:
- * 1. Getting the correct rawSlots in forwarded slots (via createSlot)
- * 2. Inheriting the slot owner's scopeId
- */
-export let currentSlotOwner: VaporComponentInstance | null = null
-
-export function setCurrentSlotOwner(
-  owner: VaporComponentInstance | null,
-): VaporComponentInstance | null {
-  try {
-    return currentSlotOwner
-  } finally {
-    currentSlotOwner = owner
-  }
-}
-
-/**
  * Get the effective slot instance for accessing rawSlots and scopeId.
- * Prefers currentSlotOwner (if inside a slot), falls back to currentInstance.
+ * Prefers the slot owner (if inside a slot), falls back to currentInstance.
  */
 export function getScopeOwner(): VaporComponentInstance | null {
-  return (currentSlotOwner || currentInstance) as VaporComponentInstance | null
+  return (currentRenderContext.slotOwner ||
+    currentInstance) as VaporComponentInstance | null
 }
 
 export function createSlot(
@@ -292,7 +273,7 @@ export function createSlot(
   // The outlet's id cell: its own `-s` id merged onto the outer slot context,
   // so forwarded slot content accumulates every level's ids (VDOM
   // processFragment concat semantics).
-  const outerSlotScopeIds = currentSlotScopeIds
+  const outerSlotScopeIds = currentRenderContext.slotScopeIds
   const slotScopeIds = scopeId
     ? outerSlotScopeIds
       ? [...outerSlotScopeIds, `${scopeId}-s`]
@@ -313,22 +294,21 @@ export function createSlot(
     if (isHydrating) hydrationCursor = enterHydrationCursor()
     // Establish the outlet cell as the creation ambient; the interop slot
     // captures it as the base patch context for the vdom-rendered content.
-    const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
-    try {
-      fragment = instance.appContext.vdom!.slot(
-        interopSlotsSource,
-        name,
-        slotProps,
-        instance,
-        {
-          fallback,
-          flags,
-          adoptAnchor: _insertionAnchor,
-        },
-      )
-    } finally {
-      setCurrentSlotScopeIds(prevSlotScopeIds)
-    }
+    fragment = withRenderContext(
+      deriveSlotScopeIds(currentRenderContext, slotScopeIds),
+      () =>
+        instance.appContext.vdom!.slot(
+          interopSlotsSource,
+          name,
+          slotProps,
+          instance,
+          {
+            fallback,
+            flags,
+            adoptAnchor: _insertionAnchor,
+          },
+        ),
+    )
   } else {
     // renderVDOMSlot wraps its fallback from flags itself, so only the
     // non-interop paths wrap here.
@@ -359,6 +339,9 @@ export function createSlot(
       : undefined
     let dynamicFragment: DynamicFragment | undefined
     if (slotFragment) {
+      // Late renders (fallbacks, branch switches) run under the outlet cell
+      // rather than the construction-time capture.
+      slotFragment.ctx = deriveSlotScopeIds(slotFragment.ctx, slotScopeIds)
       fragment = slotFragment
     } else {
       // Fast path: DynamicFragment is enough, but hydration still enters the
@@ -374,12 +357,16 @@ export function createSlot(
       )
       // A fast-path outlet joins no fallback arbitration, so its content must
       // not render under (or attach dirty-tracking to) an enclosing boundary.
-      dynamicFragment.slotBoundary = null
+      const ctx = dynamicFragment.ctx
+      dynamicFragment.ctx = deriveRenderContext(
+        ctx,
+        ctx.slotOwner,
+        null,
+        slotScopeIds,
+        ctx.suspense,
+      )
       fragment = dynamicFragment
     }
-    // Replace the construction-time capture with the outlet cell so late
-    // renders (fallbacks, branch switches) run under the merged context.
-    ;(fragment as SlotFragment | DynamicFragment).slotScopeIds = slotScopeIds
 
     const isDynamicName = isFunction(name)
 
@@ -405,17 +392,11 @@ export function createSlot(
         else renderEffect(setSlotProps)
         if (fallback) {
           const fallbackFn = fallback
-          // The fallback renders outside the fragment's own render seam, so
-          // establish the outlet cell explicitly around it. Like any fast-path
-          // outlet it must not render under an enclosing boundary.
-          const prevSlotScopeIds = setCurrentSlotScopeIds(slotScopeIds)
-          try {
-            withSlotBoundary(null, () => {
-              insert(fallbackFn(), el)
-            })
-          } finally {
-            setCurrentSlotScopeIds(prevSlotScopeIds)
-          }
+          // The fallback renders outside update(), so restore the outlet's
+          // context explicitly.
+          withRenderContext(dynamicFragment!.ctx, () => {
+            insert(fallbackFn(), el)
+          })
         }
         fragment.nodes = el
         return
@@ -503,7 +484,7 @@ function shouldUseSlotFragment(
   // chain. Everything below is boundary-independent: a non-forwarded outlet
   // never chains outward, so local fallback reachability follows the same
   // static analysis with or without an enclosing boundary.
-  if (currentSlotBoundary && isForwardedSlot(flags)) return true
+  if (currentRenderContext.slotBoundary && isForwardedSlot(flags)) return true
 
   // Without fallback, there is no fallback branch to track.
   if (!fallback) return false

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -43,8 +43,8 @@ import {
   RenderContextFragment,
   isFragment,
   resolveFragmentAnchor,
-  runWithFragmentCtxOnly,
 } from '../fragment'
+import { withRenderContext } from '../renderContext'
 import {
   advanceHydrationNode,
   claimAnchor,
@@ -153,7 +153,7 @@ export class TeleportFragment extends RenderContextFragment {
   }
 
   get scopeOwner(): GenericComponentInstance | null {
-    return (this.slotOwner ||
+    return (this.ctx.slotOwner ||
       this.renderInstance) as GenericComponentInstance | null
   }
 
@@ -169,7 +169,7 @@ export class TeleportFragment extends RenderContextFragment {
       // init and slot re-runs, where new nodes capture the ambient context.
       // The equality fast path keeps the synchronous first run free.
       renderEffect(() =>
-        runWithFragmentCtxOnly(this, () => {
+        withRenderContext(this.ctx, () => {
           // Stop the previous run's effects before tearing down its nodes;
           // components unmount here, handleChildrenUpdate detaches the DOM.
           const prevScope = this.scope
@@ -315,7 +315,7 @@ export class TeleportFragment extends RenderContextFragment {
       undefined,
       this.parentSuspense !== undefined
         ? this.parentSuspense
-        : (__FEATURE_SUSPENSE__ && isSuspenseEnabled && this.renderSuspense) ||
+        : (__FEATURE_SUSPENSE__ && isSuspenseEnabled && this.ctx.suspense) ||
             null,
     )
   }

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -23,19 +23,11 @@ import {
   parentNode,
   updateLastLocatedLogicalChild,
 } from './node'
+import { currentRenderContext } from '../renderContext'
+import { setElementScopeIdsDeep } from './scopeIdStamp'
 import { remove } from '../block'
 
 const START_TAG_RE = /^<([^\s/>]+)/
-
-// In-place stamp installed by the scope id module while slotted ids are
-// live: mismatch-recreated subtrees stamp like a client mount.
-export let mismatchStampHook: ((node: Node) => void) | null = null
-
-export function setMismatchStampHook(
-  hook: ((node: Node) => void) | null,
-): void {
-  mismatchStampHook = hook
-}
 
 export let isHydratingEnabled = false
 
@@ -638,7 +630,8 @@ function handleMismatch(
     }
     // Recreated nodes carry no SSR scope attrs; run the same creation-time
     // stamping a client render would, before server children are adopted in.
-    if (mismatchStampHook) mismatchStampHook(newNode)
+    const slotScopeIds = currentRenderContext.slotScopeIds
+    if (slotScopeIds) setElementScopeIdsDeep(newNode as Element, slotScopeIds)
   }
   if (adoptChildren && node.nodeType === 1 && !newNode.firstChild) {
     let child = node.firstChild

--- a/packages/runtime-vapor/src/dom/scopeIdStamp.ts
+++ b/packages/runtime-vapor/src/dom/scopeIdStamp.ts
@@ -1,0 +1,41 @@
+export function setElementScopeIds(el: Element, scopeIds: string[]): void {
+  for (let i = 0; i < scopeIds.length; i++) {
+    el.setAttribute(scopeIds[i], '')
+  }
+}
+
+export function setElementScopeIdsDeep(el: Element, scopeIds: string[]): void {
+  setElementScopeIds(el, scopeIds)
+  let child = el.firstElementChild
+  while (child) {
+    setElementScopeIdsDeep(child, scopeIds)
+    child = child.nextElementSibling
+  }
+}
+
+/**
+ * Stamped-variant cache: ids are written once per (template prototype × id
+ * cell) and clones inherit them via cloneNode. Never stale because scope ids
+ * are compile-time constants; entries are freed with their cell (WeakMap key).
+ */
+const stampedTemplates = new WeakMap<Node, WeakMap<string[], Node>>()
+
+export function cloneStampedTemplate(
+  prototype: Node,
+  scopeIds: string[],
+): Node {
+  if (prototype.nodeType !== 1 /* Node.ELEMENT_NODE */) {
+    return prototype.cloneNode(true)
+  }
+  let variants = stampedTemplates.get(prototype)
+  if (!variants) {
+    stampedTemplates.set(prototype, (variants = new WeakMap()))
+  }
+  let stamped = variants.get(scopeIds)
+  if (!stamped) {
+    stamped = prototype.cloneNode(true)
+    setElementScopeIdsDeep(stamped as Element, scopeIds)
+    variants.set(scopeIds, stamped)
+  }
+  return stamped.cloneNode(true)
+}

--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -12,19 +12,15 @@ import {
 } from './hydration'
 import { type Namespace, Namespaces, TemplateFlags } from '@vue/shared'
 import { _child, createTextNode } from './node'
+import { currentRenderContext } from '../renderContext'
+import { cloneStampedTemplate } from './scopeIdStamp'
 import { resolvePendingSlotContent } from './hydrateFragment'
 
 let t: HTMLTemplateElement
 
-// Clone provider installed by the scope id module while slotted ids are live
-// (this module imports no scope machinery; the common path is one null
-// check). Serves clones carrying the active ids from a stamped-variant cache.
-export let templateCloneHook: ((prototype: Node) => Node) | null = null
-
-export function setTemplateCloneHook(
-  hook: ((prototype: Node) => Node) | null,
-): void {
-  templateCloneHook = hook
+function cloneTemplate(n: Node): Node {
+  const scopeIds = currentRenderContext.slotScopeIds
+  return scopeIds ? cloneStampedTemplate(n, scopeIds) : n.cloneNode(true)
 }
 
 /*@__NO_SIDE_EFFECTS__*/
@@ -86,9 +82,7 @@ export function template(html: string, flags: number = 0, ns?: Namespace) {
     }
 
     if (node) {
-      const ret = templateCloneHook
-        ? templateCloneHook(node)
-        : node.cloneNode(true)
+      const ret = cloneTemplate(node)
       if (root) (ret as any).$root = true
       return ret
     }
@@ -106,9 +100,7 @@ export function template(html: string, flags: number = 0, ns?: Namespace) {
       t.innerHTML = html
       node = _child(t.content)
     }
-    const ret = templateCloneHook
-      ? templateCloneHook(node)
-      : node.cloneNode(true)
+    const ret = cloneTemplate(node)
     if (root) (ret as any).$root = true
     return ret
   }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -45,25 +45,18 @@ import {
   locateFragmentEnd,
   locateHydrationNode,
 } from './dom/hydration'
-import { currentSlotOwner, setCurrentSlotOwner } from './componentSlots'
 import {
-  isSuspenseEnabled,
-  parentSuspense,
-  setParentSuspense,
-} from './suspense'
-import {
-  applyScopeIdOwners,
-  currentSlotScopeIds,
-  setCurrentSlotScopeIds,
-} from './scopeId'
+  type RenderContext,
+  currentRenderContext,
+  deriveSlotBoundary,
+  withRenderContext,
+} from './renderContext'
+import { applyScopeIdOwners } from './scopeId'
 import {
   type SlotBoundaryContext,
-  currentSlotBoundary,
   hasSlotFallback,
   registerContentInvalid,
-  setCurrentSlotBoundary,
   trackSlotBoundaryDirtying,
-  withSlotBoundary,
 } from './slotBoundary'
 import {
   claimPrecedingFragmentClose,
@@ -179,39 +172,30 @@ export class VaporFragment<
 // re-renders — capture the ambient render context at construction so the
 // deferred render can restore it. Fragments that only hold externally
 // rendered content (ForFragment / ForBlock) stay on the lean base class:
-// the for pipeline restores its ambient context through closures instead,
-// once per v-for rather than once per item.
+// the for pipeline captures the context once per v-for instead.
 export class RenderContextFragment<
   T extends Block = Block,
 > extends VaporFragment<T> {
-  // render context
   readonly renderInstance: GenericComponentInstance | null = currentInstance
-  readonly slotOwner: VaporComponentInstance | null = currentSlotOwner
   readonly keepAliveCtx?: VaporKeepAliveContext | null
-  // Captured by reference: fast-path slot outlets null this right after
-  // construction — they join no fallback arbitration (see createSlot).
-  slotBoundary: SlotBoundaryContext | null = currentSlotBoundary
-  // The Suspense boundary this fragment renders *into*. Unlike
-  // `renderInstance.suspense` (the boundary its owner was mounted in), slot
-  // content can be declared outside a boundary and rendered inside one, so this
-  // has to be the ambient value at construction time. Restored alongside the
-  // other fragment-owned ambient state in `runWithFragmentCtxOnly`, so
-  // branches that first render during an update queue their post-render
-  // effects on the right boundary instead of the global queue.
-  readonly renderSuspense?: SuspenseBoundary | null
-  // Captured by reference: slot outlets replace this with their merged id cell
-  // right after construction, so late renders (branch switches, deferred
-  // fallbacks) create their DOM under the outlet's slot scope context.
-  slotScopeIds: string[] | null = currentSlotScopeIds
+  // The context this fragment's content renders under. Slot outlets replace
+  // it with their own cell right after construction (see createSlot), so late
+  // renders create their DOM under the outlet's context.
+  ctx: RenderContext = currentRenderContext
 
   constructor(nodes: T, flags: number = FRAGMENT) {
     super(nodes, flags)
     if (isKeepAliveEnabled) {
       this.keepAliveCtx = getKeepAliveContext(currentInstance)
     }
-    if (__FEATURE_SUSPENSE__ && isSuspenseEnabled) {
-      this.renderSuspense = parentSuspense
-    }
+  }
+
+  get slotBoundary(): SlotBoundaryContext | null {
+    return this.ctx.slotBoundary
+  }
+
+  get slotScopeIds(): string[] | null {
+    return this.ctx.slotScopeIds
   }
 
   protected runWithRenderCtx<R>(fn: () => R, scope?: EffectScope): R {
@@ -226,7 +210,7 @@ export function runWithRenderCtx<R>(
 ): R {
   const prevInstance = setCurrentInstance(fragment.renderInstance, scope)
   try {
-    return runWithFragmentCtxOnly(fragment, fn)
+    return withRenderContext(fragment.ctx, fn)
   } finally {
     restoreCurrentInstance(prevInstance)
   }
@@ -253,43 +237,6 @@ export function createSlotBoundary(
     getScopeIds: () => fragment.slotScopeIds,
     markDirty,
     onContentInvalid,
-  }
-}
-
-// Restores fragment-owned ambient state only. The caller must already have the
-// correct currentInstance / currentScope; use runWithRenderCtx for late renders.
-export function runWithFragmentCtxOnly<R>(
-  fragment: RenderContextFragment,
-  fn: () => R,
-): R {
-  // When ambient fragment context already matches, no ambient state needs
-  // restoring. This keeps ordinary branch renders on the cheap path.
-  const suspense =
-    __FEATURE_SUSPENSE__ && isSuspenseEnabled
-      ? fragment.renderSuspense || null
-      : null
-  const restoreSuspense =
-    __FEATURE_SUSPENSE__ && isSuspenseEnabled && parentSuspense !== suspense
-  if (
-    !restoreSuspense &&
-    currentSlotOwner === fragment.slotOwner &&
-    currentSlotBoundary === fragment.slotBoundary &&
-    currentSlotScopeIds === fragment.slotScopeIds
-  ) {
-    return fn()
-  }
-
-  const prevSuspense = restoreSuspense ? setParentSuspense(suspense) : null
-  const prevSlotOwner = setCurrentSlotOwner(fragment.slotOwner)
-  const prevBoundary = setCurrentSlotBoundary(fragment.slotBoundary)
-  const prevSlotScopeIds = setCurrentSlotScopeIds(fragment.slotScopeIds)
-  try {
-    return fn()
-  } finally {
-    setCurrentSlotScopeIds(prevSlotScopeIds)
-    setCurrentSlotBoundary(prevBoundary)
-    setCurrentSlotOwner(prevSlotOwner)
-    if (restoreSuspense) setParentSuspense(prevSuspense)
   }
 }
 
@@ -647,6 +594,7 @@ export class SlotFragment
   private localFallback?: BlockFn
   private isUpdating = false
   private ownBoundary?: SlotBoundaryContext
+  private contentCtx?: RenderContext
   // Decoded from VaporSlotFlags: forwarded roots expose their content
   // validity to the enclosing boundary (unless once, whose content never
   // changes validity) and resolve fallback in shared or inherit mode.
@@ -819,8 +767,14 @@ export class SlotFragment
     const prevLocalFallback = this.localFallback
     this.localFallback = fallback
     const boundary = this.boundary
+    // Content renders under the outlet context plus this boundary; both are
+    // fixed before the first update.
+    const contentCtx = (this.contentCtx ||= deriveSlotBoundary(
+      this.ctx,
+      boundary,
+    ))
     const slotRender = render
-      ? () => withSlotBoundary(boundary, render)
+      ? () => withRenderContext(contentCtx, render)
       : () => EMPTY_BLOCK
     this.isUpdating = true
     this.pendingRecheck = false

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -208,6 +208,12 @@ export function runWithRenderCtx<R>(
   fn: () => R,
   scope?: EffectScope,
 ): R {
+  // Renders driven by the fragment's own render effect already run under its
+  // instance; only out-of-effect renders (slot fallbacks, deferred branches,
+  // async resolution) switch it.
+  if (scope === undefined && currentInstance === fragment.renderInstance) {
+    return withRenderContext(fragment.ctx, fn)
+  }
   const prevInstance = setCurrentInstance(fragment.renderInstance, scope)
   try {
     return withRenderContext(fragment.ctx, fn)
@@ -554,7 +560,7 @@ export class DynamicFragment extends RenderContextFragment {
           }
         }
         return nodes
-      }, this.scope)
+      })
     } finally {
       // Inherit the fragment key without overriding a child's own key.
       const key = this.branchKey !== undefined ? this.branchKey : this.$key

--- a/packages/runtime-vapor/src/hmr.ts
+++ b/packages/runtime-vapor/src/hmr.ts
@@ -14,7 +14,12 @@ import {
   runDevRender,
   unmountComponent,
 } from './component'
-import { applyComponentScopeIds, setCurrentSlotScopeIds } from './scopeId'
+import { applyComponentScopeIds } from './scopeId'
+import {
+  currentRenderContext,
+  deriveSlotScopeIds,
+  withRenderContext,
+} from './renderContext'
 
 export function hmrRerender(instance: VaporComponentInstance): void {
   // A component without a separate render function (built-ins like
@@ -37,12 +42,12 @@ export function hmrRerender(instance: VaporComponentInstance): void {
   pushWarningContext(instance)
   // The rerender recreates the component's own template window, where slot
   // scope ids never apply; root-only ids are re-applied below.
-  const prevSlotScopeIds = setCurrentSlotScopeIds(null)
   try {
-    runDevRender(instance)
-    applyComponentFallthrough(instance)
+    withRenderContext(deriveSlotScopeIds(currentRenderContext, null), () => {
+      runDevRender(instance)
+      applyComponentFallthrough(instance)
+    })
   } finally {
-    setCurrentSlotScopeIds(prevSlotScopeIds)
     popWarningContext()
     restoreCurrentInstance(prev)
   }

--- a/packages/runtime-vapor/src/renderContext.ts
+++ b/packages/runtime-vapor/src/renderContext.ts
@@ -1,0 +1,101 @@
+import type { SuspenseBoundary } from '@vue/runtime-dom'
+import type { VaporComponentInstance } from './component'
+import type { SlotBoundaryContext } from './slotBoundary'
+
+export interface RenderContext {
+  readonly slotOwner: VaporComponentInstance | null
+  readonly slotBoundary: SlotBoundaryContext | null
+  readonly slotScopeIds: string[] | null
+  readonly suspense: SuspenseBoundary | null
+}
+
+export let currentRenderContext: RenderContext = {
+  slotOwner: null,
+  slotBoundary: null,
+  slotScopeIds: null,
+  suspense: null,
+}
+
+export function setRenderContext(ctx: RenderContext): RenderContext {
+  const prev = currentRenderContext
+  currentRenderContext = ctx
+  return prev
+}
+
+export function withRenderContext<R>(ctx: RenderContext, fn: () => R): R {
+  if (ctx === currentRenderContext) return fn()
+  const prev = setRenderContext(ctx)
+  try {
+    return fn()
+  } finally {
+    currentRenderContext = prev
+  }
+}
+
+export function deriveRenderContext(
+  base: RenderContext,
+  slotOwner: VaporComponentInstance | null,
+  slotBoundary: SlotBoundaryContext | null,
+  slotScopeIds: string[] | null,
+  suspense: SuspenseBoundary | null,
+): RenderContext {
+  // returns `base` when nothing changes, so unchanged contexts allocate nothing
+  return slotOwner === base.slotOwner &&
+    slotBoundary === base.slotBoundary &&
+    slotScopeIds === base.slotScopeIds &&
+    suspense === base.suspense
+    ? base
+    : { slotOwner, slotBoundary, slotScopeIds, suspense }
+}
+
+export function deriveSlotOwner(
+  base: RenderContext,
+  slotOwner: VaporComponentInstance | null,
+): RenderContext {
+  return deriveRenderContext(
+    base,
+    slotOwner,
+    base.slotBoundary,
+    base.slotScopeIds,
+    base.suspense,
+  )
+}
+
+export function deriveSlotBoundary(
+  base: RenderContext,
+  slotBoundary: SlotBoundaryContext | null,
+): RenderContext {
+  return deriveRenderContext(
+    base,
+    base.slotOwner,
+    slotBoundary,
+    base.slotScopeIds,
+    base.suspense,
+  )
+}
+
+export function deriveSlotScopeIds(
+  base: RenderContext,
+  slotScopeIds: string[] | null,
+): RenderContext {
+  return deriveRenderContext(
+    base,
+    base.slotOwner,
+    base.slotBoundary,
+    slotScopeIds,
+    base.suspense,
+  )
+}
+
+export function deriveSuspense(
+  base: RenderContext,
+  suspense: SuspenseBoundary | null,
+): RenderContext {
+  return deriveRenderContext(
+    base,
+    base.slotOwner,
+    base.slotBoundary,
+    base.slotScopeIds,
+    suspense,
+  )
+}

--- a/packages/runtime-vapor/src/scopeId.ts
+++ b/packages/runtime-vapor/src/scopeId.ts
@@ -9,89 +9,13 @@ import type { Block } from './block'
 import { isArray } from '@vue/shared'
 import { isInteropEnabled } from './vdomInteropState'
 import { getScopeOwner } from './componentSlots'
-import { setTemplateCloneHook } from './dom/template'
 import {
-  isHydrating,
-  isRecreatedNode,
-  setMismatchStampHook,
-} from './dom/hydration'
-
-/**
- * Ambient slot scope ids (the `-s` variants) active while creating DOM for
- * slot content — the vapor counterpart of the renderer's `slotScopeIds` patch
- * context. Cleared around child setup (the child captures it for root-only
- * inheritance). Mounted DOM is never retroactively re-stamped (VDOM parity).
- */
-export let currentSlotScopeIds: string[] | null = null
-
-export function setCurrentSlotScopeIds(
-  scopeIds: string[] | null,
-): string[] | null {
-  const prev = currentSlotScopeIds
-  if (scopeIds !== prev) {
-    currentSlotScopeIds = scopeIds
-    // Install the creation-seam hooks only on null↔non-null flips: the hooks
-    // read the live ambient, and non-slotted hot paths stay a single null check.
-    if (!prev || !scopeIds) {
-      if (scopeIds) {
-        setTemplateCloneHook(cloneStampedTemplate)
-        setMismatchStampHook(stampSlotScopeIds)
-      } else {
-        setTemplateCloneHook(null)
-        setMismatchStampHook(null)
-      }
-    }
-  }
-  return prev
-}
-
-function stampSlotScopeIds(node: Node): void {
-  if (node.nodeType === 1 /* Node.ELEMENT_NODE */) {
-    setElementScopeIdsDeep(node as Element, currentSlotScopeIds!)
-  }
-}
-
-/**
- * Stamped-variant cache: ids are written once per (template prototype × id
- * cell) and clones inherit them via cloneNode. Never stale because scope ids
- * are compile-time constants; entries are freed with their cell (WeakMap key).
- */
-const stampedTemplates = new WeakMap<Node, WeakMap<string[], Node>>()
-
-function cloneStampedTemplate(prototype: Node): Node {
-  if (prototype.nodeType !== 1 /* Node.ELEMENT_NODE */) {
-    return prototype.cloneNode(true)
-  }
-  const scopeIds = currentSlotScopeIds!
-  let variants = stampedTemplates.get(prototype)
-  if (!variants) {
-    stampedTemplates.set(prototype, (variants = new WeakMap()))
-  }
-  let stamped = variants.get(scopeIds)
-  if (!stamped) {
-    stamped = prototype.cloneNode(true)
-    setElementScopeIdsDeep(stamped as Element, scopeIds)
-    variants.set(scopeIds, stamped)
-  }
-  return stamped.cloneNode(true)
-}
-
-// Template clones contain no component boundaries and fresh clones carry no
-// runtime scope ids yet — plain setAttribute, no exists-check.
-function setElementScopeIdsDeep(el: Element, scopeIds: string[]): void {
-  setElementScopeIds(el, scopeIds)
-  let child = el.firstElementChild
-  while (child) {
-    setElementScopeIdsDeep(child, scopeIds)
-    child = child.nextElementSibling
-  }
-}
-
-export function setElementScopeIds(el: Element, scopeIds: string[]): void {
-  for (let i = 0; i < scopeIds.length; i++) {
-    el.setAttribute(scopeIds[i], '')
-  }
-}
+  currentRenderContext,
+  deriveSlotScopeIds,
+  withRenderContext,
+} from './renderContext'
+import { isHydrating, isRecreatedNode } from './dom/hydration'
+import { setElementScopeIds } from './dom/scopeIdStamp'
 
 /**
  * Catch-up for slot content DOM created outside the ambient window (eager
@@ -124,14 +48,12 @@ export function renderWithSlotScopeIds(
   scopeIds: string[] | null,
   render: () => Block,
 ): Block {
-  const prev = setCurrentSlotScopeIds(scopeIds)
-  try {
-    const block = render()
-    if (scopeIds && !isHydrating) stampSlotContent(block, scopeIds)
-    return block
-  } finally {
-    setCurrentSlotScopeIds(prev)
-  }
+  const block = withRenderContext(
+    deriveSlotScopeIds(currentRenderContext, scopeIds),
+    render,
+  )
+  if (scopeIds && !isHydrating) stampSlotContent(block, scopeIds)
+  return block
 }
 
 export function getCurrentScopeId(): string | undefined {

--- a/packages/runtime-vapor/src/slotBoundary.ts
+++ b/packages/runtime-vapor/src/slotBoundary.ts
@@ -1,6 +1,11 @@
 import type { EffectScope } from '@vue/reactivity'
 import { type BlockFn, isValidSlot } from './block'
 import type { VaporFragment } from './fragment'
+import {
+  currentRenderContext,
+  deriveSlotBoundary,
+  withRenderContext,
+} from './renderContext'
 
 // A slot boundary is one slot outlet's fallback-resolution point. `parent` is
 // the next boundary this outlet is allowed to inherit from; ownership caps set
@@ -24,28 +29,14 @@ export interface SlotBoundaryContext {
   onContentInvalid?: (() => void)[]
 }
 
-export let currentSlotBoundary: SlotBoundaryContext | null = null
-
-export function setCurrentSlotBoundary(
-  b: SlotBoundaryContext | null,
-): SlotBoundaryContext | null {
-  try {
-    return currentSlotBoundary
-  } finally {
-    currentSlotBoundary = b
-  }
-}
-
 export function withSlotBoundary<R>(
   boundary: SlotBoundaryContext | null,
   fn: () => R,
 ): R {
-  const prev = setCurrentSlotBoundary(boundary)
-  try {
-    return fn()
-  } finally {
-    setCurrentSlotBoundary(prev)
-  }
+  return withRenderContext(
+    deriveSlotBoundary(currentRenderContext, boundary),
+    fn,
+  )
 }
 
 // Dynamic children (`v-if`, `v-for`, interop fragments) created under a slot
@@ -54,7 +45,7 @@ export function trackSlotBoundaryDirtying(
   fragment: VaporFragment,
   onInvalid?: () => void,
 ): void {
-  const boundary = currentSlotBoundary
+  const boundary = currentRenderContext.slotBoundary
   if (!boundary) return
 
   if (onInvalid) {

--- a/packages/runtime-vapor/src/suspense.ts
+++ b/packages/runtime-vapor/src/suspense.ts
@@ -1,7 +1,6 @@
 import type { SuspenseBoundary } from '@vue/runtime-dom'
 
 export let isSuspenseEnabled = false
-export let parentSuspense: SuspenseBoundary | null = null
 // `instance.suspense` is the boundary a component was mounted in, but an
 // ancestor boundary may be removed under a different parent Suspense. Carry
 // that effective parent through synchronous scope-owned teardown, where VDOM's
@@ -16,16 +15,6 @@ export function enableSuspense(): void {
 export function withSuspenseEnabled<T>(value: T): T {
   enableSuspense()
   return value
-}
-
-export function setParentSuspense(
-  suspense: SuspenseBoundary | null,
-): SuspenseBoundary | null {
-  try {
-    return parentSuspense
-  } finally {
-    parentSuspense = suspense
-  }
 }
 
 function setCurrentUnmountSuspense(

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -84,7 +84,6 @@ import {
 } from './component'
 import {
   collectRootScopeIds,
-  currentSlotScopeIds,
   getCurrentScopeId,
   setPublishInteropScopeIds,
 } from './scopeId'
@@ -151,7 +150,6 @@ import {
   isFragment,
   isSlotResolver,
   resolveFragmentAnchor,
-  runWithFragmentCtxOnly,
 } from './fragment'
 import { SLOT_OUTLET, VDOM } from './fragmentFlags'
 import {
@@ -209,14 +207,19 @@ import {
   isKeepAliveEnabled,
 } from './keepAlive'
 import {
-  parentSuspense as currentParentSuspense,
   currentUnmountSuspense,
   enableSuspense,
   isSuspenseEnabled,
   resolveUnmountSuspense,
   runWithUnmountSuspense,
-  setParentSuspense,
 } from './suspense'
+import {
+  currentRenderContext,
+  deriveSlotScopeIds,
+  deriveSuspense,
+  setRenderContext,
+  withRenderContext,
+} from './renderContext'
 
 const EMPTY_VNODES = EMPTY_ARR as unknown as VNode[]
 
@@ -358,9 +361,9 @@ const vaporInteropImpl: VaporInVdomInterface = {
     const slotsRef = shallowRef(normalizeInteropSlots(vnode.children))
     const rawSlots = createInteropRawSlots(slotsRef)
 
-    let prevSuspense: SuspenseBoundary | null = null
+    const prevCtx = currentRenderContext
     if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && parentSuspense) {
-      prevSuspense = setParentSuspense(parentSuspense)
+      setRenderContext(deriveSuspense(prevCtx, parentSuspense))
     }
 
     const dynamicPropSource: (() => any)[] & { [interopKey]?: boolean } = [
@@ -404,9 +407,7 @@ const vaporInteropImpl: VaporInVdomInterface = {
       })
     }
 
-    if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && parentSuspense) {
-      setParentSuspense(prevSuspense)
-    }
+    setRenderContext(prevCtx)
 
     const rootEl = resolveInteropRootEl(instance)
     if (rootEl) {
@@ -1152,7 +1153,8 @@ function mountVNode(
   getFallthroughAttrs?: () => Record<string, any>,
 ): VaporFragment {
   let suspense =
-    currentParentSuspense || (parentComponent && parentComponent.suspense)
+    currentRenderContext.suspense ||
+    (parentComponent && parentComponent.suspense)
   // A vnode standing in as a component's effective root inherits fallthrough
   // attrs the same way VDOM does it — merged into the vnode's props
   // (`cloneVNode` -> `mergeProps`), so mount and patch apply them natively
@@ -1340,7 +1342,8 @@ function createVDOMComponent(
   once?: boolean,
 ): VaporFragment {
   let suspense =
-    currentParentSuspense || (parentComponent && parentComponent.suspense)
+    currentRenderContext.suspense ||
+    (parentComponent && parentComponent.suspense)
   const useBridge = shouldUseRendererBridge(component)
   const comp = useBridge ? ensureRendererBridge(component) : component
   const vnode = createVNode(
@@ -1474,7 +1477,7 @@ function createVDOMComponent(
   }
 
   vnode.scopeId = getCurrentScopeId() || null
-  vnode.slotScopeIds = currentSlotScopeIds
+  vnode.slotScopeIds = currentRenderContext.slotScopeIds
 
   const place = (
     parentNode: ParentNode,
@@ -1835,7 +1838,7 @@ function renderVDOMSlot(
   const forwarded = isForwardedSlot(flags)
   const inheritFallback = slotInheritsFallback(flags)
   const notifiesBoundary = slotNotifiesBoundary(flags)
-  let suspense = currentParentSuspense || parentComponent.suspense
+  let suspense = currentRenderContext.suspense || parentComponent.suspense
   // frag.slotScopeIds is the outlet's id cell (the ambient createSlot
   // establishes around this call) — the base patch context for content
   // patches.
@@ -2217,7 +2220,7 @@ function renderVDOMSlot(
 
   function renderContent(): void {
     notifyBeforeUpdate()
-    runWithFragmentCtxOnly(frag, () =>
+    withRenderContext(frag.ctx, () =>
       withSlotBoundary(contentBoundary, () => {
         const { content: slotContent, valid: slotContentValid } =
           resolveSlotContent()
@@ -2813,10 +2816,10 @@ function renderVaporSlot(
   contextSlotScopeIds: string[] | null,
 ): Block {
   const prev = currentInstance
-  let prevSuspense: SuspenseBoundary | null = null
+  const prevCtx = currentRenderContext
   simpleSetCurrentInstance(parentComponent)
   if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && parentSuspense) {
-    prevSuspense = setParentSuspense(parentSuspense)
+    setRenderContext(deriveSuspense(prevCtx, parentSuspense))
   }
   try {
     if (!vnode.vs || !vnode.vs.slot) {
@@ -2830,10 +2833,9 @@ function renderVaporSlot(
     const frag = createInteropFragment(EMPTY_BLOCK, null, SLOT_OUTLET)
     // The vnode-derived slot context becomes the creation ambient for the
     // vapor-rendered content, restored via the fragment's render seam.
-    frag.slotScopeIds = getInteropVaporSlotScopeIds(
-      vnode,
-      parentComponent,
-      contextSlotScopeIds,
+    frag.ctx = deriveSlotScopeIds(
+      frag.ctx,
+      getInteropVaporSlotScopeIds(vnode, parentComponent, contextSlotScopeIds),
     )
     const content = new InteropContentState()
     frag.isBlockValid = componentAsValid =>
@@ -2974,7 +2976,7 @@ function renderVaporSlot(
             )
             try {
               return finalizeResolvedContent(
-                runWithFragmentCtxOnly(frag, () => {
+                withRenderContext(frag.ctx, () => {
                   const renderSlot = () =>
                     withSlotBoundary(localFallbackBoundary, () =>
                       invokeVaporSlot(vnode),
@@ -2988,7 +2990,7 @@ function renderVaporSlot(
           })
         } else {
           resolvedContent = finalizeResolvedContent(
-            runWithFragmentCtxOnly(frag, () =>
+            withRenderContext(frag.ctx, () =>
               withSlotBoundary(localFallbackBoundary, () =>
                 invokeVaporSlot(vnode),
               ),
@@ -3069,9 +3071,7 @@ function renderVaporSlot(
       throw e
     }
   } finally {
-    if (__FEATURE_SUSPENSE__ && isSuspenseEnabled && parentSuspense) {
-      setParentSuspense(prevSuspense)
-    }
+    setRenderContext(prevCtx)
     simpleSetCurrentInstance(prev)
   }
 }
@@ -3201,7 +3201,8 @@ function createVNodeChildrenFragment(
   parentComponent: ComponentInternalInstance | null,
 ): VaporFragment {
   let suspense =
-    currentParentSuspense || (parentComponent && parentComponent.suspense)
+    currentRenderContext.suspense ||
+    (parentComponent && parentComponent.suspense)
   const frag = createInteropFragment()
   const content = new InteropContentState()
   // `isBlockValid` reports `content.valid` (VDOM-side `ensureValidVNode`), not
@@ -3270,7 +3271,7 @@ function createVNodeChildrenFragment(
     simpleSetCurrentInstance(parentComponent)
     try {
       renderEffect(() => {
-        runWithFragmentCtxOnly(frag, () => {
+        withRenderContext(frag.ctx, () => {
           const nextChildren = render()
           notifyBeforeUpdate()
           if (isHydrating) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified rendering context management across components, slots, fragments, suspense, teleportation, hydration, and VDOM interop.
  - Improved consistency when rendering nested or deferred content, including slot ownership and suspense boundaries.
  - Streamlined reactive list rendering and context restoration.

- **Bug Fixes**
  - Improved scope styling preservation during hydration and template cloning.
  - Strengthened recovery when component setup or rendering throws errors.
  - Improved suspense-boundary handling during unmounting and asynchronous rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->