### PR TITLE
fix(vapor): pass custom directive arguments as getters

### DIFF
--- a/packages-private/dts-test/vapor/directives.test-d.ts
+++ b/packages-private/dts-test/vapor/directives.test-d.ts
@@ -42,14 +42,15 @@ describe('custom directive argument and modifiers', () => {
     'foo' | 'bar',
     'arg'
   > = (_element, _value, argument, modifiers) => {
-    expectType<'arg' | undefined>(argument)
+    expectType<(() => 'arg') | undefined>(argument)
     expectType<DirectiveModifiers<'foo' | 'bar'> | undefined>(modifiers)
 
     if (argument) {
-      expectType<false>({} as IsAny<typeof argument>)
+      expectType<'arg'>(argument())
+      expectType<false>({} as IsAny<ReturnType<typeof argument>>)
 
       // @ts-expect-error argument should retain its declared type
-      expectType<'other'>(argument)
+      expectType<'other'>(argument())
     }
 
     if (modifiers) {
@@ -66,6 +67,6 @@ describe('custom directive argument and modifiers', () => {
   )
 
   withVaporDirectives({} as HTMLDivElement, [
-    [directive, () => 1, 'arg', { foo: true }],
+    [directive, () => 1, () => 'arg', { foo: true }],
   ])
 })

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -76,7 +76,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), _ctx.foo]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), () => (_ctx.foo)]])
   return n0
 }"
 `;
@@ -128,7 +128,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), "foo"]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), () => ("foo")]])
   return n0
 }"
 `;
@@ -139,7 +139,7 @@ const t0 = _template("<div>", 1)
 
 export function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()
-  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), "foo", { bar: true }]])
+  _withVaporDirectives(n0, [[_ctx.vExample, () => (_ctx.msg), () => ("foo"), { bar: true }]])
   return n0
 }"
 `;

--- a/packages/compiler-vapor/src/generators/directive.ts
+++ b/packages/compiler-vapor/src/generators/directive.ts
@@ -87,7 +87,11 @@ function genElementDirectives(
       ...genExpression(dir.exp, context),
       ')',
     ]
-    const argument = dir.arg && genExpression(dir.arg, context)
+    const argument = dir.arg && [
+      '() => (',
+      ...genExpression(dir.arg, context),
+      ')',
+    ]
     const modifiers = !!dir.modifiers.length && [
       '{ ',
       genDirectiveModifiers(dir.modifiers.map(m => m.content)),

--- a/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/customDirective.spec.ts
@@ -132,6 +132,29 @@ describe('custom directive', () => {
     ).toHaveBeenWarned()
   })
 
+  it('should pass the argument as a getter', async () => {
+    const data = ref({ arg: 'a' })
+    const dir: VaporDirective = (el, _value, arg) => {
+      watchEffect(() => {
+        ;(el as Element).setAttribute('data-arg', arg!())
+      })
+    }
+    const App = compile(
+      `<template><div v-custom:[data.arg] /><p v-custom:static /></template>`,
+      data,
+    )
+    App.directives = { custom: dir }
+
+    const { host } = define(App).render()
+    const [div, p] = Array.from(host.children)
+    expect(div.getAttribute('data-arg')).toBe('a')
+    expect(p.getAttribute('data-arg')).toBe('static')
+
+    data.value.arg = 'b'
+    await nextTick()
+    expect(div.getAttribute('data-arg')).toBe('b')
+  })
+
   it('should warn on multi-root component', () => {
     const dir: VaporDirective = vi.fn()
     const scope = effectScope()

--- a/packages/runtime-vapor/src/directives/custom.ts
+++ b/packages/runtime-vapor/src/directives/custom.ts
@@ -32,7 +32,7 @@ export type VaporDirective<
 > = (
   node: HostElement,
   value?: () => Value,
-  argument?: Arg,
+  argument?: () => Arg,
   modifiers?: DirectiveModifiers<Modifiers>,
 ) => (() => void) | void
 
@@ -41,11 +41,15 @@ type AnyVaporDirective = VaporDirective<any>
 type VaporDirectiveArguments = Array<
   | [AnyVaporDirective | undefined]
   | [AnyVaporDirective | undefined, () => any]
-  | [AnyVaporDirective | undefined, (() => any) | undefined, argument: any]
+  | [
+      AnyVaporDirective | undefined,
+      (() => any) | undefined,
+      argument: () => any,
+    ]
   | [
       AnyVaporDirective | undefined,
       value: (() => any) | undefined,
-      argument: any | undefined,
+      argument: (() => any) | undefined,
       modifiers: DirectiveModifiers,
     ]
 >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom directive arguments are now provided as reactive getter functions.
  * Dynamic directive arguments update when their underlying state changes, while static arguments remain available through constant getters.

* **Bug Fixes**
  * Improved consistency between compiled directive arguments and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->