### PR TITLE
refactor(runtime-vapor): resolve directive targets with the root chain visitor

### DIFF
--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -337,4 +337,78 @@ describe('custom directive', () => {
     app.unmount()
     expect(teardown).toHaveBeenCalledTimes(2)
   })
+
+  it('should release the previous component root before it is removed', async () => {
+    const data = ref({ show: true })
+    const states: string[] = []
+    const dir: VaporDirective = el => {
+      states.push(`apply:${el.tagName}:${el.isConnected}`)
+      return () => states.push(`cleanup:${el.tagName}:${el.isConnected}`)
+    }
+    const Child = compile(
+      `<template><div v-if="data.show" /><span v-else /></template>`,
+      data,
+    )
+    const App = compile(
+      `<template><components.Child v-custom /></template>`,
+      data,
+      { Child },
+    )
+    App.directives = { custom: dir }
+
+    const { app } = define(App).render()
+    data.value.show = false
+    await nextTick()
+    expect(states).toEqual([
+      'apply:DIV:false',
+      'cleanup:DIV:true',
+      'apply:SPAN:true',
+    ])
+
+    app.unmount()
+    expect(states[3]).toBe('cleanup:SPAN:true')
+  })
+
+  it('should keep the current root when a cached branch updates offscreen', async () => {
+    const data = ref({ current: 'CompA', show: true })
+    const teardown = vi.fn()
+    const dir: VaporDirective = vi.fn(() => teardown)
+    const CompA = compile(
+      `<template><div v-if="data.show" /><span v-else /></template>`,
+      data,
+    )
+    const CompB = compile(`<template><p /></template>`, data)
+    const App = compile(
+      `<template><KeepAlive><component :is="data.current" v-custom /></KeepAlive></template>`,
+      data,
+    )
+    App.components = { CompA, CompB }
+    App.directives = { custom: dir }
+
+    const { host, app } = define(App).render()
+    expect(dir).toHaveBeenCalledOnce()
+
+    data.value.current = 'CompB'
+    await nextTick()
+    expect(dir).toHaveBeenCalledTimes(2)
+    expect(teardown).toHaveBeenCalledOnce()
+
+    // the deactivated CompA switches its root while CompB owns the directive
+    data.value.show = false
+    await nextTick()
+    expect(dir).toHaveBeenCalledTimes(2)
+    expect(teardown).toHaveBeenCalledOnce()
+    expect(host.firstElementChild).toBeInstanceOf(HTMLParagraphElement)
+
+    data.value.current = 'CompA'
+    await nextTick()
+    expect(dir).toHaveBeenCalledTimes(3)
+    expect(teardown).toHaveBeenCalledTimes(2)
+    expect((dir as unknown as Mock).mock.calls[2][0]).toBe(
+      host.firstElementChild,
+    )
+    expect(host.firstElementChild).toBeInstanceOf(HTMLSpanElement)
+
+    app.unmount()
+  })
 })

--- a/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
+++ b/packages/runtime-vapor/__tests__/vdomInterop.spec.ts
@@ -890,6 +890,40 @@ describe('vdomInterop', () => {
       expect(dir).toHaveBeenCalledWith(el, undefined, undefined, undefined)
     })
 
+    test('re-resolve vapor custom directive when vdom child root changes', async () => {
+      const teardown = vi.fn()
+      const dir: VaporDirective = vi.fn(() => teardown)
+      const tag = ref('div')
+      const count = ref(0)
+      const VDomChild = defineComponent({
+        setup() {
+          return () => h(tag.value, String(count.value))
+        },
+      })
+      const App = compile(
+        `<template><components.VDomChild v-custom /></template>`,
+        ref(null),
+        { VDomChild },
+      )
+      App.directives = { custom: dir }
+
+      const { host } = define(App as any).render()
+      expect(dir).toHaveBeenCalledOnce()
+
+      count.value++
+      await nextTick()
+      expect(dir).toHaveBeenCalledOnce()
+      expect(teardown).not.toHaveBeenCalled()
+
+      tag.value = 'span'
+      await nextTick()
+      const el = host.firstElementChild!
+      expect(el).toBeInstanceOf(HTMLSpanElement)
+      expect(teardown).toHaveBeenCalledOnce()
+      expect(dir).toHaveBeenCalledTimes(2)
+      expect((dir as any).mock.calls[1][0]).toBe(el)
+    })
+
     test('apply custom directive to vapor child', async () => {
       const vCustom = {
         created: vi.fn(),

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1615,14 +1615,14 @@ export interface RootChainVisitor {
   // Returning true ends the descent at this fragment.
   onDynamicFragment?: (frag: DynamicFragment) => boolean | void
   // Fired on component descent, including an entry block that is itself a
-  // component.
-  onComponent?: (instance: VaporComponentInstance) => void
+  // component. Returning true ends the descent there.
+  onComponent?: (instance: VaporComponentInstance) => boolean | void
   // Components fold their own chain (attrs at creation, a chain lookup at
   // the first instance), so the descent ends there instead of entering it.
   stopAtComponent?: boolean
-  // Fired at a vnode-backed interop fragment, terminating the descent there
-  // (the fragment carries the chain across into vdom).
-  onInteropFragment?: (frag: InteropFragment) => void
+  // Fired at an interop fragment; a vnode-backed one carries the chain across
+  // into vdom. Returning true ends the descent there.
+  onInteropFragment?: (frag: InteropFragment) => boolean | void
   // Slot outlets break the effective-root chain for scope id inheritance.
   excludeSlotOutlets?: boolean
 }
@@ -1637,7 +1637,7 @@ export function getRootElement(
 
   if (isVaporComponent(block)) {
     if (visitor) {
-      if (visitor.onComponent) visitor.onComponent(block)
+      if (visitor.onComponent && visitor.onComponent(block)) return
       if (visitor.stopAtComponent) return
     }
     return getRootElement(block.block, visitor)
@@ -1659,9 +1659,8 @@ export function getRootElement(
         isInteropEnabled &&
         visitor.onInteropFragment &&
         isInteropFragment(block) &&
-        block.vnode
-      ) {
         visitor.onInteropFragment(block)
+      ) {
         return
       }
     }

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -1,5 +1,4 @@
 import { EffectScope } from '@vue/reactivity'
-import { isArray } from '@vue/shared'
 import {
   type DirectiveModifiers,
   currentInstance,
@@ -10,15 +9,14 @@ import {
   setCurrentInstance,
   warn,
 } from '@vue/runtime-dom'
-import { type Block, EMPTY_BLOCK } from '../block'
+import { EMPTY_BLOCK } from '../block'
 import {
+  type RootChainVisitor,
   type VaporComponentInstance,
   getRootElement,
-  isVaporComponent,
 } from '../component'
 import { isAsyncComponentEnabled } from '../asyncComponentState'
-import { type VaporFragment, isFragment, isInteropFragment } from '../fragment'
-import { isInteropEnabled } from '../vdomInteropState'
+import { type VaporFragment, isDynamicFragment, isFragment } from '../fragment'
 import { inOnce, withOnce } from '../once'
 
 // !! vapor directive is different from vdom directives
@@ -61,10 +59,37 @@ export function withVaporDirectives(
   const instance = currentInstance
   // Deferred (re)application keeps the once ambient it was created under.
   const once = inOnce
-  const trackedBlocks = new WeakSet<VaporFragment | VaporComponentInstance>()
   let currentElement: Element | null | undefined = null
   let directiveScope: EffectScope | undefined
   let disposed = false
+  // Set by a descent that met a root which cannot resolve yet.
+  let pending = false
+  let pendingSetups: WeakSet<VaporComponentInstance> | undefined
+
+  const visitor: RootChainVisitor = {
+    onDynamicFragment: track,
+    onComponent(block) {
+      if (__FEATURE_SUSPENSE__ && block.asyncDep && !block.asyncResolved) {
+        pending = true
+        if (!(pendingSetups ||= new WeakSet()).has(block)) {
+          pendingSetups.add(block)
+          // Suspense replaces the pending block before the component's first mount
+          onBeforeMount(applyDirectives, block)
+        }
+        return true
+      }
+      // Async wrappers keep an empty fragment until a renderable branch is available
+      if (isAsyncComponentEnabled && isAsyncWrapper(block)) {
+        const inner = block.block
+        if (isFragment(inner) && inner.nodes === EMPTY_BLOCK) pending = true
+      }
+    },
+    onInteropFragment(frag) {
+      // Interop content resolves its nodes on `syncNodes`
+      if (frag.nodes === EMPTY_BLOCK) pending = true
+      track(frag)
+    },
+  }
 
   function stopDirectiveScope() {
     if (directiveScope) {
@@ -73,12 +98,31 @@ export function withVaporDirectives(
     }
   }
 
+  function track(frag: VaporFragment): void {
+    const u = (frag.u ||= [])
+    if (u.includes(applyDirectives)) return
+    // Re-resolve the root element when the fragment updates
+    u.push(applyDirectives)
+    // A branch switch discards its root: release it while it is still in the
+    // DOM (vdom beforeUnmount). Interop fragments update on every vdom
+    // re-render and usually keep their root, so they only re-resolve.
+    if (isDynamicFragment(frag)) {
+      ;(frag.bu ||= []).push(() => {
+        // Fragments off the chain (a deactivated KeepAlive branch) keep it
+        if (currentElement && getRootElement(frag.nodes) === currentElement) {
+          currentElement = null
+          stopDirectiveScope()
+        }
+      })
+    }
+  }
+
   function applyDirectives() {
     if (disposed) return
 
-    const isRootPending = trackRootUpdates(node)
-    const element = getRootElement(node)
-    if (!element && isRootPending) {
+    pending = false
+    const element = getRootElement(node, visitor)
+    if (!element && pending) {
       // Keep null as the pending state so a resolved invalid root still warns
       if (currentElement !== null) {
         currentElement = null
@@ -118,53 +162,6 @@ export function withVaporDirectives(
     } finally {
       restoreCurrentInstance(prev)
     }
-  }
-
-  function trackRootUpdates(block: Block): boolean {
-    if (isVaporComponent(block)) {
-      if (__FEATURE_SUSPENSE__ && block.asyncDep && !block.asyncResolved) {
-        if (!trackedBlocks.has(block)) {
-          trackedBlocks.add(block)
-          // Suspense replaces the pending block before the component's first mount
-          onBeforeMount(applyDirectives, block)
-        }
-        return true
-      }
-
-      const innerBlock = block.block
-      if (trackRootUpdates(innerBlock)) return true
-
-      // Async wrappers keep an empty fragment until a renderable branch is available
-      return (
-        isAsyncComponentEnabled &&
-        isAsyncWrapper(block) &&
-        isFragment(innerBlock) &&
-        innerBlock.nodes === EMPTY_BLOCK
-      )
-    }
-    // Traverse every child so all nested fragments are tracked
-    if (isArray(block)) {
-      let hasPendingTarget = false
-      for (const child of block) {
-        if (trackRootUpdates(child)) hasPendingTarget = true
-      }
-      return hasPendingTarget
-    }
-    if (!isFragment(block)) return false
-
-    if (!trackedBlocks.has(block)) {
-      trackedBlocks.add(block)
-      // Re-resolve the root element when the fragment updates
-      ;(block.u ||= []).push(applyDirectives)
-    }
-
-    return (
-      // For VDOM interops, directives cannot resolve the root element until `syncNodes`
-      (isInteropEnabled &&
-        isInteropFragment(block) &&
-        block.nodes === EMPTY_BLOCK) ||
-      trackRootUpdates(block.nodes)
-    )
   }
 
   onScopeDispose(() => {

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -3660,7 +3660,10 @@ function publishVaporScopeIds(block: Block, scopeIds: string[]): void {
       currentScopeIds = collectRootScopeIds(instance) || []
     },
     onInteropFragment: frag => {
-      setVNodeVaporScopeIds(frag.vnode!, currentScopeIds)
+      if (frag.vnode) {
+        setVNodeVaporScopeIds(frag.vnode, currentScopeIds)
+        return true
+      }
     },
     excludeSlotOutlets: true,
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom directive behavior when component roots change, including dynamic branches, asynchronous content, suspense, and deactivated cached views.
  * Ensured directives are cleaned up before old elements are removed and reapplied to newly rendered root elements.
  * Fixed directive handling when switching VDOM-interoperable content between different root element types.
  * Improved scope handling for interoperable content without an associated virtual node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->