### PR TITLE
fix(compiler-sfc): reuse parsed parent configs across tsconfig walks (fix #15478)

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1405,6 +1405,63 @@ describe('resolveType', () => {
       expect(deps && [...deps]).toStrictEqual(['/src/types.ts'])
     })
 
+    test('ts module resolve parses a shared extended config once', () => {
+      const base = '/tsconfig.base.json'
+      const files: Record<string, string> = {
+        '/tsconfig.json': JSON.stringify({
+          files: [],
+          references: [
+            { path: './tsconfig.a.json' },
+            { path: './tsconfig.b.json' },
+            { path: './tsconfig.c.json' },
+          ],
+        }),
+        [base]: JSON.stringify({
+          compilerOptions: {
+            composite: true,
+            paths: {
+              bar: ['./user.ts'],
+            },
+          },
+        }),
+        '/user.ts': 'export type User = { bar: string }',
+      }
+      for (const name of ['a', 'b', 'c']) {
+        files[`/tsconfig.${name}.json`] = JSON.stringify({
+          extends: base,
+          include: ['**/*.ts', '**/*.vue'],
+        })
+      }
+
+      // Counting reads of the shared base is what makes this test able to fail: the
+      // traversal reaches three configs that extend it, and without a shared
+      // `extendedConfigCache` each one re-reads and re-parses it.
+      let baseReads = 0
+      const { props } = resolve(
+        `
+        import { User } from 'bar'
+        defineProps<User>()
+        `,
+        files,
+        {
+          fs: {
+            fileExists(file) {
+              return !!(files[file] ?? files[normalize(file)])
+            },
+            readFile(file) {
+              if (normalize(file) === normalize(base)) baseReads++
+              return files[file] ?? files[normalize(file)]
+            },
+          },
+        },
+      )
+
+      expect(props).toStrictEqual({
+        bar: ['String'],
+      })
+      expect(baseReads).toBe(1)
+    })
+
     test('ts module resolve w/ project reference folder', () => {
       const files = {
         '/tsconfig.json': JSON.stringify({

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1237,7 +1237,10 @@ export function invalidateTypeCache(filename: string): void {
   // A changed config can be extended by any number of others and is cached under its own
   // resolved path, so there is no single entry to drop; clearing is cheap because this
   // only runs when a config file itself changed.
-  if (filename.endsWith('.json')) extendedConfigCache.clear()
+  if (filename.endsWith('.json')) {
+    extendedConfigCache.clear()
+    tsConfigCache.clear()
+  }
   const affectedConfig = tsConfigRefMap.get(filename)
   if (affectedConfig) tsConfigCache.delete(affectedConfig)
 }

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1080,6 +1080,13 @@ interface CachedConfig {
 const tsConfigCache = createCache<CachedConfig[]>()
 const tsConfigRefMap = new Map<string, string>()
 
+// `loadTSConfig` recurses through project references, so in a workspace where every
+// package extends a shared base, that base is re-read and re-parsed once per config the
+// traversal reaches - each parse allocating its own fully expanded options. TypeScript
+// takes this cache as the 8th argument of `parseJsonConfigFileContent` and shares the
+// parsed parents instead.
+const extendedConfigCache = new Map<string, TS.ExtendedConfigCacheEntry>()
+
 function resolveWithTS(
   containingFile: string,
   source: string,
@@ -1193,6 +1200,9 @@ function loadTSConfig(
     dirname(configPath),
     undefined,
     configPath,
+    undefined,
+    undefined,
+    extendedConfigCache,
   )
   const res = [config]
   visited.add(configPath)
@@ -1224,6 +1234,10 @@ export function invalidateTypeCache(filename: string): void {
   fileToScopeCache.delete(filename)
   fileToGlobalScopeCache.delete(filename)
   tsConfigCache.delete(filename)
+  // A changed config can be extended by any number of others and is cached under its own
+  // resolved path, so there is no single entry to drop; clearing is cheap because this
+  // only runs when a config file itself changed.
+  if (filename.endsWith('.json')) extendedConfigCache.clear()
   const affectedConfig = tsConfigRefMap.get(filename)
   if (affectedConfig) tsConfigCache.delete(affectedConfig)
 }


### PR DESCRIPTION
fixes #15478

### Description

`loadTSConfig` calls `ts.parseJsonConfigFileContent` with five arguments, so the 8th
(`extendedConfigCache`) is always `undefined`, and it recurses through `projectReferences`. In a
workspace where every package `extends` a shared base, that base is re-read and re-parsed once per
config the traversal reaches, and **each parse allocates its own fully expanded options**. `visited`
is a default parameter, so it de-duplicates within a single top-level call and never across calls.

This PR threads a module-level cache into that 8th argument.

### Measured

Reproduction: https://github.com/cainrus/vue-compiler-sfc-tsconfig-repro — a generated workspace of
N packages, each with its own `tsconfig.json` extending one shared base and referencing its group,
one SFC per package importing its props type from another package by alias. One arm per process
(`tsConfigCache` is module scope). At 150 packages, node 22.23.2:

| arm | config parses | distinct expanded `paths` objects | time | retained heap |
|---|---|---|---|---|
| stock | 2900 | **2900** | 11.1 s | **1346.8 MB** |
| cached | 2900 | **1** | 1.9 s | **30.2 MB** |

The parse count is identical in both arms — the cache does not remove parses, it makes each one
cheap and stops the expanded options from being rebuilt.

On the production monorepo that prompted this (2432 components, 514 tsconfigs, 4051 project
references, a 118 KB shared base with 1342 `paths` entries), compiling 400 of its real components
through `compileScript`:

| arm | config parses | distinct expanded `paths` objects | time | retained heap |
|---|---|---|---|---|
| stock | 7351 | **7350** | 25.4 s | **2615.8 MB** |
| cached | 7351 | **3** | 8.0 s | **188.7 MB** |

### Does the cache change resolution?

`parity.mjs` in the reproduction re-implements `loadTSConfig` verbatim and runs it twice per entry
config, differing only in the 8th argument, comparing resolved `compilerOptions`,
`projectReferences` and `fileNames` for every parse: **0 mismatches** over 400 parses and 176 000
`paths` entries. Two mutation controls guard against a comparator that always prints zero — reading
a different config in the cached arm reports 336 mismatches, altering one expanded `paths` entry
reports 400. The same comparison over the production repo's configs: 831 parses, 1 116 033 `paths`
entries, 0 mismatches, controls at 114 and 831.

### Why a plain `Map` and not `createCache()`

The neighbouring caches are `createCache()` (LRU, max 500) because they are keyed per *file* or per
*nearest config*, so their working set scales with the project. This one is keyed by
**extended-config path**, so its ceiling is the number of distinct base configs a workspace has —
measured at **3** on the 514-config repository above. Capping that at 500 would add a bound that
nothing approaches.

### Why `clear()` in `invalidateTypeCache` and not a targeted `delete`

The cache is keyed by TypeScript's own resolved path form, which is not guaranteed to match the
`normalizePath`-ed filename `invalidateTypeCache` receives. A `delete` that misses is a *silent*
failure — a stale base config served in dev with nothing to indicate it — whereas `clear()` costs
one re-parse of the chain and only runs when a config file itself changed, which is why it is gated
on `.json`. Happy to switch to a targeted delete if you would rather have it.

### Tests

`ts module resolve parses a shared extended config once` in
`packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts` counts reads of the shared base
through the test's own virtual fs: three configs extend it, so without the cache it is read three
times. Verified it fails without the change — `expected 3 to be 1` — and passes with it.

A module-level cache could in principle leak between tests, since in `__TEST__` the parse host is
the caller's virtual fs. It does not: `resolve()` calls `invalidateTypeCache` for every file in the
fixture, and the `.json` gate clears the cache on any config in it. All 472 `compiler-sfc` tests
pass; `tsc --noEmit`, `eslint` and `prettier --check` are clean.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript project-reference handling when multiple configurations extend the same base configuration.
  * Prevented repeated processing of shared configuration files during aliased type resolution.
  * Ensured configuration data is refreshed correctly after JSON configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->