### PR TITLE
refactor(compiler-vapor): apply custom directives after block effects

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -224,6 +224,35 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > execution order > applies custom directives after props, children and v-model 1`] = `
+"import { resolveDirective as _resolveDirective, child as _child, next as _next, setProp as _setProp, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, setInsertionState as _setInsertionState, createIf as _createIf, createAssetComponent as _createAssetComponent, applyTextModel as _applyTextModel, withVaporDirectives as _withVaporDirectives, template as _template } from 'vue';
+const t0 = _template("<span>", 2)
+const t1 = _template("<div> <!><!><input>", 1)
+
+export function render(_ctx) {
+  const _directive_dir = _resolveDirective("dir")
+  const n7 = t1()
+  const n0 = _child(n7)
+  const n6 = _next(n0)
+  const n8 = _next(n6)
+  const n5 = _next(n8)
+  _renderEffect(() => {
+    _setProp(n7, "id", _ctx.foo)
+    _setText(n0, _toDisplayString(_ctx.bar))
+  })
+  _setInsertionState(n7, n6)
+  const n1 = _createIf(() => (_ctx.ok), () => {
+    const n3 = t0()
+    return n3
+  }, null, 33 /* TRUE_SINGLE_ROOT, TRUE_NO_SCOPE */)
+  _setInsertionState(n7, n8)
+  const n4 = _createAssetComponent("Comp")
+  _applyTextModel(n5, () => (_ctx.text), _value => (_ctx.text = _value))
+  _withVaporDirectives(n7, [[_directive_dir]])
+  return n7
+}"
+`;
+
 exports[`compile > execution order > basic 1`] = `
 "import { txt as _txt, setProp as _setProp, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div> ", 1)

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -327,6 +327,18 @@ describe('compile', () => {
       )
     })
 
+    test('applies custom directives after props, children and v-model', () => {
+      const code = compile(
+        `<div v-dir :id="foo">{{ bar }}<span v-if="ok" /><Comp /><input v-model="text" /></div>`,
+      )
+      expect(code).matchSnapshot()
+      expect(code).contains(
+        `_applyTextModel(n5, () => (_ctx.text), _value => (_ctx.text = _value))
+  _withVaporDirectives(n7, [[_directive_dir]])
+  return n7`,
+      )
+    })
+
     test('flushes previous effects before creating child component', () => {
       const code = compile(`<div>parent: {{ useId() }}</div><Child />`, {
         bindingMetadata: {

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformSlotOutlet.spec.ts.snap
@@ -86,10 +86,9 @@ export function render(_ctx) {
 `;
 
 exports[`compiler: transform <slot> outlets > error on unexpected custom directive on <slot> 1`] = `
-"import { resolveDirective as _resolveDirective, createSlot as _createSlot } from 'vue';
+"import { createSlot as _createSlot } from 'vue';
 
 export function render(_ctx) {
-  const _directive_foo = _resolveDirective("foo")
   const n0 = _createSlot()
   return n0
 }"

--- a/packages/compiler-vapor/src/generators/block.ts
+++ b/packages/compiler-vapor/src/generators/block.ts
@@ -26,6 +26,7 @@ import {
   genOperations,
 } from './operation'
 import { genChildren, genSelf } from './template'
+import { genCustomDirectives } from './directive'
 import { toValidAssetId } from '@vue/compiler-dom'
 import { VaporSlotFlags } from '@vue/shared'
 
@@ -170,6 +171,7 @@ export function genBlockContent(
   if (modelOperations.length) {
     push(...genOperations(modelOperations, context))
   }
+  push(...genCustomDirectives(operation, context))
 
   push(NEWLINE, `return `)
 

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -46,7 +46,6 @@ import {
   isSimpleIdentifier,
   toValidAssetId,
 } from '@vue/compiler-dom'
-import { genDirectivesForElement } from './directive'
 import { genEventHandler } from './event'
 import { genBlock, hasStableSlotRoot, markSlotRootOperations } from './block'
 import {
@@ -134,7 +133,6 @@ export function genCreateComponent(
       useAssetComponentHelper ? maybeSelfReference && 'true' : nsArg,
       useAssetComponentHelper && nsArg,
     ),
-    ...genDirectivesForElement(operation.id, context),
   ]
 
   function genTag() {

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -7,6 +7,7 @@ import {
   type CodeFragmentDelimiters,
   DELIMITERS_ARRAY,
   NEWLINE,
+  buildCodeFragment,
   genCall,
   genMulti,
   genOnce,
@@ -35,17 +36,29 @@ export function genBuiltinDirective(
 }
 
 /**
- * user directives via `withVaporDirectives`
+ * user directives via `withVaporDirectives`, emitted at the end of the block
+ * so the element's props, children and v-model are in place first
  */
-export function genDirectivesForElement(
-  id: number,
+export function genCustomDirectives(
+  operations: OperationNode[],
   context: CodegenContext,
 ): CodeFragment[] {
-  const dirs = filterCustomDirectives(id, context.block.operation)
-  return dirs.length ? genCustomDirectives(dirs, context) : []
+  const byElement = new Map<number, DirectiveIRNode[]>()
+  for (const oper of operations) {
+    if (oper.type === IRNodeTypes.DIRECTIVE && !oper.builtin) {
+      const dirs = byElement.get(oper.element)
+      if (dirs) dirs.push(oper)
+      else byElement.set(oper.element, [oper])
+    }
+  }
+  const [frag, push] = buildCodeFragment()
+  for (const dirs of byElement.values()) {
+    push(...genElementDirectives(dirs, context))
+  }
+  return frag
 }
 
-function genCustomDirectives(
+function genElementDirectives(
   opers: DirectiveIRNode[],
   context: CodegenContext,
 ): CodeFragment[] {
@@ -89,16 +102,4 @@ function genCustomDirectives(
       modifiers,
     )
   }
-}
-
-function filterCustomDirectives(
-  id: number,
-  operations: OperationNode[],
-): DirectiveIRNode[] {
-  return operations.filter(
-    (oper): oper is DirectiveIRNode =>
-      oper.type === IRNodeTypes.DIRECTIVE &&
-      oper.element === id &&
-      !oper.builtin,
-  )
 }

--- a/packages/compiler-vapor/src/generators/template.ts
+++ b/packages/compiler-vapor/src/generators/template.ts
@@ -1,7 +1,6 @@
 import type { CodegenContext } from '../generate'
 import { DynamicFlag, type IRDynamicInfo, type IRTemplate } from '../ir'
 import { TemplateFlags } from '@vue/shared'
-import { genDirectivesForElement } from './directive'
 import { genOperationWithInsertionState } from './operation'
 import {
   type CodeFragment,
@@ -56,7 +55,6 @@ export function genSelf(
 
   if (id !== undefined && template !== undefined) {
     push(NEWLINE, `const n${id} = ${context.tName(template)}()`)
-    push(...genDirectivesForElement(id, context))
   }
 
   if (operation) {
@@ -188,10 +186,6 @@ export function genChildren(
     if (id === child.anchor && (!child.hasDynamicChild || ownsSubtree)) {
       flushBeforeDynamic && flushBeforeDynamic(child, push)
       push(...genSelf(child, context, flushBeforeDynamic))
-    }
-
-    if (id !== undefined) {
-      push(...genDirectivesForElement(id, context))
     }
 
     prev = [variable, elementIndex, id === undefined]

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -1232,6 +1232,15 @@ function transformProp(
   }
 
   if (!isBuiltInDirective(name)) {
+    if (node.tagType === ElementTypes.SLOT) {
+      context.options.onError(
+        createCompilerError(
+          ErrorCodes.X_V_SLOT_UNEXPECTED_DIRECTIVE_ON_SLOT_OUTLET,
+          prop.loc,
+        ),
+      )
+      return
+    }
     const fromSetup = resolveSetupReference(`v-${name}`, context)
     if (fromSetup) {
       name = fromSetup

--- a/packages/compiler-vapor/src/transforms/transformSlotOutlet.ts
+++ b/packages/compiler-vapor/src/transforms/transformSlotOutlet.ts
@@ -2,10 +2,8 @@ import {
   type AttributeNode,
   type ElementNode,
   ElementTypes,
-  ErrorCodes,
   NodeTypes,
   type SimpleExpressionNode,
-  createCompilerError,
   createSimpleExpression,
   isStaticArgOf,
   isStaticExp,
@@ -13,7 +11,6 @@ import {
 import type { NodeTransform, TransformContext } from '../transform'
 import {
   type BlockIRNode,
-  type DirectiveIRNode,
   DynamicFlag,
   IRNodeTypes,
   type IRProps,
@@ -83,19 +80,6 @@ export const transformSlotOutlet: NodeTransform = (node, context) => {
       true,
     )
     irProps = isDynamic ? props : [props]
-
-    const runtimeDirective = context.block.operation.find(
-      (oper): oper is DirectiveIRNode =>
-        oper.type === IRNodeTypes.DIRECTIVE && oper.element === id,
-    )
-    if (runtimeDirective) {
-      context.options.onError(
-        createCompilerError(
-          ErrorCodes.X_V_SLOT_UNEXPECTED_DIRECTIVE_ON_SLOT_OUTLET,
-          runtimeDirective.dir.loc,
-        ),
-      )
-    }
   }
 
   return () => {

--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -489,4 +489,34 @@ describe('custom directive', () => {
 
     app.unmount()
   })
+
+  it('should apply after the element props and children are in place', () => {
+    const data = ref({ x: 'X', text: 'T', show: true })
+    let seen: Record<string, unknown> | undefined
+    const dir: VaporDirective = el => {
+      seen = {
+        attr: el.getAttribute('data-x'),
+        text: el.textContent,
+        span: !!el.querySelector('span'),
+        child: !!el.querySelector('b'),
+        connected: el.isConnected,
+      }
+    }
+    const Child = compile(`<template><b /></template>`, data)
+    const App = compile(
+      `<template><div v-custom :data-x="data.x">{{ data.text }}<span v-if="data.show" /><components.Child /></div></template>`,
+      data,
+      { Child },
+    )
+    App.directives = { custom: dir }
+
+    define(App).render()
+    expect(seen).toEqual({
+      attr: 'X',
+      text: 'T',
+      span: true,
+      child: true,
+      connected: false,
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom directives now run after an element’s properties, text, and child content are fully initialized, providing consistent access to the completed element.
  * Added validation to report an error when custom directives are used on slot outlets.

* **Tests**
  * Added coverage confirming directive execution order and slot-outlet validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->