### PR TITLE
fix(runtime-vapor): isolate custom directive errors

### DIFF
--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -411,4 +411,82 @@ describe('custom directive', () => {
 
     app.unmount()
   })
+
+  it('should isolate directive errors from the owner render', () => {
+    const data = ref(null)
+    const error = new Error('directive')
+    const dir: VaporDirective = () => {
+      throw error
+    }
+    const App = compile(
+      `<template><div><p v-custom /><i>after</i></div></template>`,
+      data,
+    )
+    App.directives = { custom: dir }
+
+    const { app, mount, html } = define(App).create()
+    const errorHandler = (app.config.errorHandler = vi.fn())
+    mount()
+    expect(errorHandler).toHaveBeenCalledOnce()
+    expect(errorHandler.mock.calls[0][0]).toBe(error)
+    expect(html()).toBe('<div><p></p><i>after</i></div>')
+
+    app.unmount()
+  })
+
+  it('should isolate directive errors on component root re-application', async () => {
+    const data = ref({ show: true })
+    const error = new Error('directive')
+    const dir: VaporDirective = el => {
+      if (el.tagName === 'SPAN') throw error
+    }
+    const Child = compile(
+      `<template><div v-if="data.show" /><span v-else /></template>`,
+      data,
+    )
+    const App = compile(
+      `<template><components.Child v-custom /></template>`,
+      data,
+      { Child },
+    )
+    App.directives = { custom: dir }
+
+    const { app, mount, html } = define(App).create()
+    const errorHandler = (app.config.errorHandler = vi.fn())
+    mount()
+    data.value.show = false
+    await nextTick()
+    expect(errorHandler).toHaveBeenCalledOnce()
+    expect(errorHandler.mock.calls[0][0]).toBe(error)
+    expect(html()).toBe('<span></span><!--if-->')
+
+    app.unmount()
+  })
+
+  it('should isolate directive cleanup errors', async () => {
+    const data = ref({ show: true })
+    const error = new Error('cleanup')
+    const teardown = vi.fn()
+    const failing: VaporDirective = () => () => {
+      throw error
+    }
+    const other: VaporDirective = () => teardown
+    const App = compile(
+      `<template><div v-if="data.show" v-failing v-other /></template>`,
+      data,
+    )
+    App.directives = { failing, other }
+
+    const { app, mount, html } = define(App).create()
+    const errorHandler = (app.config.errorHandler = vi.fn())
+    mount()
+    data.value.show = false
+    await nextTick()
+    expect(errorHandler).toHaveBeenCalledOnce()
+    expect(errorHandler.mock.calls[0][0]).toBe(error)
+    expect(teardown).toHaveBeenCalledOnce()
+    expect(html()).toBe('<!--if-->')
+
+    app.unmount()
+  })
 })

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -1,6 +1,9 @@
 import { EffectScope } from '@vue/reactivity'
 import {
   type DirectiveModifiers,
+  ErrorCodes,
+  type GenericComponentInstance,
+  callWithErrorHandling,
   currentInstance,
   isAsyncWrapper,
   onBeforeMount,
@@ -52,7 +55,7 @@ export function withVaporDirectives(
 ): void {
   // Element targets are stable, so apply synchronously in the current scope
   if (node instanceof Element) {
-    applyDirectivesToElement(node, dirs)
+    applyDirectivesToElement(node, dirs, currentInstance)
     return
   }
 
@@ -155,9 +158,9 @@ export function withVaporDirectives(
     const prev = setCurrentInstance(instance, directiveScope)
     try {
       if (once) {
-        withOnce(() => applyDirectivesToElement(element, dirs))
+        withOnce(() => applyDirectivesToElement(element, dirs, instance))
       } else {
-        applyDirectivesToElement(element, dirs)
+        applyDirectivesToElement(element, dirs, instance)
       }
     } finally {
       restoreCurrentInstance(prev)
@@ -176,11 +179,21 @@ export function withVaporDirectives(
 function applyDirectivesToElement(
   element: Element,
   dirs: VaporDirectiveArguments,
+  instance: GenericComponentInstance | null,
 ): void {
   for (const [dir, value, argument, modifiers] of dirs) {
     if (dir) {
-      const ret = dir(element, value, argument, modifiers)
-      if (ret) onScopeDispose(ret)
+      const ret = callWithErrorHandling(
+        dir,
+        instance,
+        ErrorCodes.DIRECTIVE_HOOK,
+        [element, value, argument, modifiers],
+      )
+      if (ret) {
+        onScopeDispose(() =>
+          callWithErrorHandling(ret, instance, ErrorCodes.DIRECTIVE_HOOK),
+        )
+      }
     }
   }
 }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -448,8 +448,6 @@ export class DynamicFragment extends RenderContextFragment {
         branchKey,
       )
     } finally {
-      // hooks and branch renders run user code; the caller's subscriber
-      // must come back even when one of them throws
       setActiveSub(prevSub)
     }
 

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -370,84 +370,88 @@ export class DynamicFragment extends RenderContextFragment {
     const wasMounted = prevKey !== undefined
     this.current = key
     const prevSub = setActiveSub()
-    const parent = !isHydrating ? this.getBranchParent() : null
-    // Every update after the mount-time render brackets its hooks; see the
-    // `everUpdated` field comment.
-    const isUpdate = wasMounted || (everUpdated && !!parent)
-    if (isUpdate) {
-      const bu = this.bu
-      if (bu) {
-        for (let i = 0; i < bu.length; i++) {
-          bu[i]()
+    let reusingDeferredAnchor = false
+    try {
+      const parent = !isHydrating ? this.getBranchParent() : null
+      // Every update after the mount-time render brackets its hooks; see the
+      // `everUpdated` field comment.
+      const isUpdate = wasMounted || (everUpdated && !!parent)
+      if (isUpdate) {
+        const bu = this.bu
+        if (bu) {
+          for (let i = 0; i < bu.length; i++) {
+            bu[i]()
+          }
         }
       }
-    }
-    // currently leaving: defer mounting the next branch until
-    // the leave finishes.
-    if (
-      transition &&
-      deferBranchUpdateDuringLeave(this, render, key, noScope, branchKey)
-    ) {
-      setActiveSub(prevSub)
-      return
-    }
-
-    let removePrevious: (() => void) | undefined
-    // teardown previous branch
-    if (wasMounted) {
-      const scope = this.scope
-      const previous = this.nodes
-      const removeBranch = () => remove(previous, parent || undefined)
-      let deferRemoval = false
-      if (scope) {
-        if (this.keepAliveCtx) {
-          deferRemoval = this.keepAliveCtx.prepareBranchRemoval(
-            this,
-            scope,
-            prevKey,
-          )
-        } else {
-          scope.stop()
-        }
-      }
+      // currently leaving: defer mounting the next branch until
+      // the leave finishes.
       if (
         transition &&
-        removeBranchWithLeave(
-          this,
-          transition,
-          parent,
-          render,
-          key,
-          noScope,
-          branchKey,
-        )
+        deferBranchUpdateDuringLeave(this, render, key, noScope, branchKey)
       ) {
-        // out-in: the next branch mounts after the leave finishes.
-        setActiveSub(prevSub)
         return
       }
-      if (deferRemoval) {
-        removePrevious = removeBranch
-      } else {
-        removeBranch()
+
+      let removePrevious: (() => void) | undefined
+      // teardown previous branch
+      if (wasMounted) {
+        const scope = this.scope
+        const previous = this.nodes
+        const removeBranch = () => remove(previous, parent || undefined)
+        let deferRemoval = false
+        if (scope) {
+          if (this.keepAliveCtx) {
+            deferRemoval = this.keepAliveCtx.prepareBranchRemoval(
+              this,
+              scope,
+              prevKey,
+            )
+          } else {
+            scope.stop()
+          }
+        }
+        if (
+          transition &&
+          removeBranchWithLeave(
+            this,
+            transition,
+            parent,
+            render,
+            key,
+            noScope,
+            branchKey,
+          )
+        ) {
+          // out-in: the next branch mounts after the leave finishes.
+          return
+        }
+        if (deferRemoval) {
+          removePrevious = removeBranch
+        } else {
+          removeBranch()
+        }
       }
+
+      reusingDeferredAnchor = isHydrating
+        ? prepareDeferredHydrationAnchor(this, !!render)
+        : false
+
+      this.renderBranch(
+        render,
+        transition,
+        parent,
+        key,
+        noScope,
+        isUpdate,
+        removePrevious,
+        branchKey,
+      )
+    } finally {
+      // hooks and branch renders run user code; the caller's subscriber
+      // must come back even when one of them throws
+      setActiveSub(prevSub)
     }
-
-    const reusingDeferredAnchor = isHydrating
-      ? prepareDeferredHydrationAnchor(this, !!render)
-      : false
-
-    this.renderBranch(
-      render,
-      transition,
-      parent,
-      key,
-      noScope,
-      isUpdate,
-      removePrevious,
-      branchKey,
-    )
-    setActiveSub(prevSub)
 
     if (isHydrating && this.autoHydrate && !reusingDeferredAnchor) {
       hydrateDynamicFragmentAnchor(this, render == null)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Errors thrown by custom directives are now reported through the configured error handler without interrupting component rendering.
  * Directive cleanup continues for other directives even when one cleanup operation fails.
  * Improved reliability when updating dynamic fragments, including transitions and deferred rendering scenarios.

* **Tests**
  * Added coverage for directive errors during application, re-application, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->