### PR TITLE
fix(reactivity): preserve readonly wrappers in array copy methods

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -559,3 +559,40 @@ test('should be able to trigger with triggerRef', () => {
   triggerRef(ror)
   expect(dummy).toBe(2)
 })
+
+describe('readonly(reactive(array)) element access', () => {
+  // concat/toReversed/toSorted/toSpliced go through reactiveReadArray, which
+  // wrapped elements with toReactive and so dropped the readonly layer. The
+  // giveaway is the dev warning: writing through the paths below used to land on
+  // the raw object without one, while the same write through an index warns.
+  const paths: [string, (state: any) => any][] = [
+    ['index', state => state[0]],
+    ['filter', state => state.filter(() => true)[0]],
+    ['slice', state => state.slice()[0]],
+    ['concat', state => state.concat()[0]],
+    ['toReversed', state => state.toReversed()[1]],
+    ['toSorted', state => state.toSorted()[0]],
+    ['toSpliced', state => state.toSpliced(0, 0)[0]],
+  ]
+
+  test.each(paths)('%s returns a readonly element', (_name, get) => {
+    const raw = [{ a: 1 }, { a: 2 }]
+    const state = readonly(reactive(raw))
+    const item = get(state)
+
+    expect(isReadonly(item)).toBe(true)
+    item.a = 999
+    expect(raw[0].a).toBe(1)
+    expect(`target is readonly`).toHaveBeenWarned()
+  })
+
+  test('concat wraps elements coming from a readonly argument', () => {
+    const raw = [{ a: 1 }]
+    const other = [{ b: 1 }]
+    const merged = reactive([]).concat(readonly(reactive(raw)), reactive(other))
+
+    expect(isReadonly(merged[0])).toBe(true)
+    expect(isReadonly(merged[1])).toBe(false)
+    expect(isReactive(merged[1])).toBe(true)
+  })
+})

--- a/packages/reactivity/src/arrayInstrumentations.ts
+++ b/packages/reactivity/src/arrayInstrumentations.ts
@@ -15,13 +15,20 @@ import { isArray } from '@vue/shared'
 /**
  * Track array iteration and return:
  * - if input is reactive: a cloned raw array with reactive values
+ * - if input is readonly over a reactive array: the same, but readonly
  * - if input is non-reactive or shallowReactive: the original raw array
  */
 export function reactiveReadArray<T>(array: T[]): T[] {
   const raw = toRaw(array)
   if (raw === array) return raw
   track(raw, TrackOpTypes.ITERATE, ARRAY_ITERATE_KEY)
-  return isShallow(array) ? raw : raw.map(toReactive)
+  if (isShallow(array)) return raw
+  // A readonly wrapper has to hand out readonly elements, the way the iterating
+  // methods already do via toWrapped. Kept off the reactive path so the cloned
+  // array still costs a single toReactive per element there.
+  return isReadonly(array)
+    ? raw.map(item => toWrapped(array, item))
+    : raw.map(toReactive)
 }
 
 /**


### PR DESCRIPTION
### The bug

`readonly(reactive(arr))` hands out **writable** element proxies through `concat`, `toReversed`, `toSorted` and `toSpliced`. Writes through them reach the raw objects.

```js
const raw = [{ a: 1 }, { a: 2 }]
const state = readonly(reactive(raw))

state[0].a = 999          // [Vue warn] target is readonly.   raw[0].a === 1
state.concat()[0].a = 999 // no warning.                      raw[0].a === 999
```

The dev warning is the sharpest way to see it: every path that behaves correctly warns, and the four that do not are silent. So there is no signal at all — not a thrown error, not a warning — that a frozen object was just mutated.

Affected, all four via `reactiveReadArray`: `concat` (`arrayInstrumentations.ts:50-51`), `toReversed` (`:210`), `toSorted` (`:215`), `toSpliced` (`:220`). `join` (`:143`) goes through it too but only stringifies, so nothing observable changes there.

Not affected: indexing, `filter`, `find`, `slice`, `map`, `entries`, `values` and the iterator. Plain `readonly(arr)` is also unaffected — the array instrumentations are skipped for a readonly proxy that is not also reactive (`baseHandlers.ts:89`), so this is specific to `readonly()` applied to an already-reactive array, which is the ordinary "expose read-only state" shape.

### Cause

```ts
export function reactiveReadArray<T>(array: T[]): T[] {
  const raw = toRaw(array)
  if (raw === array) return raw
  track(raw, TrackOpTypes.ITERATE, ARRAY_ITERATE_KEY)
  return isShallow(array) ? raw : raw.map(toReactive)   // <-- toReactive, not toWrapped
}
```

`toReactive` produces a reactive proxy and nothing else, so the readonly layer is gone. `toWrapped` — ten lines below in the same file — is exactly the helper for this, and it is what `[Symbol.iterator]`, `entries`, `filter`, `find`, `findLast`, `values` and the shared `apply`/`reduce` helpers already use. `reactiveReadArray` was simply never moved over to it.

### Fix

Use `toWrapped` when the array is readonly, and leave the reactive path exactly as it was:

```ts
  if (isShallow(array)) return raw
  return isReadonly(array)
    ? raw.map(item => toWrapped(array, item))
    : raw.map(toReactive)
```

The `isReadonly` branch is hoisted out of the `map` callback deliberately: on a plain reactive array the emitted code is still `raw.map(toReactive)`, one call per element, so `reactiveArray.bench.ts` is unaffected.

### Tests

Added to `readonly.spec.ts` — a `test.each` over seven access paths asserting each returns a readonly element, that the write does not reach the raw object, and that the readonly warning fires. Three of the seven (`index`, `filter`, `slice`) are guards: they pass with or without the fix, and are there so a future change cannot "fix" the four by breaking these.

Plus one case for `concat`'s arguments, since `concat` calls `reactiveReadArray` on each array it is given: merging a readonly array and a reactive one must yield readonly elements from the first and reactive elements from the second.

`vitest run packages/reactivity packages/runtime-core`: **1539 passed, 4 skipped, 0 failed**. Reverting only `arrayInstrumentations.ts` and keeping the tests fails 5 of them — the four broken methods plus the `concat` argument case — and the three guards still pass:

```
 × concat returns a readonly element
 × toReversed returns a readonly element
 × toSorted returns a readonly element
 × toSpliced returns a readonly element
 × concat wraps elements coming from a readonly argument
   Tests  5 failed | 42 passed (47)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed readonly array access and methods so returned elements retain their readonly and reactive behavior.
  * Prevented mutations through elements retrieved from readonly reactive arrays and ensured appropriate warnings are emitted.
  * Preserved element identity while keeping readonly protections intact when source data changes.
  * Improved `concat` behavior so readonly reactive elements remain protected, while writable reactive elements and other arguments retain their expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->