### PR TITLE
build: inline enum members imported under an alias

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -986,7 +986,7 @@ export class VaporComponentInstance<
    * If $attrs was used during render then the warning for failed attrs
    * fallthrough can be suppressed.
    */
-  accessedAttrs: boolean = false
+  accessedAttrs?: boolean
 
   // type only
   /**
@@ -1865,8 +1865,8 @@ class FallthroughResolveState implements RootChainVisitor {
   // nearest enclosing branch scope; lifecycle parent for retrofitted scopes
   parentScope?: EffectScope
   hasSlotOutlet?: boolean
-  // the innermost fragment's current branch is multi-root: fragments stay
-  // registered for future branches while the current render warns
+  // dev only: the innermost fragment's current branch is multi-root; fragments
+  // stay registered for future branches while the current render warns
   hasNonSingleRoot?: boolean
   // attrs fold at a component's own creation boundary
   readonly stopAtComponent = true
@@ -1900,7 +1900,7 @@ function resolveFallthroughRoot(
 ): Element | undefined {
   const root = getRootElement(block, state)
   const { innermost } = state
-  if (!root && innermost) {
+  if (__DEV__ && !root && innermost) {
     const { nodes } = innermost
     state.hasNonSingleRoot =
       isArray(nodes) && nodes.some(child => !(child instanceof Comment))

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -92,7 +92,7 @@ import {
 } from './componentProps'
 import { renderEffect } from './renderEffect'
 import { emit, normalizeEmitsOptions } from './componentEmits'
-import { setDynamicProps } from './dom/prop'
+import { patchDynamicProps } from './dom/prop'
 import {
   type LooseRawSlots,
   type RawSlots,
@@ -774,7 +774,7 @@ export function applyFallthroughProps(
 ): void {
   isApplyingFallthroughProps = true
   try {
-    setDynamicProps(el, [attrs])
+    patchDynamicProps(el, attrs)
   } finally {
     isApplyingFallthroughProps = false
   }
@@ -1256,7 +1256,7 @@ export function createPlainElement(
   if (rawProps) {
     const isSVG = ns === Namespaces.SVG
     const setFn = () =>
-      setDynamicProps(el, [resolveDynamicProps(rawProps as RawProps)], isSVG)
+      patchDynamicProps(el, resolveDynamicProps(rawProps as RawProps), isSVG)
     if (once) setFn()
     else renderEffect(setFn)
   }

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -485,7 +485,18 @@ export function setHtml(el: TargetElement, value: any): void {
 }
 
 export function setDynamicProps(el: any, args: any[], isSVG?: boolean): void {
-  const props = args.length > 1 ? mergeProps(...args) : args[0] || EMPTY_OBJ
+  patchDynamicProps(
+    el,
+    args.length > 1 ? mergeProps(...args) : args[0] || EMPTY_OBJ,
+    isSVG,
+  )
+}
+
+export function patchDynamicProps(
+  el: any,
+  props: Record<string, any>,
+  isSVG?: boolean,
+): void {
   const cacheKey = `$dprops${isApplyingFallthroughProps ? '$' : ''}`
   const prevProps = el[cacheKey] as Record<string, any> | undefined
   const nextProps: Record<string, any> = Object.create(null)

--- a/scripts/inline-enums.js
+++ b/scripts/inline-enums.js
@@ -244,10 +244,16 @@ export function inlineEnums() {
    * @type {EnumData}
    */
   const enumData = JSON.parse(readFileSync(ENUM_CACHE_PATH, 'utf-8'))
+  const enumIds = new Set(
+    Object.keys(enumData.defines).map(key => key.slice(0, key.indexOf('.'))),
+  )
+  const aliasImportRE = new RegExp(`\\b(?:${[...enumIds].join('|')})\\s+as\\s+`)
 
   // 3. during transform:
   //    3.1 files w/ enum declaration: rewrite declaration as object literal
   //    3.2 files using enum: inject into rolldown define
+  //    3.3 files importing an enum under an alias: the define only matches the
+  //        declared name, so rewrite `Alias.member` here
   /**
    * @type {import('rolldown').Plugin}
    */
@@ -297,6 +303,29 @@ export function inlineEnums() {
         }
       }
 
+      if (aliasImportRE.test(code)) {
+        for (const [alias, enumId] of collectEnumAliases(id, code, enumIds)) {
+          s = s || meta.magicString
+          const memberRE = new RegExp(
+            `(?<![.\\w$])${alias}\\.([A-Za-z_$][\\w$]*)`,
+            'g',
+          )
+          let match
+          while ((match = memberRE.exec(code))) {
+            const key = /** @type {`${string}.${string}`} */ (
+              `${enumId}.${match[1]}`
+            )
+            if (key in enumData.defines) {
+              s.update(
+                match.index,
+                match.index + match[0].length,
+                enumData.defines[key],
+              )
+            }
+          }
+        }
+      }
+
       if (s) {
         return {
           code: s,
@@ -306,4 +335,33 @@ export function inlineEnums() {
   }
 
   return [plugin, enumData.defines]
+}
+
+/**
+ * Enum ids imported under a local alias (`import { E as A }`), keyed by alias.
+ *
+ * @param {string} file
+ * @param {string} code
+ * @param {Set<string>} enumIds
+ * @returns {Map<string, string>}
+ */
+function collectEnumAliases(file, code, enumIds) {
+  const aliases = new Map()
+  const { program } = parseSync(file, code, { sourceType: 'module' })
+  for (const node of program.body) {
+    if (node.type !== 'ImportDeclaration' || node.importKind === 'type')
+      continue
+    for (const spec of node.specifiers) {
+      if (
+        spec.type === 'ImportSpecifier' &&
+        spec.importKind !== 'type' &&
+        spec.imported.type === 'Identifier' &&
+        spec.imported.name !== spec.local.name &&
+        enumIds.has(spec.imported.name)
+      ) {
+        aliases.set(spec.local.name, spec.imported.name)
+      }
+    }
+  }
+  return aliases
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dynamic prop updates for fallthrough attributes and native elements, helping ensure changes are applied consistently.
  - Fixed handling of aliased enum references during compilation, allowing enum values imported under alternate names to be processed correctly.

- **Performance**
  - Reduced unnecessary runtime initialization and development-only calculations without changing end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->