### PR TITLE
fix(runtime-vapor): warn on lifecycle hooks inside custom directives

### DIFF
--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -7,7 +7,14 @@ import {
   defineVaporComponent,
   withVaporDirectives,
 } from '../../src'
-import { currentInstance, nextTick, watchEffect } from '@vue/runtime-dom'
+import {
+  currentInstance,
+  nextTick,
+  onMounted,
+  onUpdated,
+  watchEffect,
+  watchPostEffect,
+} from '@vue/runtime-dom'
 import type { Mock } from 'vite-plus/test'
 import { compile, makeRender } from '../_utils'
 
@@ -518,5 +525,52 @@ describe('custom directive', () => {
       child: true,
       connected: false,
     })
+  })
+
+  it('should warn on lifecycle hooks registered inside a directive', () => {
+    const data = ref(null)
+    const dir: VaporDirective = () => {
+      onMounted(() => {})
+      onUpdated(() => {})
+    }
+    const App = compile(`<template><div v-custom /></template>`, data)
+    App.directives = { custom: dir }
+
+    const { html } = define(App).render()
+    expect(html()).toBe('<div></div>')
+    expect(
+      'onMounted() was called inside a custom directive',
+    ).toHaveBeenWarned()
+    expect(
+      'onUpdated() was called inside a custom directive',
+    ).toHaveBeenWarned()
+  })
+
+  it('should observe the inserted element from a post effect', async () => {
+    const data = ref({ show: true, extra: false })
+    const states: string[] = []
+    const dir: VaporDirective = el => {
+      watchPostEffect(() => states.push(`${el.tagName}:${el.isConnected}`))
+    }
+    const Child = compile(
+      `<template><div v-if="data.show" /><span v-else /></template>`,
+      data,
+    )
+    const App = compile(
+      `<template><components.Child v-custom /><p v-if="data.extra" v-custom /></template>`,
+      data,
+      { Child },
+    )
+    App.directives = { custom: dir }
+
+    const { app } = define(App).render()
+    expect(states).toEqual(['DIV:true'])
+
+    data.value.show = false
+    data.value.extra = true
+    await nextTick()
+    expect(states).toEqual(['DIV:true', 'P:true', 'SPAN:true'])
+
+    app.unmount()
   })
 })

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -181,6 +181,7 @@ function applyDirectivesToElement(
   dirs: VaporDirectiveArguments,
   instance: GenericComponentInstance | null,
 ): void {
+  const hookCounts = __DEV__ && instance ? countLifecycleHooks(instance) : null
   for (const [dir, value, argument, modifiers] of dirs) {
     if (dir) {
       const ret = callWithErrorHandling(
@@ -195,5 +196,49 @@ function applyDirectivesToElement(
         )
       }
     }
+  }
+  if (__DEV__ && hookCounts) warnLifecycleHooks(instance!, hookCounts)
+}
+
+// Lifecycle hooks are not supported inside a directive: they would attach to
+// the owner instance, not the element. Dev-only detection by hook count.
+const lifecycleHookNames: Record<string, string> = __DEV__
+  ? {
+      bm: 'onBeforeMount',
+      m: 'onMounted',
+      bu: 'onBeforeUpdate',
+      u: 'onUpdated',
+      bum: 'onBeforeUnmount',
+      um: 'onUnmounted',
+      da: 'onDeactivated',
+      a: 'onActivated',
+    }
+  : {}
+
+function countLifecycleHooks(instance: GenericComponentInstance): number[] {
+  const counts: number[] = []
+  for (const key in lifecycleHookNames) {
+    const hooks = (instance as any)[key]
+    counts.push(hooks ? hooks.length : 0)
+  }
+  return counts
+}
+
+function warnLifecycleHooks(
+  instance: GenericComponentInstance,
+  before: number[],
+): void {
+  let i = 0
+  for (const key in lifecycleHookNames) {
+    const hooks = (instance as any)[key]
+    if (hooks && hooks.length > before[i]) {
+      warn(
+        `${lifecycleHookNames[key]}() was called inside a custom directive. ` +
+          `Lifecycle hooks are not supported in Vapor directives: they attach to ` +
+          `the component, not the element. Use watchPostEffect() for work that ` +
+          `needs the element in the DOM, and return a cleanup function for teardown.`,
+      )
+    }
+    i++
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added development-time warnings when lifecycle hooks are registered inside custom directives.
  - Improved directive behavior checks for effects that observe whether elements are connected to the document.

- **Tests**
  - Added coverage for unsupported lifecycle-hook usage in custom directives.
  - Added coverage for connection-state updates when component branches switch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->