### PR TITLE
refactor(runtime-vapor): move slot hydration out of SlotFragment

### DIFF
--- a/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
+++ b/packages/runtime-vapor/src/apiCreateDynamicComponent.ts
@@ -32,6 +32,7 @@ import {
   captureHydrationCursor,
   enterHydrationCursor,
   isHydrating,
+  locateHydrationNode,
 } from './dom/hydration'
 import { DynamicFragment, finishBlockCreation } from './fragment'
 import { isInteropEnabled } from './vdomInteropState'
@@ -114,7 +115,6 @@ export function createDynamicComponent(
     0,
     __DEV__ ? 'dynamic-component' : undefined,
     false,
-    true,
     slotRoot,
     slotRoot
       ? () => {
@@ -132,6 +132,7 @@ export function createDynamicComponent(
       : undefined,
     _insertionAnchor,
   )
+  if (isHydrating) locateHydrationNode()
 
   // A `:key` joins the resolved component in the branch identity, the way a
   // vnode is matched by type and key. The pair is memoized as one token so

--- a/packages/runtime-vapor/src/apiCreateFragment.ts
+++ b/packages/runtime-vapor/src/apiCreateFragment.ts
@@ -3,6 +3,7 @@ import {
   type HydrationCursor,
   captureHydrationCursor,
   isHydrating,
+  locateHydrationNode,
 } from './dom/hydration'
 import { DynamicFragment, finishBlockCreation } from './fragment'
 import {
@@ -38,7 +39,6 @@ export function createKeyedFragment(
     0,
     __DEV__ ? 'keyed' : undefined,
     true,
-    true,
     trackSlotBoundary,
     trackSlotBoundary
       ? () => {
@@ -48,6 +48,7 @@ export function createKeyedFragment(
       : undefined,
     _insertionAnchor,
   )
+  if (isHydrating) locateHydrationNode()
 
   renderEffect(() => frag.update(render, key()))
 

--- a/packages/runtime-vapor/src/apiCreateIf.ts
+++ b/packages/runtime-vapor/src/apiCreateIf.ts
@@ -68,7 +68,6 @@ export function createIf(
       IF,
       __DEV__ ? 'if' : undefined,
       keyed,
-      false,
       trackSlotBoundary,
       trackSlotBoundary
         ? () => {

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -99,8 +99,6 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         const frag = new DynamicFragment(
           0,
           __DEV__ ? 'async component' : undefined,
-          false,
-          false,
         )
         frag.nodes = nodes
         instance.block = frag
@@ -146,6 +144,7 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         locateHydrationNode()
       } else {
         frag = new DynamicFragment(0, __DEV__ ? 'async component' : undefined)
+        if (isHydrating) locateHydrationNode()
       }
 
       // already resolved: only reached where createComponent keeps the

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -117,6 +117,7 @@ import {
   isHydrating,
   isRecreatedNode,
   locateEndAnchor,
+  locateHydrationNode,
   nextLogicalSibling,
   setCurrentHydrationNode,
   trimHydrationBoundary,
@@ -1289,6 +1290,7 @@ export function createPlainElement(
         NATIVE_CHILDREN,
         __DEV__ ? (isHydrating ? '' : 'slot') : undefined,
       )
+      if (isHydrating) locateHydrationNode()
       renderEffect(() => frag.update(getSlot(rawSlots as RawSlots, 'default')))
       if (!isHydrating) insert(frag, el)
     } else {

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -351,7 +351,6 @@ export function createSlot(
         __DEV__ ? 'slot' : undefined,
         false,
         false,
-        false,
         undefined,
         _insertionAnchor,
       )

--- a/packages/runtime-vapor/src/components/Transition.ts
+++ b/packages/runtime-vapor/src/components/Transition.ts
@@ -57,6 +57,7 @@ import {
 import {
   currentHydrationNode,
   isHydrating,
+  locateHydrationNode,
   setCurrentHydrationNode,
 } from '../dom/hydration'
 import { updateLastLocatedLogicalChild } from '../dom/node'
@@ -163,6 +164,7 @@ export const VaporTransition: FunctionalVaporComponent<TransitionProps> =
     // Transition needs a DynamicFragment to drive enter/leave on updates.
     if (instance.rawSlots.$) {
       const frag = new DynamicFragment(0, __DEV__ ? 'transition' : undefined)
+      if (isHydrating) locateHydrationNode()
       state.root = frag
       let isMounted = false
       renderEffect(() => {

--- a/packages/runtime-vapor/src/components/TransitionGroup.ts
+++ b/packages/runtime-vapor/src/components/TransitionGroup.ts
@@ -63,6 +63,7 @@ import {
   cleanupHydrationTail,
   currentHydrationNode,
   isHydrating,
+  locateHydrationNode,
   nextLogicalSibling,
   setCurrentHydrationNode,
   setMarkerlessHydrationContainer,
@@ -216,6 +217,7 @@ const VaporTransitionGroupImpl = /*@__PURE__*/ defineVaporComponent({
       0,
       __DEV__ ? 'transition-group' : undefined,
     )
+    if (isHydrating) locateHydrationNode()
     let currentTag: string | undefined
     let currentSlot: BlockFn | undefined
     let isMounted = false

--- a/packages/runtime-vapor/src/dom/hydrateFragment.ts
+++ b/packages/runtime-vapor/src/dom/hydrateFragment.ts
@@ -1,4 +1,5 @@
 import { NOOP } from '@vue/shared'
+import { queuePostFlushCb } from '@vue/runtime-dom'
 import {
   type FragmentClaim,
   advanceHydrationNode,
@@ -26,12 +27,16 @@ import {
 } from './node'
 import {
   type Block,
+  type BlockFn,
   EMPTY_BLOCK,
   findBlockBoundary,
   isValidBlock,
+  isValidSlot,
   move,
 } from '../block'
-import type { DynamicFragment } from '../fragment'
+import type { DynamicFragment, SlotFragment } from '../fragment'
+import { hasSlotFallback } from '../slotBoundary'
+import { recheckSlotResolution } from '../slotFragment'
 import { IF, NATIVE_CHILDREN, SLOT } from '../fragmentFlags'
 
 interface DeferredSlotAnchor {
@@ -795,4 +800,124 @@ export function hydrateDynamicFragmentAnchor(
   isEmpty = false,
 ): void {
   executeAnchorPlan(frag, resolveDynamicAnchor(frag, isEmpty))
+}
+
+function updateHydratingSlotContent(
+  frag: SlotFragment,
+  render: BlockFn,
+  key: any,
+): { contentStart: Node | null; contentValid: boolean } {
+  const contentStart = currentHydrationNode
+  const pending = startPendingSlotContentGuard(
+    frag.sharedFallback || hasSlotFallback(frag.boundary),
+    contentStart,
+  )
+  try {
+    frag.updateContent(render, key)
+    const contentValid = isValidSlot(frag.getContent())
+    pending.finish(contentValid)
+    return { contentStart, contentValid }
+  } finally {
+    pending.settle()
+  }
+}
+
+/** The hydrating half of `SlotFragment.updateSlot`: content, then anchor. */
+export function hydrateSlotFragmentContent(
+  frag: SlotFragment,
+  render: BlockFn,
+  hasLocalFallback: boolean,
+  key: any,
+  shouldForce: boolean,
+): void {
+  // Forwarded roots that do not own an inherited fallback restore only
+  // their exposed branch. The receiver decides its fallback after all
+  // shared roots have reported their final content/local-fallback result.
+  if (frag.sharedFallback || (frag.inheritFallback && !hasLocalFallback)) {
+    const claim = createFragmentClaim()
+    locateHydrationNode(claim)
+    const { contentStart, contentValid } = updateHydratingSlotContent(
+      frag,
+      render,
+      key,
+    )
+    const end = locateFragmentEnd(claim.start)
+    let exposedValid = contentValid
+    if (frag.sharedFallback) {
+      recheckSlotResolution(frag, shouldForce || frag.pendingRecheckForce)
+      exposedValid = isValidSlot(frag.nodes)
+    } else {
+      frag.syncNodes()
+      frag.lastNodesValid = contentValid
+    }
+    if (exposedValid) {
+      if (end) {
+        frag.anchor = claimAnchor(end)
+        advanceHydrationNode(end)
+      } else {
+        hydrateDynamicFragmentAnchor(frag, !isValidBlock(frag.nodes))
+      }
+    } else if (frag.sharedFallback) {
+      const slotEnd = getCurrentSlotEndAnchor()
+      const candidate = end && end !== slotEnd ? end : null
+      if (candidate) {
+        // Move past this candidate range so later sibling roots hydrate
+        // from their own position. The parent aggregate decision below
+        // determines whether this root actually owns the range.
+        advanceHydrationNode(candidate)
+      }
+      const anchor = claimUntrackedAnchor(
+        __DEV__ ? createComment(frag.anchorLabel ?? '') : createTextNode(),
+      )
+      frag.anchor = anchor
+      claimPrecedingFragmentClose(slotEnd)
+      const attachContent = createDeferredSlotAttach(
+        contentStart,
+        slotEnd,
+        anchor,
+        candidate,
+        candidate => (frag.anchor = claimAnchor(candidate)),
+        () => frag.nodes,
+      )
+      // Post-flush even after the verdict: the reference node's final
+      // position is only stable once the whole pass has finished.
+      const queued = queuePendingSlotContentAnchor({
+        onContent: attachContent,
+        onFallback: () => {},
+      })
+      if (!queued) {
+        if (candidate) {
+          claimAnchor(candidate)
+        }
+        queuePostFlushCb(attachContent)
+      }
+    } else {
+      // Empty forwarded content should not claim the receiver slot's
+      // SSR close marker. Queue its runtime anchor before that marker so
+      // fallback hydration can finish first and the final DOM matches CSR.
+      const anchor = (frag.anchor = claimUntrackedAnchor(
+        __DEV__ ? createComment(frag.anchorLabel ?? '') : createTextNode(),
+      ))
+      const slotEnd = getCurrentSlotEndAnchor()
+      const parent = slotEnd && slotEnd.parentNode
+      if (parent) {
+        // When the receiver fallback is a fragment, the node right
+        // before the receiver slot end is the fallback fragment's SSR
+        // close.
+        claimPrecedingFragmentClose(slotEnd)
+
+        queuePostFlushCb(() => {
+          if (slotEnd.parentNode === parent) {
+            parent.insertBefore(anchor, slotEnd)
+          }
+        })
+      }
+    }
+  } else {
+    withHydratingSlotBoundary(() => {
+      updateHydratingSlotContent(frag, render, key)
+      recheckSlotResolution(frag, shouldForce || frag.pendingRecheckForce)
+      hydrateDynamicFragmentAnchor(frag, !isValidBlock(frag.nodes))
+    })
+  }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -12,7 +12,6 @@ import {
   type TransitionOptions,
   type VaporTransitionHooks,
   insert,
-  isValidBlock,
   isValidSlot,
   move,
   remove,
@@ -26,7 +25,6 @@ import {
   type TransitionHooks,
   type VNode,
   currentInstance,
-  queuePostFlushCb,
   restoreCurrentInstance,
   setCurrentInstance,
 } from '@vue/runtime-dom'
@@ -35,15 +33,9 @@ import type { NodeRef } from './apiTemplateRef'
 import {
   type FragmentClaim,
   type HydrationCursor,
-  advanceHydrationNode,
-  claimAnchor,
   claimUntrackedAnchor,
-  createFragmentClaim,
-  currentHydrationNode,
   exitHydrationCursor,
   isHydrating,
-  locateFragmentEnd,
-  locateHydrationNode,
 } from './dom/hydration'
 import {
   type RenderContext,
@@ -54,19 +46,13 @@ import {
 import { applyScopeIdOwners } from './scopeId'
 import {
   type SlotBoundaryContext,
-  hasSlotFallback,
   registerContentInvalid,
   trackSlotBoundaryDirtying,
 } from './slotBoundary'
 import {
-  claimPrecedingFragmentClose,
-  createDeferredSlotAttach,
-  getCurrentSlotEndAnchor,
   hydrateDynamicFragmentAnchor,
+  hydrateSlotFragmentContent,
   prepareDeferredHydrationAnchor,
-  queuePendingSlotContentAnchor,
-  startPendingSlotContentGuard,
-  withHydratingSlotBoundary,
 } from './dom/hydrateFragment'
 import {
   type SlotResolutionState,
@@ -336,7 +322,6 @@ export class DynamicFragment extends RenderContextFragment {
     flags: number = 0,
     anchorLabel?: string,
     keyed: boolean = false,
-    locate: boolean = true,
     trackSlotBoundary: boolean = false,
     onInvalid?: () => void,
     adoptAnchor?: Node,
@@ -351,9 +336,7 @@ export class DynamicFragment extends RenderContextFragment {
       this.inTransition = true
     }
     if (__DEV__) this.anchorLabel = anchorLabel
-    if (isHydrating) {
-      if (locate) locateHydrationNode()
-    } else {
+    if (!isHydrating) {
       this.anchor = resolveFragmentAnchor(adoptAnchor, anchorLabel)
     }
     if (trackSlotBoundary) trackSlotBoundaryDirtying(this, onInvalid)
@@ -581,8 +564,9 @@ export class DynamicFragment extends RenderContextFragment {
 
 // SlotFragment must live in the same module as DynamicFragment: `extends`
 // reads the base class binding at module evaluation time, and fragment.ts
-// sits inside a module cycle, so hoisting the class into another module can
-// hit the base class before it is initialized depending on entry order.
+// sits inside a module cycle (block → component → componentSlots → fragment),
+// so a class hoisted into another module can hit the base class before it is
+// initialized depending on entry order.
 export class SlotFragment
   extends DynamicFragment
   implements SlotResolutionState
@@ -595,7 +579,6 @@ export class SlotFragment
   pendingRecheck = false
   pendingRecheckForce = false
   isReconciling = false
-  private readonly onContentInvalid: (() => void)[] = []
   private content: Block = EMPTY_BLOCK
   private localFallback?: BlockFn
   private isUpdating = false
@@ -605,13 +588,12 @@ export class SlotFragment
   // validity to the enclosing boundary (unless once, whose content never
   // changes validity) and resolve fallback in shared or inherit mode.
   private readonly notifyParentBoundary: boolean
-  private readonly sharedFallback: boolean
-  private readonly inheritFallback: boolean
+  readonly sharedFallback: boolean
+  readonly inheritFallback: boolean
   constructor(flags: number = 0, adoptAnchor?: Node) {
     super(
       SLOT_FRAGMENT | SLOT_RESOLVER,
       __DEV__ ? 'slot' : undefined,
-      false,
       false,
       false,
       undefined,
@@ -682,7 +664,6 @@ export class SlotFragment
       this.inheritFallback ? this.slotBoundary : null,
       () => this.localFallback,
       force => markSlotResolutionDirty(this, force),
-      this.onContentInvalid,
     ))
   }
 
@@ -721,8 +702,14 @@ export class SlotFragment
       this.activeFallback = null
       this.fallbackInserted = false
     }
-    this.onContentInvalid.length = 0
+    this.clearContentInvalid()
     disposeSlotResolution(this)
+  }
+
+  // Parked callbacks of content roots; they die with the content branch.
+  private clearContentInvalid(): void {
+    const callbacks = this.ownBoundary && this.ownBoundary.onContentInvalid
+    if (callbacks) callbacks.length = 0
   }
 
   protected getBranchParent(): ParentNode | null {
@@ -732,10 +719,9 @@ export class SlotFragment
     return this.activeFallback ? null : super.getBranchParent()
   }
 
-  private updateContent(render: BlockFn | undefined, key: any): void {
-    if (key !== this.current) {
-      this.onContentInvalid.length = 0
-    }
+  // @internal shared with hydrateSlotFragmentContent
+  updateContent(render: BlockFn | undefined, key: any): void {
+    if (key !== this.current) this.clearContentInvalid()
     // update() operates on this.nodes, but while fallback is active `nodes`
     // points at the fallback block. Aim it at the content branch so the base
     // pipeline re-renders content, then capture the result back; the
@@ -744,25 +730,6 @@ export class SlotFragment
     this.nodes = this.content
     this.update(render, key)
     this.content = this.nodes
-  }
-
-  private updateHydratingContent(
-    render: BlockFn | undefined,
-    key: any,
-  ): { contentStart: Node | null; contentValid: boolean } {
-    const contentStart = currentHydrationNode
-    const pending = startPendingSlotContentGuard(
-      this.sharedFallback || hasSlotFallback(this.boundary),
-      contentStart,
-    )
-    try {
-      this.updateContent(render, key)
-      const contentValid = isValidSlot(this.content)
-      pending.finish(contentValid)
-      return { contentStart, contentValid }
-    } finally {
-      pending.settle()
-    }
   }
 
   updateSlot(
@@ -788,99 +755,13 @@ export class SlotFragment
     try {
       const shouldForce = prevLocalFallback !== fallback
       if (isHydrating) {
-        // Forwarded roots that do not own an inherited fallback restore only
-        // their exposed branch. The receiver decides its fallback after all
-        // shared roots have reported their final content/local-fallback result.
-        if (this.sharedFallback || (this.inheritFallback && !fallback)) {
-          const claim = createFragmentClaim()
-          locateHydrationNode(claim)
-          const { contentStart, contentValid } = this.updateHydratingContent(
-            slotRender,
-            key,
-          )
-          const end = locateFragmentEnd(claim.start)
-          let exposedValid = contentValid
-          if (this.sharedFallback) {
-            recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)
-            exposedValid = isValidSlot(this.nodes)
-          } else {
-            this.syncNodes()
-            this.lastNodesValid = contentValid
-          }
-          if (exposedValid) {
-            if (end) {
-              this.anchor = claimAnchor(end)
-              advanceHydrationNode(end)
-            } else {
-              hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
-            }
-          } else if (this.sharedFallback) {
-            const slotEnd = getCurrentSlotEndAnchor()
-            const candidate = end && end !== slotEnd ? end : null
-            if (candidate) {
-              // Move past this candidate range so later sibling roots hydrate
-              // from their own position. The parent aggregate decision below
-              // determines whether this root actually owns the range.
-              advanceHydrationNode(candidate)
-            }
-            const anchor = claimUntrackedAnchor(
-              __DEV__
-                ? createComment(this.anchorLabel ?? '')
-                : createTextNode(),
-            )
-            this.anchor = anchor
-            claimPrecedingFragmentClose(slotEnd)
-            const attachContent = createDeferredSlotAttach(
-              contentStart,
-              slotEnd,
-              anchor,
-              candidate,
-              candidate => (this.anchor = claimAnchor(candidate)),
-              () => this.nodes,
-            )
-            // Post-flush even after the verdict: the reference node's final
-            // position is only stable once the whole pass has finished.
-            const queued = queuePendingSlotContentAnchor({
-              onContent: attachContent,
-              onFallback: () => {},
-            })
-            if (!queued) {
-              if (candidate) {
-                claimAnchor(candidate)
-              }
-              queuePostFlushCb(attachContent)
-            }
-          } else {
-            // Empty forwarded content should not claim the receiver slot's
-            // SSR close marker. Queue its runtime anchor before that marker so
-            // fallback hydration can finish first and the final DOM matches CSR.
-            const anchor = (this.anchor = claimUntrackedAnchor(
-              __DEV__
-                ? createComment(this.anchorLabel ?? '')
-                : createTextNode(),
-            ))
-            const slotEnd = getCurrentSlotEndAnchor()
-            const parent = slotEnd && slotEnd.parentNode
-            if (parent) {
-              // When the receiver fallback is a fragment, the node right
-              // before the receiver slot end is the fallback fragment's SSR
-              // close.
-              claimPrecedingFragmentClose(slotEnd)
-
-              queuePostFlushCb(() => {
-                if (slotEnd.parentNode === parent) {
-                  parent.insertBefore(anchor, slotEnd)
-                }
-              })
-            }
-          }
-        } else {
-          withHydratingSlotBoundary(() => {
-            this.updateHydratingContent(slotRender, key)
-            recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)
-            hydrateDynamicFragmentAnchor(this, !isValidBlock(this.nodes))
-          })
-        }
+        hydrateSlotFragmentContent(
+          this,
+          slotRender,
+          !!fallback,
+          key,
+          shouldForce,
+        )
       } else {
         this.updateContent(slotRender, key)
         recheckSlotResolution(this, shouldForce || this.pendingRecheckForce)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hydration reliability for dynamic components, conditional content, slots, transitions, and transition groups.
  - Fixed hydration cursor positioning to better align client-rendered content with server-rendered markup.
  - Improved hydration of forwarded slots and fallback content, including deferred attachment and anchor handling.
  - Corrected slot-boundary tracking during conditional rendering to help preserve expected content updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->