### PR TITLE
fix(shared): preserve comment-like text in style values

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/transformStyle.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/transformStyle.spec.ts
@@ -26,6 +26,17 @@ function transformWithStyleTransform(
 }
 
 describe('compiler: style transform', () => {
+  test('preserves comment-like text in quoted style values', () => {
+    const { node } = transformWithStyleTransform(
+      `<div style="--label: 'a/*b*/c'; /* ignored */ color: red"/>`,
+    )
+    expect(node.props[0]).toMatchObject({
+      exp: {
+        content: JSON.stringify({ '--label': "'a/*b*/c'", color: 'red' }),
+      },
+    })
+  })
+
   test('should transform into directive node', () => {
     const { node } = transformWithStyleTransform(`<div style="color: red"/>`)
     expect(node.props[0]).toMatchObject({

--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -105,6 +105,28 @@ describe('normalizeClass', () => {
 })
 
 describe('normalizeStyle', () => {
+  test.each([
+    `"a/*b*/c"`,
+    `'a/*b*/c'`,
+    String.raw`"a\"/*b*/c"`,
+    String.raw`'a\'/*b*/c'`,
+    String.raw`"a\\"`,
+    String.raw`\/*b*/`,
+    '"a\\\n/*b*/c"',
+  ])('preserves comment-like text in style values: %s', value => {
+    expect(
+      normalizeStyle([`--label: ${value}; /* 'ignored' */ color: red`]),
+    ).toEqual({ '--label': value, color: 'red' })
+  })
+
+  test('removes comments containing quotes and declarations', () => {
+    expect(
+      normalizeStyle([
+        `/* " */ color: /* ' */ red; /* --label: "ignored";\n */ margin: 0`,
+      ]),
+    ).toEqual({ color: 'red', margin: '0' })
+  })
+
   test('handles string correctly', () => {
     expect(normalizeStyle('foo')).toEqual('foo')
   })

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -26,12 +26,14 @@ export function normalizeStyle(
 
 const listDelimiterRE = /;(?![^(]*\))/g
 const propertyDelimiterRE = /:([^]+)/
-const styleCommentRE = /\/\*[^]*?\*\//g
+// Match strings and escapes first to preserve comment-like text in CSS values.
+const styleCommentRE =
+  /"(?:[^"\\]|\\[^])*"|'(?:[^'\\]|\\[^])*'|\\[^]|\/\*[^]*?\*\//g
 
 export function parseStringStyle(cssText: string): NormalizedStyle {
   const ret: NormalizedStyle = {}
   cssText
-    .replace(styleCommentRE, '')
+    .replace(styleCommentRE, match => (match.startsWith('/*') ? '' : match))
     .split(listDelimiterRE)
     .forEach(item => {
       if (item) {


### PR DESCRIPTION
Compiling `<div style="--label: 'a/*b*/c'"></div>` currently changes the custom property to `'ac'`. Array style bindings have the same problem, while native CSS and direct string bindings preserve the quoted value.

Preserve quoted strings and escapes when stripping CSS comments. Regression tests cover both style normalization and static style compilation, including escaped quotes and comments containing quotes.

Verified the rendered result against native CSS in Chromium. The affected shared, compiler and runtime tests pass, along with TypeScript and lint checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved style parsing so comment-like text inside quoted CSS values is preserved correctly.
  - Actual CSS comments are still removed while surrounding style declarations continue to parse correctly.
  - Improved handling of escaped quotes, backslashes, and newlines in custom property values.

- **Tests**
  - Added coverage for quoted comment markers and CSS comment parsing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->