### PR TITLE
fix(runtime-dom): preserve fragment anchors (fix #15468)

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -132,6 +132,12 @@ export interface RendererOptions<
   ): HostElement
   createText(text: string): HostNode
   createComment(text: string): HostNode
+  /**
+   * Creates a node used to delimit a Fragment. When omitted, Fragment
+   * delimiters are empty text nodes for backwards compatibility with custom
+   * renderers.
+   */
+  createFragmentAnchor?(text: string): HostNode
   setText(node: HostNode, text: string): void
   setElementText(node: HostElement, text: string): void
   parentNode(node: HostNode): HostElement | null
@@ -366,6 +372,7 @@ function baseCreateRenderer(
     createElement: hostCreateElement,
     createText: hostCreateText,
     createComment: hostCreateComment,
+    createFragmentAnchor: hostCreateFragmentAnchor = hostCreateText,
     setText: hostSetText,
     setElementText: hostSetElementText,
     parentNode: hostParentNode,
@@ -1065,8 +1072,14 @@ function baseCreateRenderer(
     slotScopeIds: string[] | null,
     optimized: boolean,
   ) => {
-    const fragmentStartAnchor = (n2.el = n1 ? n1.el : hostCreateText(''))!
-    const fragmentEndAnchor = (n2.anchor = n1 ? n1.anchor : hostCreateText(''))!
+    // The DOM renderer uses CDATA sections here so the anchors
+    // survive `Node.normalize()`, which removes empty text nodes.
+    const fragmentStartAnchor = (n2.el = n1
+      ? n1.el
+      : hostCreateFragmentAnchor(''))!
+    const fragmentEndAnchor = (n2.anchor = n1
+      ? n1.anchor
+      : hostCreateFragmentAnchor(''))!
 
     let { patchFlag, dynamicChildren, slotScopeIds: fragmentSlotScopeIds } = n2
 

--- a/packages/runtime-dom/__tests__/normalize.spec.ts
+++ b/packages/runtime-dom/__tests__/normalize.spec.ts
@@ -1,0 +1,28 @@
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { render } from '@vue/runtime-dom'
+
+test('Fragment anchors survive Node.normalize() before updates', async () => {
+  const root = document.createElement('div')
+  const show = ref(true)
+  render(
+    h(
+      defineComponent({
+        setup() {
+          return () =>
+            h(
+              'div',
+              show.value
+                ? [h('span', 'First'), h('span', 'Second')]
+                : [h('span', 'Replacement')],
+            )
+        },
+      }),
+    ),
+    root,
+  )
+  root.normalize()
+  show.value = false
+  await nextTick()
+  expect(root.innerHTML).toBe('<div><span>Replacement</span></div>')
+  expect(root.textContent).toBe('Replacement')
+})

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -40,6 +40,8 @@ export const mathmlNS = 'http://www.w3.org/1998/Math/MathML'
 const doc = (typeof document !== 'undefined' ? document : null) as Document
 
 const templateContainer = doc && /*@__PURE__*/ doc.createElement('template')
+const fragmentAnchorDocument =
+  doc && /*@__PURE__*/ doc.implementation.createDocument(null, null)
 
 export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   insert: (child, parent, anchor) => {
@@ -71,6 +73,12 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   },
 
   createText: text => doc.createTextNode(text),
+
+  // Fragment anchors must survive Node.normalize(), which removes empty text
+  // nodes. CDATA sections are preserved by normalize() and omitted from HTML
+  // serialization, so they don't add visible DOM markers.
+  createFragmentAnchor: text =>
+    doc.adoptNode(fragmentAnchorDocument!.createCDATASection(text)),
 
   createComment: text => doc.createComment(text),
 


### PR DESCRIPTION
## Issue

`Node.normalize()` removes the empty text nodes Vue uses as Fragment boundaries. The VNodes still keep those old anchor references, so the next update can walk through a detached range and throw `Cannot read properties of null (reading 'nextSibling')`.

This is reproducible with the case from #15468: normalize an ancestor first, then toggle a Fragment branch.

## Changes

Add an optional Fragment anchor factory to the renderer. The DOM renderer creates Fragment anchors as CDATA sections. `normalize()` leaves them in place, and they are not included in normal HTML serialization, so the rendered markup does not change.

Renderers that do not provide the new factory keep the existing empty-text-node behavior.

## Tests

- `pnpm vitest run --project unit`
- `pnpm vitest run --project unit-jsdom`
- `pnpm check`

Fixes #15468


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fragment rendering reliability when the DOM is normalized before reactive updates.
  - Fragment boundary markers now remain functional without adding visible content to serialized HTML.

- **Compatibility**
  - Custom renderers can optionally provide their own fragment anchor creation behavior.
  - Existing renderers remain supported through the default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->