### PR TITLE
fix(runtime-dom): preserve Fragment anchors during Node.normalize()

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -132,6 +132,12 @@ export interface RendererOptions<
   ): HostElement
   createText(text: string): HostNode
   createComment(text: string): HostNode
+  /**
+   * Creates a node used to delimit a Fragment. When omitted, Fragment
+   * delimiters are empty text nodes for backwards compatibility with custom
+   * renderers.
+   */
+  createFragmentAnchor?(text: string): HostNode
   setText(node: HostNode, text: string): void
   setElementText(node: HostElement, text: string): void
   parentNode(node: HostNode): HostElement | null
@@ -366,6 +372,7 @@ function baseCreateRenderer(
     createElement: hostCreateElement,
     createText: hostCreateText,
     createComment: hostCreateComment,
+    createFragmentAnchor: hostCreateFragmentAnchor = hostCreateText,
     setText: hostSetText,
     setElementText: hostSetElementText,
     parentNode: hostParentNode,
@@ -1065,8 +1072,14 @@ function baseCreateRenderer(
     slotScopeIds: string[] | null,
     optimized: boolean,
   ) => {
-    const fragmentStartAnchor = (n2.el = n1 ? n1.el : hostCreateText(''))!
-    const fragmentEndAnchor = (n2.anchor = n1 ? n1.anchor : hostCreateText(''))!
+    // The DOM renderer uses CDATA sections here so the anchors
+    // survive `Node.normalize()`, which removes empty text nodes.
+    const fragmentStartAnchor = (n2.el = n1
+      ? n1.el
+      : hostCreateFragmentAnchor(''))!
+    const fragmentEndAnchor = (n2.anchor = n1
+      ? n1.anchor
+      : hostCreateFragmentAnchor(''))!
 
     let { patchFlag, dynamicChildren, slotScopeIds: fragmentSlotScopeIds } = n2
 

--- a/packages/runtime-dom/__tests__/normalize.spec.ts
+++ b/packages/runtime-dom/__tests__/normalize.spec.ts
@@ -1,0 +1,28 @@
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { render } from '@vue/runtime-dom'
+
+test('Fragment anchors survive Node.normalize() before updates', async () => {
+  const root = document.createElement('div')
+  const show = ref(true)
+  render(
+    h(
+      defineComponent({
+        setup() {
+          return () =>
+            h(
+              'div',
+              show.value
+                ? [h('span', 'First'), h('span', 'Second')]
+                : [h('span', 'Replacement')],
+            )
+        },
+      }),
+    ),
+    root,
+  )
+  root.normalize()
+  show.value = false
+  await nextTick()
+  expect(root.innerHTML).toBe('<div><span>Replacement</span></div>')
+  expect(root.textContent).toBe('Replacement')
+})

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -40,6 +40,8 @@ export const mathmlNS = 'http://www.w3.org/1998/Math/MathML'
 const doc = (typeof document !== 'undefined' ? document : null) as Document
 
 const templateContainer = doc && /*@__PURE__*/ doc.createElement('template')
+const fragmentAnchorDocument =
+  doc && /*@__PURE__*/ doc.implementation.createDocument(null, null)
 
 export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   insert: (child, parent, anchor) => {
@@ -71,6 +73,12 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   },
 
   createText: text => doc.createTextNode(text),
+
+  // Fragment anchors must survive Node.normalize(), which removes empty text
+  // nodes. CDATA sections are preserved by normalize() and omitted from HTML
+  // serialization, so they don't add visible DOM markers.
+  createFragmentAnchor: text =>
+    doc.adoptNode(fragmentAnchorDocument!.createCDATASection(text)),
 
   createComment: text => doc.createComment(text),
 


### PR DESCRIPTION
## Summary

This fixes Fragment updates breaking after an ancestor has been normalized.

The renderer now supports a Fragment anchor factory. The DOM renderer uses CDATA sections for these anchors, so `Node.normalize()` keeps them around while normal HTML serialization stays unchanged. A regression test was added for normalize-then-update.

## What was happening

Fragment boundaries were empty text nodes. `Node.normalize()` removes empty text nodes (and merges adjacent ones), but the VNodes still kept the old anchor references. On the next update, Vue could walk past a detached anchor and throw `Cannot read properties of null (reading 'nextSibling')`.

Custom renderers keep the old behavior unless they opt into the new anchor factory.

Fixes #15468

## Tests

- `pnpm vitest run --project unit`
- `pnpm vitest run --project unit-jsdom`
- `pnpm check`